### PR TITLE
Use HTTPS URLs in marketplace configuration

### DIFF
--- a/.claude-plugin/marketplace-prerelease.json
+++ b/.claude-plugin/marketplace-prerelease.json
@@ -11,8 +11,8 @@
     {
       "name": "accelerator",
       "source": {
-        "source": "github",
-        "repo": "atomicinnovation/accelerator",
+        "source": "url",
+        "url": "https://github.com/atomicinnovation/accelerator.git",
         "ref": "v1.21.0-pre.26"
       }
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "accelerator",
       "source": {
-        "source": "github",
-        "repo": "atomicinnovation/accelerator",
+        "source": "url",
+        "url": "https://github.com/atomicinnovation/accelerator.git",
         "ref": "v1.20.0"
       }
     }


### PR DESCRIPTION
Switch from github short-form repo references to explicit HTTPS URLs. This allows the marketplace to work without a GitHub account, since HTTPS works for public repositories without authentication, while SSH requires configured keys.