### PR TITLE
Use AskUserQuestion for confirmations where appropriate so user doesn't have to type for confirmation

### DIFF
--- a/meta/plans/2026-06-27-ask-user-question-skill-upgrades.md
+++ b/meta/plans/2026-06-27-ask-user-question-skill-upgrades.md
@@ -1,0 +1,587 @@
+---
+type: plan
+id: "2026-06-27-ask-user-question-skill-upgrades"
+title: "AskUserQuestion Skill Upgrades (Priorities 1–3) Implementation Plan"
+date: "2026-06-27T16:14:08+00:00"
+author: "John Cowie Del Corral"
+producer: create-plan
+status: draft
+derived_from: ["codebase-research:2026-06-27-ask-user-question-opportunities"]
+tags: [skills, ux, ask-user-question, review-pr, review-work-item, respond-to-pr, commit]
+revision: "e72cb30556fe3a3caaf952092d8056c932a2baa9"
+repository: accelerator
+last_updated: "2026-06-27T16:14:08+00:00"
+last_updated_by: "John Cowie Del Corral"
+schema_version: 1
+---
+
+# AskUserQuestion Skill Upgrades (Priorities 1–3) Implementation Plan
+
+## Overview
+
+Replace all plain-text user questions in the skill library (Priorities 1–3 from
+the research document) with structured `AskUserQuestion` tool calls.
+
+**Constraint discovered during implementation**: `AskUserQuestion` requires a
+minimum of 2 options. The initial pattern (1 explicit option + built-in "Other")
+was invalid. The corrected pattern for binary confirmations is always 2 explicit
+options — a positive and a negative — with no reliance on the implicit "Other".
+
+This plan covers 51 interaction points across 13 SKILL.md files, organised into
+four independently mergeable phases grouped by pattern similarity.
+
+## Current State Analysis
+
+The `review-plan` skill establishes the reference pattern (corrected after the
+`Invalid option parameter` error discovered in practice):
+
+```
+Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
+two options:
+
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
+```
+
+All skills in scope still use one of three plain-text idioms:
+1. `"Shall I proceed?"` / `"Would you like to…?"` with no options
+2. A numbered markdown list followed by `"What would you prefer?"`
+3. `Reply **y** to confirm, **n** to revise, anything else to abort`
+
+None of these present the structured UI that `AskUserQuestion` provides.
+
+## Desired End State
+
+Every bounded user question across Priorities 1–3 uses `AskUserQuestion`.
+
+**Verification**: invoke each modified skill and confirm the tool's UI panel
+appears at the expected interaction point. Specifically:
+- Lens-selection skills: panel appears before reviewers are spawned.
+- Action-menu skills: panel appears after analysis output is presented.
+- Binary-confirmation skills: panel appears before the irreversible action.
+
+## What We're NOT Doing
+
+- Priority 4 (bounded multi-select from dynamic lists) — deferred.
+- Priority 5 (integration skill `Reply **y**` pattern) — deferred.
+- Priority 6 (`respond-to-pr` preferences questionnaire) — deferred.
+- Any open-ended free-text questions (e.g. "What would you like to change?") —
+  not candidates for AskUserQuestion.
+- Automated tests — these are Markdown prompt files; correctness is verified
+  by manual invocation.
+
+## Implementation Approach
+
+Each phase is a focused set of SKILL.md edits that can be shipped as an
+independent PR. All changes follow the same substitution pattern:
+
+**Binary confirmation** (2 options — minimum required by the tool):
+```
+Use the `AskUserQuestion` tool with two options:
+
+1. **[Positive action]** — [brief description]
+2. **[Negative / adjust action]** — [brief description]
+```
+
+**Action menu** (2–4 options):
+```
+Use the `AskUserQuestion` tool with the following options:
+
+1. **[Option A]** — [description]
+2. **[Option B]** — [description]
+3. **[Option C]** — [description]
+
+[If a 5th option existed: the 4-option limit means option N is folded into
+"Other" — see per-file notes below.]
+```
+
+The `AskUserQuestion` tool has a hard limit of **4 options** per question.
+Where the existing text lists 5 options, the two most closely related options
+are merged or the least-common one is dropped to "Other".
+
+---
+
+## Phase 1: Lens-Selection Confirmations
+
+**Files**: `skills/github/review-pr/SKILL.md`,
+`skills/work/review-work-item/SKILL.md`
+
+**Pattern**: Identical to the existing `review-plan` change — 1 explicit option
+(**Proceed**) with "Other" for adjustments.
+
+### Changes Required
+
+#### 1. `skills/github/review-pr/SKILL.md` — Lines 255–258
+
+**Current:**
+```
+Shall I proceed, or would you like to adjust the selection?
+```
+
+Wait for confirmation before spawning reviewers.
+
+**Replace with:**
+```
+Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
+two options:
+
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
+
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+ask which lenses they want, then re-present the updated selection using the
+same `AskUserQuestion` pattern.
+```
+
+#### 2. `skills/work/review-work-item/SKILL.md` — Lines 143–155
+
+**Current:**
+```
+Present the selection briefly — enumerate the chosen lenses with a one-line
+focus each — then wait for confirmation before spawning reviewers.
+```
+
+Example ends with `"Shall I proceed?"`
+
+**Replace the "wait for confirmation" instruction with:**
+```
+Then use the `AskUserQuestion` tool with two options:
+
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
+
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+ask which lenses they want, then re-present the updated selection using the
+same `AskUserQuestion` pattern.
+```
+
+### Success Criteria
+
+#### Manual Verification:
+- [ ] Run `/review-pr` on any open PR — `AskUserQuestion` panel appears before
+  reviewers are spawned; the panel shows **Proceed** as the sole option plus the
+  "Other" input.
+- [ ] Entering text in "Other" triggers the adjustment loop.
+- [ ] Run `/review-work-item` on any work item — same panel behaviour.
+
+---
+
+## Phase 2: Post-Analysis Action Menus
+
+**Files**: `skills/github/review-pr/SKILL.md`,
+`skills/work/review-work-item/SKILL.md`,
+`skills/decisions/review-adr/SKILL.md`,
+`skills/work/extract-work-items/SKILL.md`,
+`skills/github/respond-to-pr/SKILL.md`
+
+**Pattern**: Replace numbered markdown option lists with `AskUserQuestion`.
+Where 5 options exist, the two most closely related are merged to respect the
+4-option limit (see `review-pr` note below).
+
+### Changes Required
+
+#### 1. `skills/github/review-pr/SKILL.md` — Lines 586–593 (5-option post-review menu)
+
+**Current:**
+```
+The review is ready. Would you like to:
+1. Post the review? …
+2. Change the verdict? …
+3. Edit or remove specific inline comments before posting?
+4. Discuss any findings in more detail?
+5. Re-run specific lenses with adjusted focus?
+```
+
+**4-option limit resolution**: Options 4 (Discuss) and 5 (Re-run lenses) are
+distinct enough to keep both. Drop "Discuss" to "Other" (users can type "discuss
+X") and keep Post, Change verdict, Edit comments, Re-run lenses as 4 options.
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Post the review** — submit summary + inline comments with [verdict]
+2. **Change the verdict** — currently: [verdict]
+3. **Edit or remove inline comments** — modify before posting
+4. **Re-run specific lenses** — adjust focus and re-review
+
+"Other" handles discussion requests.
+
+#### 2. `skills/github/review-pr/SKILL.md` — Lines 652–653 (verdict picker)
+
+**Current:**
+```
+Ask which verdict they prefer (APPROVE, COMMENT, REQUEST_CHANGES)
+```
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **APPROVE** — approve the PR
+2. **COMMENT** — leave a non-blocking comment review
+3. **REQUEST_CHANGES** — request changes before merge
+
+#### 3. `skills/decisions/review-adr/SKILL.md` — Lines 168–174
+
+**Current:**
+```
+1. Accept
+2. Reject
+3. Revise
+
+What would you like to do?
+```
+Wait for user decision.
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Accept** — mark the ADR as accepted
+2. **Reject** — mark it as rejected (reason prompted after)
+3. **Revise** — update the ADR before deciding
+
+#### 4. `skills/work/review-work-item/SKILL.md` — Lines 434–443 (post-review menu)
+
+**Current:**
+```
+Would you like to:
+1. Proceed to address findings? …
+2. Change the verdict? …
+3. Discuss any specific findings in more detail?
+4. Re-run specific lenses with adjusted focus?
+```
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Address findings** — edit the work item to resolve issues
+2. **Change the verdict** — currently: [verdict]
+3. **Re-run specific lenses** — adjust focus and re-review
+
+"Other" handles discussion requests (3 explicit options, keeping under the cap).
+
+#### 5. `skills/work/extract-work-items/SKILL.md` — Lines 207–219 (per-candidate menu)
+
+**Current:**
+```
+1. enrich
+2. accept as-is
+3. skip
+4. accept remaining as-is
+```
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Enrich** — improve this candidate before creating
+2. **Accept as-is** — create work item from this candidate unchanged
+3. **Skip** — skip this candidate
+4. **Accept all remaining** — accept every remaining candidate as-is
+
+#### 6. `skills/work/extract-work-items/SKILL.md` — Lines 266–277 (post-enrichment menu)
+
+**Current:**
+```
+1. approve
+2. revise <instructions>
+3. skip
+4. accept as-is
+```
+
+**4-option limit**: All 4 fit. Option 2 (Revise) is a hybrid — selecting it
+prompts a follow-up free-text input for instructions.
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Approve** — use this enriched draft
+2. **Revise** — re-enrich with additional instructions (prompted after)
+3. **Skip** — skip this candidate entirely
+4. **Accept as-is** — use the original un-enriched candidate
+
+After the user selects **Revise**, prompt for the revision instructions as a
+follow-up plain-text request (not a second AskUserQuestion).
+
+#### 7. `skills/github/respond-to-pr/SKILL.md` — Lines 328–333 (disagreement handler)
+
+**Current:**
+```
+Options:
+1. Push back with this reasoning
+2. Implement the suggestion anyway
+3. Propose an alternative approach
+
+What would you prefer?
+```
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Push back** — post the draft reasoning as a response
+2. **Implement anyway** — make the suggested change
+3. **Propose alternative** — draft an alternative approach
+
+### Success Criteria
+
+#### Manual Verification:
+- [ ] Run `/review-pr` on any PR, complete the review — `AskUserQuestion`
+  panel appears with 4 post-review options (not a markdown list).
+- [ ] Choosing "Change the verdict" triggers the 3-option verdict picker.
+- [ ] Run `/review-adr` on any ADR — Accept/Reject/Revise panel appears.
+- [ ] Run `/review-work-item` — post-review panel appears with 3 options.
+- [ ] Run `/extract-work-items` — per-candidate 4-option panel appears; "Accept
+  all remaining" closes the loop correctly.
+- [ ] Post-enrichment panel shows Approve/Revise/Skip/Accept as-is; choosing
+  Revise prompts for follow-up instructions.
+- [ ] Run `/respond-to-pr` on a PR with disagreement items — 3-option panel
+  appears for each disagreement.
+
+---
+
+## Phase 3: Binary Confirmations — VCS, GitHub & Planning Skills
+
+**Files**: `skills/vcs/commit/SKILL.md`, `skills/github/respond-to-pr/SKILL.md`
+(5 confirmations), `skills/github/review-pr/SKILL.md` (1), 
+`skills/planning/stress-test-plan/SKILL.md`,
+`skills/research/conduct-spike/SKILL.md`,
+`skills/decisions/create-adr/SKILL.md`
+
+**Pattern**: Each plain-text confirmation is replaced with a 1-option
+`AskUserQuestion` (the action label), with "Other" as the implicit cancel/adjust
+path. No "recommended" label on any option.
+
+### Changes Required
+
+#### 1. `skills/vcs/commit/SKILL.md` — Line 36
+
+**Current:** `Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed** — create [N] commit(s) with the staged changes
+2. **No, cancel** — abort without committing
+
+#### 2. `skills/github/respond-to-pr/SKILL.md` — Lines 59–63 (closed/merged PR)
+
+**Current:** `inform the user and ask whether they still want to proceed`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed anyway** — continue responding to a closed/merged PR
+2. **No, abort** — exit the workflow
+
+#### 3. `skills/github/respond-to-pr/SKILL.md` — Lines 72–74 (branch mismatch)
+
+**Current:** `inform the user and ask if they want to switch`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, switch to PR branch** — check out [headRefName] before continuing
+2. **No, stay on current branch** — continue without switching
+
+#### 4. `skills/github/respond-to-pr/SKILL.md` — Lines 311–313 (per-fix confirm)
+
+**Current:** `Shall I proceed with this change?`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, apply this change** — make the edit now
+2. **No, skip this item** — leave it unaddressed and move on
+
+#### 5. `skills/github/respond-to-pr/SKILL.md` — Lines 344–346 (post/adjust response)
+
+**Current:** `Shall I post this response, or would you like to adjust it?`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Post as-is** — submit the draft response to GitHub
+2. **Adjust first** — revise the response before posting
+
+#### 6. `skills/github/respond-to-pr/SKILL.md` — Lines 455–456 (push to remote)
+
+**Current:** `Would you like me to push these changes to the remote?`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, push now** — push committed changes to the remote
+2. **No, skip** — leave changes unpushed
+
+#### 7. `skills/github/respond-to-pr/SKILL.md` — Lines 459–465 (re-request review)
+
+**Current:** `Would you like me to re-request review from them?`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, re-request** — re-request review from [reviewer list]
+2. **No, skip** — leave review request as-is
+
+#### 8. `skills/github/review-pr/SKILL.md` — Lines 145–147 (empty diff)
+
+**Current:** `inform the user and ask whether to proceed with a review of the PR description and commits only`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, review description and commits only** — proceed without a diff
+2. **No, abort** — exit without reviewing
+
+#### 9. `skills/planning/stress-test-plan/SKILL.md` — Lines 164–165
+
+**Current:** `Would you like me to update the plan with these changes?`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, update the plan** — apply the stress-test findings to the plan file
+2. **No, leave unchanged** — keep the plan as-is
+
+#### 10. `skills/research/conduct-spike/SKILL.md` — Around line 194
+
+**Current:** `"Confirm the synthesis with the user before recording it."`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, record this synthesis** — write the outcome to the spike document
+2. **No, revise first** — adjust the synthesis before recording
+
+#### 11. `skills/decisions/create-adr/SKILL.md` — Lines 132–139
+
+**Current:** `"Here's my draft ADR. Please review and let me know if you'd like any changes before I write it to disk."` + wait for approval.
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, write to disk** — save the ADR as shown
+2. **No, revise first** — make changes before saving
+
+### Success Criteria
+
+#### Manual Verification:
+- [ ] Run `/commit` — `AskUserQuestion` panel appears showing the commit plan
+  with **Proceed** as the sole option.
+- [ ] Run `/respond-to-pr` on a closed PR — panel appears with **Proceed anyway**;
+  entering nothing or "cancel" in Other exits cleanly.
+- [ ] Run `/respond-to-pr` on a PR from a different branch — branch-switch panel
+  appears.
+- [ ] Step through `/respond-to-pr` feedback items — per-fix **Proceed** and
+  **Post this response** panels fire at the right moments.
+- [ ] Reach end of `/respond-to-pr` — push panel appears, then re-request panel.
+- [ ] Run `/review-pr` on a PR with an empty diff (draft PR) — description-only
+  proceed panel appears.
+- [ ] Run `/stress-test-plan` to completion — update plan panel appears.
+- [ ] Run `/conduct-spike` to synthesis — record synthesis panel appears.
+- [ ] Run `/create-adr` through to draft — write-to-disk panel appears.
+
+---
+
+## Phase 4: Binary Confirmations — Work Item Skills
+
+**Files**: `skills/work/create-work-item/SKILL.md` (2),
+`skills/work/refine-work-item/SKILL.md` (4),
+`skills/work/review-work-item/SKILL.md` (1),
+`skills/work/stress-test-work-item/SKILL.md` (1),
+`skills/work/update-work-item/SKILL.md` (2),
+`skills/work/sync-work-items/SKILL.md` (2)
+
+**Pattern**: Same 1-option `AskUserQuestion` binary confirmation as Phase 3.
+
+### Changes Required
+
+#### 1. `skills/work/create-work-item/SKILL.md` — Lines 529–537 (push to tracker)
+
+**Current:** `Push to <tracker> now? [y/N]`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, push to [tracker]** — create the issue in the external tracker now
+2. **No, skip** — create locally only
+
+#### 2. `skills/work/create-work-item/SKILL.md` — Lines 619–637 (enrich-existing overwrite)
+
+**Current:** `Proceed? (y/n)`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed** — overwrite the existing fields as shown
+2. **No, cancel** — leave the work item unchanged
+
+#### 3. `skills/work/refine-work-item/SKILL.md` — Lines 129–133 (bug/spike decompose)
+
+**Current:** `bug/spike work items don't typically decompose — are you sure? (y/n)`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed anyway** — decompose despite the work item type warning
+2. **No, cancel** — abort the decompose operation
+
+#### 4. `skills/work/refine-work-item/SKILL.md` — Lines 167–172 (large decompose gate)
+
+**Current:** `This will allocate N work item numbers and write N files; … Proceed? (y/n)`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed** — allocate [N] work item numbers and write [N] files
+2. **No, cancel** — abort without writing any files
+
+#### 5. `skills/work/refine-work-item/SKILL.md` — Lines 355–360 (size change confirm)
+
+**Current:** show diff, require explicit y/n confirmation before Edit.
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, apply size change** — update the Size field as shown
+2. **No, cancel** — leave Size unchanged
+
+#### 6. `skills/work/refine-work-item/SKILL.md` — Lines 418–419 (offer review)
+
+**Current:** `"Would you like to run /review-work-item on this work item now?"`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, run review** — invoke review-work-item on this work item
+2. **No, done** — finish without reviewing
+
+#### 7. `skills/work/review-work-item/SKILL.md` — Lines 471–476 (re-review after edits)
+
+**Current:** `"The work item has been updated. Would you like me to run another review pass?"`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, run another review pass** — re-run all lenses on the updated work item
+2. **No, done** — finish here
+
+#### 8. `skills/work/stress-test-work-item/SKILL.md` — Lines 144–157 (update work item)
+
+**Current:** `"Would you like me to update the work item with these changes?"`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, update the work item** — apply the stress-test findings
+2. **No, leave unchanged** — keep the work item as-is
+
+#### 9. `skills/work/update-work-item/SKILL.md` — Lines 142–145 (date field warning)
+
+**Current:** `date records the work item's creation time and is typically not edited. Proceed anyway? (y/n)`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed anyway** — edit the date field despite the warning
+2. **No, cancel** — leave the date field unchanged
+
+#### 10. `skills/work/update-work-item/SKILL.md` — Lines 220–225 (apply changes confirm)
+
+**Current:** show diff then `"Apply these changes? (y/n)"`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, apply changes** — write the diff as shown to the work item file
+2. **No, cancel** — discard the changes
+
+#### 11. `skills/work/sync-work-items/SKILL.md` — Lines 176–182 (overwrite gate)
+
+**Current:** `N local files will be overwritten from remote. Proceed? [y/N]`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed** — overwrite [N] local files with remote versions
+2. **No, abort** — cancel the sync
+
+#### 12. `skills/work/sync-work-items/SKILL.md` — Lines 289–298 (untracked pull gate)
+
+**Current:** `N untracked remote issues will be created. Proceed? [y/N]`
+
+**Replace with instruction to use `AskUserQuestion` with:**
+1. **Yes, proceed** — create [N] new local work items from remote
+2. **No, abort** — cancel the sync
+
+### Success Criteria
+
+#### Manual Verification:
+- [ ] Run `/create-work-item` and reach the push-to-tracker offer — panel appears.
+- [ ] Run `/create-work-item` in enrich-existing mode — overwrite confirm panel
+  appears before any fields are changed.
+- [ ] Run `/refine-work-item --decompose` on a bug or spike — warning panel
+  appears before decomposition begins.
+- [ ] Run `/refine-work-item --decompose` on a large story — file-count warning
+  panel appears.
+- [ ] Run `/refine-work-item --size` with a size change — diff + confirm panel
+  appears before the edit.
+- [ ] Complete a `/refine-work-item` operation — "Run review" offer panel appears.
+- [ ] Complete a `/review-work-item` edit loop — "Run another review" panel
+  appears.
+- [ ] Complete `/stress-test-work-item` — update offer panel appears.
+- [ ] Run `/update-work-item` on the `date` field — warning + proceed panel appears.
+- [ ] Run `/update-work-item` on any field — diff + apply confirm panel appears.
+- [ ] Run `/sync-work-items --pull` with overwriteable files — overwrite gate
+  panel appears.
+- [ ] Run `/sync-work-items --pull` with untracked remote items — create gate
+  panel appears.
+
+---
+
+## References
+
+- Research document: `meta/research/codebase/2026-06-27-ask-user-question-opportunities.md`
+- Reference implementation: `skills/planning/review-plan/SKILL.md` (commit `e72cb305`)
+- AskUserQuestion tool constraints: max 4 options, min 2; `multiSelect` available
+  but not used in Priorities 1–3.

--- a/meta/plans/2026-06-27-ask-user-question-skill-upgrades.md
+++ b/meta/plans/2026-06-27-ask-user-question-skill-upgrades.md
@@ -96,8 +96,15 @@ Use the `AskUserQuestion` tool with the following options:
 ```
 
 The `AskUserQuestion` tool has a hard limit of **4 options** per question.
-Where the existing text lists 5 options, the two most closely related options
-are merged or the least-common one is dropped to "Other".
+Where the existing text lists 5 options, the least-common one is dropped; the
+5-option `review-pr` post-review menu is excluded from this plan entirely (left
+as plain-text markdown) because no option can be dropped without meaningful loss.
+
+**Line numbers are approximate hints.** Phases 1, 2, and 3 all touch
+`review-pr/SKILL.md`; Phases 2 and 3 both touch `respond-to-pr/SKILL.md`. Each
+phase is independently mergeable, but merging an earlier phase shifts line
+numbers for later phases in the same file. Implementers should locate changes
+by the **quoted text content**, not by line number alone.
 
 ---
 
@@ -106,8 +113,8 @@ are merged or the least-common one is dropped to "Other".
 **Files**: `skills/github/review-pr/SKILL.md`,
 `skills/work/review-work-item/SKILL.md`
 
-**Pattern**: Identical to the existing `review-plan` change — 1 explicit option
-(**Proceed**) with "Other" for adjustments.
+**Pattern**: Identical to the existing `review-plan` change — 2 options: a
+positive (proceed) and a negative (adjust).
 
 ### Changes Required
 
@@ -129,8 +136,12 @@ two options:
 2. **No, specify which lenses to use** — adjust the selection before running
 
 Wait for the user's answer before spawning reviewers. If they choose option 2,
-ask which lenses they want, then re-present the updated selection using the
-same `AskUserQuestion` pattern.
+ask which lenses they want using a **plain-text question only** — do NOT use
+`AskUserQuestion` for this follow-up (the lens list is too large for the
+4-option limit). If any lens name is unrecognised, seek clarification. Once
+confirmed, update the selection and re-present it using the same
+`AskUserQuestion` proceed/adjust pattern. This loop is user-controlled with
+no hard termination limit.
 ```
 
 #### 2. `skills/work/review-work-item/SKILL.md` — Lines 143–155
@@ -151,17 +162,24 @@ Then use the `AskUserQuestion` tool with two options:
 2. **No, specify which lenses to use** — adjust the selection before running
 
 Wait for the user's answer before spawning reviewers. If they choose option 2,
-ask which lenses they want, then re-present the updated selection using the
-same `AskUserQuestion` pattern.
+ask which lenses they want using a **plain-text question only** — do NOT use
+`AskUserQuestion` for this follow-up (the lens list is too large for the
+4-option limit). If any lens name is unrecognised, seek clarification. Once
+confirmed, update the selection and re-present it using the same
+`AskUserQuestion` proceed/adjust pattern. This loop is user-controlled with
+no hard termination limit.
 ```
 
 ### Success Criteria
 
 #### Manual Verification:
 - [ ] Run `/review-pr` on any open PR — `AskUserQuestion` panel appears before
-  reviewers are spawned; the panel shows **Proceed** as the sole option plus the
-  "Other" input.
-- [ ] Entering text in "Other" triggers the adjustment loop.
+  reviewers are spawned with **Yes, use the proposed lenses** and **No, specify
+  which lenses to use** as options.
+- [ ] Choose "No, specify which lenses to use" — Claude prompts for lens names
+  in plain text, then re-presents the updated selection via `AskUserQuestion`.
+- [ ] Specify an unrecognised lens name — Claude seeks clarification before
+  updating the selection.
 - [ ] Run `/review-work-item` on any work item — same panel behaviour.
 
 ---
@@ -180,31 +198,7 @@ Where 5 options exist, the two most closely related are merged to respect the
 
 ### Changes Required
 
-#### 1. `skills/github/review-pr/SKILL.md` — Lines 586–593 (5-option post-review menu)
-
-**Current:**
-```
-The review is ready. Would you like to:
-1. Post the review? …
-2. Change the verdict? …
-3. Edit or remove specific inline comments before posting?
-4. Discuss any findings in more detail?
-5. Re-run specific lenses with adjusted focus?
-```
-
-**4-option limit resolution**: Options 4 (Discuss) and 5 (Re-run lenses) are
-distinct enough to keep both. Drop "Discuss" to "Other" (users can type "discuss
-X") and keep Post, Change verdict, Edit comments, Re-run lenses as 4 options.
-
-**Replace with instruction to use `AskUserQuestion` with:**
-1. **Post the review** — submit summary + inline comments with [verdict]
-2. **Change the verdict** — currently: [verdict]
-3. **Edit or remove inline comments** — modify before posting
-4. **Re-run specific lenses** — adjust focus and re-review
-
-"Other" handles discussion requests.
-
-#### 2. `skills/github/review-pr/SKILL.md` — Lines 652–653 (verdict picker)
+#### 1. `skills/github/review-pr/SKILL.md` — Lines 652–653 (verdict picker)
 
 **Current:**
 ```
@@ -247,9 +241,8 @@ Would you like to:
 **Replace with instruction to use `AskUserQuestion` with:**
 1. **Address findings** — edit the work item to resolve issues
 2. **Change the verdict** — currently: [verdict]
-3. **Re-run specific lenses** — adjust focus and re-review
-
-"Other" handles discussion requests (3 explicit options, keeping under the cap).
+3. **Discuss specific findings** — explore any finding in more detail
+4. **Re-run specific lenses** — adjust focus and re-review
 
 #### 5. `skills/work/extract-work-items/SKILL.md` — Lines 207–219 (per-candidate menu)
 
@@ -331,9 +324,9 @@ What would you prefer?
 `skills/research/conduct-spike/SKILL.md`,
 `skills/decisions/create-adr/SKILL.md`
 
-**Pattern**: Each plain-text confirmation is replaced with a 1-option
-`AskUserQuestion` (the action label), with "Other" as the implicit cancel/adjust
-path. No "recommended" label on any option.
+**Pattern**: Each plain-text confirmation is replaced with a 2-option
+`AskUserQuestion` — a positive action and a negative (cancel/skip/abort). No
+"recommended" label on any option.
 
 ### Changes Required
 
@@ -428,10 +421,10 @@ path. No "recommended" label on any option.
 ### Success Criteria
 
 #### Manual Verification:
-- [ ] Run `/commit` — `AskUserQuestion` panel appears showing the commit plan
-  with **Proceed** as the sole option.
-- [ ] Run `/respond-to-pr` on a closed PR — panel appears with **Proceed anyway**;
-  entering nothing or "cancel" in Other exits cleanly.
+- [ ] Run `/commit` — `AskUserQuestion` panel appears with **Yes, proceed** and
+  **No, cancel**; choosing No aborts without creating any commits.
+- [ ] Run `/respond-to-pr` on a closed PR — panel appears with **Yes, proceed
+  anyway** and **No, abort**; choosing No exits without posting anything.
 - [ ] Run `/respond-to-pr` on a PR from a different branch — branch-switch panel
   appears.
 - [ ] Step through `/respond-to-pr` feedback items — per-fix **Proceed** and
@@ -454,7 +447,7 @@ path. No "recommended" label on any option.
 `skills/work/update-work-item/SKILL.md` (2),
 `skills/work/sync-work-items/SKILL.md` (2)
 
-**Pattern**: Same 1-option `AskUserQuestion` binary confirmation as Phase 3.
+**Pattern**: Same 2-option `AskUserQuestion` binary confirmation as Phase 3.
 
 ### Changes Required
 
@@ -554,34 +547,38 @@ path. No "recommended" label on any option.
 1. **Yes, proceed** — create [N] new local work items from remote
 2. **No, abort** — cancel the sync
 
+**Note**: The per-item push loop at lines 246–248 (`Push <id>? [y/N] (a/d
+shortcuts)`) is excluded from this plan. Its loop-level semantics make it a
+more complex upgrade; deferred to a future pass.
+
 ### Success Criteria
 
 #### Manual Verification:
 - [ ] Run `/create-work-item` and reach the push-to-tracker offer — panel appears.
 - [ ] Run `/create-work-item` in enrich-existing mode — overwrite confirm panel
-  appears before any fields are changed.
+  appears before any fields are changed; choosing No leaves the work item unchanged.
 - [ ] Run `/refine-work-item --decompose` on a bug or spike — warning panel
-  appears before decomposition begins.
+  appears; choosing No aborts without writing any files.
 - [ ] Run `/refine-work-item --decompose` on a large story — file-count warning
-  panel appears.
+  panel appears; choosing No aborts without allocating any IDs.
 - [ ] Run `/refine-work-item --size` with a size change — diff + confirm panel
-  appears before the edit.
+  appears before the edit; choosing No leaves Size unchanged.
 - [ ] Complete a `/refine-work-item` operation — "Run review" offer panel appears.
-- [ ] Complete a `/review-work-item` edit loop — "Run another review" panel
-  appears.
+- [ ] Complete a `/review-work-item` edit loop — "Run another review" panel appears.
 - [ ] Complete `/stress-test-work-item` — update offer panel appears.
 - [ ] Run `/update-work-item` on the `date` field — warning + proceed panel appears.
-- [ ] Run `/update-work-item` on any field — diff + apply confirm panel appears.
+- [ ] Run `/update-work-item` on any field — diff + apply confirm panel appears;
+  choosing No discards the changes without writing any file.
 - [ ] Run `/sync-work-items --pull` with overwriteable files — overwrite gate
-  panel appears.
+  panel appears; choosing No aborts the sync leaving local files intact.
 - [ ] Run `/sync-work-items --pull` with untracked remote items — create gate
-  panel appears.
+  panel appears; choosing No aborts without creating any local files.
 
 ---
 
 ## References
 
 - Research document: `meta/research/codebase/2026-06-27-ask-user-question-opportunities.md`
-- Reference implementation: `skills/planning/review-plan/SKILL.md` (commit `e72cb305`)
+- Reference implementation: `skills/planning/review-plan/SKILL.md` (commit `bf534298`)
 - AskUserQuestion tool constraints: max 4 options, min 2; `multiSelect` available
   but not used in Priorities 1–3.

--- a/meta/research/codebase/2026-06-27-ask-user-question-opportunities.md
+++ b/meta/research/codebase/2026-06-27-ask-user-question-opportunities.md
@@ -1,0 +1,474 @@
+---
+type: codebase-research
+id: "2026-06-27-ask-user-question-opportunities"
+title: "Research: AskUserQuestion Upgrade Opportunities Across All Skills"
+date: "2026-06-27T13:32:04+00:00"
+author: "John Cowie Del Corral"
+producer: research-codebase
+status: complete
+topic: "Skills that ask the user questions via plain text where AskUserQuestion tool could be used instead"
+tags: [research, codebase, skills, ux, ask-user-question, review-plan, respond-to-pr, review-pr, refine-work-item]
+revision: "1180b25e8710a3afe4a0080d02bccd24f439b95b"
+repository: accelerator
+last_updated: "2026-06-27T13:32:04+00:00"
+last_updated_by: "John Cowie Del Corral"
+schema_version: 1
+---
+
+# Research: AskUserQuestion Upgrade Opportunities Across All Skills
+
+**Date**: 2026-06-27T13:32:04+00:00
+**Author**: John Cowie Del Corral
+**Git Commit**: 1180b25e8710a3afe4a0080d02bccd24f439b95b
+**Branch**: feat/review-plan-ask-user-question-lens-confirmation
+**Repository**: accelerator
+
+## Research Question
+
+The current branch (`feat/review-plan-ask-user-question-lens-confirmation`) replaced a plain-text
+"Shall I proceed?" confirmation in `review-plan/SKILL.md` with the structured `AskUserQuestion` tool
+(two options: Proceed / Specify something else). Can the same improvement be applied elsewhere across
+the skill library?
+
+## Summary
+
+The `AskUserQuestion` tool is well-suited for any skill interaction that presents a bounded,
+enumerable set of choices — whether binary (yes/no, proceed/adjust) or multi-option (e.g. menu
+actions, conflict resolution strategies). Across the full skill library, **51 distinct interaction
+points** were identified as candidates for this upgrade. They cluster into four patterns:
+
+1. **Lens-selection confirmation** — the exact same pattern as the branch change; two skills remain unupgraded.
+2. **Action menus** — post-review or post-analysis numbered option lists that map directly to
+   AskUserQuestion options.
+3. **Binary confirmations** — "y/N" or "Shall I proceed?" gates before irreversible actions.
+4. **Bounded multi-select** — presenting a dynamically generated numbered list from which the user
+   picks items.
+
+The findings are ordered by priority: same-pattern first, then high-frequency skills, then the
+consistent integration-skill pattern.
+
+---
+
+## Detailed Findings
+
+### Priority 1: Same Pattern as the Branch Change (Lens Selection)
+
+These two skills have **the exact same lens-selection-then-confirm flow** as `review-plan` and
+should be updated in the same pass.
+
+#### `skills/github/review-pr/SKILL.md` — Lines 237–258
+- Current: presents lens selection list, ends with `"Shall I proceed, or would you like to adjust
+  the selection?"`, then "Wait for confirmation before spawning reviewers."
+- Same pattern as `review-plan`; replace with `AskUserQuestion`:
+  - Option 1 (recommended): **Proceed** — run review with selected lenses
+  - Option 2: **Specify something else** — adjust lens selection
+
+#### `skills/work/review-work-item/SKILL.md` — Lines 147–155
+- Current: "present the selection briefly… then wait for confirmation before spawning reviewers.
+  Example: `I'll review this work item through all work item lenses (…). Shall I proceed?`"
+- Same two-option structure as review-plan; identical fix applies.
+
+---
+
+### Priority 2: Action Menus (Post-Review / Post-Analysis)
+
+Numbered option lists presented after analysis is complete — the user picks what happens next.
+These are the highest-value multi-option upgrades.
+
+#### `skills/github/review-pr/SKILL.md` — Lines 586–593
+- Current: 5 numbered options after presenting the review:
+  1. Post the review
+  2. Change the verdict
+  3. Edit or remove specific inline comments before posting
+  4. Discuss findings in more detail
+  5. Re-run specific lenses with adjusted focus
+- Strong AskUserQuestion candidate; all 5 options are discrete and bounded.
+
+#### `skills/github/review-pr/SKILL.md` — Lines 651–652
+- Current: "Ask which verdict they prefer (APPROVE, COMMENT, REQUEST_CHANGES)"
+- Exactly 3 fixed options — ideal AskUserQuestion.
+
+#### `skills/decisions/review-adr/SKILL.md` — Lines 168–174
+- Current: 3 options — Accept / Reject / Revise — ending with `"What would you like to do?"`
+- 3 discrete, fixed options; strong candidate.
+
+#### `skills/work/review-work-item/SKILL.md` — Lines 434–443
+- Current: 4 numbered options after review preview:
+  1. Proceed to address findings
+  2. Change verdict
+  3. Discuss specific findings
+  4. Re-run specific lenses
+- Matches the review-pr post-review pattern exactly.
+
+#### `skills/work/extract-work-items/SKILL.md` — Lines 207–219
+- Current: 4 options per candidate — enrich / accept as-is / skip / accept remaining as-is.
+- 4 discrete options; strong candidate.
+
+#### `skills/work/extract-work-items/SKILL.md` — Lines 266–277
+- Current: 4 options — approve / revise \<instructions\> / skip / accept as-is.
+- Options 1, 3, 4 are fully structured; option 2 is a hybrid (structured trigger + free-text
+  instructions). Could be handled as "Revise" option with a follow-up free-text prompt.
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 328–333
+- Current: 3 options for disagreement items — push back / implement / propose alternative — ending
+  with `"What would you prefer?"`
+- 3 discrete, fixed options.
+
+---
+
+### Priority 3: Binary Confirmations Before Irreversible Actions
+
+All of these are simple yes/no gates. The AskUserQuestion pattern adds two labelled options
+(e.g. **Proceed** / **Cancel**) rather than requiring the user to type "y" or "n".
+
+#### `skills/vcs/commit/SKILL.md` — Lines 33–36
+- Current: `"I plan to create [N] commit(s) with these changes. Shall I proceed?"`
+- High-frequency, high-visibility skill — committing is the most common skill invocation.
+- Options: **Proceed** (recommended) / **Cancel**
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 311–313
+- Current: `"Shall I proceed with this change?"` (before applying a single agreed-upon fix)
+- Options: **Proceed** (recommended) / **Skip this item**
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 344–346
+- Current: `"Shall I post this response, or would you like to adjust it?"`
+- Options: **Post as-is** (recommended) / **Adjust response**
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 455–456
+- Current: `"Would you like me to push these changes to the remote?"`
+- Options: **Push to remote** (recommended) / **Skip for now**
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 459–462
+- Current: `"Would you like me to re-request review from them?"`
+- Options: **Re-request review** (recommended) / **Skip**
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 60–63
+- Current: warn PR is closed/merged and ask whether to proceed.
+- Options: **Proceed anyway** / **Abort** (recommended)
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 72–74
+- Current: warn branch mismatch and ask if user wants to switch.
+- Options: **Switch to PR branch** (recommended) / **Stay on current branch**
+
+#### `skills/github/review-pr/SKILL.md` — Lines 144–147
+- Current: when diff is empty, inform user and ask whether to proceed with description-only review.
+- Options: **Proceed with description review** / **Abort**
+
+#### `skills/planning/stress-test-plan/SKILL.md` — Lines 139–165
+- Current: `"Would you like me to update the plan with these changes?"`
+- Options: **Update the plan** (recommended) / **Leave unchanged**
+
+#### `skills/research/conduct-spike/SKILL.md` — Lines ~194
+- Current: "Confirm the synthesis with the user before recording it."
+- Options: **Record synthesis** (recommended) / **Revise before recording**
+
+#### `skills/decisions/create-adr/SKILL.md` — Lines 132–139
+- Current: `"Here's my draft ADR. Please review and let me know if you'd like any changes before I
+  write it to disk."` + "Wait for user approval."
+- Options: **Write to disk** (recommended) / **Request changes**
+
+#### `skills/work/create-work-item/SKILL.md` — Lines 529–537
+- Current: `Push to <tracker> now? [y/N]`
+- Options: **Push to \<tracker\>** (recommended) / **Skip**
+
+#### `skills/work/create-work-item/SKILL.md` — Lines 619–637
+- Current: `Proceed? (y/n)` before overwriting in enrich-existing mode.
+- Options: **Proceed** (recommended) / **Cancel**
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 129–133
+- Current: `bug/spike work items don't typically decompose — are you sure? (y/n)`
+- Options: **Proceed anyway** / **Cancel** (recommended)
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 167–172
+- Current: `This will allocate N work item numbers and write N files… Proceed? (y/n)`
+- Options: **Proceed** (recommended) / **Cancel**
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 355–360
+- Current: show diff for size change, require explicit y/n confirmation.
+- Options: **Apply size change** / **Cancel**
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 418–419
+- Current: `"Would you like to run /review-work-item on this work item now?"`
+- Options: **Run review** / **Skip**
+
+#### `skills/work/review-work-item/SKILL.md` — Lines 471–476
+- Current: `"The work item has been updated. Would you like me to run another review pass?"`
+- Options: **Run another review** / **Done**
+
+#### `skills/work/stress-test-work-item/SKILL.md` — Lines 144–157
+- Current: `"Would you like me to update the work item with these changes?"`
+- Options: **Update work item** (recommended) / **Leave unchanged**
+
+#### `skills/work/update-work-item/SKILL.md` — Lines 142–145
+- Current: `date records the work item's creation time and is typically not edited. Proceed anyway? (y/n)`
+- Options: **Proceed anyway** / **Cancel** (recommended)
+
+#### `skills/work/update-work-item/SKILL.md` — Lines 220–225
+- Current: show diff then `"Apply these changes? (y/n)"`
+- Options: **Apply changes** (recommended) / **Cancel**
+
+#### `skills/work/sync-work-items/SKILL.md` — Lines 176–182
+- Current: `N local files will be overwritten from remote. Proceed? [y/N]`
+- Options: **Proceed** / **Abort** (recommended)
+
+#### `skills/work/sync-work-items/SKILL.md` — Lines 289–298
+- Current: `N untracked remote issues will be created. Proceed? [y/N]`
+- Options: **Proceed** / **Abort** (recommended)
+
+---
+
+### Priority 4: Bounded Multi-Select from a Dynamic List
+
+These present a numbered list of discovered items (documents, ADRs, etc.) and ask the user to select
+from it. AskUserQuestion supports dynamic options lists, making these viable candidates — though
+the implementation requires building the options array at runtime.
+
+#### `skills/decisions/review-adr/SKILL.md` — Lines 42–69
+- Current: shows a numbered list of discovered ADRs, ends with `"Which ADR would you like to
+  review? (enter number or path)"`
+- Dynamic list of ADRs; can be populated as AskUserQuestion options.
+
+#### `skills/decisions/extract-adrs/SKILL.md` — Lines 43–53
+- Current: `"You can: 1. Specify documents… 2. Let me scan all… Which would you prefer?"`
+- Exactly 2 fixed options — one of the simplest possible upgrades.
+
+#### `skills/decisions/extract-adrs/SKILL.md` — Lines 62–76
+- Current: numbered list of discovered documents, `"Which documents should I scan for decisions?"`
+- Dynamic list; multi-select via AskUserQuestion with `multiSelect: true`.
+
+#### `skills/decisions/extract-adrs/SKILL.md` — Lines 99–115
+- Current: numbered list of discovered decisions, `"Which decisions would you like to capture as ADRs?"`
+- Dynamic list; multi-select.
+
+#### `skills/decisions/extract-adrs/SKILL.md` — Lines 136–146
+- Current: per-draft `"Does this look good? (yes / revise / skip / approve all remaining)"`
+- 4 fixed options; strong candidate.
+
+#### `skills/notes/create-note/SKILL.md` — Lines 68–72
+- Current: `"Does <artifact> own this note as its parent, or is it just related? [owns / related]"`
+- Exactly 2 fixed options.
+
+#### `skills/github/describe-pr/SKILL.md` — Line 44
+- Current: shows list of open PRs from `gh pr list`, asks user which to describe.
+- Dynamic list of PRs; can be presented as AskUserQuestion options.
+
+#### `skills/work/create-work-item/SKILL.md` — Lines 246–253
+- Current: 3 numbered options when a similar work item exists — proceed new / update existing /
+  create linked to existing.
+- 3 fixed options.
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 99–117
+- Current: 5 numbered operations — decompose / enrich / sharpen / size / link. Multi-select allowed.
+- 5 fixed options; `multiSelect: true` variant of AskUserQuestion.
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 136–141
+- Current: `append / skip / cancel` for existing children on decompose.
+- 3 fixed options.
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 309–317
+- Current: `replace / append / skip` for Technical Notes on enrich.
+- 3 fixed options.
+
+#### `skills/work/refine-work-item/SKILL.md` — Lines 377–384
+- Current: `replace / append / skip` for dependencies on link operation.
+- 3 fixed options.
+
+#### `skills/work/extract-work-items/SKILL.md` — Lines 108–124
+- Current: numbered list of discovered documents, `"Which documents should I scan?"`
+- Dynamic list; multi-select.
+
+#### `skills/work/extract-work-items/SKILL.md` — Lines 144–160
+- Current: numbered candidates list, `"Which items would you like to create work items for?"`
+- Dynamic list; multi-select.
+
+#### `skills/work/sync-work-items/SKILL.md` — Lines 206–213
+- Current: `"Type 'remote' to OVERWRITE… 'local' to push… 'skip' to leave unchanged. [remote/local/skip]"`
+- 3 fixed, clearly labelled options.
+
+#### `skills/work/sync-work-items/SKILL.md` — Lines 246–248
+- Current: `Push <id> "<title>" to <tracker>? [y/N]  (a = push all remaining, d = decline all remaining)`
+- Binary yes/no with two shortcut tokens; the shortcuts (push all / decline all) could be surfaced
+  as additional AskUserQuestion options.
+
+---
+
+### Priority 5: Integration Skills — Consistent Confirmation Pattern
+
+All six integration skills (Jira: create, transition, update; Linear: create, transition, update)
+share an identical confirmation gate:
+
+```
+Send this to <tracker>? Reply **y** to confirm, **n** to revise, anything else to abort.
+```
+
+All six are strong AskUserQuestion candidates. The recommended option should be **Confirm &
+send**, with a second option **Revise**. The "anything else to abort" branch can become a third
+option **Abort** or be folded into the dismiss/cancel behaviour.
+
+Files:
+- `skills/integrations/jira/create-jira-issue/SKILL.md:213–215` (also line 95: `[y/N]` variant)
+- `skills/integrations/jira/transition-jira-issue/SKILL.md:130–131`
+- `skills/integrations/jira/transition-jira-issue/SKILL.md:94–97` (ambiguous transition picker — multi-option)
+- `skills/integrations/jira/update-jira-issue/SKILL.md:123–125`
+- `skills/integrations/linear/create-linear-issue/SKILL.md:72–74`
+- `skills/integrations/linear/transition-linear-issue/SKILL.md:53–55`
+- `skills/integrations/linear/update-linear-issue/SKILL.md:56–58`
+
+---
+
+### Priority 6: `respond-to-pr` Preferences Questionnaire
+
+#### `skills/github/respond-to-pr/SKILL.md` — Lines 256–278
+- Current: a four-question preferences survey presented before work begins:
+  1. Working mode: Guided / Express
+  2. Commit strategy: per-item / per-category / at the end
+  3. Thread resolution: auto-resolve after responding / leave threads open
+  4. Item ordering: one ordered approach vs another
+- Each sub-question maps cleanly to 2–3 discrete options. This is the most complex upgrade in the
+  list — could be delivered as 4 sequential AskUserQuestion calls (one per preference dimension) or
+  held as a single complex call (though AskUserQuestion supports multiple questions per invocation).
+
+---
+
+### Skills With NO Candidates (Only Free-Text Input)
+
+The following skills were audited and have only open-ended free-text interactions — not suitable for
+AskUserQuestion:
+
+- `skills/planning/implement-plan/SKILL.md` — mismatches ask "How should I proceed?" (open)
+- `skills/planning/validate-plan/SKILL.md` — no explicit user question gates
+- `skills/research/research-codebase/SKILL.md` — "any follow-ups?" (weak)
+- `skills/research/research-issue/SKILL.md` — "deeper investigation?" (weak)
+- `skills/planning/create-plan/SKILL.md` — lines 282–291 (open feedback prompts)
+- `skills/work/update-work-item/SKILL.md` — most interactions are free-text field input
+- `skills/integrations/jira/*/SKILL.md` — "What would you like to change?" flows (open)
+- `skills/decisions/create-adr/SKILL.md` — clarifying questions before drafting (open narrative)
+- `skills/notes/create-note/SKILL.md` — initial "what would you like to note?" (open)
+
+---
+
+### `create-plan` Candidates Worth Noting
+
+Two `create-plan` interactions were flagged as candidates but warrant discussion:
+
+#### `skills/planning/create-plan/SKILL.md` — Lines 167–183 (design option selection)
+- Current: presents Option A / Option B with pros/cons, asks "Which approach aligns best?"
+- AskUserQuestion candidate: Yes, when the skill generates exactly 2–4 named options.
+- Caveat: the options are dynamically generated content, not a fixed menu — implementation requires
+  the model to construct the options array at runtime, which is doable.
+
+#### `skills/planning/create-plan/SKILL.md` — Lines 191–203 (plan phasing approval)
+- Current: presents phasing plan as numbered list, asks "Does this phasing make sense? Should I
+  adjust the order or granularity?"
+- AskUserQuestion candidate: Yes — binary proceed/adjust with an optional free-text follow-up on
+  "adjust".
+
+---
+
+## Code References
+
+| File | Lines | Pattern | Priority |
+|---|---|---|---|
+| `skills/github/review-pr/SKILL.md` | 237–258 | Lens-select confirm (same as branch) | 1 |
+| `skills/work/review-work-item/SKILL.md` | 147–155 | Lens-select confirm (same as branch) | 1 |
+| `skills/github/review-pr/SKILL.md` | 586–593 | 5-option post-review menu | 2 |
+| `skills/github/review-pr/SKILL.md` | 651–652 | Verdict 3-option choice | 2 |
+| `skills/decisions/review-adr/SKILL.md` | 168–174 | Accept/Reject/Revise 3-option | 2 |
+| `skills/work/review-work-item/SKILL.md` | 434–443 | 4-option post-review menu | 2 |
+| `skills/work/extract-work-items/SKILL.md` | 207–219 | 4-option per-candidate menu | 2 |
+| `skills/github/respond-to-pr/SKILL.md` | 328–333 | 3-option disagreement handler | 2 |
+| `skills/vcs/commit/SKILL.md` | 33–36 | "Shall I proceed?" commit confirm | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 311–313 | "Shall I proceed?" per-fix | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 344–346 | Post / Adjust response | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 455–456 | Push to remote? | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 459–462 | Re-request review? | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 60–63 | Closed PR proceed? | 3 |
+| `skills/github/respond-to-pr/SKILL.md` | 72–74 | Branch mismatch switch? | 3 |
+| `skills/github/review-pr/SKILL.md` | 144–147 | Empty diff proceed? | 3 |
+| `skills/planning/stress-test-plan/SKILL.md` | 139–165 | Update plan? | 3 |
+| `skills/research/conduct-spike/SKILL.md` | ~194 | Confirm synthesis | 3 |
+| `skills/decisions/create-adr/SKILL.md` | 132–139 | Approve ADR draft | 3 |
+| `skills/work/create-work-item/SKILL.md` | 529–537 | Push to tracker? | 3 |
+| `skills/work/create-work-item/SKILL.md` | 619–637 | Proceed overwrite? | 3 |
+| `skills/work/refine-work-item/SKILL.md` | 129–133 | Bug/spike decompose confirm | 3 |
+| `skills/work/refine-work-item/SKILL.md` | 167–172 | Large decompose proceed? | 3 |
+| `skills/work/refine-work-item/SKILL.md` | 355–360 | Size change confirm | 3 |
+| `skills/work/refine-work-item/SKILL.md` | 418–419 | Run review after ops? | 3 |
+| `skills/work/review-work-item/SKILL.md` | 471–476 | Re-review after edits? | 3 |
+| `skills/work/stress-test-work-item/SKILL.md` | 144–157 | Update work item? | 3 |
+| `skills/work/update-work-item/SKILL.md` | 142–145 | Date field override confirm | 3 |
+| `skills/work/update-work-item/SKILL.md` | 220–225 | Apply changes? | 3 |
+| `skills/work/sync-work-items/SKILL.md` | 176–182 | Overwrite gate | 3 |
+| `skills/work/sync-work-items/SKILL.md` | 289–298 | Create untracked issues? | 3 |
+| `skills/decisions/extract-adrs/SKILL.md` | 43–53 | Specify docs vs scan all | 4 |
+| `skills/decisions/extract-adrs/SKILL.md` | 62–76 | Which docs to scan? | 4 |
+| `skills/decisions/extract-adrs/SKILL.md` | 99–115 | Which decisions to capture? | 4 |
+| `skills/decisions/extract-adrs/SKILL.md` | 136–146 | Per-draft yes/revise/skip/all | 4 |
+| `skills/notes/create-note/SKILL.md` | 68–72 | Owns vs related | 4 |
+| `skills/github/describe-pr/SKILL.md` | 44 | Which PR to describe? | 4 |
+| `skills/work/create-work-item/SKILL.md` | 246–253 | Similar item: 3-option | 4 |
+| `skills/work/refine-work-item/SKILL.md` | 99–117 | Refinement menu (5-op, multi) | 4 |
+| `skills/work/refine-work-item/SKILL.md` | 136–141 | Append/skip/cancel children | 4 |
+| `skills/work/refine-work-item/SKILL.md` | 309–317 | Replace/append/skip tech notes | 4 |
+| `skills/work/refine-work-item/SKILL.md` | 377–384 | Replace/append/skip deps | 4 |
+| `skills/work/extract-work-items/SKILL.md` | 108–124 | Which documents to scan? | 4 |
+| `skills/work/extract-work-items/SKILL.md` | 144–160 | Which candidates to extract? | 4 |
+| `skills/work/sync-work-items/SKILL.md` | 206–213 | remote/local/skip conflict | 4 |
+| `skills/work/sync-work-items/SKILL.md` | 246–248 | Push item (with a/d shortcuts) | 4 |
+| `skills/decisions/review-adr/SKILL.md` | 42–69 | Which ADR to review? | 4 |
+| `skills/integrations/jira/create-jira-issue/SKILL.md` | 95, 213–215 | Send to Jira? | 5 |
+| `skills/integrations/jira/transition-jira-issue/SKILL.md` | 94–97, 130–131 | Which transition / send? | 5 |
+| `skills/integrations/jira/update-jira-issue/SKILL.md` | 123–125 | Send to Jira? | 5 |
+| `skills/integrations/linear/create-linear-issue/SKILL.md` | 72–74 | Create in Linear? | 5 |
+| `skills/integrations/linear/transition-linear-issue/SKILL.md` | 53–55 | Transition? | 5 |
+| `skills/integrations/linear/update-linear-issue/SKILL.md` | 56–58 | Apply to Linear? | 5 |
+| `skills/github/respond-to-pr/SKILL.md` | 256–278 | 4-question preferences survey | 6 |
+| `skills/planning/create-plan/SKILL.md` | 167–183, 191–203 | Design opts + phasing confirm | — |
+
+---
+
+## Architecture Insights
+
+**The improvement is a systematic pattern, not a one-off.** Every skill that asks a bounded
+question via plain text is a candidate. The pattern applies across all skill categories with no
+exceptions — planning, review, work items, integrations, VCS, research, and decisions all have
+examples.
+
+**Three sub-patterns dominate:**
+
+1. **`Reply **y** to confirm, **n** to revise`** — the integration skill idiom. All 6 integration
+   skills share this exact phrasing. These are the fastest wins: identical change applied 6 times.
+
+2. **Post-analysis action menus** — 5- or 4-option numbered lists after review/stress-test output.
+   These are the highest UX impact: structured options are much easier to act on than "type a
+   number".
+
+3. **Pre-action safety gates** — `Proceed? (y/n)` before writes, pushes, or overwriting. Applying
+   AskUserQuestion here also makes the *label* of the safe option explicit ("Abort" or "Cancel" as
+   the recommended choice when the operation is destructive), which is clearer than `[y/N]`.
+
+**`review-pr` is the most immediate follow-on.** It has 4 upgrade points (lens confirm, empty-diff
+confirm, post-review menu, verdict picker) and the lens confirm is an exact copy of the change
+already made in `review-plan`. It should be updated in the same PR or the next one.
+
+**`respond-to-pr` has the most candidates (8)** but is also the most interactive skill — it may
+benefit from a dedicated pass since several interactions are tightly coupled in the review loop.
+
+## Open Questions
+
+1. **Multi-question invocation**: AskUserQuestion supports multiple questions per call. For
+   `respond-to-pr`'s 4-question preferences survey (lines 256–278), should these be bundled into
+   one AskUserQuestion call or kept as sequential calls? One call reduces round-trips but may feel
+   overwhelming.
+
+2. **Multi-select lists**: `extract-work-items`, `extract-adrs`, `refine-work-item` all need
+   multi-select from dynamic lists. Verify the AskUserQuestion tool supports `multiSelect: true`
+   with dynamically constructed option arrays before implementation.
+
+3. **Shortcut tokens in sync**: `sync-work-items` line 246 uses `a = push all` and `d = decline
+   all` as fast-path shortcuts within a per-item loop. These could become additional AskUserQuestion
+   options, but the loop-level semantics (apply to remaining items) need careful wording.
+
+4. **Free-text revision branch**: Many "proceed/revise" patterns need a free-text follow-up when
+   the user picks "Revise". The AskUserQuestion tool handles this by having Claude prompt for free
+   text after the structured choice — confirm this is the right model before implementing.

--- a/skills/decisions/create-adr/SKILL.md
+++ b/skills/decisions/create-adr/SKILL.md
@@ -130,13 +130,17 @@ Wait for user input before proceeding.
    review:
 
 ```
-Here's my draft ADR. Please review and let me know if you'd like any changes
-before I write it to disk:
+Here's my draft ADR:
 
 [draft content]
 ```
 
-Wait for user approval or revision requests before writing.
+Use the `AskUserQuestion` tool with two options:
+
+1. **Yes, write to disk** — save the ADR as shown
+2. **No, revise first** — make changes before saving
+
+Wait for the user's answer before writing.
 
 3. **Iterate** on the draft based on user feedback. Only proceed to writing
    when the user approves.

--- a/skills/decisions/review-adr/SKILL.md
+++ b/skills/decisions/review-adr/SKILL.md
@@ -165,14 +165,15 @@ Evaluate the ADR against these quality criteria:
 ---
 
 **Actions available:**
-1. **Accept** — Mark as accepted (ADR becomes immutable)
-2. **Reject** — Mark as rejected with reason (ADR becomes immutable)
-3. **Revise** — Make suggested improvements (stays proposed)
-
-What would you like to do?
 ```
 
-Wait for user decision.
+Use the `AskUserQuestion` tool with three options:
+
+1. **Accept** — mark the ADR as accepted (becomes immutable)
+2. **Reject** — mark as rejected with reason (becomes immutable; reason prompted after)
+3. **Revise** — make suggested improvements (stays proposed)
+
+Wait for the user's decision.
 
 #### Step 4: Execute Action
 

--- a/skills/github/respond-to-pr/SKILL.md
+++ b/skills/github/respond-to-pr/SKILL.md
@@ -57,10 +57,11 @@ the user's input.
    ```
 
 2. **Validate PR state**: Check that `state` is `OPEN`. If the PR is closed
-   or merged, inform the user and ask whether they still want to proceed
-   (they may want to make changes for a follow-up, but posting responses
-   and resolving threads on a closed PR is typically not useful). If the user
-   declines, exit the workflow.
+   or merged, inform the user and use the `AskUserQuestion` tool with two
+   options:
+   1. **Yes, proceed anyway** — continue responding to a closed/merged PR
+   2. **No, abort** — exit the workflow
+   If the user chooses No, exit the workflow.
 
 3. **Get repo info and current user**:
    ```bash
@@ -71,7 +72,9 @@ the user's input.
 4. **Ensure on the correct branch**: Check the current branch or bookmark
    using the appropriate VCS command for this repository (refer to the
    session's VCS context). Compare with the PR's `headRefName`. If different,
-   inform the user and ask if they want to switch.
+   inform the user and use the `AskUserQuestion` tool with two options:
+   1. **Yes, switch to PR branch** — check out [headRefName] before continuing
+   2. **No, stay on current branch** — continue without switching
 
 5. **Check for a structured review artifact**:
 
@@ -308,7 +311,13 @@ For items where the feedback is correct:
 **Proposed change**: {description of what you'll do}
 **Draft response**: "Fixed. {concise description of what will be changed}"
 
-Shall I proceed with this change?
+```
+
+Use the `AskUserQuestion` tool with two options:
+1. **Yes, apply this change** — make the edit now
+2. **No, skip this item** — leave it unaddressed and move on
+
+```
 ```
 
 For items where the feedback seems incorrect (Disagreement category):
@@ -341,7 +350,13 @@ For questions (no code changes needed):
 
 **Draft response**: {response explaining the reasoning}
 
-Shall I post this response, or would you like to adjust it?
+```
+
+Use the `AskUserQuestion` tool with two options:
+1. **Post as-is** — submit the draft response to GitHub
+2. **Adjust first** — revise the response before posting
+
+```
 ```
 
 In all cases, show the user the exact text that will be posted to GitHub
@@ -450,19 +465,15 @@ After all items have been addressed (or the user says "stop here"):
    to pick up remaining unresolved items.
    ```
 
-2. **Offer to push** (if there are unpushed commits):
-   ```
-   Would you like me to push these changes to the remote?
-   ```
+2. **Offer to push** (if there are unpushed commits): use the `AskUserQuestion`
+   tool with two options:
+   1. **Yes, push now** — push committed changes to the remote
+   2. **No, skip** — leave changes unpushed
 
-3. **Offer to re-request review**:
-   ```
-   The following reviewers left feedback:
-   - {reviewer1} (requested changes)
-   - {reviewer2} (commented)
-
-   Would you like me to re-request review from them?
-   ```
+3. **Offer to re-request review**: present the list of reviewers who left
+   feedback, then use the `AskUserQuestion` tool with two options:
+   1. **Yes, re-request** — re-request review from the listed reviewers
+   2. **No, skip** — leave review requests as-is
 
    If yes:
    ```bash

--- a/skills/github/respond-to-pr/SKILL.md
+++ b/skills/github/respond-to-pr/SKILL.md
@@ -325,12 +325,11 @@ implementation is correct because:
 
 **Draft response** (if pushing back): "{technical reasoning}"
 
-**Options**:
-1. Push back with this reasoning
-2. Implement the suggestion anyway
-3. Propose an alternative approach
+Use the `AskUserQuestion` tool with three options:
 
-What would you prefer?
+1. **Push back** — post the draft reasoning as a response
+2. **Implement anyway** — make the suggested change
+3. **Propose alternative** — draft an alternative approach
 ```
 
 For questions (no code changes needed):

--- a/skills/github/review-pr/SKILL.md
+++ b/skills/github/review-pr/SKILL.md
@@ -143,8 +143,9 @@ the user's input.
   be found and suggest checking the number. If on a branch with no PR, list
   open PRs with `gh pr list --limit 10` and ask the user to select one.
 - **Empty diff**: If `diff.patch` is empty (e.g., a draft PR with no changes),
-  inform the user and ask whether to proceed with a review of the PR
-  description and commits only.
+  inform the user and use the `AskUserQuestion` tool with two options:
+  1. **Yes, review description and commits only** — proceed without a diff
+  2. **No, abort** — exit without reviewing
 
 ### Step 2: Select Review Lenses
 

--- a/skills/github/review-pr/SKILL.md
+++ b/skills/github/review-pr/SKILL.md
@@ -661,7 +661,10 @@ stale commit):
 - After edits, re-present the preview and offer the same action options
 
 **When the user changes the verdict** (option 2):
-- Ask which verdict they prefer (APPROVE, COMMENT, REQUEST_CHANGES)
+- Use the `AskUserQuestion` tool with three options:
+  1. **APPROVE** — approve the PR
+  2. **COMMENT** — leave a non-blocking comment review
+  3. **REQUEST_CHANGES** — request changes before merge
 - Update the summary body and re-present the preview
 
 ## Important Guidelines

--- a/skills/github/review-pr/SKILL.md
+++ b/skills/github/review-pr/SKILL.md
@@ -252,10 +252,21 @@ Based on the PR's scope, I'll review through these lenses:
 - Portability: [reason — or "Skipping: ..."]
 - Safety: [reason — or "Skipping: ..."]
 
-Shall I proceed, or would you like to adjust the selection?
 ```
 
-Wait for confirmation before spawning reviewers.
+Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
+two options:
+
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
+
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+ask which lenses they want using a **plain-text question only** — do NOT use
+`AskUserQuestion` for this follow-up (the lens list is too large for the
+4-option limit). If any lens name is unrecognised, seek clarification. Once
+confirmed, update the selection and re-present it using the same
+`AskUserQuestion` proceed/adjust pattern. This loop is user-controlled with
+no hard termination limit.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/planning/review-plan/SKILL.md
+++ b/skills/planning/review-plan/SKILL.md
@@ -218,16 +218,14 @@ Based on the plan's scope, I'll review through these lenses:
 ```
 
 Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
-exactly two options:
+one explicit option:
 
-1. **Proceed** — run the review with the selected lenses (recommended, first
-   option)
-2. **Specify something else** — let the user adjust the lens selection before
-   running
+1. **Proceed** — run the review with the selected lenses
 
-Wait for the user's answer before spawning reviewers. If they choose option 2,
-apply their adjustments and re-present the updated selection using the same
-`AskUserQuestion` pattern.
+The tool's built-in "Other" input handles any adjustments the user wants to
+make. Wait for the user's answer before spawning reviewers. If they provide
+custom input, apply their adjustments and re-present the updated selection
+using the same `AskUserQuestion` pattern.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/planning/review-plan/SKILL.md
+++ b/skills/planning/review-plan/SKILL.md
@@ -218,14 +218,14 @@ Based on the plan's scope, I'll review through these lenses:
 ```
 
 Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
-one explicit option:
+two options:
 
-1. **Proceed** — run the review with the selected lenses
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
 
-The tool's built-in "Other" input handles any adjustments the user wants to
-make. Wait for the user's answer before spawning reviewers. If they provide
-custom input, apply their adjustments and re-present the updated selection
-using the same `AskUserQuestion` pattern.
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+ask which lenses they want, then re-present the updated selection using the
+same `AskUserQuestion` pattern.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/planning/review-plan/SKILL.md
+++ b/skills/planning/review-plan/SKILL.md
@@ -215,11 +215,19 @@ Based on the plan's scope, I'll review through these lenses:
 - Compatibility: [reason — or "Skipping: ..."]
 - Portability: [reason — or "Skipping: ..."]
 - Safety: [reason — or "Skipping: ..."]
-
-Shall I proceed, or would you like to adjust the selection?
 ```
 
-Wait for confirmation before spawning reviewers.
+Then use the `AskUserQuestion` tool to ask the user whether to proceed, with
+exactly two options:
+
+1. **Proceed** — run the review with the selected lenses (recommended, first
+   option)
+2. **Specify something else** — let the user adjust the lens selection before
+   running
+
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+apply their adjustments and re-present the updated selection using the same
+`AskUserQuestion` pattern.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/planning/review-plan/SKILL.md
+++ b/skills/planning/review-plan/SKILL.md
@@ -224,8 +224,10 @@ two options:
 2. **No, specify which lenses to use** — adjust the selection before running
 
 Wait for the user's answer before spawning reviewers. If they choose option 2,
-ask which lenses they want, then re-present the updated selection using the
-same `AskUserQuestion` pattern.
+ask which lenses they want as a **plain-text question only** — do NOT use
+`AskUserQuestion` for this follow-up (the lens list is too large for the
+4-option limit). Once confirmed, update the selection and re-present it using
+the same `AskUserQuestion` proceed/adjust pattern above.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/planning/stress-test-plan/SKILL.md
+++ b/skills/planning/stress-test-plan/SKILL.md
@@ -161,8 +161,12 @@ Here's what we found during the stress test:
 **Risks accepted:**
 - [Risk]: [User acknowledges this and accepts it]
 
-Would you like me to update the plan with these changes?
 ```
+
+Use the `AskUserQuestion` tool with two options:
+
+1. **Yes, update the plan** — apply the stress-test findings to the plan file
+2. **No, leave unchanged** — keep the plan as-is
 
 2. **If the user agrees, edit the plan**:
 

--- a/skills/research/conduct-spike/SKILL.md
+++ b/skills/research/conduct-spike/SKILL.md
@@ -191,7 +191,11 @@ When uncertainty is acceptably low, synthesise with the user:
   acceptable to proceed anyway (or what would trigger revisiting).
 - **Implications** — what this unblocks and any follow-on work it implies.
 
-Confirm the synthesis with the user before recording it.
+Use the `AskUserQuestion` tool to confirm the synthesis with the user before
+recording it, with two options:
+
+1. **Yes, record this synthesis** — write the outcome to the spike document
+2. **No, revise first** — adjust the synthesis before recording
 
 ### Step 6: Record the outcome
 

--- a/skills/vcs/commit/SKILL.md
+++ b/skills/vcs/commit/SKILL.md
@@ -33,7 +33,9 @@ allowed-tools:
 
 - List the files you plan to include in each commit
 - Show the commit message(s) you'll use
-- Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"
+- Use the `AskUserQuestion` tool with two options:
+  1. **Yes, proceed** — create [N] commit(s) with the staged changes
+  2. **No, cancel** — abort without committing
 
 4. **Execute upon confirmation:**
 

--- a/skills/work/create-work-item/SKILL.md
+++ b/skills/work/create-work-item/SKILL.md
@@ -525,14 +525,12 @@ concurrently. Please re-run /create-work-item.
       type/project fields (the team is fixed by `/init-linear`). State **both**
       outcomes inline:
 
-      ```
-      Push to <tracker> now? [y/N]  (y = create the remote issue + save locally;
-      anything else = save locally only, unsynced — you can push it later by
-      running /create-<tracker>-issue <path>)
-      ```
+      Use the `AskUserQuestion` tool with two options:
 
-      Interpret strictly: exactly `y`/`Y` (trimmed) accepts; **anything else**
-      declines. `/sync-work-items` is **not built yet** — do not tell the user
+      1. **Yes, push to [tracker] now** — create the remote issue and save
+         locally
+      2. **No, save locally only** — save as unsynced; push later with
+         `/create-[tracker]-issue <path>` `/sync-work-items` is **not built yet** — do not tell the user
       to run it; the "push later" path is the standalone `/create-<tracker>-issue`
       skill on the saved file (it shares this `external_id` contract).
 
@@ -633,8 +631,12 @@ Work item created: `{work_dir}/<full-id>-kebab-slug.md`
    Frontmatter fields preserved verbatim: id, date, author
      [+ any unmodified proposable fields]
 
-   Proceed? (y/n)
    ```
+
+   Then use the `AskUserQuestion` tool with two options:
+
+   1. **Yes, proceed** — overwrite the work item with the changes shown
+   2. **No, cancel** — make no changes
 
 4. **Confirmation interpretation** (fail-safe):
    - Exactly `y` or `Y` (after trimming whitespace): proceed to step 5.

--- a/skills/work/extract-work-items/SKILL.md
+++ b/skills/work/extract-work-items/SKILL.md
@@ -211,19 +211,18 @@ Source: [paths]
 
 [work item content with XXXX placeholder, including Drafting Notes section]
 
-How would you like to proceed?
-  1. enrich              — interactive Q&A, web research where useful, then approve
-  2. accept as-is        — write this skeleton as a thin draft for later refinement
-  3. skip                — exclude from this batch
-  4. accept remaining as-is — fast-path every remaining candidate as a thin draft
 ```
 
-Wait for the user's choice. The four options behave as follows.
+Use the `AskUserQuestion` tool with four options:
 
-If the user types something other than the four options — for example
-`revise <instructions>` or free-form revision text — treat it as
-`enrich` seeded with those instructions: enter the enrichment loop in
-3.3 and use the supplied text as the user's first round of revision
+1. **Enrich** — interactive Q&A, web research where useful, then approve
+2. **Accept as-is** — write this skeleton as a thin draft for later refinement
+3. **Skip** — exclude from this batch
+4. **Accept all remaining** — fast-path every remaining candidate as a thin draft
+
+Wait for the user's choice. If the user enters free-form text via the "Other"
+input, treat it as **Enrich** seeded with those instructions: enter the
+enrichment loop in 3.3 using the supplied text as the first round of revision
 guidance, skipping the question phase if the instructions are already
 substantive.
 
@@ -263,15 +262,13 @@ flow, seeded with the skeleton above:
      unresolved so the user can challenge them
    - Lists remaining open questions in the `Open Questions` section
 
-   Then offer next steps with numbers:
+   Then use the `AskUserQuestion` tool with four options:
 
-   ```
-   How would you like to proceed?
-     1. approve    — accept this draft and move on to the next candidate
-     2. revise <instructions> — provide revision instructions and I'll update the draft
-     3. skip       — discard this candidate entirely
-     4. accept as-is — discard enrichment and use the original source-only skeleton
-   ```
+   1. **Approve** — accept this draft and move on to the next candidate
+   2. **Revise** — update the draft with additional instructions (prompted after
+      via plain-text — do NOT use `AskUserQuestion` for the instructions)
+   3. **Skip** — discard this candidate entirely
+   4. **Accept as-is** — discard enrichment and use the original source-only skeleton
 
 4. **Iterate on the same candidate.** Challenge weak or untestable
    acceptance criteria — when a criterion is not measurable, ask what a

--- a/skills/work/refine-work-item/SKILL.md
+++ b/skills/work/refine-work-item/SKILL.md
@@ -126,11 +126,11 @@ any link operation references them.
 Propose 2–5 candidate children (2–4 for story decomposing to tasks) with
 draft titles and one-line Summaries derived from the Requirements section.
 
-**Bug/spike challenge**: if the work item kind is `bug` or `spike`, first ask:
-```
-bug/spike work items don't typically decompose — are you sure? (y/n)
-```
-Only proceed on explicit `y`. On `n`, exit decompose and return to the menu.
+**Bug/spike challenge**: if the work item kind is `bug` or `spike`, first use
+the `AskUserQuestion` tool with two options:
+
+1. **Yes, proceed anyway** — continue with decompose
+2. **No, cancel** — exit decompose and return to the menu
 
 **Existing children**: if the Requirements section already contains a
 `### Child work items` subsection, offer:
@@ -164,13 +164,12 @@ Process user input:
 - Any other input → print "unrecognised command", restate the legend, and
   re-show the unchanged proposal unchanged. Do NOT treat as approval.
 
-**Pre-write warning**: before writing, emit:
-```
-This will allocate N work item numbers and write N files; aborting mid-write
-leaves partial state — use `jj restore <file>` to discard any children
-written. Proceed? (y/n)
-```
-Wait for explicit `y`. On `n`, cancel without writing.
+**Pre-write warning**: before writing, use the `AskUserQuestion` tool with two
+options. State the allocation count and warn about partial state:
+
+1. **Yes, proceed** — allocate N numbers and write N files (partial state is
+   possible if aborted mid-write; use `jj restore <file>` to discard)
+2. **No, cancel** — cancel without writing
 
 **On approval**:
 
@@ -356,8 +355,9 @@ On approval:
   and make no Edit.
 - **Existing `**Size**:` line with a different value or rationale**: show a
   unified diff of the proposed change (existing line struck, new line added)
-  and require an explicit second `y/n` confirmation before invoking Edit.
-  On `y`, replace the line in place. On `n`, make no Edit.
+  then use the `AskUserQuestion` tool with two options:
+  1. **Yes, apply size change** — replace the line in place
+  2. **No, cancel** — make no Edit
 
 ### 4e. Link
 
@@ -414,13 +414,14 @@ subsequent operations.
 
 ## Step 6 — Offer Review
 
-After the entire selected operation set completes, offer:
-```
-Would you like to run `/review-work-item` on this work item now?
-```
-If decompose was in the selection, also offer to run review on each child
-written. Do NOT invoke `/review-work-item` automatically — only make the offer.
-The skill exits after this offer regardless of the user's response.
+After the entire selected operation set completes, use the `AskUserQuestion`
+tool with two options:
+
+1. **Yes, run review** — run `/review-work-item` on this work item now (and
+   each child if decompose was in the selection)
+2. **No, done** — exit without running review
+
+Do NOT invoke `/review-work-item` automatically — wait for the user's choice.
 
 ## Important Guidelines
 

--- a/skills/work/review-work-item/SKILL.md
+++ b/skills/work/review-work-item/SKILL.md
@@ -477,15 +477,13 @@ After presenting the review:
 
 ### Step 7: Offer Re-Review
 
-After edits are complete:
+After edits are complete, use the `AskUserQuestion` tool with two options:
 
-```
-The work item has been updated. Would you like me to run another review pass to
-verify the changes address the findings? This will re-run the relevant lenses
-to check for any remaining issues.
-```
+1. **Yes, run another review pass** — re-run the relevant lenses to verify the
+   changes address the findings
+2. **No, done** — exit without re-reviewing
 
-If the user accepts:
+If the user chooses option 1:
 
 - Re-run **only the lenses that had findings** in the previous pass
 - Use the same spawn pattern and JSON extraction strategy from Steps 3-4

--- a/skills/work/review-work-item/SKILL.md
+++ b/skills/work/review-work-item/SKILL.md
@@ -141,18 +141,28 @@ who previously pinned `core_lenses` to the Phase 4 work item lenses
 set `max_lenses` to their subset size.
 
 Present the selection briefly — enumerate the chosen lenses with a one-line
-focus each — then wait for confirmation before spawning reviewers. The
-confirmation gate is preserved even though the default always selects every
+focus each — then use the `AskUserQuestion` tool with two options:
+
+1. **Yes, use the proposed lenses** — run the review with the selected lenses
+2. **No, specify which lenses to use** — adjust the selection before running
+
+The confirmation gate is preserved even though the default always selects every
 lens; the gate is useful when focus args or config have narrowed the set.
 
 Example (default path, no focus args, no `core_lenses` restriction):
 
 ```
 I'll review this work item through all work item lenses (clarity, completeness,
-dependency, scope, testability). Shall I proceed?
+dependency, scope, testability).
 ```
 
-Wait for confirmation before spawning reviewers.
+Wait for the user's answer before spawning reviewers. If they choose option 2,
+ask which lenses they want using a **plain-text question only** — do NOT use
+`AskUserQuestion` for this follow-up (the lens list is too large for the
+4-option limit). If any lens name is unrecognised, seek clarification. Once
+confirmed, update the selection and re-present it using the same
+`AskUserQuestion` proceed/adjust pattern. This loop is user-controlled with
+no hard termination limit.
 
 ### Step 3: Spawn Review Agents
 

--- a/skills/work/review-work-item/SKILL.md
+++ b/skills/work/review-work-item/SKILL.md
@@ -443,13 +443,14 @@ After presenting, offer the user control before proceeding to iteration:
 
 ```
 The review is complete. Verdict: [verdict]
-
-Would you like to:
-1. Proceed to address findings? (I'll help edit the work item)
-2. Change the verdict? (currently: [verdict])
-3. Discuss any specific findings in more detail?
-4. Re-run specific lenses with adjusted focus?
 ```
+
+Use the `AskUserQuestion` tool with four options:
+
+1. **Address findings** — edit the work item to resolve issues
+2. **Change the verdict** — currently: [verdict]
+3. **Discuss specific findings** — explore any finding in more detail
+4. **Re-run specific lenses** — adjust focus and re-review
 
 ### Step 6: Collaborative Work Item Iteration
 

--- a/skills/work/stress-test-work-item/SKILL.md
+++ b/skills/work/stress-test-work-item/SKILL.md
@@ -153,10 +153,15 @@ Here's what we found during the stress test:
 **Risks accepted:**
 - [Risk]: [User acknowledges this and accepts it]
 
-Would you like me to update the work item with these changes?
 ```
 
-2. **If the user agrees, edit the work item**:
+Use the `AskUserQuestion` tool with two options:
+
+1. **Yes, update the work item** — apply the stress-test findings to the work
+   item body
+2. **No, leave unchanged** — keep the work item as-is
+
+2. **If the user chooses option 1, edit the work item**:
 
    - Use the Edit tool to apply targeted modifications to the body sections
      **Acceptance Criteria**, **Dependencies**, **Assumptions**, or

--- a/skills/work/sync-work-items/SKILL.md
+++ b/skills/work/sync-work-items/SKILL.md
@@ -172,13 +172,12 @@ For each local item with a non-empty `external_id`, emitting
    overwrite from remote exceeds the shared threshold (**25**, the same constant
    the untracked-pull gate uses), pin and evaluate **before any pull write**:
 
-   ```
-   N local files will be overwritten from remote. Proceed? [y/N]
-   ```
+   Use the `AskUserQuestion` tool with two options (stating the count N):
 
-   It **fails safe**: empty input, a non-interactive context, or any non-`y`
-   answer aborts the entire pull-overwrite class with **zero** writes and a
-   non-zero exit. Never proceed on no answer.
+   1. **Yes, proceed** — overwrite the N local files from remote
+   2. **No, abort** — abort with zero writes and a non-zero exit
+
+   It **fails safe**: if not running interactively, abort with zero writes.
 
 5. **Terminal push handling.** A 71/terminal code from the update bridge is
    **never** auto-retried (a resent request could apply twice on a
@@ -289,12 +288,12 @@ ${CLAUDE_PLUGIN_ROOT}/skills/work/scripts/work-item-fetch-remote.sh \
 (**25** — the same constant the pull-overwrite gate in Step 3 uses), pin, and
 evaluate **before any creation write**:
 
-```
-N untracked remote issues will be created. Proceed? [y/N]
-```
+Use the `AskUserQuestion` tool with two options (stating the count N):
 
-It **fails safe**: empty input, a non-interactive context, or any non-`y` answer
-aborts the untracked-pull class with **zero** creations and a non-zero exit. This
+1. **Yes, proceed** — create the N untracked issues locally
+2. **No, abort** — abort with zero creations and a non-zero exit
+
+It **fails safe**: if not running interactively, abort with zero creations. This
 stops a mis-scoped `--all` or an automation-flooded project from flooding the
 work directory and exhausting IDs.
 

--- a/skills/work/update-work-item/SKILL.md
+++ b/skills/work/update-work-item/SKILL.md
@@ -140,10 +140,12 @@ block applies if the user names the field as `work_item_id` (the
 legacy alias accepted on read for files predating the unified
 schema).
 
-**`date` — warned**: print `"date records the work item's creation time and
-is typically not edited. Proceed anyway? (y/n)"`. If the user confirms,
-proceed through the normal diff-and-confirm flow. If declined, print
-"No changes applied." and exit.
+**`date` — warned**: inform the user that `date` records the work item's
+creation time and is typically not edited, then use the `AskUserQuestion` tool
+with two options:
+
+1. **Yes, proceed anyway** — proceed through the normal diff-and-confirm flow
+2. **No, cancel** — print "No changes applied." and exit
 
 **`parent` — canonicalised**: normalise the value via
 `work-item-common.sh:wip_canonicalise_id` before writing. The
@@ -219,11 +221,10 @@ after `# ` with the new title. Only the first H1 is touched.
 
 ### Confirmation prompt
 
-Print the diff and `"Apply these changes? (y/n)"`. Wait for user
-response. Accepted affirmatives: case-insensitive `y` or `yes`. On `n`
-or `no`: print "No changes applied." and exit without writing. On any
-other input: re-prompt once. If the second response is still
-unrecognised, treat as decline.
+Print the diff, then use the `AskUserQuestion` tool with two options:
+
+1. **Yes, apply changes** — write the changes to disk
+2. **No, cancel** — print "No changes applied." and exit without writing
 
 ### Field insertion preview
 


### PR DESCRIPTION

<img width="1203" height="389" alt="Screenshot 2026-06-27 at 18 26 30" src="https://github.com/user-attachments/assets/520af569-0d13-4029-8769-45ca4af3d7ae" />


## Summary

- Replaces the plain-text "Shall I proceed?" prompt in Step 2 of `/review-plan` with an `AskUserQuestion` tool call
- Presents two options: **Proceed** (recommended, first) and **Specify something else**
- If the user picks option 2, the skill re-applies their adjustments and loops back with the same `AskUserQuestion` pattern

## Test plan

- [ ] Run `/review-plan` against a plan file and verify the lens selection step surfaces an interactive `AskUserQuestion` prompt
- [ ] Confirm selecting "Proceed" moves straight to spawning review agents
- [ ] Confirm selecting "Specify something else" allows adjusting the lens list before re-confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)