### PR TITLE
Match work_item_id in visualiser search

### DIFF
--- a/meta/plans/2026-06-22-0125-search-id-matching.md
+++ b/meta/plans/2026-06-22-0125-search-id-matching.md
@@ -11,7 +11,7 @@ parent: "work-item:0125"
 derived_from: ["codebase-research:2026-06-22-0125-search-id-matching"]
 tags: [visualiser, search, indexer]
 revision: "9b00844d77584e964f34faac55fd3be02c88220d"
-repository: "douala"
+repository: "accelerator"
 last_updated: "2026-06-22T16:03:30+00:00"
 last_updated_by: "Phil Helm"
 schema_version: 1

--- a/meta/plans/2026-06-22-0125-search-id-matching.md
+++ b/meta/plans/2026-06-22-0125-search-id-matching.md
@@ -1,0 +1,629 @@
+---
+type: plan
+id: "2026-06-22-0125-search-id-matching"
+title: "Visualiser Search Work-Item-ID Matching Implementation Plan"
+date: "2026-06-22T15:42:50+00:00"
+author: "Phil Helm"
+producer: create-plan
+status: draft
+work_item_id: "work-item:0125"
+parent: "work-item:0125"
+derived_from: ["codebase-research:2026-06-22-0125-search-id-matching"]
+tags: [visualiser, search, indexer]
+revision: "9b00844d77584e964f34faac55fd3be02c88220d"
+repository: "douala"
+last_updated: "2026-06-22T16:03:30+00:00"
+last_updated_by: "Phil Helm"
+schema_version: 1
+---
+
+# Visualiser Search Work-Item-ID Matching Implementation Plan
+
+## Overview
+
+Make the visualiser's `/api/search` match a query against each entry's
+`work_item_id`, so typing a work item's number finds the item. This is a small,
+additive change to the ranking function `classify()`, fixing a gap against work
+item 0054's stated-but-non-functional design (ID lookup via the exact-slug
+bucket). Scope is the local `work_item_id` only.
+
+## Current State Analysis
+
+`classify()` in
+[`skills/visualisation/visualise/server/src/api/search.rs`](../../skills/visualisation/visualise/server/src/api/search.rs)
+(lines 56–80) ranks each `IndexEntry` against the lowercased query using only
+three fields — `title`, `slug`, and `body_preview` — across four buckets
+(`ExactSlug`, `Prefix`, `Interior`, `Body`). It never reads any ID field.
+
+A work item's `slug` is the filename tail *after* the ID
+(`0054-sidebar-search.md` → `sidebar-search`), and its numeric identity lives in
+`IndexEntry.work_item_id` (populated from the frontmatter `id:` key, normalised —
+`indexer.rs:1346–1382`). Because the bare ID is in none of the three searched
+fields, an ID query can never match → "No matches".
+
+`work_item_id` is **already a field** on `IndexEntry` (`indexer.rs:170`), so no
+struct or indexer change is needed. Full grounding:
+[`meta/research/codebase/2026-06-22-0125-search-id-matching.md`](../research/codebase/2026-06-22-0125-search-id-matching.md).
+
+### Key Discoveries:
+
+- `classify()` matched-field set is the sole defect site — `search.rs:56-80`.
+- `IndexEntry.work_item_id: Option<String>` is already populated — `indexer.rs:170`, `indexer.rs:1346-1382`.
+- The struct doc comment at `indexer.rs:167-170` is **stale** — it says the value
+  is filename-derived, but it is actually read from frontmatter `id:`. Worth
+  correcting while here.
+- Test harness drives the real axum handler over a temp corpus — `tests/api_search.rs:13-22`.
+- **Fixture gotcha**: `seeded_cfg_with_work_items` (`tests/common/mod.rs:120-141`)
+  writes work items with **no `id:`** → `work_item_id: None`; it cannot exercise
+  ID matching. New tests must write fixtures carrying `id:`.
+- Tests require `cargo test --no-default-features --features dev-frontend` (the
+  default `embed-dist` build script needs a built frontend).
+
+## Desired End State
+
+Typing a work item's number into the visualiser search box surfaces that item.
+Specifically, in `/api/search`:
+
+- A query equal to a work item's id — in full (`0042`), unpadded (`42`), or,
+  under a project-code config, the full key (`ENG-0042`) — ranks in the top
+  (`ExactSlug`) "exact identity" bucket.
+- **Numeric queries are matched against the id's bare numeric form** (leading
+  zeros and any project-code prefix stripped). So `42` finds `0042` *and*
+  `ENG-0042` (config-independent), while `00` — which unpads to empty — matches
+  no id at all. A prefix of that numeric form ranks in `Prefix`; an interior
+  substring ranks in `Interior`.
+- **Non-numeric queries substring-match the full lowercased id**, so `eng-0042`
+  still finds `ENG-0042` across the exact/prefix/interior tiers.
+- **The result set is capped at `MAX_RESULTS`**, applied *after* bucket sorting.
+  This bounds any broad-match query (e.g. a single-letter or project-code
+  fragment like `eng` that prefixes every id) to a fixed-size response, while the
+  bucket order guarantees the truncation only ever drops the lowest-relevance
+  tail — exact/prefix hits are never cut. This is the general flood backstop; we
+  deliberately do **not** add per-field matching heuristics to suppress floods.
+  Note this is **general search-handler hardening, not id-specific**: the cap sits
+  in the shared projection chain, so it now bounds title/slug/body queries too —
+  a behavioural change from the previously-unbounded result set (a corpus with
+  >`MAX_RESULTS` legitimate title matches now truncates). Bucket ordering makes
+  this safe (only the lowest-relevance tail is dropped), but the contract change
+  is wider than the id feature that motivates it. One accepted rough edge: the
+  truncation is currently unsignalled at the UI — the results meta-row shows a
+  bare count (`{N} matches`), so a user whose broad query legitimately exceeds the
+  cap sees exactly `MAX_RESULTS` with no "showing first N" affordance. A
+  truncation indicator is the natural follow-up (alongside the id-chip work),
+  out of scope here.
+- Existing title/slug/body ranking and template exclusion are unchanged; all
+  existing `api_search` tests still pass.
+
+Verified by the new and existing tests in `tests/api_search.rs` and by a manual
+check in the running visualiser.
+
+## What We're NOT Doing
+
+- Matching `external_id` / remote tracker keys (not indexed; needs new plumbing —
+  deferred to a future advanced-search work item). When that work lands, the
+  consistent successor is the **dedicated-field** approach (option 2 in the
+  research: an `external_id: Option<String>` on `IndexEntry` populated during
+  indexing, mirroring `work_item_id`), and the per-tier matching ladder in
+  `classify()` should at that point be refactored to iterate a slice of
+  candidate id fields per tier rather than gaining a fourth hand-written copy.
+  That refactor needs a **per-field numeric-reduction policy**, not a single
+  shared `numeric_key`: external keys (e.g. `PP-76`) also have a trailing digit
+  run, so iterating candidate fields with one shared reduction would let a numeric
+  query (`76`) collide across `work_item_id` *and* `external_id`. Decide per field
+  which participate in bare-numeric matching. That refactor is also the natural
+  window to rename `ExactSlug` → an "exact identity" variant: it already churns
+  the ordering tests, so the rename the bucket-reuse decision defers (see below)
+  pays its cost in a change that touches those tests anyway.
+- Tag search, document-type scoping, a dedicated results view, or result sorting
+  (advanced-search scope, untracked).
+- **Gating which fields/queries can match to suppress floods** (e.g. requiring a
+  numeric query to contain a digit, or anchoring the non-numeric id match to a
+  prefix). A short fragment legitimately matching many items is *bounded* by the
+  `MAX_RESULTS` cap rather than *prevented* by a matching heuristic — the cap is
+  general (it catches flood vectors we haven't enumerated) and avoids the
+  least-surprise risk of a heuristic silently refusing a query a user typed.
+  Accepted consequence: under a project-code config, typing the bare code (`eng`)
+  prefix-matches and returns up to `MAX_RESULTS` work items.
+- **Closing the unpadded-tolerance gap for mixed-alphanumeric full keys.** Unpadded
+  tolerance is *numeric-only*: a purely-numeric query is reduced via `numeric_key`,
+  but a mixed query like `eng-42` takes the non-numeric branch and substring-matches
+  the **full** lowercased id, so it does **not** match a zero-padded `ENG-0042`
+  (`eng-42` is neither a substring nor prefix of `eng-0042`). The bare number `42`
+  and the exact padded key `eng-0042` both find it; only the unpadded *prefixed*
+  form misses. Accepted as a known gap for this scope — closing it would mean
+  applying numeric reduction to a CODE-prefixed query's trailing digit run, which
+  widens the matching behaviour. (Note `normalise_id` can also store an id
+  *unpadded* as `ENG-42`, in which case `eng-42` matches exactly — so whether a
+  mixed query works depends on how the id was stored; documented here rather than
+  smoothed over.)
+- **Surfacing the matched ID in results** — `SearchResultRow` keeps its current
+  wire shape (`docType`/`title`/`slug`/`mtimeMs`). This is a **known UX rough
+  edge**: an id-matched row shows only its title/slug, so a user who typed a
+  number sees no on-row indication of *why* it matched (the `Highlight`
+  component highlights the title only, so it highlights nothing). Accepted for
+  this tightly-scoped fix; surfacing a highlightable id chip is a follow-up
+  (touches the wire shape, the frontend row, and their tests).
+- Renaming the `ExactSlug` bucket variant (an exact ID reuses it as the
+  "exact identity" tier; renaming would churn the ordering tests for no
+  behavioural gain). Instead, add a one-line doc comment on the variant stating
+  it is the "exact identity" tier — exact slug **or** exact `work_item_id` — so
+  the overloaded semantics are documented at the definition site.
+- Changing the frontend "No matches" hint copy. It mentions "a doc id", which
+  becomes truthful for **work items**; note that decisions/plans/reviews/RCAs
+  carry `work_item_id: None` and so remain unmatchable by id, so the generic
+  "doc id" wording slightly over-promises. Left as-is (vague enough); tightening
+  toward "a work item number" is an optional follow-up.
+
+## Implementation Approach
+
+Single phase, test-driven (per the project's create-plan instructions: TDD where
+applicable; phases independently mergeable — there is one self-contained phase).
+Add `work_item_id` into `classify()` alongside `slug`, reusing the existing
+exact/prefix/interior tiering, with one piece of bespoke normalisation, and add a
+result cap as a general flood backstop:
+
+- **Numeric queries match the id's bare numeric form.** For a purely-numeric
+  query, both the query and the id are reduced to their **bare numeric form** —
+  leading zeros and any non-digit (project-code) prefix stripped — before the
+  exact/prefix/interior comparison. `42` and `0042` both reduce to `42` and
+  exactly match `0042`/`ENG-0042`. This gives unpadded tolerance, makes it
+  config-independent (the project-code path needs no separate handling), and
+  ranks the genuinely-relevant hit highly: an exact number is `ExactSlug`, a
+  prefix is `Prefix`. `00` reduces to empty and matches no id — cleaner than
+  returning an arbitrary capped slice for a degenerate query.
+- **Non-numeric queries substring-match the full lowercased id**, preserving the
+  ability to type a full prefixed key (`eng-0042`) or a project-code fragment.
+- **Cap the result set at `MAX_RESULTS`, applied after bucket sorting.** Liberal
+  substring matching means a short fragment can match many entries (a bare
+  project code like `eng` prefixes every id; a single digit interior-matches many
+  numeric keys). Rather than gate matching with per-field heuristics — which risk
+  silently refusing a query a user legitimately typed — bound the *volume*: the
+  cap truncates the concatenated, bucket-sorted results, so it only ever drops
+  the lowest-relevance tail (`Interior`/`Body`) and never an exact/prefix hit.
+  This is general (it bounds flood vectors we haven't enumerated) and matches the
+  defensive spirit of the existing `MAX_Q_LEN` cap in the same handler.
+
+A small `numeric_key()` helper does the reduction. Correct the stale struct doc
+comment in the same change. The sketches below are the intended shape; exact
+mechanics are settled under TDD against the test contract in Section 1.
+
+## Phase 1: Match `work_item_id` in `classify()`
+
+### Overview
+
+Extend the ranker to consult `work_item_id`, driven by failing tests first.
+
+### Changes Required:
+
+#### 1. Failing tests (write first)
+
+**File**: `skills/visualisation/visualise/server/tests/api_search.rs`
+**Changes**: Add a local fixture helper that writes a work item carrying an
+`id:` frontmatter key (so `work_item_id` is populated), and a test contract that
+pins **tier placement** (not just presence) plus the negative and flood cases.
+Use `common::seeded_cfg` (which yields the default-numeric work-item config) and
+create `meta/work` in the temp dir.
+
+The bucket is not observable in the wire shape, so tier is pinned the same way
+the existing `bucket_*` tests do it — by seeding a competitor that lands in a
+strictly lower bucket and asserting the relative order (buckets are concatenated
+in `ExactSlug < Prefix < Interior < Body` order, so a higher-tier hit always
+precedes a lower-tier one regardless of the within-bucket mtime/rel_path sort).
+
+**mtime control for the same-bucket-fallback test (item 4)**: item 4 relies on
+the *within-bucket* `rel_path` tiebreak to flip the order when `id_prefix` is
+deleted (the deletion drops both entries into the *same* `Interior` bucket, and
+the `rel_path` ordering must then decide). The within-bucket sort key is
+`(Reverse(mtime_ms), rel_path)`, so `rel_path` only breaks ties when mtimes are
+equal. `write_work_item` writes files sequentially (giving them different
+mtimes), so item 4 **must** pin both the target and competitor to the same
+`mtime_ms` via `common::set_mtime_ms` — otherwise the later-written file sorts
+first regardless of `rel_path` and the mutation does not reliably flip the order.
+Items 2/3/5/9 pin a *cross-bucket* order (or detect the mutation as a
+disappearance) and are robust to mtime ties without this; only item 4 needs it.
+
+```rust
+fn write_work_item(
+    dir: &Path,
+    id: &str,
+    slug_tail: &str,
+    title: &str,
+) -> std::path::PathBuf {
+    let filename = format!("{id}-{slug_tail}.md");
+    let content =
+        format!("---\nid: \"{id}\"\ntitle: \"{title}\"\n---\n# body\n");
+    let path = dir.join(&filename);
+    std::fs::write(&path, content).unwrap();
+    path
+}
+```
+
+The contract (test names indicative; each builds an `AppState` over a temp
+corpus and inspects the JSON `results`, as the existing suite does):
+
+1. **`work_item_id_fixture_is_populated`** — guards the load-bearing assumption
+   the research flagged (the inverse of the `seeded_cfg_with_work_items` gotcha):
+   after building the state, assert via the index snapshot that the fixture
+   entry's `work_item_id` is `Some("0042")` and not `None`. If this regresses
+   (e.g. a config change requires a project code), this test names the real cause
+   rather than letting the search assertions fail opaquely.
+
+2. **`work_item_id_exact_ranks_above_body`** — seed `0042-login-form` *and* a
+   competitor whose **body** contains `0042` (so it lands in `Body`). Query
+   `0042`; assert `results[0].slug == "login-form"` (exact identity outranks a
+   body hit). The competitor proves the match is genuinely tiered, not incidental.
+
+3. **`unpadded_numeric_query_is_exact`** — query `42` against `0042`; assert the
+   item is returned and ranks `ExactSlug` (above a body-only competitor on `42`),
+   since `42` reduces to the same numeric key as `0042`.
+
+4. **`work_item_id_prefix_outranks_interior`** — query `004` (reduces to `4`)
+   against target `0042` (`42` → prefix-matches `4`) **and** an interior-only
+   competitor `0014-zzz` (`14` → contains `4`, does not start with it). Assert
+   the target ranks **above** the competitor. This isolates the prefix branch:
+   `4` is *also* an interior substring of `42`, so a presence-only assertion
+   would not catch a removed `id_prefix` (the target would merely fall to
+   `Interior`). The competitor's `rel_path` (`0014-…`) sorts before the target's
+   (`0042-…`), so if `id_prefix` is deleted both land in `Interior` and the
+   competitor sorts *first* — flipping the order and failing the test. (The
+   target's title/slug must not prefix-match `004`/`4`, so the only prefix signal
+   is the id.) **Pin both fixtures to the same `mtime_ms` via
+   `common::set_mtime_ms`** (see "mtime control" above) — without it the
+   within-bucket order is decided by mtime, not `rel_path`, and the mutation may
+   not flip.
+
+5. **`work_item_id_interior_outranks_nothing_but_below_prefix`** — query `2`
+   (reduces to `2`) against target `0042` (`42` → interior-matches `2`, not
+   prefix/exact) **and** a prefix competitor `0020-aaa` (`20` → prefix-matches
+   `2`). Assert the target is returned and ranks **below** the competitor
+   (`Interior` < `Prefix`). Isolates the interior branch: deleting `id_interior`
+   drops the target to `Body` (no body match) so it disappears entirely, failing
+   the "target is returned" assertion.
+
+6. **`numeric_query_does_not_match_unrelated_id`** (negative) — query `0099`
+   against `0042` (`99` is absent from `42`); assert the item is **not** in
+   results.
+
+7. **`all_zero_query_does_not_flood`** (flood guard) — seed two id-bearing work
+   items (e.g. `0042`, `0001`); query `00` (reduces to empty); assert neither is
+   returned. Because the bucket is unobservable, this is an *absence* assertion,
+   so it also silently requires that neither fixture's title or body contains the
+   substring `00` — choose titles and bodies that demonstrably exclude `00` (the
+   `write_work_item` helper's fixed `# body` is fine; pass titles free of `00`),
+   and comment that the assertion specifically guards the `id_active` empty-key
+   branch (not incidental field contents). Pins the anti-flood behaviour.
+
+8. **`none_id_entry_is_not_matched_by_number`** — write a second work item
+   *without* an `id:` key (→ `work_item_id: None`) and content free of the query
+   digits; assert a numeric query returns only the id-bearing item and never the
+   `None`-id entry (and does not panic). Covers the common `None` case across the
+   corpus.
+
+9. **`project_code_config_matches_numeric_and_full_key`** — build a
+   `WorkItemConfig` with a project code so the fixture's `work_item_id` is
+   `ENG-0042`. Note the fixture's *filename* stays `0042-…` while the stored
+   `work_item_id` is `ENG-0042` (normalisation prepends the code); the test must
+   assert against the **normalised** `ENG-0042`, not the filename form. **First**
+   assert (item-1 style) that the populated `work_item_id` is `Some("ENG-0042")`
+   so the config→`work_item_id` wiring is pinned explicitly — then assert both
+   `q=42` (numeric tail) and `q=eng-0042` (full key, case-folded) return the item,
+   and `q=0042` returns it via the numeric tail (`numeric_key("eng-0042") == "42"
+   == numeric_key("0042")`, not a direct string match). Confirms the unpadded
+   tolerance is config-independent. (Prefer the integration form. If seeding a
+   project-code config proves heavyweight and this drops to a unit test over
+   `classify()`/`numeric_key()`, keep the population assertion under a
+   project-code config so the wiring — the real integration risk — is still
+   covered.)
+
+10. **`results_are_capped_and_preserve_top_hits`** — seed one exact-match target
+    plus more than `MAX_RESULTS` entries that only interior-match the same query
+    (e.g. many work items whose numeric keys share an interior digit); query so
+    all match; assert `results.len() == MAX_RESULTS` **and** the exact-match
+    target is `results[0]`. Pins both the cap value and that bucket ordering
+    protects high-relevance hits from truncation. Reference the `MAX_RESULTS`
+    constant in the assertion (not the literal `50`, which the plan treats as
+    non-contractual), and construct the >`MAX_RESULTS` flood entries so each
+    *only* interior-matches the query (distinct numeric keys sharing one interior
+    digit, none exact/prefix-matching it) so none perturbs `results[0]` or the
+    tier split.
+
+11. **`non_numeric_id_prefix_outranks_interior`** (non-numeric prefix branch) —
+    under a project-code config (so ids are `ENG-…`), query `eng-00` against
+    target `ENG-0042` (`eng-0042` starts with `eng-00` → `id_prefix`). The
+    interior competitor cannot interior-match `eng-00` via its **id** — every
+    normalised id has shape `eng-<digits>`, so `eng-00` can only occur at offset 0
+    (a prefix), never as a non-leading substring. So the competitor must
+    interior-match `eng-00` via a **non-id field**: e.g. a title containing
+    `releng-00x` (and an id that does *not* prefix-match `eng-00`, e.g.
+    `ENG-7777`). Assert the target ranks **above** the competitor, pinning the
+    non-numeric `id_prefix` branch — note `eng-0042` also *contains* `eng-00`, so
+    deleting `id_prefix` leaves the target in `Interior` (via `id_interior`)
+    alongside the competitor, and the order then flips. Pin both fixtures to the
+    same `mtime_ms` and make the competitor's `rel_path` sort first (same
+    mechanism as item 4) so the flip is deterministic. Without this test the
+    non-numeric path is exercised only at the exact tier (item 9), so a dropped or
+    prefix-anchored non-numeric branch would ship green.
+
+12. **`non_numeric_id_interior_matches`** (non-numeric interior branch) — under a
+    project-code config, query an *interior* fragment of the full key (e.g.
+    `ng-00` against `ENG-0042`, which contains but does not start with `ng-00`)
+    against the target **and** a `Prefix` competitor. The competitor's `Prefix`
+    placement must come from its **title/slug** (e.g. a title starting `ng-00…`),
+    not its id — no normalised id starts with `ng-`. Assert the target is returned
+    and ranks **below** the competitor (`Interior` < `Prefix`, cross-bucket —
+    robust to mtime). Deleting `id_interior` for the non-numeric path drops the
+    target to `Body` (no body match) so it disappears, failing the "target is
+    returned" assertion.
+
+Also add cheap **unit tests over `numeric_key()`** directly (no `AppState`):
+`"0042"`→`"42"`, `"eng-0042"`→`"42"`, `"ops-7"`→`"7"` (note `normalise_id` passes
+foreign prefixes through *unpadded*), `"0000"`/`""`→`""`, and an all-letters
+input. These pin the riskiest new logic independently of the integration
+fixtures.
+
+Optionally extend item 9 (or add a sibling) to seed a **foreign-prefixed** id
+distinct from the configured code (e.g. `OPS-7` under an `ENG` config —
+`normalise_id` stores it verbatim) and assert both `q=7` and `q=ops-7` surface it.
+This lifts the multi-prefix-coexistence coverage from the `numeric_key` unit level
+to the end-to-end search-behaviour level.
+
+**Location**: `numeric_key()` (and `classify()`) are private to
+`src/api/search.rs`, so these unit tests **cannot** live in `tests/api_search.rs`
+— that is a separate crate that sees only the library's `pub` surface. Put them
+in a new `#[cfg(test)] mod tests { use super::*; … }` block inside
+`src/api/search.rs` (same crate, can call the private helpers). The integration
+contract (items 1–12) stays in `tests/api_search.rs`. Do **not** widen
+`numeric_key`/`classify` visibility to `pub(crate)` just to test them — the
+in-module test block is the idiomatic Rust approach and keeps the surface
+private.
+
+Run the new tests first; confirm the matching/ordering assertions FAIL before
+the `classify()`/cap changes (the id path and cap do not exist yet), then make
+them pass.
+
+#### 2. Extend `classify()`
+
+**File**: `skills/visualisation/visualise/server/src/api/search.rs`
+**Changes**: Add a `numeric_key()` helper, and consult `work_item_id` across the
+exact/prefix/interior tiers using the numeric reduction for numeric queries and
+the raw lowercased id otherwise. Update the function doc comment to match.
+
+```rust
+/// Bare numeric form of an id, used for padding-tolerant numeric matching:
+/// leading non-digit prefix and leading zeros stripped.
+/// `"0042"` -> `"42"`, `"eng-0042"` -> `"42"`, `"0000"`/`""` -> `""`.
+/// Assumes the normalised-id shape from `WorkItemConfig::normalise_id` — bare
+/// digits or `CODE-digits` with an alphabetic prefix — so the digits are the
+/// trailing run; a future id shape with digits elsewhere would mis-key.
+fn numeric_key(id_lc: &str) -> &str {
+    id_lc
+        .rsplit(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or("")
+        .trim_start_matches('0')
+}
+
+/// Classify a single entry into a ranking bucket against the lowercased query.
+/// Returns `None` when no field matches.
+///
+/// Matched fields: `title`, `slug`, `work_item_id`, then (lazily) `body_preview`.
+/// `title`, `slug` and `work_item_id` are short and lowercased eagerly;
+/// `body_preview` is lowercased only on the fall-through path, avoiding the
+/// largest allocation when matches come from the cheaper fields.
+///
+/// `work_item_id` matching: a purely-numeric query is compared against the id's
+/// bare numeric form (see `numeric_key`), so `42`/`0042` exactly match
+/// `0042`/`ENG-0042` and `00` (which reduces to empty) matches nothing; any other
+/// query substring-matches the full lowercased id (so `eng-0042` matches
+/// `ENG-0042`).
+fn classify(entry: &IndexEntry, q_lc: &str) -> Option<Bucket> {
+    let title_lc = entry.title.to_ascii_lowercase();
+    let slug_lc = entry.slug.as_deref().map(str::to_ascii_lowercase);
+    let id_lc = entry.work_item_id.as_deref().map(str::to_ascii_lowercase);
+
+    // For a numeric query, compare query and id in bare numeric form; otherwise
+    // compare against the full lowercased id. A numeric query of all zeros
+    // reduces to empty and must match no id (`id_active` guards that).
+    let q_is_num = q_lc.bytes().all(|b| b.is_ascii_digit());
+    let id_q: &str = if q_is_num { q_lc.trim_start_matches('0') } else { q_lc };
+    let id_cmp: Option<&str> =
+        id_lc.as_deref().map(|id| if q_is_num { numeric_key(id) } else { id });
+    let id_active = !id_q.is_empty();
+    let id_exact = id_active && id_cmp == Some(id_q);
+    let id_prefix =
+        id_active && id_cmp.is_some_and(|id| !id.is_empty() && id.starts_with(id_q));
+    let id_interior =
+        id_active && id_cmp.is_some_and(|id| !id.is_empty() && id.contains(id_q));
+
+    if slug_lc.as_deref() == Some(q_lc) || id_exact {
+        return Some(Bucket::ExactSlug);
+    }
+    let title_prefix = title_lc.starts_with(q_lc);
+    let slug_prefix = slug_lc.as_deref().is_some_and(|s| s.starts_with(q_lc));
+    if title_prefix || slug_prefix || id_prefix {
+        return Some(Bucket::Prefix);
+    }
+    let title_interior = title_lc.contains(q_lc);
+    let slug_interior = slug_lc.as_deref().is_some_and(|s| s.contains(q_lc));
+    if title_interior || slug_interior || id_interior {
+        return Some(Bucket::Interior);
+    }
+    let body_lc = entry.body_preview.to_ascii_lowercase();
+    if body_lc.contains(q_lc) {
+        return Some(Bucket::Body);
+    }
+    None
+}
+```
+
+(`q_lc` is non-empty here — the handler rejects empty/whitespace queries before
+`classify()`, so a non-numeric query always yields a non-empty `id_q`.) Also add
+the one-line "exact identity tier" doc comment on the `Bucket::ExactSlug` variant
+(per *What We're NOT Doing*).
+
+Implementer notes (settle under TDD; none change behaviour):
+- **Hoist the query-level facts.** `q_is_num`/`id_q` depend only on the query, not
+  the entry; optionally compute them once in the `search()` handler and pass them
+  in, so `classify()` reads as "match this entry against a prepared query" (and the
+  Performance section's "once per query" framing becomes literally true). The
+  sketch's per-entry form is the un-hoisted starting point; this is a clarity-only
+  choice (see Performance Considerations), not a measurable win.
+- **Consider an `id_bucket(id_cmp, id_q) -> Option<Bucket>` extraction** if the
+  `id_*` binding block reads densely — it folds the empty-guard logic (why
+  `id_exact` leans on `id_active` while prefix/interior re-check `!id.is_empty()`)
+  into one tested unit, mirroring the `numeric_key` extraction. Only if it stays
+  simpler than the inline form.
+- **Record the ladder-refactor trigger at the call site**, not only in the plan:
+  a one-line comment near `classify()` noting "if a third matchable id field is
+  added, refactor to iterate candidate fields per tier" so the next author meets
+  the threshold in the code.
+
+#### 3. Correct the stale struct doc comment
+
+**File**: `skills/visualisation/visualise/server/src/indexer.rs` (lines 167–170)
+**Changes**: The current comment is wrong on **two** counts — the source ("via
+the scan regex") *and* the `Some`/`None` conditions ("when the filename
+matches"). Replace the whole comment, e.g.:
+
+```rust
+/// Work-item identity, read from the frontmatter `id:` key and normalised via
+/// `WorkItemConfig::normalise_id`. `Some(id)` only when the entry is a work item
+/// whose frontmatter carries an `id:`; `None` for non-work-item types and for
+/// work items lacking a frontmatter `id:`.
+work_item_id: Option<String>,
+```
+
+Confirm against the population path (`indexer.rs:1346–1384`) before settling the
+exact wording.
+
+#### 4. Cap the result set
+
+**File**: `skills/visualisation/visualise/server/src/api/search.rs`
+**Changes**: Add a `MAX_RESULTS` constant and truncate the bucket-sorted results
+in the `search()` handler. The truncation must come **after** the buckets are
+concatenated in order, so it drops only the lowest-relevance tail:
+
+```rust
+/// Hard cap on returned rows. Bounds the response for broad-match queries (a
+/// short fragment can match many entries); applied after bucket ordering so only
+/// the lowest-relevance tail is dropped, never an exact/prefix hit.
+const MAX_RESULTS: usize = 50;
+
+// in search(), the projection chain:
+let results: Vec<SearchResultRow> = buckets
+    .into_iter()
+    .flatten()
+    .filter_map(|e| project(&e))
+    .take(MAX_RESULTS)
+    .collect();
+```
+
+Pick the constant to comfortably exceed any plausible intentional result set
+while still bounding a flood (50 is a reasonable starting point; it is not a
+behavioural contract beyond "bounded"). `take` is applied after `filter_map` so
+slug-less entries don't consume a slot.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [x] The new tier/negative/flood/cap/non-numeric tests (contract items 1–12
+      above) plus the `numeric_key` unit tests fail before the `classify()`/cap
+      changes (red), pass after (green):
+      `cd skills/visualisation/visualise/server && cargo test --no-default-features --features dev-frontend --test api_search`
+- [x] Mutation checks hold: removing `id_prefix` flips the order in the
+      prefix-outranks-interior test (item 4, with equal mtimes so the `rel_path`
+      tiebreak decides); removing `id_interior` makes the target disappear in item
+      5; removing the *non-numeric* `id_prefix`/`id_interior` branches is caught by
+      items 11/12; the all-zeros flood-guard fails if `00` matches via the id
+      path; and the cap test (item 10) fails if truncation is removed. Note: item
+      10 does **not** distinguish "truncate before vs after bucket sorting" — the
+      lone exact target lands at `results[0]` either way. To pin truncation
+      *order*, add an assertion that seeds >`MAX_RESULTS` `Prefix` hits plus some
+      `Interior` hits and checks the surviving rows are all `Prefix`-tier (fails
+      if truncation precedes bucket concatenation); since the tier is not in the
+      wire shape, distinguish the two groups by a slug/title marker (e.g. `pfx-NN`
+      vs `int-NN`) and assert every surviving slug carries the `Prefix` marker.
+      Otherwise drop the order-sensitivity claim, since the cap truncates an
+      already-ordered `flatten()`.
+- [x] The whole `api_search` suite passes (no regression to bucket ordering or
+      template exclusion).
+- [x] Server check is green (format + clippy + types): `mise run server:check`
+
+#### Manual Verification:
+
+- [ ] In a running visualiser (`mise run dev`), focusing the sidebar search and
+      typing a work item's number (e.g. `0125`) surfaces that item; typing the
+      unpadded number (e.g. `125`) also surfaces it.
+- [ ] A broad-match query (e.g. a common two-digit fragment, or the project code
+      under a project-code config) returns a bounded list rather than the whole
+      corpus. (The frontend gates searches at ≥ 2 characters — `use-search.ts` —
+      so a single digit never reaches the API; use a 2+ character query here.)
+- [ ] Title / slug / body searches behave exactly as before.
+
+---
+
+## Testing Strategy
+
+### Unit / Integration Tests:
+
+The contract in *Phase 1 → Section 1* (items 1–12): fixture-population guard,
+exact-above-body, unpadded-numeric-is-exact, prefix-outranks-interior,
+interior-below-prefix, the non-matching negative, the all-zeros flood guard, the
+`None`-id entry, the project-code config, the result cap, and the non-numeric
+prefix/interior branches — plus direct `numeric_key()` unit tests (in an
+in-module `#[cfg(test)]` block, since the helper is private). Tiers are pinned by
+relative ordering against an adjacent-bucket competitor (with a `rel_path`
+tiebreak — backed by equal mtimes — that flips the order if a branch is
+mis-tiered), not just presence, so a deleted or mis-tiered branch fails a test.
+
+- Existing suite guards against regressions (bucket ordering, case-insensitivity,
+  template exclusion, length cap, no path/relpath match).
+
+### Manual Testing Steps:
+
+1. `mise run dev`, open the visualiser.
+2. Press `/`, type a known work item number → the item appears.
+3. Type its unpadded number → still appears.
+4. Type a title fragment and a slug → unchanged behaviour.
+
+## Performance Considerations
+
+`work_item_id` is a short `Option<String>` already on the entry; lowercasing it
+adds one tiny allocation per *id-bearing work item* (the `Option::map` is a no-op
+on the `None` majority — non-work-item types and id-less work items), in line with
+the existing eager title/slug lowercasing. The `numeric_key` reduction and the `q_is_num`/`id_q` derivation are
+borrowed-`&str` operations (no allocation); they run inside `classify()` so they
+are recomputed per entry, but each is a trivial scan of the short (≤`MAX_Q_LEN`)
+query string. (If desired, `q_is_num`/`id_q` could be hoisted into the handler
+and passed in, computing them once per query — a readability/clarity choice, not
+a measurable win.) All of it is dwarfed by the pre-existing full-index snapshot
+clone in the handler (`state.indexer.all()` clones every `IndexEntry`,
+frontmatter blob included), which is the only meaningful per-query cost and is
+intentionally left unchanged here. The `MAX_RESULTS` cap additionally bounds the
+response payload and the work done by `project()` and JSON serialisation for
+broad-match queries — but note it bounds the *response*, not per-query CPU: it
+runs after the snapshot clone, after every non-template entry has been
+title-lowercased, and after the matched-set sort (which allocates a `rel_path`
+key per match), so a flood still does O(corpus) work before truncation. At this
+scale that floor is small and is the intentionally-untouched snapshot cost above.
+
+## Migration Notes
+
+None — no schema, data, or wire-shape changes.
+
+`numeric_key()` is kept **query-side** (recomputed per entry per query) rather than
+precomputing a searchable numeric form on `IndexEntry` at index time: that keeps
+the indexer and the serialised `IndexEntry` shape untouched and colocates all
+matching logic in `classify()`. The index-side precompute becomes worth revisiting
+only if the per-query full-index clone is eliminated (so per-entry recomputation
+stops being free relative to it) or the candidate id-field set multiplies (see the
+`external_id` note in *What We're NOT Doing*) — tie the boundary move to one of
+those forces rather than treating it as an open option.
+
+## References
+
+- Original work item: `meta/work/0125-visualiser-search-id-matching.md`
+- Related research: `meta/research/codebase/2026-06-22-0125-search-id-matching.md`
+- Origin of the search endpoint / non-functional design decision: `meta/work/0054-sidebar-search.md`
+- Defect site: `skills/visualisation/visualise/server/src/api/search.rs:56-80`

--- a/meta/plans/2026-06-22-0125-search-id-matching.md
+++ b/meta/plans/2026-06-22-0125-search-id-matching.md
@@ -552,14 +552,14 @@ slug-less entries don't consume a slot.
 
 #### Manual Verification:
 
-- [ ] In a running visualiser (`mise run dev`), focusing the sidebar search and
+- [x] In a running visualiser (`mise run dev`), focusing the sidebar search and
       typing a work item's number (e.g. `0125`) surfaces that item; typing the
       unpadded number (e.g. `125`) also surfaces it.
-- [ ] A broad-match query (e.g. a common two-digit fragment, or the project code
+- [x] A broad-match query (e.g. a common two-digit fragment, or the project code
       under a project-code config) returns a bounded list rather than the whole
       corpus. (The frontend gates searches at ≥ 2 characters — `use-search.ts` —
       so a single digit never reaches the API; use a 2+ character query here.)
-- [ ] Title / slug / body searches behave exactly as before.
+- [x] Title / slug / body searches behave exactly as before.
 
 ---
 

--- a/meta/research/codebase/2026-06-22-0125-search-id-matching.md
+++ b/meta/research/codebase/2026-06-22-0125-search-id-matching.md
@@ -11,7 +11,7 @@ parent: "work-item:0125"
 topic: "How visualiser search ranks/matches entries, and how work_item_id and external_id flow into the search index"
 tags: [research, codebase, visualiser, search, indexer]
 revision: "9b00844d77584e964f34faac55fd3be02c88220d"
-repository: "douala"
+repository: "accelerator"
 last_updated: "2026-06-22T15:38:13+00:00"
 last_updated_by: "Phil Helm"
 schema_version: 1
@@ -22,8 +22,8 @@ schema_version: 1
 **Date**: 2026-06-22T15:38:13+00:00
 **Author**: Phil Helm
 **Git Commit**: 9b00844d77584e964f34faac55fd3be02c88220d
-**Branch**: douala
-**Repository**: douala
+**Branch**: visualiser-search-work-item-id
+**Repository**: accelerator
 
 ## Research Question
 

--- a/meta/research/codebase/2026-06-22-0125-search-id-matching.md
+++ b/meta/research/codebase/2026-06-22-0125-search-id-matching.md
@@ -1,0 +1,226 @@
+---
+type: codebase-research
+id: "2026-06-22-0125-search-id-matching"
+title: "Research: Visualiser search matching of work_item_id and external_id"
+date: "2026-06-22T15:38:13+00:00"
+author: "Phil Helm"
+producer: research-codebase
+status: complete
+work_item_id: "0125"
+parent: "work-item:0125"
+topic: "How visualiser search ranks/matches entries, and how work_item_id and external_id flow into the search index"
+tags: [research, codebase, visualiser, search, indexer]
+revision: "9b00844d77584e964f34faac55fd3be02c88220d"
+repository: "douala"
+last_updated: "2026-06-22T15:38:13+00:00"
+last_updated_by: "Phil Helm"
+schema_version: 1
+---
+
+# Research: Visualiser search matching of work_item_id and external_id
+
+**Date**: 2026-06-22T15:38:13+00:00
+**Author**: Phil Helm
+**Git Commit**: 9b00844d77584e964f34faac55fd3be02c88220d
+**Branch**: douala
+**Repository**: douala
+
+## Research Question
+
+For work item 0125 (`meta/work/0125-visualiser-search-id-matching.md`): how does
+the visualiser search rank/match entries, and how do `work_item_id` and
+`external_id` flow into the search index? The goal is to ground a plan that makes
+`/api/search` match the work item ID and the full external (tracker) ID. Specific
+questions: how `classify()` and the search handler work; how `work_item_id` and
+`external_id` are populated on `IndexEntry`; **whether `external_id` is a field on
+`IndexEntry` at all**; the existing test suite and fixtures; and the frontend
+empty-state hint copy.
+
+## Summary
+
+- The search ranker, `classify()`, matches a query against exactly three fields:
+  `title`, `slug`, and `body_preview`. It never consults any ID field. This is
+  the whole bug.
+- `work_item_id` **is** a field on `IndexEntry`, populated from the frontmatter
+  `id:` key (normalised), so matching it is a small additive change to
+  `classify()` mirroring the existing slug tiering.
+- **`external_id` is NOT a field on `IndexEntry`, and the string `external_id`
+  does not appear anywhere in `server/src`.** It is only reachable through the
+  generic `frontmatter: serde_json::Value` blob carried on each entry. So
+  matching `external_id` requires either reading it out of that JSON in
+  `classify()` (mirroring `extract_facet_value`'s `status` path) or adding a
+  dedicated indexed field.
+- There is a clean, in-repo precedent for the frontmatter-JSON read:
+  `extract_facet_value` reads `status` via
+  `entry.frontmatter.get("status").and_then(|v| v.as_str())`, gated on
+  `frontmatter_state == "parsed"`.
+- The test suite (`tests/api_search.rs`) drives the real HTTP handler against a
+  temp-dir corpus. A live gotcha: the shared `seeded_cfg_with_work_items`
+  fixtures have **no `id:` frontmatter**, so their `work_item_id` is `None` and
+  they cannot exercise ID matching — new tests must write fixtures carrying `id:`
+  (and `external_id:` for that case).
+- The frontend empty-state already tells users to "Try … a doc id", which the
+  backend cannot currently honour.
+
+## Detailed Findings
+
+### Search ranking — `classify()` and the handler
+
+`skills/visualisation/visualise/server/src/api/search.rs`
+
+- The bucket enum (`search.rs:41-48`) is a four-tier ranking:
+  `ExactSlug = 0`, `Prefix = 1`, `Interior = 2`, `Body = 3`.
+- `classify()` (`search.rs:56-80`) lowercases `title` and `slug` eagerly,
+  `body_preview` lazily, and matches in this order: exact slug → title/slug
+  prefix → title/slug interior (substring) → body-preview substring. **No ID
+  field is read.** This is the precise location of the defect.
+- The handler `search()` (`search.rs:95-138`) trims/caps the query
+  (`MAX_Q_LEN = 128`), lowercases it, snapshots the index, skips
+  `DocTypeKey::Templates`, buckets every entry via `classify()`, sorts each
+  bucket by `(mtime desc, rel_path asc)`, then projects to the wire shape via
+  `project()` (`search.rs:85-93`), which drops slug-less entries.
+- `SearchResultRow` (`search.rs:27-34`) is the wire shape: `doc_type`, `title`,
+  `slug`, `mtime_ms` (camelCase on the wire). Note it carries no ID field today;
+  matching by ID does not require changing the wire shape (the slug/title still
+  identify the row), but a plan may choose to surface the matched ID.
+
+### `work_item_id` — present, frontmatter-`id:`-derived
+
+`skills/visualisation/visualise/server/src/indexer.rs`
+
+- `IndexEntry.work_item_id: Option<String>` exists (`indexer.rs:170`). **Note:**
+  the doc comment there currently says "filename-derived via the scan regex",
+  but that is stale — see the population path below; the value is actually read
+  from frontmatter `id:`.
+- Population (`indexer.rs:1346-1382`): for `DocTypeKey::WorkItems`, the slug is
+  derived from the filename via the scan regex (tail after the ID), while the
+  identity is read from the **frontmatter `id:` key** through
+  `read_fm_id("id")`, which routes the raw value through
+  `WorkItemConfig::normalise_id`. For non-work-item types, `work_item_id` is
+  `None` (`indexer.rs:1383-1384`).
+- `normalise_id` (`config.rs:207`) with the default numeric config returns the
+  bare digits unchanged (`"0042"` → `"0042"`); with a project code it yields
+  `"ENG-0042"`, and passes through already-prefixed foreign keys verbatim.
+- Consequence for the bug: a work item `0054-sidebar-search.md` has slug
+  `sidebar-search` and `work_item_id` `Some("0054")` (only if its frontmatter
+  carries `id: "0054"`). The bare ID `0054` is therefore absent from `title`,
+  `slug`, and `body_preview` — confirming why an ID query never matches.
+
+### `external_id` — NOT indexed; only in the frontmatter blob
+
+- `grep -rn "external_id" server/src` returns **zero matches**. `external_id` is
+  not a struct field and is not referenced anywhere in the server.
+- The only access path is the generic frontmatter JSON on each entry:
+  `IndexEntry.frontmatter: serde_json::Value` (`indexer.rs:172`), built at
+  `indexer.rs:1398-1412` by copying every parsed frontmatter key/value verbatim
+  into a `serde_json::Map` (so the key is exactly `external_id`, snake_case).
+  When frontmatter is absent/malformed the value is `Null` and
+  `frontmatter_state` is `"absent"`/`"malformed"`.
+- **Precedent to mirror** — `extract_facet_value` (`indexer.rs:72-106`) reads the
+  `status` facet straight from the blob:
+  ```rust
+  if entry.frontmatter_state != "parsed" { return None; }
+  entry.frontmatter.get("status").and_then(|v| v.as_str()).map(...)
+  ```
+  An `external_id` read in `classify()` would use the same shape.
+- Sparsity: per the work-item template and `create-work-item`, `external_id` is
+  omit-when-empty and only present on synced items, and only on work items — so
+  the match path must treat absence as the common case (cheap early-out).
+
+### Test suite and fixtures
+
+`skills/visualisation/visualise/server/tests/api_search.rs` and
+`tests/common/mod.rs`
+
+- Tests build a real `AppState` over a `tempfile::tempdir()` corpus and drive the
+  axum router via `oneshot` (`api_search.rs:13-22`). Assertions inspect the JSON
+  `results` array (slug/title/docType/mtimeMs).
+- Existing coverage pins bucket ordering (`bucket_1_exact_slug_first`,
+  `bucket_2_prefix_before_interior`, `bucket_3_title_slug_before_bucket_4_body_preview`),
+  case-insensitivity, template exclusion, mtime/path tiebreaks, the length cap,
+  and the "no path/relpath match" negative.
+- `common::seeded_cfg` (`mod.rs:15`) seeds decisions/plans/reviews/RCA but
+  `work_item: None` → the indexer falls back to `WorkItemConfig::default_numeric()`
+  (`server.rs:79-81`).
+- **Gotcha** `common::seeded_cfg_with_work_items` (`mod.rs:120-141`) writes
+  `0001-todo-fixture.md` etc. **without an `id:` frontmatter key**, so those
+  entries get `work_item_id: None` and **cannot** exercise ID matching. New tests
+  must write their own work-item fixtures that include `id: "0042"` (and, for the
+  external case, `external_id: "ATO-123"`). Confirmed empirically:
+  `seeded_cfg_with_work_items` entries show `wid=None` in the index snapshot.
+- Tests must be run with `cargo test --no-default-features --features dev-frontend`
+  — the default `embed-dist` feature's build script requires a built
+  `frontend/dist/index.html`.
+
+### Frontend empty-state copy
+
+`skills/visualisation/visualise/frontend/src/components/Sidebar/SearchResultsPanel.tsx`
+
+- The "No matches" block (`SearchResultsPanel.tsx:99-108`) renders:
+  "Nothing in `meta/` matches "{query}". Try a slug, a fragment of a title, or a
+  **doc id**." Once the backend matches IDs, this hint becomes truthful; no copy
+  change is strictly required, though the plan may align wording.
+
+## Code References
+
+- `skills/visualisation/visualise/server/src/api/search.rs:41-48` — `Bucket` ranking enum.
+- `skills/visualisation/visualise/server/src/api/search.rs:56-80` — `classify()`; the matched-field set (the defect site).
+- `skills/visualisation/visualise/server/src/api/search.rs:85-138` — `project()` and the `search()` handler.
+- `skills/visualisation/visualise/server/src/indexer.rs:162-196` — `IndexEntry` struct (no `external_id` field; has `work_item_id`, `frontmatter`, `frontmatter_state`).
+- `skills/visualisation/visualise/server/src/indexer.rs:72-106` — `extract_facet_value`; the frontmatter-JSON read pattern to mirror.
+- `skills/visualisation/visualise/server/src/indexer.rs:1346-1384` — work-item slug + `work_item_id` population (frontmatter `id:` via `read_fm_id`).
+- `skills/visualisation/visualise/server/src/indexer.rs:1398-1412` — frontmatter → `serde_json` map construction.
+- `skills/visualisation/visualise/server/src/config.rs:207` — `normalise_id`.
+- `skills/visualisation/visualise/server/src/server.rs:79-81` — default-numeric `WorkItemConfig` when unconfigured.
+- `skills/visualisation/visualise/server/tests/api_search.rs:13-22,129-216` — test harness and bucket-ordering tests.
+- `skills/visualisation/visualise/server/tests/common/mod.rs:120-141` — `seeded_cfg_with_work_items` (no `id:` → `work_item_id: None`).
+- `skills/visualisation/visualise/frontend/src/components/Sidebar/SearchResultsPanel.tsx:99-108` — "No matches" hint copy.
+
+## Architecture Insights
+
+- The ranker is intentionally field-restricted (0054's design): a fixed
+  four-bucket order with no per-type ID code path. Adding ID matching is additive
+  — slot the ID fields into the existing tiers rather than introduce a new bucket.
+- The `ExactSlug` bucket is really an "exact identity" tier; an exact ID match
+  belongs there. The plan should decide whether to rename the variant or simply
+  reuse it (renaming touches the bucket-ordering tests).
+- Two routes for `external_id`, to be decided in planning:
+  1. **Read from `entry.frontmatter` in `classify()`** (mirrors
+     `extract_facet_value`'s `status`): no struct/indexer change, gated on
+     `frontmatter_state == "parsed"`; cheapest, but re-reads JSON per query per
+     entry and keeps `external_id` un-normalised.
+  2. **Add `external_id: Option<String>` to `IndexEntry`**, populated during
+     indexing like `work_item_id`: consistent with the dedicated-field treatment
+     of `work_item_id`, friendlier to reuse (e.g. future facets), but touches the
+     struct, the indexer, and any serialisation/tests over `IndexEntry`.
+  `work_item_id` matching is unaffected by this choice — it is already a field.
+- Matching style agreed on the work item: exact + prefix + interior, mirroring
+  slug. Interior matching means a bare-number query substring-matches a
+  zero-padded `work_item_id` (typing `42` finds `0042`) and substring-matches a
+  prefixed `external_id` (typing `123` finds `ATO-123`) — accepted behaviour.
+
+## Historical Context
+
+- `meta/work/0054-sidebar-search.md` (done) — built `/api/search` and the
+  four-bucket ranker. Its design note (line ~121) claimed work-item-by-ID lookup
+  would work via the exact-slug bucket "without a separate ID-aware code path";
+  this research confirms that claim never held, because the work-item slug
+  excludes the bare ID. Work item 0125 fixes this gap.
+- `meta/work/0041-library-page-wrapper-and-overview-hub.md` (done) — sort +
+  faceted filtering, but for the Library **list views**, not the search box;
+  prior art for any future "advanced search", which is currently untracked.
+- `meta/work/0036-sidebar-redesign.md` (done) — parent epic of 0053/0054/0055.
+
+## Related Research
+
+- None found specific to search matching prior to this document.
+
+## Open Questions
+
+- `external_id` representation: read from the frontmatter blob in `classify()`
+  (option 1) vs add an indexed field (option 2)? Recommendation leans option 1
+  for a tightly-scoped bug fix, but the plan owns this call.
+- Bucket placement for an exact ID hit: reuse `ExactSlug` as-is, or rename the
+  variant to reflect "exact identity" (the latter touches ordering tests).
+- Whether to align the frontend empty-state copy (no functional need once IDs
+  match).

--- a/meta/reviews/plans/2026-06-22-0125-search-id-matching-review-1.md
+++ b/meta/reviews/plans/2026-06-22-0125-search-id-matching-review-1.md
@@ -1,0 +1,595 @@
+---
+type: plan-review
+id: "2026-06-22-0125-search-id-matching-review-1"
+title: "Plan Review: Visualiser Search Work-Item-ID Matching"
+date: "2026-06-22T15:49:14+00:00"
+author: "Phil Helm"
+producer: review-plan
+status: complete
+target: "plan:2026-06-22-0125-search-id-matching"
+reviewer: "Phil Helm"
+verdict: "COMMENT"
+lenses: [correctness, code-quality, test-coverage, architecture, performance, usability]
+review_number: 1
+review_pass: 2
+tags: [visualiser, search, indexer]
+last_updated: "2026-06-22T16:03:30+00:00"
+last_updated_by: "Phil Helm"
+schema_version: 1
+---
+
+## Plan Review: Visualiser Search Work-Item-ID Matching
+
+**Verdict:** REVISE
+
+This is a tightly-scoped, well-grounded, additive change that correctly
+localises the fix to the single defect site (`classify()`) and reuses the
+existing four-bucket ranker — architecture and performance are sound, and the
+plan's "negligible cost" claim holds (the per-query cost is dominated by the
+pre-existing full-snapshot clone, not the new ID lowercasing). The plan needs
+revision in two areas before implementation: the **test suite as specified does
+not pin the behaviour the plan promises** (the two tests assert match *presence*
+but never the bucket/tier placement that the Desired End State is entirely
+about, and the "exact" test does not isolate the exact tier), and **interior
+substring matching on zero-padded numeric IDs floods results for short numeric
+queries** while the matched ID is invisible in the result row — so a user cannot
+tell why a row matched. None of the findings are structural-redesign blockers;
+they are addressable with targeted edits to the test plan and one
+behaviour/scope decision on interior matching.
+
+### Cross-Cutting Themes
+
+- **Tests don't verify the ranking behaviour the plan is about** (flagged by:
+  test-coverage, correctness) — The Desired End State makes three tier claims
+  (exact→`ExactSlug`, prefix→`Prefix`, interior→`Interior`), but both proposed
+  tests only assert `results.iter().any(...)`. There is no prefix-tier test, the
+  "exact" test's query `0042` also satisfies the prefix and interior branches
+  (so deleting the exact branch leaves it green), and no test pins ordering. The
+  feature's whole point — *where* an ID match ranks — is unverified.
+
+- **Short numeric queries flood the Interior bucket** (flagged by: correctness,
+  usability) — `id_interior = id_lc.contains(q_lc)` against bare zero-padded IDs
+  means a two-digit query (`00`, `02`) substring-matches a large fraction of all
+  work items. The frontend gates queries at length ≥ 2 (`use-search.ts:8`), so
+  the single-digit `0`/`1` case the correctness agent raised cannot reach the
+  API — but two-digit numeric queries are common and the backend applies no
+  result cap. Compounded by the next theme, these hits are also unexplained.
+
+- **Matched ID is invisible / config-dependent** (flagged by: usability,
+  architecture) — `SearchResultRow` carries no ID field, so an ID match shows a
+  title/slug containing none of the query digits (the `Highlight` component
+  highlights nothing). Separately, "unpadded tolerance" relies on the *string
+  form* of the normalised ID: under a project-code config the ID is `ENG-0042`,
+  the exact tier needs the full `eng-0042` typed, and the plan's tests only cover
+  the default-numeric config.
+
+- **Tripled per-tier ladder is reaching its limit** (flagged by: code-quality,
+  architecture) — `classify()` now repeats exact/prefix/interior across three
+  fields, with `external_id` explicitly slated to become a fourth. Acceptable at
+  three fields; worth a note that the next field should trigger a small refactor
+  to iterate candidate fields per tier.
+
+### Tradeoff Analysis
+
+- **Scope discipline vs explainability**: The plan deliberately leaves the wire
+  shape (`SearchResultRow`) untouched. That keeps the change minimal, but
+  usability argues an ID match is unexplained without surfacing the matched ID.
+  Recommendation: keep the wire shape out of scope for this fix, but record the
+  invisible-ID rough edge explicitly as a known limitation rather than a closed
+  decision, and reconsider it alongside the flooding decision below.
+
+- **Interior-match simplicity vs result noise**: Reusing slug-style interior
+  matching gives unpadded tolerance "for free", but produces the short-numeric
+  flood. Recommendation: decide and *document* the intended behaviour — e.g.
+  strip leading zeros and match the unpadded form (so `42`→`0042` works but `00`
+  doesn't fan out), or gate interior ID matching on query length/numeric form —
+  and pin it with a test. A bespoke normalisation here is a reasonable cost.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Test Coverage**: Tests assert match presence but never pin the bucket/tier the plan promises
+  **Location**: Phase 1, Section 1: Failing tests / Testing Strategy
+  Both tests assert only `results.iter().any(|r| slug == "login-form")` — never which bucket the match lands in nor its order relative to other entries. The plan's central behavioural promise (tier placement) is therefore untested; mutations that mis-tier the ID match survive.
+
+- 🟡 **Test Coverage**: The "exact" test does not isolate the exact tier — query `0042` also matches prefix and interior
+  **Location**: Phase 1, Section 1: Failing tests
+  `work_item_id_exact_match` queries `0042`, which is simultaneously an exact, prefix, and interior match of `0042`. The test passes even if the new `id_lc == Some(q_lc)` ExactSlug branch is deleted entirely — the exact branch has no test that fails when it is removed.
+
+- 🟡 **Test Coverage**: No test for the prefix tier of `work_item_id`
+  **Location**: Phase 1, Section 2: Extend classify() / Testing Strategy
+  The plan adds an `id_prefix` term and lists it in the Desired End State, but no test exercises a prefix-only ID query (e.g. `004` against `0042`). Deleting the `id_prefix` term survives the suite.
+
+- 🟡 **Usability / Correctness**: Short numeric queries flood the Interior bucket with unexplained hits
+  **Location**: Desired End State / Phase 1, Section 2: id_interior branch
+  Two-digit numeric queries substring-match a large swathe of zero-padded IDs (`00` matches every `00xx`); the frontend min-length floor of 2 blocks only the single-digit case, and the backend applies no result cap. The intended item is buried among hits whose visible title/slug don't contain the query.
+
+- 🟡 **Usability**: Matched ID is invisible in the result row, so ID matches look unexplained
+  **Location**: What We're NOT Doing / Phase 1, Section 2
+  `SearchResultRow` carries only `doc_type`/`title`/`slug`/`mtime_ms`. When a user types `0042`, the row shows "Login form" / `login-form` — nothing containing `0042`, and the `Highlight` component highlights nothing. The user cannot tell why the row matched. Either surface the ID or record this as a known UX rough edge rather than a closed decision.
+
+#### Minor
+
+- 🔵 **Correctness**: Exact-id tier is unreachable for prefixed IDs unless the user types the full lowercased key
+  **Location**: Phase 1, Section 2: Extend classify() — exact-id branch under project-code configs
+  Under a project-code config `work_item_id` is `eng-0042`, so the exact branch only fires for `eng-0042`; a natural `0042` falls through to Interior. The plan's tests use only the default-numeric config, leaving this divergence unverified.
+
+- 🔵 **Architecture**: "Unpadded tolerance" guarantee is config-dependent and untested for project-code IDs
+  **Location**: Implementation Approach / Desired End State
+  The interior-match strategy couples ID-search ergonomics to the incidental string form of a normalised ID (`0042` vs `ENG-0042`). The "no bespoke normalisation needed" claim holds only for the default-numeric mode. Narrow the guarantee in the Desired End State, or add a project-code fixture test.
+
+- 🔵 **Test Coverage**: No negative test for an ID that should NOT match
+  **Location**: Phase 1, Section 1: Failing tests / Testing Strategy
+  No test that a non-matching numeric query (e.g. `0099` against a `0042` item) returns no false positive. A regression making ID matching over-broad would not be caught.
+
+- 🔵 **Test Coverage**: No coverage that `work_item_id: None` entries are handled safely and don't false-match
+  **Location**: Phase 1, Section 2: Extend classify()
+  Non-work-item entries (plans/decisions/RCAs) all have `work_item_id: None` — the common case across the corpus — yet no test confirms they neither panic nor false-match on a numeric query.
+
+- 🔵 **Test Coverage**: Fixture-population assumption is load-bearing but only implicitly verified
+  **Location**: Phase 1, Section 1: Failing tests
+  The whole suite rests on `write_work_item` producing `work_item_id: Some("0042")` under default-numeric normalisation — the inverse of the documented `seeded_cfg_with_work_items` gotcha. Add a one-line snapshot assertion or comment so a future config change surfaces the root cause clearly.
+
+- 🔵 **Code Quality**: `classify()` doc-comment update is named but its replacement text is unspecified
+  **Location**: Phase 1, Section 2: Extend classify()
+  Step 2 says "Update the function doc comment" but the code block omits it. The existing comment's eager/lazy lowercasing claim is now incomplete (it doesn't mention `work_item_id`). Without the replacement text the implementer may recreate exactly the kind of stale comment this change fixes elsewhere.
+
+- 🔵 **Code Quality**: Indexer doc-comment correction is under-specified
+  **Location**: Phase 1, Section 3: Correct the stale struct doc comment
+  The stale comment at `indexer.rs:167-170` has *two* wrong claims — the "filename-derived" source and the `Some`/`None` conditions. The plan directs fixing the source but not the conditions. Quote the full replacement.
+
+- 🔵 **Architecture**: `ExactSlug` reuse leaves a domain-clarity gap
+  **Location**: What We're NOT Doing — ExactSlug reuse
+  Reusing the variant (declining the rename) is the right churn trade, but the name now misleads about its semantics. Add a one-line doc comment on the variant noting it is the "exact identity" tier covering exact slug OR exact `work_item_id`.
+
+#### Suggestions
+
+- 🔵 **Code Quality / Architecture**: Tripled exact/prefix/interior tiering invites a small extract as the field set grows
+  **Location**: Phase 1, Section 2: Extend classify()
+  Acceptable at three fields, but `external_id` is already slated as a fourth. Note in the plan that the next field should trigger a refactor to iterate a `[Option<&str>]` of candidate fields per tier, so fields slot in by data rather than triplicated edits.
+
+- 🔵 **Architecture**: Record the evolutionary direction for the deferred `external_id`
+  **Location**: What We're NOT Doing — external_id deferral
+  This change sets a precedent (dedicated typed fields drive matching). Add a sentence noting the dedicated-field approach is the consistent successor for `external_id`, so the deferred work inherits clear intent.
+
+- 🔵 **Performance**: Eager `id_lc` lowercasing for a sparse field is harmless — keep as-is
+  **Location**: Performance Considerations
+  `Option::map` over `None` allocates nothing and IDs are tiny; the plan's "negligible" claim is accurate. No change recommended; the real per-query lever (out of scope) is the full-snapshot clone in the handler, not ID lowercasing.
+
+- 🔵 **Usability**: Empty-state hint says "doc id" but the feature matches only work-item IDs
+  **Location**: What We're NOT Doing — frontend copy
+  Decisions/plans/reviews have `work_item_id: None`, so searching their identifiers still yields nothing despite the generic "doc id" phrasing. Either keep the vague copy (acceptable) and note the limitation, or tighten toward "a work item number".
+
+- 🔵 **Usability**: Exact-ID hit not guaranteed to rank first within the shared top bucket
+  **Location**: Desired End State
+  An exact ID shares `ExactSlug` with exact-slug hits, ordered only by `(mtime desc, rel_path asc)`, so it is top-*bucket* but not necessarily the top *row*. Acceptable for a scoped fix; note that exact-ID is co-equal with exact-slug so the expectation is explicit.
+
+### Strengths
+
+- ✅ Tightly scoped and well-grounded: confines the change to the single defect
+  site (`classify()`) with no struct, indexer, or wire-shape change — minimal
+  blast radius, and the research backing is thorough.
+- ✅ Reuses the existing four-bucket tiering rather than inventing a new bucket
+  or per-type ID code path, consistent with the deliberately field-restricted
+  ranker from work item 0054.
+- ✅ Genuinely test-first with a credible red state (neither `0042` nor `42`
+  appears in any seeded field today), and the new fixture is well-isolated so a
+  passing assertion can only come from the new `work_item_id` path.
+- ✅ Correctly identifies and avoids the documented fixture gotcha
+  (`seeded_cfg_with_work_items` yields `work_item_id: None`) by writing its own
+  id-bearing fixture.
+- ✅ Preserves the deliberate lazy `body_preview` lowercasing optimisation and
+  proactively corrects the stale `indexer.rs` struct doc comment while in the
+  area.
+- ✅ The "What We're NOT Doing" boundaries are explicit and well-justified
+  (deferring `external_id`, declining the bucket rename, leaving the wire shape
+  untouched), and tradeoffs are acknowledged rather than hidden.
+- ✅ Performance claim is accurate: the added cost is dwarfed by the pre-existing
+  snapshot clone, which the plan correctly leaves untouched.
+
+### Recommended Changes
+
+1. **Strengthen the test plan to pin tier placement, not just presence**
+   (addresses: "Tests assert match presence…", "The 'exact' test does not
+   isolate the exact tier", "No test for the prefix tier", "No negative test",
+   "No coverage that `work_item_id: None`…")
+   Revise Phase 1 Section 1 so the tests mirror the existing
+   `bucket_1_exact_slug_first` / `bucket_2_prefix_before_interior` patterns:
+   seed a competing entry and assert the exact-ID item ranks at `results[0]`;
+   add a prefix-only test (`004`→`0042`); add a negative test (`0099` returns no
+   match); and add an assertion that `None`-id entries seeded by `seeded_cfg`
+   never appear for a numeric query.
+
+2. **Decide and document the short-numeric interior-match behaviour**
+   (addresses: "Short numeric queries flood the Interior bucket")
+   Choose between (a) strip leading zeros and match the unpadded form, (b) gate
+   interior ID matching on query length/numeric form, or (c) accept the flood
+   and cap results — then state the choice in the Desired End State and pin it
+   with a test (e.g. `42`→`0042` matches but `00` does not broadly fan out).
+
+3. **Resolve the invisible-matched-ID UX, even if deferring**
+   (addresses: "Matched ID is invisible in the result row")
+   Either bring surfacing `work_item_id` in `SearchResultRow` into scope, or add
+   it to "What We're NOT Doing" explicitly as a known UX rough edge with a
+   follow-up pointer — not silently.
+
+4. **Specify the doc-comment replacement texts**
+   (addresses: "`classify()` doc-comment update… unspecified", "Indexer
+   doc-comment correction… under-specified")
+   Quote the full replacement for both the `classify()` function comment
+   (covering eager `work_item_id` lowercasing) and the `indexer.rs:167-170`
+   struct comment (correcting both the source *and* the `Some`/`None`
+   conditions).
+
+5. **Address project-code-config behaviour**
+   (addresses: "Exact-id tier is unreachable for prefixed IDs", "'Unpadded
+   tolerance' guarantee is config-dependent")
+   Either narrow the Desired End State to state the unpadded-tolerance and
+   exact-tier guarantees apply to the default-numeric config, or add a
+   project-code fixture test confirming the `0042`/`42` behaviour against
+   `ENG-0042`.
+
+6. **Add forward-looking notes (low effort)**
+   (addresses: "ExactSlug reuse… domain-clarity gap", "Tripled tiering",
+   "Record the evolutionary direction for `external_id`")
+   A one-line doc comment on the `ExactSlug` variant, and a sentence in "What
+   We're NOT Doing" noting the per-tier ladder should be refactored to iterate
+   candidate fields when `external_id` lands via the dedicated-field approach.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Correctness
+
+**Summary**: The core change — slotting `work_item_id` into the existing
+exact/prefix/interior tiers of `classify()` — is logically sound: the exact-tier
+ordering (id checked before slug, both returning `ExactSlug`) is consistent,
+empty/whitespace ids cannot spuriously match because `normalise_id` rejects them
+and the handler rejects empty queries, and the `Option`/`as_deref` plumbing
+mirrors the existing slug handling correctly. The principal correctness risk is
+the unbounded interior substring match against zero-padded numeric ids: short
+numeric queries (`0`, `1`) will substring-match a large fraction of all work
+items, which the plan neither acknowledges nor tests. The two proposed tests do
+genuinely isolate id-only matching (the chosen slug/title/body avoid the query
+tokens), but they only assert presence, not the bucket/ranking the Desired End
+State claims.
+
+**Strengths**:
+- Exact-tier ordering is correct: `id_lc == q_lc` and `slug == q_lc` both return
+  `Bucket::ExactSlug`, so there is no ambiguity when an id equals a slug —
+  within-bucket ordering is the existing mtime/rel_path sort.
+- Empty/whitespace `work_item_id` cannot produce a false match: `normalise_id`
+  returns `None` for empty/whitespace input, and the handler rejects
+  empty/whitespace queries before `classify()`.
+- The two proposed tests correctly isolate id-only matching — the fixture's slug,
+  title and body contain neither `0042` nor `42`, so a passing assertion proves
+  the match came from `work_item_id`.
+- The `Option`/`as_deref`/`is_some_and` plumbing for `id_lc` faithfully mirrors
+  the existing slug handling, so absent ids short-circuit without panics.
+
+**Findings**:
+- 🟡 **major** (high) — Short numeric queries interior-match nearly every
+  zero-padded work-item id. *Location: Phase 1, Section 2: Extend classify() —
+  id_interior branch; Desired End State.* `id_interior = id_lc.contains(q_lc)`
+  runs unconditionally against zero-padded numeric IDs; a single-or-double-digit
+  query dumps most work items into Interior, swamping relevant title/slug
+  results. Decide and document intended behaviour for short numeric queries and
+  add a test pinning it. *(Reviewer note: the frontend gates at length ≥ 2, so
+  the single-digit case cannot reach the API; two-digit floods remain.)*
+- 🔵 **minor** (high) — Tests assert presence but not the bucket/ranking the
+  plan promises. *Location: Phase 1, Section 1; Desired End State.* Both tests
+  assert only `.any(...)`; a regression that mis-tiers an exact id into Interior
+  would still pass. Seed a competing entry and assert `results[0]`.
+- 🔵 **minor** (medium) — Exact-id tier is unreachable for prefixed ids unless
+  the user types the full lowercased key. *Location: Phase 1, Section 2 —
+  exact-id branch under project-code configs.* Under a project code,
+  `work_item_id` is `eng-0042`; a `0042` query falls through to Interior. Accept
+  and document, or normalise the query before comparison; add a prefixed-config
+  test.
+
+### Code Quality
+
+**Summary**: The plan is a small, well-scoped additive change that correctly
+preserves the lazy `body_preview` lowercasing optimisation. The main quality
+concern is that the proposed `classify()` rewrite triples the
+exact/prefix/interior tiering across three near-identical fields, pushing
+cognitive load up just as the matched-field set is likely to keep growing
+(`external_id` is a deferred follow-on). Two specification gaps reduce
+maintainability: the `classify()` doc-comment update and the indexer struct
+doc-comment correction are both named as required but neither supplies the
+replacement text.
+
+**Strengths**:
+- Preserves the lazy `body_preview` lowercasing optimisation — `id_lc` is
+  lowercased eagerly alongside title/slug (all short), body lazily on
+  fall-through.
+- Reuses the existing four-bucket tiering rather than inventing a new ID bucket
+  or per-type code path (KISS/YAGNI; interior match gives unpadded tolerance for
+  free).
+- Correctly identifies and plans to fix the stale `indexer.rs` struct doc
+  comment while in the area.
+- Scope boundaries are explicit and disciplined (no wire-shape change, no bucket
+  rename, `external_id` deferred).
+
+**Findings**:
+- 🔵 **minor** (high) — `classify()` doc-comment update is named but its
+  replacement text is unspecified. *Location: Phase 1, Section 2.* The existing
+  comment's eager/lazy claim omits the new `work_item_id` lowercasing; without
+  the replacement the implementer may recreate a stale comment. Specify the new
+  text.
+- 🔵 **minor** (medium) — Indexer doc-comment correction under-specified given
+  the actual stale text. *Location: Phase 1, Section 3.* The stale comment's
+  `Some`/`None` conditions are also wrong (gated on frontmatter `id:`, not
+  filename match), and the plan does not call this out. Quote the full
+  replacement.
+- 🔵 **minor** (medium) — Tripled exact/prefix/interior tiering invites a small
+  extract as the field set grows. *Location: Phase 1, Section 2.* Readable at
+  three fields, but `external_id` is slated next; consider a `&[Option<&str>]`
+  candidate-fields iteration per tier — only if it stays simpler than the
+  explicit form.
+
+### Test Coverage
+
+**Summary**: The plan is test-driven and the two proposed integration tests
+correctly target the previously-unmatched path, and the red-green claim is sound.
+However, the tests assert only match presence (`.any(...)`) and never pin the
+bucket/ordering that the Desired End State explicitly promises, so several
+mutations of the new code survive. There are also no tests for the prefix tier,
+an isolated exact-vs-interior distinction, the negative (non-matching ID) case,
+or `work_item_id: None` entries.
+
+**Strengths**:
+- Genuinely test-first: tests fail before the change, and the red state is
+  credible since neither `0042` nor `42` appears in any seeded field.
+- The new fixture helper is well-isolated — a passing assertion can only come
+  from the new `work_item_id` path.
+- Drives the real axum handler over a temp corpus (integration level at the
+  right boundary), consistent with the existing suite.
+- Correctly avoids the documented fixture gotcha by writing its own id-bearing
+  fixture; `seeded_cfg` already maps `doc_paths['work']` and `id:"0042"`
+  normalises to `Some("0042")` under default-numeric.
+
+**Findings**:
+- 🟡 **major** (high) — Tests assert match presence but never pin the bucket/tier
+  the Desired End State promises. *Location: Phase 1, Section 1 / Testing
+  Strategy.* Mutations survive (moving the ExactSlug branch into Prefix/Interior,
+  collapsing to a single `contains`). Add a test seeding a competing entry and
+  asserting `results[0]`.
+- 🟡 **major** (high) — The "exact" test does not isolate the exact tier — query
+  `0042` also matches prefix and interior. *Location: Phase 1, Section 1.* The
+  test passes even if the exact branch is deleted; the name overstates what is
+  verified. Pin via bucket placement.
+- 🟡 **major** (high) — No test for the prefix tier of `work_item_id`. *Location:
+  Phase 1, Section 2 / Testing Strategy.* Deleting the `id_prefix` term survives
+  the suite. Add a strict-prefix test (`004`→`0042`).
+- 🔵 **minor** (high) — No negative test for an ID that should NOT match.
+  *Location: Phase 1, Section 1 / Testing Strategy.* Add `0099` returns no false
+  positive.
+- 🔵 **minor** (medium) — No coverage that `work_item_id: None` entries are
+  handled safely and don't false-match. *Location: Phase 1, Section 2.* Add an
+  assertion that a numeric query returns only the id-bearing work item.
+- 🔵 **minor** (medium) — Fixture-population assumption is load-bearing but only
+  implicitly verified. *Location: Phase 1, Section 1.* Add a one-line snapshot
+  assertion that the fixture entry's `work_item_id` is `Some`, or a comment
+  noting the default-numeric reliance.
+
+### Architecture
+
+**Summary**: A tightly-scoped, additive change that correctly localises the fix
+to `classify()` without touching the struct, indexer, or wire shape — a sound
+evolutionary move that respects the existing field-restricted ranker design. The
+decisions to reuse `ExactSlug` and defer `external_id` are explicitly reasoned
+and defensible. The main concern is that slotting a third match-field into the
+hand-rolled per-tier boolean ladder repeats a pattern showing strain, and the
+doc-comment/bucket-naming choices leave latent domain-clarity debt.
+
+**Strengths**:
+- Confines the change to a single cohesive site with no struct/indexer/wire-shape
+  change — minimal blast radius.
+- Reuses existing tiering rather than a new bucket or per-type code path,
+  consistent with work item 0054's design.
+- "What We're NOT Doing" boundaries are explicit and well-justified.
+- Proactively corrects the stale `work_item_id` doc comment.
+- Tradeoffs acknowledged rather than hidden.
+
+**Findings**:
+- 🔵 **minor** (high) — The revised `classify()` repeats the exact/prefix/interior
+  ladder across three fields with `external_id` slated as a fourth; the structure
+  does not scale open-closed. *Location: Phase 1, Section 2.* Note that once
+  `external_id` lands the per-tier logic should iterate a `[&str]` of candidate
+  fields per tier.
+- 🔵 **minor** (medium) — `ExactSlug` reuse leaves a domain-alignment gap; the
+  variant name no longer matches the concept it represents. *Location: What We're
+  NOT Doing — ExactSlug reuse.* Keep the name but add a one-line doc comment that
+  it is the "exact identity" tier (exact slug OR exact `work_item_id`).
+- 🔵 **minor** (medium) — The unpadded-query tolerance is config-dependent
+  (`ENG-0042` under a project code) and untested. *Location: Implementation
+  Approach / Desired End State.* Narrow the guarantee to default-numeric, or add
+  a project-code fixture test.
+- 🔵 **suggestion** (low) — The plan does not record which `external_id`
+  evolutionary path this fix biases toward; the change sets a dedicated-field
+  precedent. *Location: What We're NOT Doing — external_id deferral.* Add a
+  sentence noting the dedicated-field approach is the consistent successor.
+
+### Performance
+
+**Summary**: A small additive change to a search ranker over an in-memory
+snapshot of a developer's local `meta/` corpus (hundreds to low-thousands of
+entries, not a high-scale endpoint). The plan's "negligible" claim is correct:
+the per-entry cost is dominated by the pre-existing full-snapshot clone in the
+handler. The only proportionate observation is that `id_lc` is lowercased eagerly
+even though `work_item_id` is `None` for most entries, but at this scale this is
+immaterial and not worth changing.
+
+**Strengths**:
+- Reuses existing tiering — no new passes over the data; stays single-pass O(n)
+  per query.
+- Interior substring matching gives unpadded tolerance without a precomputation
+  pass.
+- Preserves lazy lowercasing of `body_preview` (the largest allocation).
+- Correctly scoped to `classify()` with no new I/O or change to the
+  snapshot/locking model.
+
+**Findings**:
+- 🔵 **suggestion** (high) — Eager `id_lc` lowercasing for a sparse field is
+  harmless but could be lazy/borrowed. *Location: Performance Considerations;
+  Phase 1, Section 2.* Keep as written for readability/consistency; do not
+  change. The real lever (if ever needed) is the snapshot clone, not ID
+  lowercasing.
+- 🔵 **minor** (high) — Per-query cost is dominated by the full-snapshot clone,
+  not `classify()`. *Location: Performance Considerations (handler context the
+  plan does not change).* `state.indexer.all()` deep-copies every IndexEntry
+  including the serde_json frontmatter blob. No action for this work item;
+  context only — confirms the plan's "negligible" claim.
+
+### Usability
+
+**Summary**: A well-scoped, additive change that closes a genuine discoverability
+gap and honours the existing "try a doc id" empty-state hint. The main concerns:
+interior substring matching on zero-padded numeric IDs makes short numeric queries
+noisy and unexplained because the result row never shows the matched ID; and
+exact-ID hits share the top bucket with exact-slug hits ordered only by mtime, so
+an exact ID is not guaranteed to appear first.
+
+**Strengths**:
+- Closes a real discoverability gap; the "Try … a doc id" hint becomes truthful.
+- Reuses existing tiering — least-surprise extension.
+- Unpadded-query tolerance matches how people type IDs.
+- Manual verification covers both padded and unpadded queries plus a regression
+  check.
+
+**Findings**:
+- 🔴/🟡 **major** (high) — Matched ID is invisible in the result row, so ID
+  matches look unexplained. *Location: What We're NOT Doing / Phase 1, Section 2.*
+  `SearchResultRow` carries no ID; the `Highlight` component highlights only the
+  title, so an ID hit highlights nothing. Surface the ID, or call it out as a
+  known rough edge rather than a closed decision.
+- 🟡 **major** (high) — Short numeric interior matches flood results with
+  unexplained hits. *Location: Desired End State / Phase 1, Section 2.* The
+  frontend min-length floor of 2 blocks single-digit floods, but two-digit
+  numeric queries are common and the backend applies no result cap. Gate ID
+  interior matching on a numeric/longer-query heuristic, anchor to the unpadded
+  form, and/or cap results.
+- 🔵 **minor** (medium) — Exact-ID hit not guaranteed to rank first within the
+  shared top bucket. *Location: Desired End State.* Ordered only by
+  `(mtime desc, rel_path asc)`; note that exact-ID is co-equal with exact-slug.
+- 🔵 **minor** (medium) — Empty-state hint says "doc id" but the feature matches
+  only work-item IDs. *Location: What We're NOT Doing — frontend copy.*
+  Decisions/plans/reviews have `work_item_id: None`. Keep the vague copy and note
+  the limitation, or tighten toward "a work item number".
+
+## Re-Review (Pass 2) — 2026-06-22T16:03:30+00:00
+
+**Verdict:** COMMENT
+
+The revisions resolved the bulk of pass 1: the numeric-form reduction
+(`numeric_key`) is logically sound (traced clean across all named edge cases),
+the short-numeric flood is genuinely killed (`00` → empty → no match), the
+matched-ID-invisibility and `external_id` direction are documented, the
+doc-comment texts are specified, and the project-code case is folded in
+config-independently. Two pass-1 themes recurred in a new form and warrant
+attention but sit **below the configured REVISE threshold** (3+ majors): a
+**test-contract defect** (the prefix-only test does not actually isolate the
+prefix branch) and a **new flood vector** (a non-numeric project-code fragment
+like `eng` substring-matches every work item). Both are concrete and cheap to
+fix; the plan is otherwise implementation-ready.
+
+### Previously Identified Issues
+
+- 🟡 **Test Coverage**: Tests assert presence not bucket placement —
+  **Resolved**. The 9-item contract pins tiers via ordering against a
+  lower-bucket competitor (sound: cross-bucket order is by bucket index, robust
+  to temp-dir mtime ties).
+- 🟡 **Test Coverage**: "Exact" test doesn't isolate the exact tier —
+  **Resolved**. Item 2 (`exact_ranks_above_body`) pins exact via ordering.
+- 🟡 **Test Coverage**: No prefix-tier test — **Partially resolved**. A
+  prefix test was added, but as specified it does not isolate the prefix branch
+  — see new issue below.
+- 🟡 **Usability / Correctness**: Short numeric queries flood — **Resolved**
+  for the numeric path (`numeric_key` reduces `00` to empty). A non-numeric
+  flood variant surfaced — see new issue below.
+- 🟡 **Usability**: Matched ID invisible in result row — **Resolved** (now a
+  documented, accepted rough edge with a follow-up pointer; re-confirmed minor).
+- 🔵 **Correctness**: Exact-id unreachable for prefixed IDs — **Resolved**.
+  `numeric_key` makes `42`/`0042` exact-match `ENG-0042`; full key `eng-0042`
+  also matches.
+- 🔵 **Architecture**: Unpadded tolerance config-dependent/untested —
+  **Resolved**. Reduction is config-independent; test item 9 covers project-code.
+- 🔵 **Test Coverage**: No negative / no `None`-id test — **Resolved** (items 6
+  and 8).
+- 🔵 **Test Coverage**: Fixture-population assumption unverified — **Resolved**
+  (item 1 asserts `work_item_id == Some(...)`).
+- 🔵 **Code Quality**: `classify()` and indexer doc-comment texts unspecified —
+  **Resolved** (both quoted; indexer `Some`/`None` conditions corrected).
+- 🔵 **Architecture**: `ExactSlug` domain-clarity gap — **Resolved** (one-line
+  "exact identity tier" doc comment specified).
+- 🔵 **Architecture/Code Quality**: Tripled tiering / `external_id` direction —
+  **Resolved** as documented deferral (recurs only as an accepted minor).
+
+### New Issues Introduced
+
+- 🟡 **major** (Correctness + Test Coverage, high) — **Prefix-only test does not
+  isolate the prefix branch.** For `004` vs `0042` the reduced forms are `4` vs
+  `42`; `4` is *both* a prefix and an interior substring of `42`, so deleting
+  `id_prefix` demotes the hit to `Interior` but it is **still returned**. The
+  presence-only assertion passes, so the Success-Criteria "mutation check"
+  guarantee is false. *Fix*: pin tier via ordering against an interior-only
+  competitor (as items 2/3 do), and apply the same to the interior-only test
+  (item 5) so it pins `Interior` not just presence.
+- 🟡 **major** (Usability, high) — **Non-numeric project-code fragment floods.**
+  The non-numeric branch does `full_id.contains(q_lc)`, so under a project-code
+  config typing `eng` (or `e`, `-`) substring-matches every `ENG-…` id and
+  returns the whole work-item corpus in Interior — the same flood class the
+  numeric path was redesigned to avoid. *Fix*: gate the non-numeric id path on
+  the query containing a digit, or require a prefix (start-anchored) match for
+  the non-numeric id form; document the decision alongside the numeric guard.
+- 🔵 **minor** (Usability, high) — Short interior **numeric** matches are
+  unintuitive for ID lookup (`2` surfaces `0042`; `42` surfaces `0042` and
+  `0420`). Consider dropping interior matching for the numeric id path (exact +
+  prefix only) so a number behaves like an identifier lookup, or document the
+  fan-out as intentional in the Desired End State.
+- 🔵 **minor** (Test Coverage, medium) — `numeric_key` edge cases and unpadded
+  prefixed IDs (`normalise_id` passes `OPS-7` through *unpadded*) are untested;
+  add cheap direct unit tests over `numeric_key()`.
+- 🔵 **minor** (Test Coverage, medium) — Mixed-alphanumeric queries (`eng-42`)
+  take neither reduction and so won't match `ENG-0042`; pin or document this
+  boundary.
+- 🔵 **minor** (Correctness + Architecture, medium/low) — `numeric_key` relies on
+  the digits being the trailing run (an invariant enforced in `config.rs`);
+  add a one-line note documenting the cross-module assumption.
+- 🔵 **minor** (Code Quality, high) — The `id_*` binding block is dense (the
+  empty-guard is split across `id_active` and three `!id.is_empty()` checks);
+  consider extracting an `id_bucket(id_cmp, id_q) -> Option<Bucket>` helper.
+- 🔵 **suggestion** (Performance, high) — Performance Considerations says `id_q`
+  is "computed once per query"; in the sketch it is recomputed per entry inside
+  `classify()` (cheap, allocation-free). Reword, or hoist `q_is_num`/`id_q` into
+  the handler so the claim is literally true.
+- 🔵 **minor** (Test Coverage, medium) — Project-code test's unit-test fallback
+  would bypass `normalise_id`; if taken, add a population assertion under a
+  project-code config.
+- 🔵 **suggestion** (Architecture, medium) — When the deferred `external_id`
+  refactor lands, prefer precomputing searchable id forms at *index* time so
+  `classify()` becomes pure literal matching, rather than keeping `numeric_key`
+  query-side.
+
+### Assessment
+
+The plan is in good shape and close to implementation-ready. With 2 major
+findings it falls below this project's REVISE threshold (3), so the verdict is
+COMMENT — but both majors are worth addressing before implementation because
+they are cheap and concrete: the prefix-test fix is a one-competitor ordering
+assertion, and the non-numeric flood needs a single accept/reject decision
+(digit-gate or start-anchor the non-numeric id path) mirroring the numeric guard
+already made. The minor cluster (numeric-path interior fan-out, `numeric_key`
+unit tests, the dense `id_*` block, the per-query/per-entry wording) can be
+folded in opportunistically or deferred.
+
+---
+*Re-review generated by /accelerator:review-plan*

--- a/meta/reviews/plans/2026-06-22-0125-search-id-matching-review-2.md
+++ b/meta/reviews/plans/2026-06-22-0125-search-id-matching-review-2.md
@@ -1,0 +1,610 @@
+---
+type: plan-review
+id: "2026-06-22-0125-search-id-matching-review-2"
+title: "Plan Review: Visualiser Search Work-Item-ID Matching"
+date: "2026-06-22T16:49:13+00:00"
+author: "Phil Helm"
+producer: review-plan
+status: complete
+parent: "plan:2026-06-22-0125-search-id-matching"
+target: "plan:2026-06-22-0125-search-id-matching"
+relates_to: ["plan-review:2026-06-22-0125-search-id-matching-review-1"]
+reviewer: "Phil Helm"
+verdict: "COMMENT"
+lenses: [correctness, code-quality, test-coverage, architecture, performance, usability]
+review_number: 2
+review_pass: 2
+tags: [visualiser, search, indexer]
+last_updated: "2026-06-23T08:55:02+00:00"
+last_updated_by: "Phil Helm"
+schema_version: 1
+---
+
+## Plan Review: Visualiser Search Work-Item-ID Matching
+
+**Verdict:** REVISE
+
+The plan has materially improved since review-1: the `numeric_key()` reduction is
+logically sound across the edge cases (`00`→empty, unpadded `ops-7`, project-code
+`ENG-0042`), the numeric-path flood is genuinely killed, the project-code case is
+folded in config-independently, the `MAX_RESULTS` cap addresses review-1's
+non-numeric flood, and the doc-comment texts and evolutionary direction are now
+specified. Architecture and performance are sound and the plan's "negligible
+cost" claim holds. The verdict is REVISE not because the design is wrong but
+because the **test contract does not yet pin several behaviours its own Success
+Criteria claim it pins** — most importantly, the headline prefix-isolation test
+(item 4) relies on an mtime tiebreak the fixture never controls, so the very
+mutation it advertises catching can survive. A second cluster concerns the
+**non-numeric id path**, which is now the feature's weak spot: its prefix/interior
+branches are untested, an unpadded full key (`eng-42`) silently misses, and the
+project-code fragment flood leans entirely on the cap. None are
+structural-redesign blockers; all are addressable with targeted edits to the test
+plan plus two small scope/wording decisions.
+
+### Cross-Cutting Themes
+
+- **The test contract pins less than its Success Criteria claim** (flagged by:
+  test-coverage, correctness) — Item 4 (prefix-outranks-interior) depends on the
+  `(Reverse(mtime), rel_path)` within-bucket sort, but `write_work_item` never
+  equalises mtimes, so with `id_prefix` deleted the newer file can still sort
+  first and the mutation survives. The cap test (item 10) cannot distinguish
+  "truncate before vs after bucket sorting" as claimed, because the single
+  ExactSlug target lands at `results[0]` either way. And the `numeric_key()` "unit
+  tests, no AppState" cannot compile where the plan implies, since the helper is
+  private to `src/api/search.rs` while the tests live in the separate
+  `tests/api_search.rs` crate.
+
+- **The non-numeric id path is the new weak spot** (flagged by: test-coverage,
+  correctness, usability) — Only the non-numeric *exact* tier is tested (item 9);
+  the non-numeric `id_prefix`/`id_interior` branches — which back the "type a full
+  prefixed key or a project-code fragment" promise — are unpinned, so deleting or
+  anchoring them ships green. Behaviourally, the same branch makes `eng-42`
+  silently match nothing against `ENG-0042` (unpadded tolerance is numeric-only),
+  and a bare `eng` substring-matches the whole work-item corpus, bounded only by
+  the cap.
+
+- **`MAX_RESULTS` is broader and blunter than its "flood backstop" framing**
+  (flagged by: correctness, architecture, performance, usability) — Applied in the
+  shared projection chain, the cap silently changes the result-volume contract for
+  *every* query type (title/slug/body included), not just id floods — a 0054
+  contract shift bundled into an id fix. It bounds the response payload but not the
+  per-query CPU (snapshot clone, per-entry lowercasing, matched-set sort remain
+  O(corpus)), and its truncation is invisible to the user.
+
+- **The frontend layer is under-modelled in the spec** (flagged by: usability) —
+  The 2-char min-length gate (`use-search.ts`) makes the single-digit interior
+  behaviour described in the Desired End State and a manual-verification step
+  unreachable through the UI, and the matched id never appears anywhere on the
+  result row (the slug shown is the tail *after* the id), so an id-matched row
+  gives no confirmation of why it matched.
+
+### Tradeoff Analysis
+
+- **Cap generality vs contract precision**: The cap-over-heuristics decision is
+  architecturally the right least-surprise call, and the plan argues it well. The
+  cost is that it changes the global search contract and is non-ID-specific.
+  Recommendation: keep the cap, but state explicitly that it hardens *all* query
+  paths (not just id floods) and reference the `MAX_RESULTS` constant from the
+  test rather than the literal `50` (the plan itself calls the value
+  non-contractual).
+
+- **Scope discipline vs explainability (invisible matched id)**: The plan already
+  documents this as an accepted rough edge with a follow-up pointer — that
+  decision stands. The usability lens sharpens *why* it stings (the row shows
+  none of the typed digits, not merely "no highlight"). Recommendation: keep
+  deferring, but consider the near-free win of rendering the full filename
+  (`0042-login-form`) in the existing sub-line so the id is at least visible
+  without a wire-shape change.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Test Coverage**: Item 4's prefix-isolation depends on an mtime tiebreak the fixture never pins
+  **Location**: Phase 1, Section 1, item 4 (`work_item_id_prefix_outranks_interior`) + `write_work_item` sketch
+  The within-bucket sort is `(Reverse(mtime_ms), rel_path)`; `rel_path` only breaks ties when mtimes are equal. `write_work_item` writes files sequentially and never calls `set_mtime_ms`, so the target and competitor get different mtimes and the newer sorts first regardless of `rel_path`. With `id_prefix` deleted, both fall to `Interior` but the order may not flip — the headline mutation the Success Criteria promises to catch can survive.
+
+- 🟡 **Test Coverage**: Non-numeric `id_prefix`/`id_interior` branches are never pinned
+  **Location**: Phase 1, Section 1, item 9 + classify() non-numeric branch
+  The contract tests the non-numeric path only at the exact tier (`q=eng-0042`). No test exercises a non-numeric prefix (`eng-00`/`eng`) or interior (`ng-00`) match, so a mutation that drops or prefix-anchors those branches passes the whole suite — yet they back the "type a full prefixed key or a project-code fragment" promise.
+
+- 🟡 **Test Coverage**: `numeric_key()` "unit tests, no AppState" cannot live in the integration crate
+  **Location**: Phase 1, Section 1, final paragraph; item 9 fallback
+  `numeric_key()` (and `classify()`) are private to `src/api/search.rs`; the tests live in `tests/api_search.rs`, a separate crate seeing only the `pub` surface. As written these unit tests won't compile, and the plan designates them as the pins for "the riskiest new logic". The plan should specify a `#[cfg(test)] mod tests` inside `search.rs` (or `pub(crate)` the helper).
+
+- 🟡 **Test Coverage**: Cap test does not distinguish "truncate before vs after bucket sorting"
+  **Location**: Phase 1, Success Criteria (mutation checks) + item 10
+  The Success Criteria claim the cap test "fails if truncation is applied before bucket sorting." But the single ExactSlug target lands at `results[0]` whether `take()` runs before or after the per-bucket sort, so item 10's two assertions are identical under both implementations — the stated mutation is not actually caught.
+
+- 🟡 **Usability**: Frontend 2-char min-length gate makes single-digit interior matching unreachable
+  **Location**: Desired End State + Phase 1 Manual Verification
+  `use-search.ts` only searches at `length >= 2`. The Desired End State and the "typing a single common digit" manual-verification step describe behaviour the UI can never trigger — a reviewer following the steps with one digit sees nothing.
+
+- 🟡 **Usability**: Id-matched rows give zero feedback about *why* they matched
+  **Location**: What We're NOT Doing — "Surfacing the matched ID"
+  The row's title gets `Highlight` (no-op for an id query), and the sub-line shows `docType/slug` where slug is the tail *after* the id — so the typed number appears nowhere. The plan accepts this as a rough edge (decision stands), but the framing ("highlights nothing") understates that the row offers no confirmation at all.
+
+#### Minor
+
+- 🔵 **Correctness**: Unpadded full-key query (`eng-42`) silently matches nothing against `ENG-0042`
+  **Location**: Desired End State / Phase 1, Section 2
+  Unpadded tolerance applies only to purely-numeric queries; `eng-42` takes the non-numeric branch and fails exact/prefix/interior against `eng-0042`, even though `42` and `eng-0042` both find it. Whether it matches depends on how the id was stored (`normalise_id` keeps `ENG-42` unpadded). Document the gap or extend the reduction to a CODE-prefixed query's trailing digit run.
+
+- 🔵 **Correctness / Architecture**: `MAX_RESULTS` silently changes the existing title/slug/body result-volume contract
+  **Location**: Phase 1, Section 4 / Desired End State
+  The cap sits in the shared projection chain, so it bounds every query type, not just id floods — a behavioural shift to a pre-existing concern (0054 implicitly returned all matches) bundled into an id fix. Sound, but the "existing ranking unchanged" framing under-states it. Reword to state the cap is general search-handler hardening; optionally land it as its own revertable commit.
+
+- 🔵 **Test Coverage**: Cap test couples to the literal `MAX_RESULTS` value and risks tier bleed
+  **Location**: Phase 1, Section 1, item 10
+  Asserting `results.len() == 50` freezes a value the plan calls non-contractual, and the 51+ generated flood keys must be constructed so none accidentally exact/prefix-matches the query. Reference the `MAX_RESULTS` constant and generate interior-only-matching keys.
+
+- 🔵 **Test Coverage**: All-zeros flood guard (item 7) needs fixtures' title/body explicitly free of `00`
+  **Location**: Phase 1, Section 1, item 7 + `write_work_item`
+  The bucket is unobservable, so the test asserts absence from results — which silently also requires neither fixture's title/body contains `00`. The helper doesn't enforce it; pin titles/bodies that exclude `00`/`0` so the test verifies the `id_active` empty-key guard, not incidental field contents.
+
+- 🔵 **Code Quality**: The `id_*` binding block is dense and carries an undocumented empty-guard asymmetry
+  **Location**: Phase 1, Section 2 — the `id_*` bindings
+  Seven new bindings with inline closures pack the function's new cognitive load; the reason `id_exact` relies on `id_active` while prefix/interior re-check `!id.is_empty()` is subtle. Consider extracting `id_bucket(id_lc, q_lc) -> Option<Bucket>` (mirroring the `numeric_key` extraction), or at least an inline comment.
+
+- 🔵 **Correctness**: Project-code test (item 9) must assert against the normalised `work_item_id`, not the filename id
+  **Location**: Phase 1, Section 1, item 9
+  Under a project-code config, `id: "0042"` normalises to `work_item_id: ENG-0042` while the filename stays `0042-…`. A test authored against the filename form would assert the wrong value or pass for the wrong reason. Add the item-1-style population guard (`Some("ENG-0042")`) first, then the query assertions.
+
+- 🔵 **Performance**: `MAX_RESULTS` bounds the payload but not the snapshot clone, per-entry lowercasing, or the matched-set sort
+  **Location**: Performance Considerations
+  The cap runs after `state.indexer.all()` clones the corpus, after every entry is title-lowercased, and after `sort_by_cached_key` allocates a `rel_path` key per match. A bare-code flood still does O(corpus) work before truncation. Acceptable at scale; note the cap bounds the *response*, not per-query CPU.
+
+- 🔵 **Usability**: "a doc id" empty-state hint over-promises for `None`-id document types
+  **Location**: What We're NOT Doing — frontend copy
+  Only work items carry a matchable id; decisions/plans/reviews/RCAs remain unmatchable. The cheapest user-facing accuracy win is to tighten the copy to "a work item number" in the same PR (one string + its snapshot) rather than defer.
+
+- 🔵 **Usability**: Bare-project-code query returns a bounded but undifferentiated, silently-capped wall
+  **Location**: Desired End State / What We're NOT Doing
+  `eng` returns up to 50 near-identical rows (no on-row id) with no signal that results were truncated. Consider having the match-count meta row signal truncation ("50+ matches — narrow your query"); low priority, pairs with the id-chip follow-up.
+
+#### Suggestions
+
+- 🔵 **Code Quality / Performance**: Hoist `q_is_num`/`id_q` into the handler
+  **Location**: Phase 1, Section 2 / Performance Considerations
+  Both depend only on the query, yet are recomputed per entry inside `classify()`. Hoisting computes them once and makes `classify()` read as "match this entry against a prepared query" — clarity over a measurable win, as the plan already notes. This also makes the "computed once per query" wording literally true.
+
+- 🔵 **Code Quality**: Put the ladder-refactor trigger at the call site, not only in the plan
+  **Location**: What We're NOT Doing — tripled tiering
+  The exact/prefix/interior comparison is now hand-written three times with `external_id` slated as a fourth. The deferral is fine, but add a one-line note near `classify()` itself so the next author meets the "refactor when a third matchable id field lands" threshold at the code, not in an archived plan.
+
+- 🔵 **Architecture**: Record that the `external_id` successor needs a *per-field* numeric-reduction policy
+  **Location**: What We're NOT Doing — external_id deferral
+  `numeric_key` assumes the work-item id shape (trailing digit run). External ids (`PP-76`) would let a numeric query collide across both candidate fields once the ladder iterates them, so the successor needs a per-field policy for which fields participate in bare-numeric matching — not a single shared `numeric_key`.
+
+- 🔵 **Architecture**: Tie the index-side precompute option to a concrete trigger
+  **Location**: Implementation Approach / Performance Considerations
+  Keeping `numeric_key` query-side is correct now. Note that moving to index-time precompute becomes worth it only if the per-query snapshot clone is eliminated (so recomputation stops being free relative to it) or candidate id fields multiply — so a future contributor knows when the boundary should move.
+
+- 🔵 **Test Coverage**: Add an integration case for a foreign-prefix id distinct from the configured code
+  **Location**: Phase 1, Section 1, item 9
+  `numeric_key` covers `ops-7`→`7` at the unit level, but no integration test confirms an `OPS-7` item (distinct from the configured `ENG`) is findable by `q=7` and `q=ops-7` end-to-end — the multi-prefix coexistence `normalise_id` is designed for.
+
+- 🔵 **Correctness**: Note that any all-zeros numeric query (`0`, `000`) is an intentional id-path no-op
+  **Location**: Phase 1, Section 2 — `q_is_num` derivation
+  The `00` flood-guard logic generalises: `0`/`000` also reduce to empty and match no id. Internally consistent and bounded; just note the test contract's `00` case stands in for the whole all-zeros class.
+
+### Strengths
+
+- ✅ The pass-1 substance is resolved: `numeric_key` traces clean across all named
+  edge cases, the numeric flood is genuinely killed, and the project-code case is
+  config-independent.
+- ✅ Tightly scoped and well-grounded — confines matching to `classify()` with no
+  struct/indexer/wire-shape change; the `numeric_key`/`classify` split keeps the
+  ranking logic pure and unit-testable in the imperative shell.
+- ✅ The cap-over-heuristics decision is the right least-surprise call and is
+  argued on architectural grounds, aligned with the existing `MAX_Q_LEN`
+  precedent; truncation after bucket ordering correctly protects exact/prefix
+  hits.
+- ✅ Tier placement is (mostly) pinned by relative ordering against an
+  adjacent-bucket competitor rather than presence — the correct mutation-resistant
+  technique, matching the existing `bucket_*` suite.
+- ✅ Negative, degenerate, and `None`-id cases are covered (items 6, 7, 8), and the
+  fixture-population guard (item 1) inverts the documented `seeded_cfg_with_work_items`
+  gotcha so a config regression names its own cause.
+- ✅ Doc-comment corrections (both the `classify()` function comment and the stale
+  `indexer.rs` struct comment, including its `Some`/`None` conditions) are quoted
+  in full and verified accurate against the population path.
+- ✅ Performance claim is accurate: the added cost is dwarfed by the pre-existing
+  full-snapshot clone, which the plan correctly leaves untouched.
+- ✅ Evolutionary direction for the deferred `external_id` (dedicated-field
+  successor + ladder refactor) and the `ExactSlug` overloading are documented
+  rather than left implicit.
+
+### Recommended Changes
+
+1. **Fix the prefix/interior tier-isolation tests to control mtime**
+   (addresses: "Item 4's prefix-isolation depends on an mtime tiebreak", "All-zeros
+   flood guard needs fixtures free of the query")
+   Have item 4 (and item 5) set both target and competitor to the *same*
+   `mtime_ms` via `common::set_mtime_ms`, so the `rel_path` tiebreak deterministically
+   fires and the deleted-`id_prefix`/`id_interior` mutation actually flips the
+   order. State this requirement in the contract.
+
+2. **Pin the non-numeric id prefix and interior branches**
+   (addresses: "Non-numeric `id_prefix`/`id_interior` branches are never pinned")
+   Add at least one non-numeric prefix-tier test (e.g. project-code config,
+   `q=eng-00` against `ENG-0042` + a body-only competitor, ordering asserted) and
+   ideally a non-numeric interior case, mirroring items 4–5.
+
+3. **Specify where the `numeric_key()` unit tests live**
+   (addresses: "`numeric_key()` unit tests cannot live in the integration crate")
+   State that they go in a new `#[cfg(test)] mod tests` inside `src/api/search.rs`
+   (same crate, can call the private helper), distinct from the integration
+   contract in `tests/api_search.rs`.
+
+4. **Correct the cap test's stated mutation guarantee**
+   (addresses: "Cap test does not distinguish truncate before vs after bucket
+   sorting", "Cap test couples to the literal value")
+   Either drop the "applied before bucket sorting" clause from the Success
+   Criteria, or add an assertion that exercises it (e.g. seed >`MAX_RESULTS`
+   Prefix hits plus some Interior hits and assert the truncated set is all
+   Prefix-tier). Reference the `MAX_RESULTS` constant rather than `50`.
+
+5. **Reconcile the frontend layer with the spec**
+   (addresses: "2-char gate makes single-digit matching unreachable", "a doc id
+   hint over-promises")
+   Reword the Desired End State and manual-verification steps to use 2+ character
+   examples (or note single-digit is server-only), and tighten the empty-state
+   copy to "a work item number" in the same PR.
+
+6. **Sharpen the cap and non-numeric documentation**
+   (addresses: "`MAX_RESULTS` silently changes the title/slug/body contract",
+   "Unpadded full-key `eng-42` silently misses")
+   State that the cap is general search-handler hardening (affects all query
+   paths), and add the `eng-42`-misses gap to "What We're NOT Doing" (or extend
+   the reduction to a CODE-prefixed query's trailing digit run).
+
+7. **Fold in the low-effort notes** (addresses: the suggestion cluster)
+   Per-field numeric-reduction policy for the `external_id` successor; the
+   index-side precompute trigger; the call-site ladder-refactor trigger; the
+   all-zeros generalisation note; and (optional) hoisting `q_is_num`/`id_q`.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Correctness
+
+**Summary**: The `classify()` sketch and `numeric_key()` helper are logically
+sound for the canonical id shapes guaranteed by `WorkItemConfig::normalise_id`
+(bare digits, `CODE-digits`, or foreign-prefix forms with the digit run always
+trailing), and the boolean ladder correctly handles the degenerate `00`→empty and
+`None`-id cases via the `id_active` guard. The numeric-vs-non-numeric matching
+split introduces a least-surprise asymmetry: unpadded tolerance exists only for
+purely-numeric queries, so an unpadded full key like `eng-42` silently matches
+nothing against `ENG-0042`. The `MAX_RESULTS` cap is applied correctly (after
+bucket concatenation, after `filter_map`) but silently changes title/slug/body
+result volume too.
+
+**Strengths**:
+- The `00`→empty / all-zeros degenerate case is correctly neutralised: id_q="",
+  id_active=false, every id_* boolean short-circuits — matched by flood test 7.
+- `numeric_key()`'s trailing-digit-run extraction is correct for every shape
+  `normalise_id` can produce, and the doc comment scopes the assumption and flags
+  the future-id-shape risk.
+- `take(MAX_RESULTS)` after `flatten().filter_map(project)` is correct: it counts
+  only successfully-projected rows and drops only the lowest-relevance tail.
+- `None`-id and empty-query preconditions are explicitly reasoned about; is_some_and
+  guards prevent any None/empty dereference.
+
+**Findings**:
+- 🔵 **minor** (high) — Unpadded full-key query (`eng-42`) silently matches nothing
+  against `ENG-0042`. *Location: Desired End State; Phase 1, Section 2.* The
+  non-numeric branch fails exact/prefix/interior; whether it matches depends on
+  how the id was stored. Document, or extend the reduction to a CODE-prefixed
+  query's trailing digit run.
+- 🔵 **minor** (high) — `MAX_RESULTS` silently changes existing title/slug/body
+  result volume, not just id matches. *Location: Phase 1, Section 4.* The cap is in
+  the shared projection chain; the "existing ranking unchanged" framing
+  under-states its scope.
+- 🔵 **minor** (medium) — `q_is_num` treats a single `0` query as numeric, making
+  it match no id. *Location: Phase 1, Section 2 — q_is_num.* Internally consistent
+  and bounded; note the `00` case generalises to all-zeros.
+- 🔵 **minor** (medium) — Project-code config diverges fixture filename id from the
+  stored `work_item_id`. *Location: Phase 1, Section 1, item 9.* Assert against the
+  normalised `ENG-0042`, not the filename form; add the population guard first.
+
+### Code Quality
+
+**Summary**: An unusually well-reasoned small change: it isolates the single
+defect site, threads the new logic through the existing bucket tiers, and
+documents its accepted trade-offs explicitly. The main code-quality risks are
+local readability ones — the dense `id_*` binding block packs a lot of
+conditional logic inline, and the exact/prefix/interior ladder is now tripled
+across title/slug/id (with `external_id` flagged as a future fourth copy), which
+the plan acknowledges but defers. Naming, helper extraction, doc-comment
+corrections, and testability are handled thoughtfully.
+
+**Strengths**:
+- The stale `IndexEntry.work_item_id` doc comment is correctly identified as wrong
+  on both counts and a concrete, verified replacement is supplied.
+- `numeric_key()` is extracted as a named, unit-tested helper with a doc comment
+  stating its assumption and failure mode.
+- Extends the existing bucket tiering in-place rather than building a separate id
+  path; the lazy `body_preview` lowercasing is preserved in the updated comment.
+- Accepted trade-offs are documented at their definition sites and in "What We're
+  NOT Doing".
+- `MAX_RESULTS` is justified by analogy to the existing `MAX_Q_LEN` cap.
+
+**Findings**:
+- 🔵 **minor** (medium) — The `id_*` binding block is dense and carries an
+  undocumented empty-guard asymmetry. *Location: Phase 1, Section 2.* Consider an
+  `id_bucket(id_lc, q_lc) -> Option<Bucket>` extraction (mirroring `numeric_key`),
+  or an inline comment on why `id_exact` need not re-check emptiness.
+- 🔵 **minor** (high) — The tripled matching ladder is a DRY smell the plan defers
+  acting on. *Location: What We're NOT Doing.* Defensible for this scope; make the
+  trigger explicit with a one-line note near `classify()` itself, not only in the
+  archived plan.
+- 🔵 **suggestion** (medium) — `MAX_RESULTS` test couples to the literal value the
+  plan calls non-contractual. *Location: Phase 1, Section 4 / item 10.* Reference
+  the constant and seed `MAX_RESULTS + N` via it.
+- 🔵 **suggestion** (low) — `id_q`/`q_is_num` are query-level facts computed in the
+  per-entry hot loop. *Location: Phase 1, Section 2.* Lean toward hoisting to the
+  handler for conceptual clarity.
+
+### Test Coverage
+
+**Summary**: The plan is unusually test-forward — a 10-item integration contract
+plus direct `numeric_key` unit tests, with most tiers pinned by relative ordering
+against an adjacent-bucket competitor rather than mere presence, the right
+mutation-resistant technique. However, several pins are weaker than claimed: the
+prefix-outranks-interior test relies on an mtime tiebreak the fixture never
+controls, the cap test does not distinguish the "truncate before vs after bucket
+sorting" mutation the Success Criteria assert, the non-numeric id prefix/interior
+branches are never exercised, and the "direct `numeric_key()` unit tests" cannot
+live where the plan implies because the helper is private to a separate test
+crate. Fixable contract refinements, not a flawed strategy.
+
+**Strengths**:
+- Tier placement is pinned by relative ordering against a deliberately-seeded
+  adjacent-bucket competitor (items 2–5, 9), matching the existing `bucket_*`
+  convention.
+- Item 1 (fixture-population guard) inverts the documented
+  `seeded_cfg_with_work_items` gotcha, surfacing config regressions by name.
+- The contract is explicit about red-before-green and enumerates specific
+  mutations to catch — a genuine mutation-testing attempt.
+- Negative (item 6), all-zeros flood (item 7), and `None`-id (item 8) cases all
+  guard real edge behaviours of the bare-numeric reduction.
+
+**Findings**:
+- 🟡 **major** (high) — Item 4's mutation-resistance depends on an mtime tiebreak
+  the fixture never pins. *Location: Phase 1, Section 1, item 4 + write_work_item.*
+  The within-bucket sort is `(Reverse(mtime), rel_path)`; sequential writes give
+  unequal mtimes, so a deleted `id_prefix` may not flip the order. Set both
+  fixtures to the same `mtime_ms` via `set_mtime_ms`.
+- 🟡 **major** (medium) — Cap test does not distinguish "truncate before vs after
+  bucket sorting" as the Success Criteria claim. *Location: Success Criteria +
+  item 10.* The single ExactSlug target lands at `results[0]` either way. Drop the
+  clause or add an assertion that exercises it.
+- 🟡 **major** (high) — Direct `numeric_key()`/`classify()` unit tests cannot live
+  in the integration test crate. *Location: Phase 1, Section 1, final paragraph.*
+  Both helpers are private; the tests would not compile from `tests/api_search.rs`.
+  Specify a `#[cfg(test)] mod tests` inside `search.rs`.
+- 🟡 **major** (high) — Non-numeric id prefix and interior branches are never
+  pinned. *Location: item 9 + classify() non-numeric branch.* Only the non-numeric
+  exact tier is tested; deleting/anchoring the prefix/interior branches ships
+  green. Add a non-numeric prefix (and ideally interior) tier test.
+- 🔵 **minor** (high) — All-zeros flood guard needs its fixtures' title/body
+  explicitly free of the query. *Location: item 7.* The absence assertion silently
+  also requires no field contains `00`; pin titles/bodies that exclude `00`/`0`.
+- 🔵 **minor** (medium) — Cap test couples to the `MAX_RESULTS` value and risks
+  tier bleed in the flood fixtures. *Location: item 10.* Reference the constant;
+  generate interior-only-matching keys.
+- 🔵 **suggestion** (medium) — No integration coverage of a foreign-prefix id
+  distinct from the configured project code. *Location: item 9.* Add an `OPS-7`
+  item under an `ENG` config, findable by `q=7` and `q=ops-7`.
+
+### Architecture
+
+**Summary**: A well-scoped, additive change that slots id matching into the
+existing four-bucket ranker without new structural seams, keeps the matching logic
+as pure testable functions in the imperative shell, and documents its tradeoffs
+and evolutionary direction thoroughly. The two genuine architectural decisions —
+bounding output via `MAX_RESULTS` rather than gating input via heuristics, and
+deferring `external_id` to a dedicated-field successor with a ladder refactor —
+are sound and explicitly justified. The main observations are that the cap is a
+cross-cutting behavioural change to the whole search contract bundled into an id
+fix, and that the documented `external_id` successor will inherit a numeric-key
+generalisation problem the plan should name now.
+
+**Strengths**:
+- Additive design reusing the existing tiering rather than a new bucket or
+  per-type id path — minimal new structure, consistent with 0054.
+- Clean functional-core / imperative-shell separation: `numeric_key()`/`classify()`
+  pure and unit-testable; the volume cap in the handler.
+- Evolutionary direction for `external_id` explicitly documented (dedicated-field
+  option, candidate-field ladder refactor).
+- The cap-vs-heuristics tradeoff is argued on architectural grounds and aligned
+  with the `MAX_Q_LEN` precedent.
+- Boundary-touching tradeoffs are each surfaced in "What We're NOT Doing".
+
+**Findings**:
+- 🔵 **minor** (high) — `MAX_RESULTS` is a cross-cutting search-contract change
+  bundled into an id-matching fix. *Location: Phase 1, Section 4.* It truncates
+  every query path, not just id floods — a 0054 contract shift. Call out the
+  general scope; optionally land it as its own revertable commit.
+- 🔵 **minor** (medium) — The documented `external_id` successor inherits a
+  numeric-key cross-field generalisation hazard. *Location: What We're NOT Doing.*
+  `numeric_key` assumes the work-item id shape; iterating candidate fields would
+  let a numeric query collide across fields. Flag the need for a per-field policy.
+- 🔵 **suggestion** (high) — Query-side `numeric_key` is right now; record the
+  index-side trigger condition. *Location: Implementation Approach.* Tie the
+  boundary move to eliminating the per-query clone or multiplying id fields.
+- 🔵 **suggestion** (high) — `ExactSlug` overloading is acceptable but weakens
+  domain alignment. *Location: What We're NOT Doing.* Fine to ship; fold a rename
+  into the future `external_id` ladder refactor that already touches these
+  branches.
+
+### Performance
+
+**Summary**: The Performance Considerations section is accurate and appropriately
+proportionate for the stated scale (a search ranker over an in-memory snapshot of
+hundreds to low-thousands of local entries). It correctly identifies the
+pre-existing full-snapshot clone as the only meaningful per-query cost, leaves it
+untouched, and honestly flags the per-entry recompute of numeric-query state as a
+readability-not-performance choice. The new work adds negligible cost and the cap
+is a net positive for broad-match payloads.
+
+**Strengths**:
+- Correctly identifies the dominant per-query cost (`state.indexer.all()` clones
+  every `IndexEntry` including the frontmatter blob) and rightly leaves it out of
+  scope.
+- The lazy `body_preview` lowercasing optimisation is preserved in the new sketch.
+- `MAX_RESULTS` is applied via `.take()` after `filter_map(project)`, genuinely
+  bounding `project()` clones and JSON serialisation for broad-match queries.
+- `numeric_key()` and the `q_is_num`/`id_q` derivation are borrowed-`&str` scans
+  over the short query with no heap allocation.
+- Honest about the recompute tradeoff, framing the hoist as clarity not a win.
+
+**Findings**:
+- 🔵 **suggestion** (high) — Per-entry recompute of `q_is_num`/`id_q` is correct to
+  note but trivially hoistable. *Location: Performance Considerations; Phase 1,
+  Section 2.* Both are loop invariants; hoisting removes them at zero behavioural
+  cost.
+- 🔵 **suggestion** (high) — `id_lc` lowercasing allocates only for the sparse
+  populated subset, not every entry. *Location: Performance Considerations.* Tighten
+  the wording to "per id-bearing work item".
+- 🔵 **minor** (medium) — `MAX_RESULTS` bounds payload/serialisation but not the
+  snapshot clone, per-entry lowercasing, or the matched-set sort. *Location:
+  Performance Considerations.* A bare-code flood still does O(corpus) work before
+  truncation; note the cap bounds the response, not per-query CPU.
+
+### Usability
+
+**Summary**: The plan delivers a genuine DX win — making work-item numbers
+findable closes a long-standing least-surprise gap. The accepted-tradeoff framing
+is mostly honest and well-reasoned (the cap over matching heuristics is the right
+least-surprise call). However, the plan reasons about the search experience almost
+entirely at the server/ranking layer and under-weights the frontend gate and
+result-row presentation: a 2-character min-length gate makes part of the
+documented interior fan-out and a manual-verification step unreachable, and the
+"invisible matched id" is sharper than the plan implies because the row never
+displays the id anywhere, so an id-matched row gives zero feedback about why it
+matched.
+
+**Strengths**:
+- Closes a real least-surprise defect: typing a work item's number now works.
+- Unpadded/config-independent numeric matching matches how developers refer to
+  items.
+- Choosing a general volume cap over per-field gating is the right least-surprise
+  call and is documented.
+- Bucket-ordered truncation guarantees exact/prefix hits are never dropped.
+- Reuses the existing tiering rather than a parallel ranking concept.
+
+**Findings**:
+- 🟡 **major** (high) — Frontend 2-char min-length gate makes single-digit interior
+  matching unreachable. *Location: Desired End State + Manual Verification.*
+  `use-search.ts` only searches at `length >= 2`; the single-digit examples and
+  manual step can never trigger through the UI.
+- 🟡 **major** (high) — Id-matched rows give zero feedback about why they matched.
+  *Location: What We're NOT Doing.* The row's title highlight no-ops and the
+  sub-line shows the slug tail (after the id), so the typed number appears nowhere.
+  Decision to defer stands, but the framing understates the gap.
+- 🔵 **minor** (high) — "a doc id" empty-state hint over-promises for `None`-id doc
+  types. *Location: What We're NOT Doing — frontend copy.* Tighten to "a work item
+  number" in the same PR (one string + snapshot).
+- 🔵 **minor** (medium) — Bare-project-code query returns a bounded but
+  undifferentiated, silently-capped wall. *Location: Desired End State.* Consider
+  signalling truncation in the match-count row; low priority.
+- 🔵 **minor** (medium) — All-zeros query silently returns nothing with no
+  actionable feedback. *Location: Desired End State.* Falls through to the generic
+  "No matches"; acceptable, just note it is intentionally indistinguishable from a
+  normal miss.
+
+## Re-Review (Pass 2) — 2026-06-23T08:55:02+00:00
+
+**Verdict:** COMMENT
+
+The pass-1 (review-2) edits resolve the substance across all five re-run lenses.
+Correctness traced the new `eng-42` gap, the `MAX_RESULTS` hardening note, the
+all-zeros generalisation, and item 9's normalised-id assertion all clean, with no
+new defects. Architecture and code-quality confirmed the new notes are sound and
+internally consistent. Test-coverage confirmed the four major test-contract fixes
+(item 4 mtime control, in-module `numeric_key` tests, the honest cap Success
+Criteria, the constant-referencing cap fixtures) — **but caught one real defect
+the edits introduced**: the new item 11 prescribed an interior-only competitor
+*whose id contains but does not start with `eng-00`*, which is not constructible
+(every normalised id is `eng-<digits>`, so `eng-00` can only occur at offset 0).
+That single major was fixed in a follow-up edit (competitor now interior-matches
+via a non-id field), along with the related clarity/consistency items. With one
+major (now resolved) the verdict is COMMENT; after the follow-up edits the plan
+has no outstanding actionable findings and is implementation-ready.
+
+### Previously Identified Issues
+
+- 🟡 **Test Coverage**: Item 4's prefix-isolation depended on an unpinned mtime
+  tiebreak — **Resolved**. The "mtime control" subsection + explicit
+  `set_mtime_ms` requirement make the `rel_path` tiebreak load-bearing; mechanism
+  verified sound (`0014-zzz` sorts before `0042`).
+- 🟡 **Test Coverage**: Non-numeric `id_prefix`/`id_interior` branches unpinned —
+  **Resolved** (items 11/12 added), though item 11 as first written was not
+  constructible — see New Issues; now fixed.
+- 🟡 **Test Coverage**: `numeric_key()` unit tests couldn't compile in the
+  integration crate — **Resolved**. In-module `#[cfg(test)] mod tests` in
+  `search.rs` now specified, with a note not to widen visibility.
+- 🟡 **Test Coverage**: Cap test couldn't distinguish truncate-before-vs-after
+  sorting — **Resolved**. Success Criteria now candid; optional order-pinning
+  assertion added (with an observability marker convention).
+- 🟡 **Usability**: 2-char gate made single-digit matching unreachable —
+  **Resolved**. Manual step now uses a 2+ char query and notes the `use-search.ts`
+  gate; remaining single-digit mentions are correctly server-side flood-vector
+  descriptions.
+- 🟡 **Usability**: Matched id invisible in the result row — **Accepted/Resolved**
+  (deferral decision taken; documented as an accepted rough edge with a follow-up
+  pointer).
+- 🔵 **Correctness**: `eng-42` silently misses — **Resolved** (documented as a
+  known gap; the prose, including the unpadded-`ENG-42` subtlety, traced correct).
+- 🔵 **Correctness/Architecture**: `MAX_RESULTS` changes the all-query contract —
+  **Resolved** (general-hardening note added; accurate).
+- 🔵 **Correctness**: single-`0`/all-zeros no-op — **Resolved** (generalisation
+  documented).
+- 🔵 **Test Coverage**: item 7 fixtures / item 9 normalised-id assertion / cap
+  constant-coupling — **Resolved**.
+- 🔵 **Code Quality**: dense `id_*` block, call-site refactor trigger, hoist —
+  **Resolved** (implementer-notes block added).
+- 🔵 **Architecture**: `external_id` per-field policy, index-side trigger,
+  ExactSlug rename window — **Resolved** (notes added; rename folded into the
+  refactor scope).
+
+### New Issues Introduced (and addressed)
+
+- 🟡 **major** (Test Coverage, high) — **Item 11's interior-only id competitor was
+  not constructible** (`eng-00` can only be a prefix of an `eng-<digits>` id).
+  *Fixed*: the competitor now interior-matches `eng-00` via a non-id field (title),
+  with an id that doesn't prefix-match, and the same-mtime/`rel_path` flip
+  mechanism stated.
+- 🔵 **minor** (Test Coverage, high) — Item 12's "Prefix competitor on the same
+  fragment" cannot be id-based. *Fixed*: now specifies the competitor prefix-matches
+  via title/slug.
+- 🔵 **minor** (Test Coverage, medium) — The red/green Success-Criteria bullet
+  still said "items 1–10", omitting 11/12. *Fixed*: now "items 1–12".
+- 🔵 **minor** (Test Coverage, low) — The optional cap-order assertion lacked a
+  tier-observability mechanism. *Fixed*: added a slug/title marker convention.
+- 🔵 **minor** (Usability, medium) — The widened cap's truncation is unsignalled at
+  the UI meta-row. *Fixed*: documented as an accepted rough edge with a follow-up
+  pointer.
+- 🔵 **minor** (Code Quality, high) — The hoist was recommended more strongly in the
+  implementer note than in Performance Considerations. *Fixed*: softened to
+  "optionally" and cross-referenced.
+
+### Assessment
+
+The plan is implementation-ready. All review-2 findings are resolved, and the one
+genuine defect introduced during iteration (item 11's non-constructible fixture)
+was caught by the re-review and fixed. No outstanding majors. The remaining
+deferred items (id surfacing, empty-state copy, UI truncation indicator) are
+explicitly recorded as accepted rough edges with follow-up pointers, not silent
+gaps.
+
+---
+*Re-review generated by /accelerator:review-plan*

--- a/meta/work/0125-visualiser-search-id-matching.md
+++ b/meta/work/0125-visualiser-search-id-matching.md
@@ -1,0 +1,127 @@
+---
+type: work-item
+id: "0125"
+title: "Visualiser Search Does Not Match Work Item IDs"
+date: "2026-06-22T15:30:57+00:00"
+author: Phil Helm
+producer: create-work-item
+status: draft
+kind: bug
+priority: medium
+relates_to: ["work-item:0054"]
+tags: [visualiser, search]
+last_updated: "2026-06-22T15:42:00+00:00"
+last_updated_by: Phil Helm
+schema_version: 1
+---
+
+# 0125: Visualiser Search Does Not Match Work Item IDs
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Phil Helm
+
+## Summary
+
+Typing a work item's number into the visualiser sidebar search box returns
+"No matches", even when that item exists. The search backend ranks entries
+only on title, slug, and body preview — it never consults the item's ID — so
+no ID query can ever match.
+
+## Context
+
+Work item 0054 ("Sidebar Search Input and API Search Endpoint") built the
+`GET /api/search` endpoint and its four-bucket ranking. 0054 explicitly
+decided (its design notes, line 121) that "search work items by ID" would be
+served by the exact-slug bucket — "typing `0054` puts work item 0054 at the
+top" — without a dedicated ID-aware code path.
+
+That decision does not hold in practice: a work item's slug is the filename
+tail *after* the ID (`0054-sidebar-search.md` → slug `sidebar-search`), so the
+bare ID is absent from every field the ranker inspects. The ID lives in a
+separate `work_item_id` field on the index entry (derived from frontmatter
+`id:`), which `classify()` never reads. This is a gap against 0054's
+stated-but-non-functional behaviour, not a new capability.
+
+The empty-results panel compounds the confusion: it advises users to "Try a
+slug, a fragment of a title, or a doc id" — but a doc id is exactly what the
+backend cannot match.
+
+## Requirements
+
+Reproduction:
+1. Open the visualiser with at least one work item present (e.g. `id: 0054`).
+2. Focus the sidebar search box and type the work item's number (`0054`).
+
+Expected: the matching work item appears in the results.
+Actual: the panel shows "No matches".
+
+The fix must:
+- Match the query against the entry's `work_item_id` (local `id`), in addition
+  to the existing title / slug / body-preview fields.
+- Apply the same exact / prefix / interior tiering already used for the slug,
+  so an exact ID ranks at the top, a prefix matches, and an interior substring
+  matches (typing `42` finds `0042`).
+- Not change the existing ranking behaviour for title / slug / body matches.
+
+## Acceptance Criteria
+
+- [ ] Given a work item `id: "0042"`, when I search `0042`, then it appears in
+      the results (ranked in the top/exact bucket).
+- [ ] Given a work item `id: "0042"`, when I search `42`, then it appears
+      (interior substring match against the zero-padded id).
+- [ ] Given a query that matches no id, title, slug, or body, then the panel
+      still shows "No matches" (no false positives).
+- [ ] All existing `/api/search` ranking and exclusion tests continue to pass
+      (no regression to bucket ordering or template exclusion).
+
+## Open Questions
+
+- None outstanding — scope confirmed (local work item `id` only).
+  `external_id`/tracker-key matching, tags, type-scoping, and a results view are
+  deferred to a future, currently-untracked advanced-search work item.
+
+## Dependencies
+
+- Relates to: 0054 (origin of the search endpoint and the non-functional
+  design decision this fixes).
+
+## Assumptions
+
+- "Work item number" means the `id` frontmatter field (surfaced by the indexer
+  as `work_item_id`), matched as a string with substring tolerance rather than
+  numeric equality.
+
+## Technical Notes
+
+- Root cause is in `classify()` at
+  [`skills/visualisation/visualise/server/src/api/search.rs`](../../skills/visualisation/visualise/server/src/api/search.rs)
+  — it inspects `title`, `slug`, and `body_preview` only.
+- `IndexEntry.work_item_id` is already populated on the entry from the
+  frontmatter `id:` key (see `indexer.rs`), so the fix is additive to the
+  existing bucketing — no struct or indexer change needed.
+- Two implementation options for the plan to weigh: (a) extend `classify()` to
+  consult `work_item_id`; (b) change work-item slug derivation to include the
+  bare ID so the exact-slug bucket works as 0054 intended. Option (a) is
+  preferred — explicit and does not alter slugs used elsewhere.
+- `external_id` was considered and explicitly dropped from this work item: it is
+  not currently an indexed field (it lives only in the frontmatter blob), so
+  matching it needs new plumbing that belongs with the broader advanced-search
+  effort, not this bug fix.
+
+## Drafting Notes
+
+- Classified as a bug (not a feature) because it is a gap against 0054's
+  documented intent.
+- Confirmed with the requester: match scope is `work_item_id` only.
+  `external_id`/tracker-key matching was dropped because it is not an indexed
+  field and would require new plumbing; tags and broader "advanced search"
+  (type-scoping, dedicated results view, sort, faceting) are out of scope. All
+  are deferred to a future, currently-untracked advanced-search work item.
+
+## References
+
+- Related: 0054 (`meta/work/0054-sidebar-search.md`)
+- Advanced-search enhancement (type-scoping / results view / sort / tag search)
+  is currently untracked — a separate work item is being created to capture it.

--- a/skills/visualisation/visualise/server/src/api/search.rs
+++ b/skills/visualisation/visualise/server/src/api/search.rs
@@ -18,6 +18,12 @@ use crate::server::AppState;
 /// whitespace cannot be used to pad past the cap.
 const MAX_Q_LEN: usize = 128;
 
+/// Hard cap on returned rows. Bounds the response for broad-match queries (a
+/// short fragment can match many entries); applied after bucket ordering so
+/// only the lowest-relevance tail is dropped, never an exact/prefix hit. The
+/// value is a generous backstop, not a wire contract beyond "bounded".
+const MAX_RESULTS: usize = 50;
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct SearchQuery {
     #[serde(default)]
@@ -41,35 +47,82 @@ pub(crate) struct SearchResponse {
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Bucket {
+    /// Exact-identity tier: an exact slug **or** an exact `work_item_id`
+    /// (numeric-reduced for numeric queries — see `classify`).
     ExactSlug = 0,
     Prefix = 1,
     Interior = 2,
     Body = 3,
 }
 
+/// Bare numeric form of an id, used for padding-tolerant numeric matching:
+/// leading non-digit prefix and leading zeros stripped.
+/// `"0042"` -> `"42"`, `"eng-0042"` -> `"42"`, `"0000"`/`""` -> `""`.
+/// Assumes the normalised-id shape from `WorkItemConfig::normalise_id` — bare
+/// digits or `CODE-digits` with an alphabetic prefix — so the digits are the
+/// trailing run; a future id shape with digits elsewhere would mis-key.
+fn numeric_key(id_lc: &str) -> &str {
+    id_lc
+        .rsplit(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or("")
+        .trim_start_matches('0')
+}
+
 /// Classify a single entry into a ranking bucket against the lowercased query.
 /// Returns `None` when no field matches.
 ///
-/// Performance: title and slug are short and lowercased eagerly; `body_preview`
-/// is lowercased only after the title/slug paths fail, avoiding the largest
-/// allocation in the common case where matches come from title/slug.
+/// Matched fields: `title`, `slug`, `work_item_id`, then (lazily)
+/// `body_preview`. `title`, `slug` and `work_item_id` are short and lowercased
+/// eagerly; `body_preview` is lowercased only on the fall-through path, avoiding
+/// the largest allocation when matches come from the cheaper fields.
+///
+/// `work_item_id` matching: a purely-numeric query is compared against the id's
+/// bare numeric form (see `numeric_key`), so `42`/`0042` exactly match
+/// `0042`/`ENG-0042` and `00` (which reduces to empty) matches nothing; any
+/// other query substring-matches the full lowercased id (so `eng-0042` matches
+/// `ENG-0042`).
+///
+/// If a third matchable id field is added (e.g. `external_id`), refactor to
+/// iterate candidate id fields per tier with a per-field numeric-reduction
+/// policy, rather than hand-copying this block a third time.
 fn classify(entry: &IndexEntry, q_lc: &str) -> Option<Bucket> {
     let title_lc = entry.title.to_ascii_lowercase();
     let slug_lc = entry.slug.as_deref().map(str::to_ascii_lowercase);
+    let id_lc = entry.work_item_id.as_deref().map(str::to_ascii_lowercase);
 
-    if let Some(s) = slug_lc.as_deref() {
-        if s == q_lc {
-            return Some(Bucket::ExactSlug);
-        }
+    // For a numeric query, compare query and id in bare numeric form; otherwise
+    // compare against the full lowercased id. A numeric query of all zeros
+    // reduces to empty and must match no id (`id_active` guards that). `q_lc` is
+    // non-empty here (the handler rejects empty/whitespace queries).
+    let q_is_num = q_lc.bytes().all(|b| b.is_ascii_digit());
+    let id_q: &str = if q_is_num {
+        q_lc.trim_start_matches('0')
+    } else {
+        q_lc
+    };
+    let id_cmp: Option<&str> =
+        id_lc
+            .as_deref()
+            .map(|id| if q_is_num { numeric_key(id) } else { id });
+    let id_active = !id_q.is_empty();
+    let id_exact = id_active && id_cmp == Some(id_q);
+    let id_prefix = id_active
+        && id_cmp.is_some_and(|id| !id.is_empty() && id.starts_with(id_q));
+    let id_interior = id_active
+        && id_cmp.is_some_and(|id| !id.is_empty() && id.contains(id_q));
+
+    if slug_lc.as_deref() == Some(q_lc) || id_exact {
+        return Some(Bucket::ExactSlug);
     }
     let title_prefix = title_lc.starts_with(q_lc);
     let slug_prefix = slug_lc.as_deref().is_some_and(|s| s.starts_with(q_lc));
-    if title_prefix || slug_prefix {
+    if title_prefix || slug_prefix || id_prefix {
         return Some(Bucket::Prefix);
     }
     let title_interior = title_lc.contains(q_lc);
     let slug_interior = slug_lc.as_deref().is_some_and(|s| s.contains(q_lc));
-    if title_interior || slug_interior {
+    if title_interior || slug_interior || id_interior {
         return Some(Bucket::Interior);
     }
     let body_lc = entry.body_preview.to_ascii_lowercase();
@@ -132,7 +185,25 @@ pub(crate) async fn search(
         .into_iter()
         .flatten()
         .filter_map(|e| project(&e))
+        .take(MAX_RESULTS)
         .collect();
 
     Ok(Json(SearchResponse { results }).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numeric_key_reduces_to_bare_trailing_digit_run() {
+        assert_eq!(numeric_key("0042"), "42");
+        assert_eq!(numeric_key("eng-0042"), "42");
+        // normalise_id passes foreign prefixes through unpadded.
+        assert_eq!(numeric_key("ops-7"), "7");
+        assert_eq!(numeric_key("0000"), "");
+        assert_eq!(numeric_key(""), "");
+        // No digits at all reduces to empty.
+        assert_eq!(numeric_key("abc"), "");
+    }
 }

--- a/skills/visualisation/visualise/server/src/indexer.rs
+++ b/skills/visualisation/visualise/server/src/indexer.rs
@@ -164,9 +164,10 @@ pub struct IndexEntry {
     pub path: PathBuf,
     pub rel_path: PathBuf,
     pub slug: Option<String>,
-    /// Filename-derived work-item ID (via the configured scan regex).
-    /// `Some(id)` when the entry is a work-item and the filename matches;
-    /// `None` for non-work-item types or unmatched filenames.
+    /// Work-item identity, read from the frontmatter `id:` key and normalised
+    /// via `WorkItemConfig::normalise_id`. `Some(id)` only when the entry is a
+    /// work item whose frontmatter carries an `id:`; `None` for non-work-item
+    /// types and for work items lacking a frontmatter `id:`.
     pub work_item_id: Option<String>,
     pub title: String,
     pub frontmatter: serde_json::Value,

--- a/skills/visualisation/visualise/server/tests/api_search.rs
+++ b/skills/visualisation/visualise/server/tests/api_search.rs
@@ -428,3 +428,503 @@ async fn mixed_case_query_and_field_classify_correctly() {
         .iter()
         .any(|r| r["slug"].as_str() == Some("foo-bar")));
 }
+
+// --- work_item_id matching (work item 0125) ---------------------------------
+
+/// Write a work-item fixture. `filename_stem` is the file name without `.md`
+/// (must begin with `<digits>-` so a slug derives), and `id` is the optional
+/// frontmatter `id:` value — `None` omits the key so the entry's
+/// `work_item_id` is `None`. Filename and frontmatter id are decoupled so the
+/// project-code tests can pin a specific `rel_path` ordering independent of the
+/// stored id.
+fn write_work_item(
+    dir: &Path,
+    filename_stem: &str,
+    id: Option<&str>,
+    title: &str,
+    body: &str,
+) -> std::path::PathBuf {
+    let id_line = id.map(|v| format!("id: \"{v}\"\n")).unwrap_or_default();
+    let content = format!("---\n{id_line}title: \"{title}\"\n---\n{body}\n");
+    let path = dir.join(format!("{filename_stem}.md"));
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+fn result_slugs(v: &serde_json::Value) -> Vec<String> {
+    v["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["slug"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+fn slug_pos(v: &serde_json::Value, slug: &str) -> Option<usize> {
+    result_slugs(v).iter().position(|s| s == slug)
+}
+
+// Item 1: guards the load-bearing assumption (inverse of the
+// `seeded_cfg_with_work_items` gotcha): a fixture carrying `id:` populates
+// `work_item_id`. If this regresses, it names the real cause rather than
+// letting the search assertions fail opaquely.
+#[tokio::test]
+async fn work_item_id_fixture_is_populated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let snapshot = state.indexer.all().await;
+    let entry = snapshot
+        .iter()
+        .find(|e| e.slug.as_deref() == Some("login-form"))
+        .expect("fixture entry must be indexed");
+    assert_eq!(entry.work_item_id.as_deref(), Some("0042"));
+}
+
+// Item 2: an exact id match outranks a body hit on the same query.
+#[tokio::test]
+async fn work_item_id_exact_ranks_above_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    // Competitor: body contains 0042 -> Body bucket only.
+    write_work_item(
+        &work,
+        "0099-other",
+        Some("0099"),
+        "Other thing",
+        "mentions 0042 inline",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=0042", state).await;
+    assert_eq!(
+        v["results"][0]["slug"].as_str(),
+        Some("login-form"),
+        "exact id must outrank a body hit; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 3: an unpadded numeric query (`42`) reduces to the same numeric key as
+// `0042` and ranks exact (above a body-only competitor).
+#[tokio::test]
+async fn unpadded_numeric_query_is_exact() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    write_work_item(
+        &work,
+        "0099-other",
+        Some("0099"),
+        "Other thing",
+        "ref 42 here",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=42", state).await;
+    assert_eq!(
+        v["results"][0]["slug"].as_str(),
+        Some("login-form"),
+        "unpadded `42` must exact-match `0042`; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 4: prefix outranks interior, isolating the numeric `id_prefix` branch.
+// Query `004` reduces to `4`; target `0042` -> key `42` (prefix-matches `4`),
+// competitor `0014` -> key `14` (interior-matches `4`). Mtimes pinned equal so
+// the within-bucket `rel_path` tiebreak (competitor `0014-…` sorts first)
+// flips the order if `id_prefix` is deleted.
+#[tokio::test]
+async fn work_item_id_prefix_outranks_interior() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    let target = write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    let competitor = write_work_item(
+        &work,
+        "0014-zzz",
+        Some("0014"),
+        "Some thing",
+        "# body",
+    );
+    common::set_mtime_ms(&target, 5_000_000).unwrap();
+    common::set_mtime_ms(&competitor, 5_000_000).unwrap();
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=004", state).await;
+    let tp = slug_pos(&v, "login-form").expect("target must be returned");
+    let cp = slug_pos(&v, "zzz").expect("competitor must be returned");
+    assert!(
+        tp < cp,
+        "prefix (target) must outrank interior (competitor); got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 5: interior is returned but ranks below a prefix competitor, isolating
+// the numeric `id_interior` branch. Query `2`; target `0042` -> key `42`
+// (interior-matches `2`), competitor `0020` -> key `20` (prefix-matches `2`).
+// Deleting `id_interior` drops the target to Body (no body match) so it
+// disappears, failing the "target returned" assertion.
+#[tokio::test]
+async fn work_item_id_interior_outranks_nothing_but_below_prefix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    write_work_item(&work, "0020-aaa", Some("0020"), "Some thing", "# body");
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=2", state).await;
+    let tp = slug_pos(&v, "login-form").expect("target must be returned");
+    let cp = slug_pos(&v, "aaa").expect("prefix competitor must be returned");
+    assert!(
+        cp < tp,
+        "prefix competitor must outrank interior target; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 6 (negative): a numeric query absent from the id's numeric key matches
+// nothing.
+#[tokio::test]
+async fn numeric_query_does_not_match_unrelated_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=0099", state).await;
+    assert!(
+        slug_pos(&v, "login-form").is_none(),
+        "0099 must not match 0042; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 7 (flood guard): `00` reduces to the empty numeric key and must match no
+// id. Titles/bodies are deliberately free of the substring `00`, so this
+// asserts specifically the `id_active` empty-key branch (not incidental field
+// contents).
+#[tokio::test]
+async fn all_zero_query_does_not_flood() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    write_work_item(
+        &work,
+        "0001-todo-item",
+        Some("0001"),
+        "Todo item",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=00", state).await;
+    assert!(
+        slug_pos(&v, "login-form").is_none()
+            && slug_pos(&v, "todo-item").is_none(),
+        "all-zero query must match no id; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 8: a `None`-id entry (no `id:` key) is never matched by a number, and
+// the query does not panic.
+#[tokio::test]
+async fn none_id_entry_is_not_matched_by_number() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+    // No `id:` key -> work_item_id None; content free of the query digits.
+    write_work_item(&work, "0050-plain-item", None, "Plain item", "# body");
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=42", state).await;
+    assert!(
+        slug_pos(&v, "login-form").is_some(),
+        "id-bearing item must match"
+    );
+    assert!(
+        slug_pos(&v, "plain-item").is_none(),
+        "None-id entry must not match a number; got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 9: under a project-code config the numeric tail and the full case-folded
+// key both match, config-independently. Asserts the wiring (work_item_id ==
+// `ENG-0042`) first so a config->work_item_id regression is named explicitly.
+#[tokio::test]
+async fn project_code_config_matches_numeric_and_full_key() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg_project_code(tmp.path(), "ENG");
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    // Filename stays 0042-…; normalisation prepends the code -> ENG-0042.
+    write_work_item(
+        &work,
+        "0042-login-form",
+        Some("0042"),
+        "Login form",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+
+    let snapshot = state.indexer.all().await;
+    let entry = snapshot
+        .iter()
+        .find(|e| e.slug.as_deref() == Some("login-form"))
+        .expect("fixture entry must be indexed");
+    assert_eq!(
+        entry.work_item_id.as_deref(),
+        Some("ENG-0042"),
+        "project code must be wired into work_item_id"
+    );
+
+    for q in ["42", "eng-0042", "0042"] {
+        let uri = format!("/api/search?q={q}");
+        let v = fetch_search(&uri, state.clone()).await;
+        assert!(
+            slug_pos(&v, "login-form").is_some(),
+            "q={q} must surface the item; got {:?}",
+            result_slugs(&v)
+        );
+    }
+}
+
+// Item 9 sibling: a foreign-prefixed id distinct from the configured code
+// (`OPS-7` under an `ENG` config) is stored verbatim by normalise_id and is
+// reachable by both its numeric tail and its full key.
+#[tokio::test]
+async fn foreign_prefixed_id_matches_under_project_code() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg_project_code(tmp.path(), "ENG");
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0007-ops-task",
+        Some("OPS-7"),
+        "Ops task",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+
+    let snapshot = state.indexer.all().await;
+    let entry = snapshot
+        .iter()
+        .find(|e| e.slug.as_deref() == Some("ops-task"))
+        .expect("fixture entry must be indexed");
+    assert_eq!(entry.work_item_id.as_deref(), Some("OPS-7"));
+
+    for q in ["7", "ops-7"] {
+        let uri = format!("/api/search?q={q}");
+        let v = fetch_search(&uri, state.clone()).await;
+        assert!(
+            slug_pos(&v, "ops-task").is_some(),
+            "q={q} must surface OPS-7; got {:?}",
+            result_slugs(&v)
+        );
+    }
+}
+
+// Item 10: the result set is capped at MAX_RESULTS, applied after bucket
+// sorting so the lone exact hit survives at the top. (50 == api::search::
+// MAX_RESULTS, kept in sync; the value is not a wire contract.)
+#[tokio::test]
+async fn results_are_capped_and_preserve_top_hits() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg(tmp.path());
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    // Exact target: numeric_key("0007") == "7".
+    write_work_item(
+        &work,
+        "0007-exact-target",
+        Some("0007"),
+        "Exact target",
+        "# body",
+    );
+    // 55 interior-only entries: ids 1700..=1754 -> keys "17XX", each contains
+    // `7` interiorly (never as a prefix, never exact), so none perturbs the top.
+    for i in 0..55u32 {
+        let id = (1700 + i).to_string();
+        let stem = format!("{id}-flood-item");
+        write_work_item(&work, &stem, Some(&id), "Flood item", "# body");
+    }
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=7", state).await;
+    let results = v["results"].as_array().unwrap();
+    assert_eq!(
+        results.len(),
+        50,
+        "result set must be capped at MAX_RESULTS"
+    );
+    assert_eq!(
+        results[0]["slug"].as_str(),
+        Some("exact-target"),
+        "exact hit must survive truncation at the top"
+    );
+}
+
+// Item 11 (non-numeric prefix branch): under a project-code config, `eng-00`
+// prefix-matches `ENG-0042`'s full key. The competitor interior-matches via a
+// *title* (`releng-00x`), not its id (`ENG-7777`). Mtimes pinned equal and the
+// competitor's rel_path (`0001-…`) sorts first, so deleting the non-numeric
+// `id_prefix` branch (which leaves the target in Interior via id_interior)
+// flips the order.
+#[tokio::test]
+async fn non_numeric_id_prefix_outranks_interior() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg_project_code(tmp.path(), "ENG");
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    let target = write_work_item(
+        &work,
+        "0042-target",
+        Some("0042"),
+        "Target item",
+        "# body",
+    );
+    // Filename 0001-… (sorts first); id ENG-7777 (no eng-00 match); title
+    // interior-matches eng-00.
+    let competitor = write_work_item(
+        &work,
+        "0001-comp",
+        Some("ENG-7777"),
+        "releng-00x competitor",
+        "# body",
+    );
+    common::set_mtime_ms(&target, 5_000_000).unwrap();
+    common::set_mtime_ms(&competitor, 5_000_000).unwrap();
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=eng-00", state).await;
+    let tp = slug_pos(&v, "target").expect("target must be returned");
+    let cp = slug_pos(&v, "comp").expect("competitor must be returned");
+    assert!(
+        tp < cp,
+        "non-numeric prefix (target) must outrank interior (competitor); got {:?}",
+        result_slugs(&v)
+    );
+}
+
+// Item 12 (non-numeric interior branch): `ng-00` interior-matches `ENG-0042`
+// but is not a prefix of it. The competitor's Prefix placement comes from its
+// *title* (`ng-00 …`), not its id. Cross-bucket (Interior < Prefix), robust to
+// mtime. Deleting the non-numeric `id_interior` branch drops the target to Body
+// (no body match), so it disappears.
+#[tokio::test]
+async fn non_numeric_id_interior_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = common::seeded_cfg_project_code(tmp.path(), "ENG");
+    let work = tmp.path().join("meta/work");
+    std::fs::create_dir_all(&work).unwrap();
+    write_work_item(
+        &work,
+        "0042-target",
+        Some("0042"),
+        "Target item",
+        "# body",
+    );
+    write_work_item(
+        &work,
+        "0001-comp",
+        Some("ENG-7777"),
+        "ng-00 competitor",
+        "# body",
+    );
+
+    let activity = Arc::new(Activity::new());
+    let state = AppState::build(cfg, activity).await.unwrap();
+    let v = fetch_search("/api/search?q=ng-00", state).await;
+    let tp = slug_pos(&v, "target").expect("target must be returned");
+    let cp = slug_pos(&v, "comp").expect("prefix competitor must be returned");
+    assert!(
+        cp < tp,
+        "prefix competitor must outrank interior target; got {:?}",
+        result_slugs(&v)
+    );
+}

--- a/skills/visualisation/visualise/server/tests/common/mod.rs
+++ b/skills/visualisation/visualise/server/tests/common/mod.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use accelerator_visualiser::config::{Config, TemplateTiers};
+use accelerator_visualiser::config::{
+    Config, RawWorkItemConfig, TemplateTiers,
+};
 
 // Shared helper compiled into every integration test binary; only some use
 // it, so binaries that don't would otherwise flag it as dead code.
@@ -137,5 +139,19 @@ pub fn seeded_cfg_with_work_items(tmp: &Path) -> Config {
     )
     .unwrap();
     cfg.doc_paths.insert("work".into(), work);
+    cfg
+}
+
+// Seeds the standard corpus plus a project-code work-item config (e.g.
+// `ENG`), so frontmatter `id: "0042"` normalises to `ENG-0042`. Used by the
+// search id-matching suite to exercise the non-numeric / project-code paths.
+#[allow(dead_code)]
+pub fn seeded_cfg_project_code(tmp: &Path, code: &str) -> Config {
+    let mut cfg = seeded_cfg(tmp);
+    cfg.work_item = Some(RawWorkItemConfig {
+        scan_regex: format!("^({code}-[0-9]{{4}})-"),
+        id_pattern: "{project}-{number:04d}".to_string(),
+        default_project_code: Some(code.to_string()),
+    });
     cfg
 }


### PR DESCRIPTION
## Summary

Extends visualiser search to match on `work_item_id`, alongside related work-item tooling and test hardening accumulated on this branch.

## Changes

- **Visualiser search** — match `work_item_id` in search; update indexer and add `api_search` integration tests (~500 lines).
- **Work items** — link 0124–0156 to Linear and refresh the sync baseline.
- **Prevention tests** — agent-invocation prevention tests for 0120 (research, plan, review); harden the no-input migration stall regression test; cross-check tolerant unknown backfill against the corpus validator.

## Test plan

- [ ] `mise run check`
- [ ] `cd skills/visualisation/visualise/server && cargo test`