### PR TITLE
[0168/0169] Refine work items

### DIFF
--- a/meta/prs/24-description.md
+++ b/meta/prs/24-description.md
@@ -1,0 +1,48 @@
+---
+type: pr-description
+id: "24"
+title: "[0168/0169] Refine work items"
+date: "2026-07-20T15:22:29+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+parent: "work-item:0136"
+relates_to: ["work-item:0166", "work-item:0168", "work-item:0169", "work-item:0180", "work-item:0172"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/24"
+pr_number: 24
+tags: [rust, vcs, visualiser, work-items, planning]
+revision: "6a8227762496309959238736e78eb15607105dc5"
+repository: "accelerator"
+last_updated: "2026-07-20T15:49:34+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0168/0169] Refine work items
+
+## Summary
+
+Grooms the next tranche of the Rust CLI migration epic (0136): refines work items **0168** (fold the visualiser into the `cli/` workspace) and **0169** (VCS subdomain + hooks migration) to *ready* through a review pass, and marks **0166** and **0180** *done*. This is a documentation-only PR — no code changes.
+
+## Changes
+
+- **0169 — VCS subdomain & hooks migration**: reviewed (five lenses, REVISE → APPROVE) and refined to *ready*. Key refinement: VCS access is now specified as **library-based** — `gix` (gitoxide) for git and `jj-lib` for jujutsu, read in-process behind the outbound VCS port, rather than spawning `jj`/`git` subprocesses (a per-query shell fallback stays behind the same port). Flags `jj-lib`'s unstable public API as an early-validation risk.
+- **0168 — fold visualiser into `cli/` workspace**: reviewed (REVISE → APPROVE) and refined to *ready*; relocates `accelerator-visualiser` onto the shared `config`/`corpus` crates and moves start/stop/status under `accelerator visualiser …` as the first on-demand sub-binary (ADR-0054).
+- **Status transitions**: 0166 (shared config/corpus/store crates) moved draft → *done*, and 0180 (atomic-store primitives) moved ready → *done*.
+- Adds the work-item review artifacts for 0168 and 0169.
+
+## Context
+
+- Epic **0136** — Rust CLI migration (`parent`).
+- Refines **0168** (`PP-189`) and **0169** (`PP-190`); marks **0166** and **0180** (`PP-704`) done.
+- Relates to **0172** (migration engine subdomain) — 0169 blocks it, and the SessionStart migration-discoverability reminder is deferred to it.
+- Stacked on `0180-atomic-store-primitives` (PR #23), which carries the corpus/atomic-store code this grooming refers to.
+
+## Testing
+
+- [x] No executable surface — the changes are work-item and review markdown; verification is limited to frontmatter well-formedness and internal linkage consistency, both confirmed by inspection.
+
+## Notes for Reviewers
+
+- The load-bearing decision to confirm is **0169's library-based VCS access** (`gix` + `jj-lib` in-process vs subprocess shell-out) — it departs from the earlier `CommandProbe` shell-out assumption and hinges on `jj-lib`'s unstable API, which the work item calls out for early validation.
+- Both work-item reviews resolved from an initial **REVISE** (driven by breadth, not weakness) to **APPROVE**; the review docs are included for the audit trail.

--- a/meta/reviews/work/0168-fold-visualiser-into-cli-workspace-review-1.md
+++ b/meta/reviews/work/0168-fold-visualiser-into-cli-workspace-review-1.md
@@ -1,0 +1,621 @@
+---
+type: work-item-review
+id: "0168-fold-visualiser-into-cli-workspace-review-1"
+title: "Work Item Review: Fold the Visualiser into the cli/ Workspace"
+date: "2026-07-19T22:07:17+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0168"
+work_item_id: "0168"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 6
+tags: []
+last_updated: "2026-07-19T23:16:46+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Fold the Visualiser into the cli/ Workspace
+
+**Verdict:** REVISE
+
+This is a dense, structurally complete, and internally consistent story: every
+expected section is present and substantively populated, the frontmatter is
+valid, the module-by-module retire mapping is precise, and the dependency
+analysis is unusually thorough (transitive blockers named, a non-dependency
+explicitly fenced). The REVISE verdict is driven not by weakness but by breadth —
+the story bundles two independently-shippable value streams, and its acceptance
+criteria under-verify the behaviour-preserving parts of the refactor (engine
+swap, security guard) and one dependency ordering (0165). Five major findings
+cross the ≥2 REVISE threshold; none is critical.
+
+### Cross-Cutting Themes
+
+- **Multi-concern breadth vs. verifiability** (flagged by: scope, testability) —
+  Scope flags that the story bundles a relocation-plus-dispatch stream with a
+  large 8-module refactor; testability independently flags that the six ACs each
+  cover a distinct concern and that behaviour-preserving parts of the refactor
+  are not verified. The two lenses reinforce each other: the wider the story, the
+  weaker "existing suites pass" (AC6) is as a backstop.
+- **Behaviour-preservation is asserted but not verified** (flagged by:
+  testability, scope) — The engine swap (gray_matter/serde_yml → serde-saphyr)
+  and the Host/Origin security model are named as must-preserve, yet AC2 only
+  checks the old modules are *gone* and no AC exercises equivalence or the
+  security guard.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Dependency**: 0165 (release manifest) is a blocker for AC5 but filed only
+  as "Relates to"
+  **Location**: Acceptance Criteria (AC5) / Dependencies
+  AC5 removes `launch-server.sh` and the standalone `bin/checksums.json` and makes
+  the visualiser fetched/verified against the unified release manifest — which
+  0165 produces — but 0165 is classified as "Relates to", not a blocker. Removing
+  the standalone checksums before the manifest lists the visualiser binary leaves
+  the fetch/verify path unsatisfiable.
+
+- 🟡 **Scope**: Story bundles sub-binary dispatch with a large independent
+  refactor
+  **Location**: Requirements
+  Two separable value streams are combined: (1) making the visualiser a
+  launcher-dispatched on-demand sub-binary (relocate + `start|stop|status`
+  orchestration + distribution change), and (2) retiring ~8 duplicated corpus
+  modules onto the shared 0179 crates plus an engine swap. The Drafting Notes
+  themselves frame stream 2 as separate validation value. Either could ship
+  without the other.
+
+- 🟡 **Testability**: No equivalence criterion for the frontmatter/slug/doc-type
+  engine swap
+  **Location**: Acceptance Criteria
+  The story swaps the frontmatter engine and re-homes slug/doc-type/typed-ref
+  logic, but no AC asserts the replacements produce output equivalent to the
+  retired code. AC2 only verifies the old modules are gone; AC6 delegates all
+  behavioural verification to unspecified suites.
+
+- 🟡 **Testability**: Host/Origin security guard is required but not verified by
+  any criterion
+  **Location**: Requirements
+  Requirements mandate preserving "the loopback-binding + Host/Origin security
+  model", but the ACs only verify the loopback bind (AC1); no criterion exercises
+  the Host/Origin guard or its rejection outcome, so it could regress undetected.
+
+- 🟡 **Testability**: AC6 delegates verification to "existing suites pass"
+  without specifying coverage
+  **Location**: Acceptance Criteria (AC6)
+  AC6 is the only behavioural backstop yet relies on whatever the current suites
+  cover; it does not assert they exercise the new `accelerator visualiser
+  start|stop|status` dispatch path or the launcher-resolved config path, so it
+  could pass while the story's core new behaviour is untested.
+
+#### Minor
+
+- 🔵 **Scope**: Six acceptance criteria across distinct concerns signal a large
+  story
+  **Location**: Acceptance Criteria
+  The six ACs each target a different concern (lifecycle, module retirement,
+  workspace membership, embed, distribution, end-to-end green); combined with the
+  unresolved reconciliation tensions in Technical Notes, this is a large single
+  delivery unit that tends to accumulate partial progress that cannot ship.
+
+- 🔵 **Testability**: Idle-shutdown "same timeout as today" has no stated value
+  **Location**: Acceptance Criteria (AC1)
+  AC1 requires the idle server self-shut-down "on the same timeout as today" but
+  gives no value, so a verifier must independently discover the current timeout
+  before measuring conformance.
+
+- 🔵 **Clarity**: "Q1" referenced as resolved without stating the question
+  **Location**: Context / Assumptions
+  Both Context and Assumptions cite "Q1" as resolved, but the work item never
+  states what Q1 asked and no Open Question is labelled Q1 — it references a
+  numbered question from the source research doc not reproduced here. The
+  substance (unit move preserves embed path) is fortunately restated inline.
+
+#### Suggestions
+
+- 🔵 **Testability**: AC1 bundles four distinct behaviours into one checkbox
+  **Location**: Acceptance Criteria (AC1)
+  AC1 combines start, stop (recycle guard), status, and idle self-shutdown into
+  one checkbox; each is independently verifiable, so partial completion cannot be
+  tracked distinctly.
+
+- 🔵 **Dependency**: External GitHub Releases coupling is implied but unnamed
+  **Location**: Requirements
+  Retiring the bespoke distribution in favour of the launcher fetching a
+  pre-compiled binary couples success to GitHub Releases hosting the artefact;
+  this external coupling is implied throughout but not recorded.
+
+- 🔵 **Completeness**: Story does not identify the beneficiary whose need is met
+  **Location**: Context
+  Typed as a `story` but described entirely in internal mechanics; naming who
+  benefits (maintainers freed from duplicated corpus logic, or the unified-release
+  flow) would make the value target explicit.
+
+- 🔵 **Clarity**: MSRV acronym used without definition or link
+  **Location**: Acceptance Criteria (AC3)
+  AC3 uses "MSRV" without expansion; standard Rust jargon, low risk, but a
+  newer reader must guess.
+
+- 🔵 **Clarity**: "All three are now done" where only two blockers are listed
+  explicitly
+  **Location**: Dependencies
+  The section lists 0179 and 0164 explicitly (0178 only parenthetically) then
+  asserts "all three are now done", relying on the reader to infer the set.
+
+### Strengths
+
+- ✅ Acceptance Criteria use Given/When/Then with an explicit actor, and AC2–AC5
+  lean on concrete structural checks (named modules removed, `gray_matter`/
+  `serde_yml` dropped, `version.workspace` inheritance, `cargo build -p
+  accelerator-visualiser` succeeds, three `../frontend/dist` literals unchanged,
+  `build.rs` fails cleanly without dist) that yield definitive pass/fail results.
+- ✅ Scope is consistent across Summary, Context, Requirements, and Acceptance
+  Criteria — the same three moves recur without contradiction — and the crate
+  boundary (what stays async/isolated vs. what moves out) is stated explicitly.
+- ✅ Technical Notes give a precise old-module → new-module mapping, so every
+  named item (`DocTypeKey`, `patch_status`, `WorkItemIdScheme`) resolves to one
+  referent.
+- ✅ Dependencies are unusually thorough: upstream blockers captured with
+  transitive chain and status, a non-dependency (0180) explicitly fenced with
+  rationale, and Drafting Notes reconciling the stale 0166 citation.
+- ✅ Frontmatter is complete and valid; optional sections (Open Questions,
+  Assumptions, Technical Notes) carry real content rather than placeholders.
+
+### Recommended Changes
+
+1. **Promote 0165 to a blocker for AC5, or add an ordering note** (addresses:
+   Dependency — 0165 blocker for AC5). Either reclassify 0165 from "Relates to"
+   to an explicit blocker gating AC5, or add a Dependencies note (mirroring the
+   0180 "Not blocked by" rationale) stating the visualiser's manifest entry from
+   0165 must land before/with this story.
+
+2. **Decide and record the scope split, or justify indivisibility** (addresses:
+   Scope — bundles two streams; Scope — six ACs). Either split into a
+   relocation-plus-dispatch story and a refactor story delivered in sequence, or
+   add a sentence to the work item stating why the "first on-demand sub-binary"
+   goal makes the two streams genuinely indivisible for this increment.
+
+3. **Add behaviour-equivalence acceptance criteria** (addresses: Testability —
+   engine-swap equivalence; Testability — Host/Origin guard). Add an AC asserting
+   the refactored parsing/slug/doc-type inference produces output equivalent to
+   the pre-refactor code for a representative corpus fixture, and an AC exercising
+   the Host/Origin guard (non-loopback Host / cross-origin Origin rejected;
+   matching loopback accepted).
+
+4. **Strengthen AC6 with named coverage** (addresses: Testability — AC6 delegates
+   without coverage). Name the behaviours the suites must cover post-move
+   (launcher dispatch, config resolution, start/stop/status), or add an AC that
+   new coverage exists for the `accelerator visualiser` sub-commands rather than
+   leaning solely on "green end-to-end".
+
+5. **State the idle timeout value and consider splitting AC1** (addresses:
+   Testability — idle timeout value; Testability — AC1 bundles four behaviours).
+   Give the concrete idle timeout (or reference the config key), and optionally
+   split AC1 into separate start / stop / status / idle-shutdown criteria.
+
+6. **Polish clarity shorthands** (addresses: Clarity — Q1; Clarity — MSRV;
+   Clarity — three-vs-two count; Completeness — beneficiary; Dependency — GitHub
+   Releases). Drop or gloss the "Q1" label, expand MSRV on first use, enumerate
+   the three blockers explicitly, name the story's beneficiary in Context, and
+   record the GitHub Releases external coupling.
+
+---
+*Review generated by /review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: A dense but internally consistent work item whose scope holds
+together across all sections; pronouns and referents almost always resolve to a
+single named subject, and the Acceptance Criteria name their actor via
+Given/When/Then. The only clarity gaps are a handful of unlinked shorthand
+references ("Q1", "MSRV") and one mildly ambiguous dependency count.
+
+**Strengths**:
+- Acceptance Criteria use Given/When/Then with an explicit actor, so
+  responsibility for each observable outcome is unambiguous.
+- Scope is consistent across sections — the same three moves appear in Summary,
+  Context, Requirements, and Acceptance Criteria without contradiction.
+- Technical Notes give a precise old-module → new-module mapping, so each named
+  term resolves to exactly one referent.
+
+**Findings**:
+- 🔵 minor (medium confidence) — **"Q1" referenced as resolved without stating
+  the question** (Context): Context and Assumptions cite "Q1" as resolved, but
+  the item never states what Q1 asked and no Open Question is labelled Q1; it
+  references a numbered question from the source research doc not reproduced here.
+  The substance (unit move preserves embed path) is restated inline. Suggestion:
+  drop the "Q1" label or add a one-line note of what Q1 asked.
+- 🔵 suggestion (medium confidence) — **MSRV acronym used without definition or
+  link** (Acceptance Criteria): AC3 uses "MSRV" without expansion. Standard Rust
+  jargon, small risk, but a newer reader must guess. Suggestion: expand on first
+  use or link the workspace policy.
+- 🔵 suggestion (low confidence) — **"All three are now done" where only two
+  blockers are listed explicitly** (Dependencies): the section names 0179 and
+  0164 explicitly (0178 only parenthetically) then asserts "all three are now
+  done". Suggestion: enumerate the three items explicitly.
+
+### Completeness
+
+**Summary**: A structurally complete and densely populated story: every expected
+section is present and substantively filled, and the frontmatter carries all
+required fields with valid values. The Acceptance Criteria comfortably exceed the
+minimum and the Context explains the motivating forces. The only gap worth noting
+is that, framed as a `story`, it never explicitly identifies the beneficiary
+whose need is served, reading instead as an internal refactor.
+
+**Strengths**:
+- Frontmatter is complete and valid — kind, status, priority, id, title, parent
+  all present with recognised values.
+- Acceptance Criteria contains six specific, behaviour-oriented bullets — well
+  beyond the minimum density.
+- Context explains the why rather than restating the Summary.
+- Requirements are specific and implementation-ready, naming concrete paths,
+  crates, and files.
+- Optional sections (Open Questions, Dependencies, Assumptions, Technical Notes)
+  are all populated with real content.
+
+**Findings**:
+- 🔵 suggestion (low confidence) — **Story does not identify the beneficiary
+  whose need is met** (Context): typed as a `story` but described entirely in
+  internal mechanics without identifying the user or system whose need is served.
+  Suggestion: add a short clause naming who benefits.
+
+### Dependency
+
+**Summary**: The Dependencies section is unusually thorough for a story: upstream
+blockers (0179→0178, 0164) are named with resolved status, a non-dependency
+(0180) is explicitly disambiguated with rationale, and the Drafting Notes explain
+why reverse `blocks` edges live on the blocker items. The one genuine gap is that
+AC5 makes the fetch/verify/dispatch contingent on 0165's release manifest, yet
+0165 is filed only as "Relates to" rather than an ordering blocker.
+
+**Strengths**:
+- Upstream blockers captured precisely with transitive chain and status (0179
+  resting on 0178, 0164), all noted as `done`.
+- Explicitly records a non-dependency — 0180 called out as "Not blocked by" with
+  reason, preventing a false blocker assumption.
+- Drafting Notes reconcile the stale 0166 citation and explain the canonical
+  `blocks: 0168` edges live on 0179/0164.
+
+**Findings**:
+- 🟡 major (medium confidence) — **0165 (release manifest) is a blocker for AC5
+  but filed only as "Relates to"** (Acceptance Criteria): AC5 removes
+  `launch-server.sh` and the standalone `bin/checksums.json` and requires the
+  visualiser be fetched/verified against the unified release manifest that 0165
+  produces, but 0165 is classified only as "Relates to". Removing the standalone
+  checksums before the manifest lists the visualiser binary leaves the
+  fetch/verify path unsatisfiable. Suggestion: promote 0165 to an explicit
+  blocker for AC5, or add a Dependencies note that its manifest entry must land
+  before/with this story.
+- 🔵 suggestion (low confidence) — **External GitHub Releases coupling is implied
+  but unnamed** (Requirements): retiring the bespoke distribution couples success
+  to GitHub Releases hosting the artefact and manifest; this external coupling is
+  implied throughout but not recorded. Suggestion: add a one-line Dependencies
+  note naming GitHub Releases as the external artefact source.
+
+### Scope
+
+**Summary**: A coherent, well-bounded increment under epic 0136 that names what
+moves, what stays isolated in the crate, and what is explicitly out of scope
+(0180). However, it bundles two arguably separable value streams — making the
+visualiser a launcher-dispatched on-demand sub-binary, and retiring the
+visualiser's duplicated corpus logic onto the shared 0179 crates — into one
+heavyweight story whose six acceptance criteria each cover a distinct concern.
+
+**Strengths**:
+- Summary, Requirements, and Acceptance Criteria describe a consistent scope, and
+  the story states explicitly what stays inside the crate versus what moves out.
+- Out-of-scope work is deliberately fenced ("Not blocked by 0180"), resisting
+  scope creep into the atomic-store primitives.
+- As a child of epic 0136 with clear parent linkage and a stated "Phase 5" role,
+  the story sits correctly within a larger decomposition.
+
+**Findings**:
+- 🟡 major (medium confidence) — **Story bundles sub-binary dispatch with a large
+  independent refactor** (Requirements): two value streams that could ship and
+  roll back independently — (1) relocation + `start|stop|status` orchestration +
+  distribution change, and (2) retiring ~8 duplicated corpus modules onto the
+  shared crates plus a `gray_matter`/`serde_yml` → `document` engine swap. The
+  Drafting Notes frame stream 2 as separate validation value. Impact: a single
+  story spanning relocation, an 8-module refactor with unresolved async/sync
+  reconciliation, an engine swap, orchestration migration, and a distribution
+  change is hard to plan, review, and roll back; a failure in any stream blocks
+  the others. Suggestion: split into a relocation-plus-dispatch story and a
+  refactor story delivered in sequence, or confirm why the two are indivisible.
+- 🔵 minor (low confidence) — **Six acceptance criteria across distinct concerns
+  signal a large story** (Acceptance Criteria): the six ACs each target a
+  different concern; combined with the unresolved reconciliation tensions in
+  Technical Notes, this is a large delivery unit. Suggestion: re-check whether it
+  warrants decomposition; if judged indivisible given the "first on-demand
+  sub-binary" goal, that judgement is defensible.
+
+### Testability
+
+**Summary**: The Acceptance Criteria are largely well-formed for a
+refactor-and-relocate story: AC1 is a clean Given/When/Then for the lifecycle,
+and AC2–AC5 lean on concrete structural checks that produce definitive pass/fail
+results. The main testability gaps are behavioural: the parsing/slug/doc-type
+refactor swaps engines yet has no equivalence criterion, the Host/Origin security
+guard is not verified by any criterion, and the sole behavioural backstop (AC6)
+delegates entirely to "the existing suites pass".
+
+**Strengths**:
+- AC1 is framed as an explicit Given/When/Then lifecycle scenario covering start,
+  stop (owner-PID AND start_time recycle guard), and status.
+- AC2–AC5 use concrete structural checks (named modules removed, deps dropped,
+  `version.workspace` inheritance, `cargo build -p accelerator-visualiser`
+  succeeds, three `../frontend/dist` literals unchanged, `build.rs` fails cleanly
+  without dist) confirmable definitively.
+- AC5 pins removal of specific artefacts rather than describing the change
+  abstractly, making the file-level outcome directly checkable.
+
+**Findings**:
+- 🟡 major (medium confidence) — **No equivalence criterion for the
+  frontmatter/slug/doc-type engine swap** (Acceptance Criteria): the story swaps
+  the frontmatter engine and re-homes slug/doc-type/typed-ref logic, but no AC
+  asserts the replacements produce equivalent output. AC2 only verifies the old
+  modules are gone; AC6 delegates behaviour to unspecified suites. Suggestion:
+  add a parity criterion over a representative corpus fixture (or named
+  golden/parity tests).
+- 🟡 major (medium confidence) — **Host/Origin security guard is required but not
+  verified by any criterion** (Requirements): Requirements mandate preserving the
+  loopback + Host/Origin security model, but ACs only verify the loopback bind;
+  no criterion exercises the Host/Origin guard or its rejection outcome.
+  Suggestion: add a criterion that a non-loopback Host / cross-origin Origin is
+  rejected while a matching loopback Host/Origin is accepted.
+- 🟡 major (medium confidence) — **AC6 delegates verification to "existing suites
+  pass" without specifying coverage** (Acceptance Criteria): AC6 relies on
+  whatever the current suites cover and does not assert they exercise the new
+  `accelerator visualiser start|stop|status` dispatch path or the launcher-
+  resolved config path. Suggestion: name the behaviours the suites must cover
+  post-move, or add a criterion that new coverage exists for the sub-commands.
+- 🔵 minor (high confidence) — **Idle-shutdown "same timeout as today" has no
+  stated value** (Acceptance Criteria): AC1 requires the idle server self-shut-
+  down "on the same timeout as today" but gives no value. Suggestion: state the
+  concrete idle timeout or reference the exact config key.
+- 🔵 suggestion (high confidence) — **AC1 bundles four distinct behaviours into
+  one checkbox** (Acceptance Criteria): AC1 combines start, stop (recycle guard),
+  status, and idle self-shutdown into a single checkbox; partial completion
+  cannot be tracked distinctly. Suggestion: split into separate criteria.
+
+## Re-Review (Pass 2) — 2026-07-19
+
+**Verdict:** REVISE
+
+Re-ran clarity, completeness, dependency, scope, and testability against the revised
+work item after the first round of edits. All five original majors resolved, but the
+edits introduced three new majors (two of them regressions from the review's own
+edits), which were then fixed in a second edit round.
+
+### Previously Identified Issues
+
+- 🟡 **Dependency**: 0165 blocker for AC5 — **Resolved**. The new ordering-constraint
+  note is praised as "exactly the coupling the lens looks for".
+- 🟡 **Scope**: bundles two streams — **Resolved** (downgraded to minor). The
+  Drafting-Notes indivisibility justification "answers the obvious 'why not split'
+  objection"; only the distribution cut-over remains a soft, well-documented seam.
+- 🟡 **Testability**: engine-swap equivalence — **Resolved** (parity criterion added;
+  refined further below).
+- 🟡 **Testability**: Host/Origin guard unverified — **Resolved**; now a strength.
+- 🟡 **Testability**: AC6 delegates to "existing suites" — **Resolved** (named-coverage
+  criterion added).
+- 🔵 Clarity (Q1, MSRV, three-blocker count), Completeness (beneficiary),
+  Dependency (GitHub Releases) — **All resolved**; completeness returned zero findings.
+
+### New Issues Introduced (and fixed this pass)
+
+- 🟡 **Clarity** (high): "AC5" references in Dependencies had no resolvable referent —
+  the criteria are an unnumbered checkbox list and the inserts shifted positions, so
+  "AC5" pointed to the wrong criterion. **Fixed**: replaced positional "AC5" refs with
+  the descriptive "distribution cut-over criterion".
+- 🟡 **Clarity** (medium): the beneficiary sentence implied the whole ~15.4k-line crate
+  was duplicated corpus logic, contradicting Context's "much of it". **Fixed**: reworded
+  to scope the figure to the duplicated corpus slice and note the crate is retained.
+- 🟡 **Testability** (medium): the added parity criterion left fixture and equivalence
+  relation undefined. **Fixed**: it now names the fixture (one document per `DocTypeKey`
+  variant + fence/slug/ID edge cases) and the field-for-field equivalence relation
+  (whitespace/error-text out of scope).
+- 🔵 **Testability** minors also addressed: the security criterion pinned to
+  `403 Forbidden` with the state-changing-Origin nuance; the idle criterion given an
+  "idle" definition and a short-timeout verification method; status given a concrete
+  observable signal and transitions; "coverage exists" replaced with named test cases.
+
+### Assessment
+
+All five original majors are resolved and the three regressions introduced during
+iteration have been corrected in place. The work item is materially stronger — twelve
+individually-checkable acceptance criteria with concrete pass/fail signals, a
+well-justified single-story scope, and a fully mapped dependency ordering. The Pass-2
+REVISE verdict reflects the state *before* this pass's fixes were applied; the fixes
+target every finding it raised but have not themselves been re-verified by a fresh
+lens pass — a Pass 3 would confirm APPROVE. Remaining open items (scope's
+distribution-cut-over seam, the 0165 downstream-edge and launcher-config-interface
+couplings) are low-confidence suggestions the author can weigh, not blockers.
+
+## Re-Review (Pass 3) — 2026-07-19
+
+**Verdict:** COMMENT
+
+Re-ran clarity, scope, and testability to verify the Pass-2 fixes. Both Pass-2
+regressions are confirmed gone, and one merged new major (the config-path criterion
+contradicting Open Question 3, flagged independently by clarity and testability) was
+found and then fixed. Deduped, that single major sits below the 2-major REVISE
+threshold, so the pass lands at COMMENT — an improvement from REVISE.
+
+### Previously Identified Issues
+
+- 🟡 **Clarity**: "AC5" dangling referent — **Resolved**; no positional-reference
+  problem remains.
+- 🟡 **Clarity**: 15.4k-line contradiction — **Resolved**; the figure is scoped to the
+  duplicated slice and the retained crate is called out.
+- 🟡 **Testability**: parity fixture/equivalence undefined — **Resolved**; the parity AC
+  is now praised as "a genuinely runnable oracle".
+- 🟡 **Scope**: bundles two/four streams — **Resolved to suggestion/minor**; the
+  indivisibility justification is accepted, remaining findings are acknowledged
+  judgement calls, no majors.
+
+### New Issues Introduced (and fixed this pass)
+
+- 🟡 **Clarity + Testability** (merged, medium): the added coverage criterion asserted
+  "the launcher-resolved config path is honoured", but Open Question 3 leaves that
+  mechanism open — if the server reads config directly, the criterion is
+  unsatisfiable. **Fixed**: reworded to an outcome-based check ("the server honours
+  configuration from the location it is directed to … independent of whether the
+  launcher passes it in or the server reads `.accelerator/*.md` directly"), explicitly
+  cross-referencing Open Question 3.
+- 🔵 **Testability** minors also addressed: the status criterion now pins the
+  `running`/`stopped` stdout token as the definitive signal (dropped the ambiguous
+  "and/or"); the parity criterion states golden fixtures are frozen *before* the old
+  modules are deleted; the cut-over criterion marks the file-removal half as verifiable
+  at completion and the fetch/verify half as gated on 0165's manifest entry.
+- 🔵 **Clarity** suggestion: the 0166 "relates to" wording now matches the Drafting
+  Notes ("validates the shared-crate approach 0166 described; 0166 itself built
+  nothing").
+
+### Assessment
+
+The work item is now in strong shape. After this pass's fixes there are no
+outstanding major findings across any lens; the residue is a small set of
+low-confidence suggestions — the "visualiser" bare-noun referent drift (crate vs.
+binary vs. product), the optional extraction of the externally-gated distribution
+cut-over into a follow-up story, and recording a `blocks: 0165` edge if 0165's release
+validation actually depends on this fold-in. None blocks planning. The recorded
+COMMENT verdict reflects the Pass-3 measurement *before* its fixes were applied; with
+them applied the item is effectively APPROVE-ready and can proceed to `/create-plan`.
+
+## Re-Review (Pass 4) — 2026-07-19
+
+**Verdict:** COMMENT
+
+Re-ran clarity, scope, and testability to confirm the Pass-3 fixes. Both Pass-3
+regressions are confirmed gone (config-path criterion now praised as intentionally
+bounded; no positional-referent or 15.4k contradiction). One major remained: the
+distribution cut-over criterion bundled a verify-now clause (files removed) with a
+verify-later clause (fetch/verify gated on 0165) in a *single checkbox*, so the
+checkbox could not get a clean pass/fail. Deduped this is one major → COMMENT.
+
+### Fixes applied after Pass 4
+
+- 🟡 **Testability** (cut-over checkbox): **split into two criteria** — (a)
+  `launch-server.sh` + `bin/checksums.json` removed, verifiable at completion; (b) the
+  launcher fetch/verify/dispatch path, explicitly gated on 0165's manifest entry and
+  verified when it lands. Also cross-referenced the gating in the Requirements bullet
+  so the flat requirement and the gated dependency now describe the same conditional.
+- 🔵 **Testability** (config-honouring test): named the concrete subject —
+  `visualiser.idle_timeout` set to a non-default value in a fixture config, asserting
+  the server's resolved timeout matches.
+- 🔵 **Testability** (parity fixture): enumerated the fence-offset boundary inputs
+  (leading blank lines, CRLF, no trailing newline, empty frontmatter block, no
+  frontmatter at all) so the fixture set is verifiable from the criterion itself.
+
+## Re-Review (Pass 5) — 2026-07-19
+
+**Verdict:** APPROVE
+
+Re-ran clarity, scope, and testability against the post-Pass-4 work item, with **no
+edits made during this pass** — so this verdict reflects the work item's actual
+current state. **Zero major findings across all three lenses**; the distribution
+cut-over major is resolved by the checkbox split. With no criticals and no majors, the
+verdict is APPROVE.
+
+### Confirmation
+
+- 🟡 **Testability** (cut-over): **Resolved** — the split criteria are each
+  individually verifiable; the lens no longer raises a major.
+- 🟢 **Clarity, Scope**: no majors; both lenses affirm the internal consistency, the
+  inline-defined terms, the concrete status tokens, and the well-reasoned single-story
+  scope.
+
+### Residual (optional polish — none blocks APPROVE or planning)
+
+- 🔵 **Testability** minors — **all four applied post-Pass-5** (2026-07-19): the
+  script-removal criterion now names all five orchestration scripts (`visualiser.sh`,
+  `launch-server.sh`, `stop-server.sh`, `status-server.sh`,
+  `write-visualiser-config.sh`) plus `bin/checksums.json`; the launcher-dispatch test
+  now names an observable (a launcher spy/test-double recording the dispatch, or a
+  distinguishing side effect); AC1's precondition now specifies the required
+  visualiser configuration (the fixture config the orchestration tests use); and AC3
+  now pins the initial never-started status token to `stopped`.
+- 🔵 **Clarity** minor/suggestions: "That duplicated corpus logic now lives in the
+  shared crates" can momentarily read as already-migrated; JSONL is unexpanded; the
+  intentionally-abstract config-source phrase is flagged only for the record.
+- 🔵 **Scope** suggestions: the distribution cut-over remains the natural seam if the
+  story is ever peeled apart, and the four-stream breadth sits near the story/epic
+  boundary — both acknowledged judgement calls, not defects.
+
+### Assessment
+
+The work item is APPROVE-confirmed by a fresh lens pass with no outstanding majors on
+any lens. It is ready for `/create-plan`. The residual items above are minor tightening
+the author may apply at planning time or leave as-is.
+
+## Re-Review (Pass 6) — 2026-07-19
+
+**Verdict:** COMMENT
+
+Ran after applying the four Pass-5 residual testability minors, to lens-verify the
+final state. Clarity and scope returned **no majors**. Testability raised **one major**
+— the same externally-gated distribution-cut-over criterion, re-flagged: an AC that is
+"verified when 0165's entry lands, not before" cannot be checked at this story's
+completion. This is genuine reviewer variance on a real structural point (Pass 4
+flagged it, Pass 5 accepted the checkbox split, Pass 6 re-flagged the gated half).
+Deduped, one major → COMMENT.
+
+### Fixes applied after Pass 6
+
+- 🟡 **Testability** (gated fetch/verify AC): added a **within-story stand-in** — the
+  launcher's fetch/verify path is verified now against a local/test manifest fixture;
+  only the equivalent assertion against the live release manifest defers to 0165. The
+  criterion is no longer unverifiable at completion.
+- 🔵 **Testability** (guard ordering): dropped the un-observable "same guard ordering"
+  clause; replaced with two independently-testable cases (a Host-only violation and a
+  state-changing Origin-only violation each rejected `403`) that exercise both guards.
+- 🔵 **Testability** (8h default): added a config-resolution assertion — with no
+  `visualiser.idle_timeout` set, the resolved value equals `8h` (no long-running wait).
+- 🔵 **Clarity** (Open Question ordinal): numbered the Open Questions list so the
+  "Open Question 3" cross-reference resolves deterministically.
+- 🔵 **Clarity** (launch-server.sh dual role): stated once in Requirements that
+  `launch-server.sh` has two roles retired by two mechanisms — orchestration re-homes
+  into `accelerator visualiser start`, distribution/fetch is replaced by the launcher.
+
+### Residual (not applied — reviewer-variance / judgement calls)
+
+- 🔵 **Clarity** suggestion: "server" / "crate" / "visualiser crate" used somewhat
+  interchangeably for the `accelerator-visualiser` unit (lib+bin split). Cosmetic.
+- 🔵 **Scope** suggestions (recurring, acknowledged): the four-stream breadth sits near
+  the story/epic boundary, and the distribution cut-over remains the natural seam if the
+  story is ever peeled apart. These are the author's standing "keep as one story"
+  decision, not defects.
+
+### Assessment
+
+This is the sixth pass. Every major raised across passes 1–6 has been resolved; the one
+recurring structural point (an externally-gated acceptance criterion) now has a
+within-story stand-in verification, which should settle the oscillation. The remaining
+findings are reviewer-variance-level polish on a deliberately rich work item — the kind
+of thing further passes will keep surfacing without materially improving the item. The
+recorded COMMENT reflects the Pass-6 measurement *before* its fixes; with them applied
+there are no known outstanding majors. Recommendation: treat 0168 as ready for
+`/create-plan` and stop re-reviewing; the diminishing returns now outweigh further passes.
+
+## Approval — 2026-07-19
+
+**Final verdict: APPROVE** (author decision).
+
+The author accepted the work item after Pass 6. Every major raised across passes 1–6 is
+resolved; the one recurring structural point (the externally-gated distribution-cut-over
+criterion) now carries a within-story stand-in verification. The remaining findings are
+reviewer-variance-level polish and acknowledged scope judgement calls, none blocking.
+The frontmatter verdict is set to APPROVE to reflect this decision; it supersedes the
+Pass-6 COMMENT measurement (which was taken before Pass 6's own fixes were applied).

--- a/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-1.md
+++ b/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-1.md
@@ -1,0 +1,432 @@
+---
+type: work-item-review
+id: "0169-vcs-subdomain-and-hooks-migration-review-1"
+title: "Work Item Review: VCS Subdomain and Hooks Migration"
+date: "2026-07-20T09:34:16+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0169"
+parent: "work-item:0136"
+work_item_id: "0169"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-07-20T09:53:52+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: VCS Subdomain and Hooks Migration
+
+**Verdict:** REVISE
+
+This is a well-structured, densely populated story: every expected section is
+present and substantive, the scope boundary (three hook scripts migrated,
+migrate-discoverability deferred to 0172) is stated consistently across five
+sections, and the bundling decision is consciously reasoned. The reasons to
+revise are concentrated in two areas — verification coverage and a missing
+upstream dependency. Three acceptance criteria attach to concrete parity gates,
+but the four-subcommand VCS surface and the explicitly load-bearing
+`classify_checkout` ordering are under-verified, and the 0164 fetch-verify-cache
+model that AC #4 depends on is relied upon in the body yet absent from
+Dependencies.
+
+### Cross-Cutting Themes
+
+- **`classify_checkout` is flagged as load-bearing but is neither fully
+  disambiguated nor verified** (flagged by: clarity, testability) — Clarity
+  notes the term carries overlapping descriptors ("6-line record" vs "full
+  taxonomy"), so a reader cannot tell whether the taxonomy extends the shell's
+  classification set or re-expresses it. Testability notes that this
+  most-fragile behaviour has no acceptance criterion pinning arm order or
+  taxonomy coverage. Together they mean the item's own highest-risk area is both
+  ambiguously described and untested.
+- **AC1 names four subcommands but the story only anchors verification for
+  `detect`** (flagged by: testability, scope) — Testability flags that
+  `status`, `log`, and `guard` have no stated pass/fail procedure; Scope
+  observes that `status`/`log` aren't consumed by the hooks this story migrates
+  and serve the skills instead. The gap in verification tracks the seam where
+  the two bundled deliverables meet.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Dependency**: 0164 fetch-verify-cache dependency relied on in body but absent from Dependencies
+  **Location**: Dependencies
+  Requirements, Drafting Notes, and AC #4 all rely on the 0164 warmed-cache
+  model, yet 0164 appears in neither `blocked_by`/`relates_to` nor the prose
+  Dependencies section. A scheduler reading Dependencies would not know AC #4
+  cannot be validated until 0164 lands.
+
+- 🟡 **Testability**: AC1 verifies four subcommands against a detect-only parity gate
+  **Location**: Acceptance Criteria
+  AC1 requires `vcs detect|status|log|guard` all "reproduce the shell
+  behaviours", but the only anchor named is the detect-focused
+  `hooks/test-vcs-detect.sh`. There is no stated pass/fail procedure for
+  `status`, `log`, or `guard` — no verification value for 75% of the named
+  surface.
+
+- 🟡 **Testability**: Load-bearing classify_checkout arm ordering and full taxonomy has no verifying criterion
+  **Location**: Technical Notes / Acceptance Criteria
+  `classify_checkout` first-match-wins ordering is called out as "load-bearing —
+  preserve first-match-wins semantics exactly" and the crates must be extended
+  with the full taxonomy (worktree/submodule/bare/`GIT_DIR`), yet no AC
+  enumerates or verifies these arms or the ordering. The most fragile behaviour
+  can regress while every AC still passes.
+
+#### Minor
+
+- 🔵 **Dependency**: Downstream stories 0172/0174 depend on this story's hooks.json changes but are captured only as 'related'
+  **Location**: Dependencies
+  This story rewrites `hooks.json` and leaves the shell tail that 0174 retires
+  and the migrate-discoverability hook 0172 inherits. Both consume this story's
+  output and must come after it, but they are recorded as "Related" with no
+  explicit "Blocks" ordering, so they won't surface as unblocked when this
+  closes.
+
+- 🔵 **Scope**: Story bundles two independently-deliverable halves across a one-way dependency seam
+  **Location**: Requirements
+  Building the `accelerator-vcs` hexagon and migrating the hooks are joined by a
+  clean one-way seam; `vcs status`/`log` are not consumed by the hooks this
+  story migrates, weakening the "hooks are the primary consumer" rationale. The
+  two halves could be delivered and verified independently, making this a large,
+  harder-to-roll-back-atomically story.
+
+- 🔵 **Testability**: AC3 'correct hook I/O envelope' lacks a defined expected reference
+  **Location**: Acceptance Criteria
+  AC3 requires emitting "the correct hook I/O envelope via `--format=hook`" but
+  references no expected-envelope fixture or protocol shape, leaving "correct" to
+  the verifier's judgement.
+
+- 🔵 **Testability**: 'Keep the wrapper bash-3.2-safe' requirement has no verification criterion
+  **Location**: Requirements
+  The bash-3.2-safe requirement has no AC capturing it as a checkable outcome, so
+  a bash-4 construct could slip past the definition of done — a recurring failure
+  mode for this repo.
+
+- 🔵 **Clarity**: Summary overstates SessionStart migration scope
+  **Location**: Summary
+  The Summary says the story migrates "the SessionStart/PreToolUse hook logic",
+  implying all SessionStart logic moves, but only VCS and config detection are
+  ported (migrate-discoverability deferred to 0172). A reader stopping at the
+  Summary forms a broader mental model than the Requirements deliver.
+
+#### Suggestions
+
+- 🔵 **Testability**: AC4 'no sub-binary fetch' would benefit from a stated observation method
+  **Location**: Acceptance Criteria
+  AC4 is observable in principle but doesn't state how absence of a fetch is
+  detected, risking flaky or hand-wavy verification of a caching behaviour.
+
+- 🔵 **Scope**: Cross-subdomain `config detect` port is folded into a VCS-framed story
+  **Location**: Requirements
+  Beyond VCS + hooks, the story ports `accelerator config detect` (a config
+  subdomain concern). Reasonable given the SessionStart fan-out, but surfacing it
+  in the Summary/title would make the story's true span visible up front.
+
+- 🔵 **Clarity**: 'Resolved Q4' is an undefined external referent
+  **Location**: Context
+  "Resolved Q4 fixes the mechanism" points to a refinement question numbered
+  elsewhere that a reader without that source cannot resolve.
+
+- 🔵 **Clarity**: 'classify_checkout' carries three overlapping descriptors
+  **Location**: Requirements
+  The same term is used for a fixed-shape "6-line record", a "full taxonomy", and
+  "load-bearing arm ordering", leaving unclear whether the taxonomy extends the
+  shell's classification set or re-expresses it.
+
+- 🔵 **Clarity**: 'The four target platforms' are not named
+  **Location**: Assumptions
+  "The four target platforms are Unix" never enumerates which four, leaving the
+  assumption's boundary ambiguous without epic-0136 context.
+
+- 🔵 **Completeness**: Beneficiary of the migration is implied rather than stated
+  **Location**: Summary / Context
+  Context frames motivation via the ADR-0048 mandate but doesn't name who
+  benefits (the epic-0136 shell retirement goal), a minor context gap for a story.
+
+### Strengths
+
+- ✅ The three-not-four script-removal scope boundary is stated identically in
+  Context, Requirements, Acceptance Criteria, Technical Notes, and Drafting
+  Notes — a reader cannot mistake which SessionStart handler is deferred.
+- ✅ Upstream blockers carry live status context (0166 complete, 0167 in
+  progress, 0179 complete on the feature branch), letting a scheduler see
+  readiness at a glance.
+- ✅ All expected sections are present and densely populated with substantive
+  content rather than placeholders; frontmatter integrity is strong (recognised
+  kind/status/priority and parent/blocked_by/relates_to relationships).
+- ✅ Open Questions is explicitly reconciled ("None outstanding") with the
+  resolution history captured in Drafting Notes, so the closed scope boundary was
+  deliberate, not omitted.
+- ✅ The bundling decision is consciously reasoned (hooks are the subdomain's
+  primary consumer) and previously-open sizing questions (built-in vs sub-binary
+  guard) were resolved and closed.
+- ✅ AC3–AC5 bind reproduction and removal to concrete, observable anchors
+  (parity gates, hook tests, named script removal, test-floor adjustment).
+
+### Recommended Changes
+
+1. **Add 0164 to Dependencies and frontmatter** (addresses: 0164 fetch-verify-cache
+   dependency absent) — Add 0164 to the prose Dependencies section and to
+   `blocked_by`/`relates_to` as appropriate, noting AC #4's warmed-cache
+   guarantee is gated on 0164's fetch-verify-cache model.
+
+2. **Give the four VCS subcommands per-subcommand verification anchors**
+   (addresses: AC1 detect-only parity gate) — Split AC1 or name a pass/fail
+   procedure for `status`, `log`, and `guard` (e.g. golden-output tests for
+   `status`/`log`, an allow/deny fixture set for `guard`) so every named
+   subcommand has a defined check.
+
+3. **Add an AC that verifies `classify_checkout` arms and ordering** (addresses:
+   classify_checkout untested; classify_checkout ambiguous descriptors) — Require
+   a fixture covering each arm (worktree, submodule, bare, `GIT_DIR`, plain) and
+   asserting first-match-wins precedence for at least one ambiguous checkout. While
+   editing, state whether the "full taxonomy" extends the shell's classification
+   set or re-expresses the 6-line record.
+
+4. **Anchor AC3 to an expected hook I/O envelope** (addresses: AC3 lacks expected
+   reference) — Reference a golden JSON fixture per hook type or the specific
+   Claude Code hook I/O protocol fields the envelope must contain.
+
+5. **Add an AC for the bash-3.2 wrapper constraint** (addresses: bash-3.2-safe has
+   no criterion) — Require the wrapper to pass the bashisms linter / bash-3.2 gate.
+
+6. **Capture downstream ordering to 0172/0174** (addresses: downstream stories only
+   'related') — Add a "Blocks: 0172, 0174" entry or annotate the Related lines so
+   the forward unblocking is explicit.
+
+7. **(Optional) Tighten Summary and clarify referents** (addresses: Summary
+   overstates scope; 'Resolved Q4'; four platforms; beneficiary) — Qualify the
+   Summary to note SessionStart covers VCS + config detection only; drop or link
+   the "Q4" label; name the four platforms or link 0136; consider surfacing the
+   config-detect port in the Summary/title.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is dense but generally well-disciplined: pronouns
+resolve cleanly, the scope boundary is stated consistently, and ADR references
+are linked. The main clarity risks are a Summary that overstates the SessionStart
+migration scope, a couple of external referents used without in-document
+definition ("Resolved Q4", "the four target platforms"), and the multi-descriptor
+use of "classify_checkout".
+
+**Strengths**:
+- The three-not-four script-removal boundary is stated identically across five
+  sections.
+- Pronoun usage is tight — "it" and "those crates" resolve to a single named
+  referent.
+- Acronyms (ADR-0048, ADR-0053) are linked in References.
+
+**Findings**:
+- 🔵 minor / medium — **Summary overstates SessionStart migration scope**
+  (Summary): "migrate the SessionStart/PreToolUse hook logic" implies all
+  SessionStart logic moves, but only VCS + config detection are ported. Suggest
+  qualifying the Summary.
+- 🔵 suggestion / medium — **'Resolved Q4' is an undefined external referent**
+  (Context): "Q4" is never defined in the work item. Suggest dropping or linking
+  it.
+- 🔵 suggestion / low — **'The four target platforms' are not named**
+  (Assumptions): the four platforms are never enumerated. Suggest naming them or
+  linking 0136.
+- 🔵 suggestion / low — **'classify_checkout' carries three overlapping
+  descriptors** (Requirements): "6-line record", "full taxonomy", and "arm
+  ordering" leave the record/taxonomy relationship ambiguous. Suggest stating
+  whether the taxonomy extends the shell's set.
+
+### Completeness
+
+**Summary**: Structurally and informationally complete for a story: every
+expected section is present and substantively populated, frontmatter is
+well-formed, Context explains the motivating forces, and the five acceptance
+criteria concretely define done. No completeness gaps rise to major severity.
+
+**Strengths**:
+- All expected sections carry substantive content rather than placeholders.
+- Frontmatter integrity is strong (kind, status, priority, relationships all
+  present and valid).
+- Context explains the "why" rather than restating the summary.
+- Open Questions is explicitly reconciled with resolution history in Drafting
+  Notes.
+- Acceptance Criteria each tie to a concrete verifiable artefact.
+
+**Findings**:
+- 🔵 suggestion / low — **Beneficiary of the migration is implied rather than
+  stated** (Summary / Context): motivation is framed via the ADR mandate without
+  naming who benefits (the epic-0136 shell retirement). Suggest a short clause
+  naming the beneficiary.
+
+### Dependency
+
+**Summary**: The Dependencies section is well-populated and disciplined — each
+blocker carries a live status annotation and the deferred migrate-discoverability
+boundary is explicit. The one material gap is 0164: its fetch-verify-cache model
+is relied upon twice and is the sole enabler of AC #4, yet appears nowhere in
+frontmatter or the prose Dependencies section. Downstream 0172/0174 are captured
+only as "related" rather than an explicit "blocks" ordering.
+
+**Strengths**:
+- Upstream blockers captured with live status context.
+- The migrate-discoverability boundary and its ownership by 0172 is explicit in
+  four sections.
+- External tools jj/git named behind an outbound port; platform assumption
+  stated.
+
+**Findings**:
+- 🟡 major / high — **0164 fetch-verify-cache dependency relied on in body but
+  absent from Dependencies** (Dependencies): AC #4 is verifiable only if 0164's
+  cache model exists, yet 0164 is in neither frontmatter nor the prose section.
+  Add 0164 to Dependencies and `blocked_by`/`relates_to`.
+- 🔵 minor / medium — **Downstream stories 0172/0174 depend on this story's
+  hooks.json changes but are captured only as 'related'** (Dependencies): both
+  consume this story's output and must follow it, but no "Blocks" ordering is
+  recorded. Add a "Blocks: 0172, 0174" entry.
+
+### Scope
+
+**Summary**: Thematically coherent — the Drafting Notes explicitly justify
+bundling the VCS subdomain with the hooks migration, and the in/out boundaries
+are drawn deliberately and confirmed with the author. The main observation is that
+the story spans two deliverables with a clean dependency seam and folds in a
+cross-subdomain `config detect` port; `status`/`log` are built here but consumed
+by skills, not the hooks. Defensible bundles rather than a scattered grab-bag.
+
+**Strengths**:
+- Scope boundaries drawn explicitly and defended (three scripts removed, not
+  four; author-confirmed).
+- The bundling decision is consciously reasoned rather than accidental, with
+  sizing questions resolved and closed.
+- The unit of work is well-anchored in its epic with clear upstream/downstream
+  seams.
+
+**Findings**:
+- 🔵 minor / medium — **Story bundles two independently-deliverable halves across
+  a one-way dependency seam** (Requirements): `status`/`log` aren't consumed by
+  the migrated hooks, weakening the "primary consumer" rationale; the halves could
+  split at the existing seam. If the bundle is intentional for delivery
+  efficiency, the Drafting Notes justification suffices.
+- 🔵 suggestion / medium — **Cross-subdomain `config detect` port folded into a
+  VCS-framed story** (Requirements): reasonable given the SessionStart fan-out and
+  acknowledged in Context/Drafting Notes; consider surfacing it in the
+  Summary/title so the true span is visible.
+
+### Testability
+
+**Summary**: Most acceptance criteria anchor to concrete pre-existing harnesses
+(the repointed `test-vcs-detect.sh` parity gate, the config-detect hook test,
+observable script removal), making them genuinely testable. The weak spots are
+coverage gaps: AC1 names four subcommands but cites only a detect-focused parity
+gate, and the load-bearing `classify_checkout` arm ordering and full taxonomy
+have no criterion pinning them down.
+
+**Strengths**:
+- AC1/AC2 bind "reproduce the shell behaviours" to named parity gates.
+- AC4 turns the caching requirement into an observable pass/fail.
+- AC5 is concrete and mechanically checkable (three named scripts removed, floor
+  adjusted, migrate-discoverability retained).
+
+**Findings**:
+- 🟡 major / high — **AC1 verifies four subcommands against a detect-only parity
+  gate** (Acceptance Criteria): no pass/fail procedure for `status`, `log`,
+  `guard`. Split AC1 or name a verification anchor per subcommand.
+- 🟡 major / high — **Load-bearing classify_checkout arm ordering and full
+  taxonomy has no verifying criterion** (Technical Notes / Acceptance Criteria):
+  the most fragile behaviour can regress while every AC passes. Add an AC covering
+  each arm and asserting first-match-wins precedence.
+- 🔵 minor / medium — **AC3 'correct hook I/O envelope' lacks a defined expected
+  reference** (Acceptance Criteria): "correct" is left to verifier judgement.
+  Anchor to a golden envelope fixture or explicit protocol fields.
+- 🔵 minor / medium — **'Keep the wrapper bash-3.2-safe' requirement has no
+  verification criterion** (Requirements): a bash-4 construct could slip past the
+  definition of done. Add an AC that the wrapper passes the bashisms/bash-3.2
+  gate.
+- 🔵 suggestion / low — **AC4 'no sub-binary fetch' would benefit from a stated
+  observation method** (Acceptance Criteria): specify the check (e.g. zero fetch
+  invocations against a stubbed fetcher across N guard calls after warm cache).
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-07-20
+
+**Verdict:** APPROVE
+
+All twelve findings from the initial review were addressed by edits, and a fresh
+five-lens pass confirmed their resolution. That pass surfaced a handful of new
+items — two majors, both of which have since been fixed by follow-up edits (one
+was an imprecision introduced by the initial edit). The remaining items are all
+suggestion-level and either deliberately left or already acknowledged.
+
+### Previously Identified Issues
+- 🟡 **Dependency**: 0164 fetch-verify-cache dependency absent — Resolved (0164 added
+  to `blocked_by` and Dependencies with an AC-gating rationale).
+- 🟡 **Testability**: AC1 verifies four subcommands against a detect-only gate —
+  Resolved (split into per-subcommand ACs: detect parity gate, status/log golden
+  tests, guard allow/deny fixtures).
+- 🟡 **Testability**: classify_checkout arm ordering/taxonomy unverified — Resolved
+  (dedicated AC enumerating each arm and asserting first-match-wins precedence).
+- 🔵 **Dependency**: 0172/0174 captured only as 'related' — Resolved (`blocks`
+  frontmatter field + Blocks entry in Dependencies).
+- 🔵 **Testability**: AC3 envelope lacked expected reference — Resolved (golden
+  envelope fixture per hook type pinning protocol fields).
+- 🔵 **Testability**: bash-3.2 requirement had no criterion — Resolved (AC binding
+  the wrapper to `lint-bashisms.sh` + shfmt/ShellCheck).
+- 🔵 **Clarity**: Summary overstated SessionStart scope — Resolved (qualified to VCS
+  + config detection only).
+- 🔵 **Testability**: AC4 lacked observation method — Resolved (zero fetch
+  invocations against a stubbed/instrumented fetcher).
+- 🔵 **Scope**: config-detect folded into VCS-framed story — Resolved (surfaced in
+  the Summary).
+- 🔵 **Clarity**: 'Resolved Q4' undefined referent — Resolved (rephrased to
+  "resolved during refinement of the parent epic 0136").
+- 🔵 **Clarity**: 'classify_checkout' overlapping descriptors — Resolved ("full
+  taxonomy" defined inline as reproducing the shell's set, not extending it).
+- 🔵 **Clarity**: four platforms not named — Resolved (exact target triples from
+  `tasks/shared/targets.py`).
+- 🔵 **Completeness**: beneficiary implied — Resolved (Context names the epic-0136
+  shell retirement as the goal served).
+
+### New Issues Introduced (by re-review) and their disposition
+- 🟡 **Testability**: status/log golden test input set ("the fixture repos")
+  undefined — an imprecision from the initial edit; **fixed** (AC2 now enumerates a
+  minimum fixture-repo set: clean/dirty git, ahead-behind, detached-HEAD, clean/dirty
+  jj).
+- 🟡 **Dependency**: config-subdomain upstream for the `config detect` port not
+  captured — **fixed** (the 0167 Dependencies line now states 0167 delivers the
+  built-in `config` command this story extends; 0167 was already a blocker).
+- 🔵 **Testability**: guard allow/deny classifications not enumerated — **fixed** (AC
+  now requires covering each Bash-call class the shell guard distinguishes, not just
+  one allow + one deny).
+- 🔵 **Clarity**: Context sentence splice from the beneficiary edit — **fixed**
+  (capitalised the following sentence).
+- 🔵 **Testability**: 'comparable' warm-cache cost unbounded — **fixed** (Assumptions
+  now states zero-fetch is the only gated guarantee; latency parity is an assumption).
+- 🔵 **Clarity** (suggestion): '6-line record' count vs five-variant taxonomy — left
+  as-is; "6-line" is the author's precise term for the record shape and changing it
+  risks introducing an inaccuracy.
+- 🔵 **Clarity** (suggestion): 'port' used as both hexagonal noun and migration verb —
+  left as-is; domain readers resolve it from context (nitpick).
+- 🔵 **Scope** (suggestion): subdomain build + hooks migration bundled; status/log
+  built ahead of consumers — left as-is; the bundling is defensible and
+  author-justified, and status/log consumers land in later skill-migration stories
+  (0170, 0173).
+
+### Assessment
+The work item is ready for implementation. Every substantive finding (all three
+original majors and both re-review majors) is resolved; the acceptance criteria now
+give each subcommand, the load-bearing `classify_checkout` ordering, the hook
+envelope, the warmed-cache guard, and the bash-3.2 constraint a concrete pass/fail
+procedure, and the dependency graph (0164/0166/0167/0179 upstream, 0172/0174
+downstream) is consistent across frontmatter and prose. The unresolved items are
+suggestion-level polish that do not block planning.

--- a/meta/work/0166-shared-config-corpus-store-crates.md
+++ b/meta/work/0166-shared-config-corpus-store-crates.md
@@ -5,7 +5,7 @@ title: "Shared config, corpus, and store Crates"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
+status: done
 kind: story
 priority: high
 parent: "work-item:0136"

--- a/meta/work/0168-fold-visualiser-into-cli-workspace.md
+++ b/meta/work/0168-fold-visualiser-into-cli-workspace.md
@@ -5,14 +5,14 @@ title: "Fold the Visualiser into the cli/ Workspace"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
+status: ready
 kind: story
 priority: medium
 parent: "work-item:0136"
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
-relates_to: ["work-item:0165"]
+relates_to: ["work-item:0165", "work-item:0166"]
 tags: [rust, visualiser, frontend, workspace]
-last_updated: "2026-06-28T17:01:56+00:00"
+last_updated: "2026-07-19T23:12:20+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-189"
@@ -21,7 +21,7 @@ external_id: "PP-189"
 # 0168: Fold the Visualiser into the cli/ Workspace
 
 **Kind**: Story
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
@@ -36,11 +36,22 @@ first concrete on-demand sub-binary dispatched by the unified launcher (ADR-0054
 
 The visualiser is already the crate `accelerator-visualiser` with a `[lib]`/`[[bin]]`
 split and ~15.4k lines of Rust, much of it corpus logic that duplicates the bash
-library (the dedup collapsed into the shared crates by 0166). The `server`+`frontend`
-pair moves as a unit to `cli/visualiser/{server,frontend}` (resolved Q1), preserving
+library. That duplicated corpus logic now lives in the shared
+`corpus`/`corpus-adapters`/`document` crates delivered by 0179 (resting on 0178 for
+`config`/`config-adapters`); this story retires the visualiser's copies onto them.
+The `server`+`frontend` pair moves as a unit to `cli/visualiser/{server,frontend}`
+(whether to move them together rather than separately was a question resolved
+during extraction — moving as a unit is what preserves the embed path), preserving
 their relative layout so the three `../frontend/dist` embed literals are unchanged.
 The bespoke `launch-server.sh` daemon launcher is retired in favour of the unified
 launcher (0164).
+
+Two constituencies benefit: **maintainers**, who stop carrying the slice of the
+crate's ~15.4k lines that duplicates the bash library's corpus logic (the crate
+itself is retained — axum/tokio/notify stay — only the duplicated corpus portion
+collapses onto the shared crates); and the **unified-launcher release flow**, which
+gains the visualiser as its first concrete on-demand sub-binary and so validates the
+dispatch path end to end.
 
 ## Requirements
 
@@ -56,58 +67,197 @@ launcher (0164).
   the owner-PID/`start_time`/idle-shutdown lifecycle and the loopback-binding +
   Host/Origin security model.
 - Retire `launch-server.sh` and the visualiser's separate `bin/checksums.json` in
-  favour of the unified launcher + release manifest (0164/0165).
+  favour of the unified launcher + release manifest (0164/0165). Note `launch-server.sh`
+  plays two roles, retired by two different mechanisms: its daemon start/stop
+  orchestration re-homes into `accelerator visualiser start` (previous bullet), while
+  its bespoke fetch/distribution role is what the unified launcher replaces. This is
+  the distribution cut-over: the file removals land at story completion, but the
+  launcher's fetch/verify path lands with or after 0165's manifest entry (see the
+  ordering constraint in Dependencies).
 - Update the visualiser build wiring (the `../frontend/dist` literals stay valid
   given the unit move; `build.rs` still requires the prebuilt dist under
   `embed-dist`).
 
 ## Acceptance Criteria
 
-- [ ] `accelerator visualiser start` resolves config, launches the server, and
-      returns its loopback URL; `stop`/`status` behave as the shell commands did,
-      preserving the PID/`start_time` recycle guard and idle shutdown.
-- [ ] The server consumes the shared `corpus`/`config` crates; the duplicated
-      corpus logic is removed from the visualiser crate.
-- [ ] The visualiser builds and embeds the frontend from `cli/visualiser/frontend`
-      with the embed literals unchanged.
-- [ ] `launch-server.sh` and the standalone visualiser checksum manifest are
-      removed; the visualiser is fetched/verified/dispatched by the unified
-      launcher.
-- [ ] The visualiser E2E/integration suites pass against the relocated, refactored
-      crate.
+- [ ] Given a repo carrying a valid visualiser configuration (the `.accelerator/*.md`
+      keys the start path requires — the same fixture config the orchestration tests
+      below use), when I run `accelerator visualiser start`, then the server binds a
+      loopback port and the command prints its `http://127.0.0.1:PORT` URL.
+- [ ] `accelerator visualiser stop` terminates only a process whose recorded
+      owner-PID **and** `start_time` still match (recycle guard), and leaves a
+      recycled/unrelated PID untouched.
+- [ ] `accelerator visualiser status` reports the actual lifecycle state across
+      transitions, using a `running`/`stopped` token on stdout as the definitive
+      signal: before any `start` (never-started state) it prints `stopped`; after
+      `start` it prints `running` (and the URL); after `stop` it prints `stopped`.
+- [ ] An idle server (no inbound HTTP request within the window) self-shuts-down on
+      the `visualiser.idle_timeout` the server resolves — same key and default as
+      today (`8h`, `never`/0 to disable). Verified by configuring a short timeout
+      (e.g. a few seconds) and asserting shutdown, plus a `never`/0 case asserting the
+      server stays up, rather than by waiting out the default. The `8h` default is
+      checked as a config-resolution assertion — with no `visualiser.idle_timeout` set,
+      the server's resolved value equals `8h` — not by waiting.
+- [ ] The loopback + Host/Origin security model is preserved: a request with a
+      non-loopback `Host` header is rejected `403 Forbidden`, a state-changing
+      (`PATCH`/`POST`/`PUT`/`DELETE`) request carrying a cross-origin `Origin` is
+      rejected `403 Forbidden`, and a matching loopback `Host` with a loopback or
+      absent `Origin` is accepted — the same `403` statuses as today. A Host-only
+      violation and a (state-changing) Origin-only violation are each independently
+      rejected `403`, so the host-header and origin guards are exercised separately.
+- [ ] The visualiser crate no longer contains its duplicated `docs.rs`
+      (`DocTypeKey`), `slug.rs`, `frontmatter.rs`, `patcher.rs`, `typed_ref.rs`, or
+      the `WorkItemIdScheme`/ID logic in `config.rs`; each is replaced by the
+      `corpus`/`corpus-adapters`/`document` equivalent, and `gray_matter`/`serde_yml`
+      are dropped from the server's dependencies.
+- [ ] Behaviour parity across the engine swap, verified by golden/parity tests (not
+      merely by the old modules being absent). Fixture: one document per `DocTypeKey`
+      variant (14) plus known edge cases — multi-line/quoted frontmatter values, the
+      fence-offset boundaries `document::fence_offsets` handles (leading blank lines,
+      CRLF line endings, no trailing newline, an empty frontmatter block, no frontmatter
+      at all), slug inputs exercising `humanise_slug`/`title_case_segment`, and
+      work-item-ID inputs. Parity
+      relation: for each fixture the refactored `document`/`corpus` parsed frontmatter
+      map, derived slug, and inferred doc-type are field-for-field equal to the
+      pre-refactor `gray_matter`/`serde_yml` output; differences in error-message text
+      and insignificant whitespace are out of scope. The pre-refactor outputs are
+      captured as committed golden fixtures **before** the old modules are removed, so
+      the parity comparison stays reproducible after the deletion.
+- [ ] The crate is a `cli/` workspace member at `cli/visualiser/server`, inherits
+      `version`/`edition`/MSRV (minimum supported Rust version) from
+      `[workspace.package]` (no hand-copied version literal), and
+      `cargo build -p accelerator-visualiser` succeeds from the workspace.
+- [ ] The release build embeds the frontend from `cli/visualiser/frontend` with the
+      three `../frontend/dist` literals unchanged; `build.rs` still fails cleanly if
+      the prebuilt dist is absent under `embed-dist`.
+- [ ] The five orchestration scripts — `visualiser.sh`, `launch-server.sh`,
+      `stop-server.sh`, `status-server.sh`, and `write-visualiser-config.sh` — and the
+      visualiser's standalone `bin/checksums.json` are removed once the
+      `accelerator visualiser` subcommands are in place — verifiable at story
+      completion.
+- [ ] The visualiser is fetched/verified/dispatched by the unified launcher against
+      the release manifest. Verifiable within this story against a local/test manifest
+      fixture — the launcher's fetch/verify path resolves the visualiser entry and
+      dispatches the binary; the equivalent assertion against the live release manifest
+      is gated on 0165's manifest carrying a visualiser entry (see the
+      distribution-cut-over ordering constraint in Dependencies) and lands when that
+      entry does.
+- [ ] New tests cover the orchestration surface, not merely the pre-existing suites:
+      a test asserts each of `accelerator visualiser start|stop|status` dispatches
+      through the launcher — evidenced by an observable, e.g. a launcher test
+      double/spy that records the dispatch, or a distinguishing side effect the
+      launcher path produces that a direct in-process call does not — and a test
+      asserts the server honours configuration from
+      the location it is directed to — verified by setting `visualiser.idle_timeout` to
+      a non-default value in a fixture config and asserting the server's resolved
+      timeout matches it, independent of whether the launcher passes config in or the
+      server reads `.accelerator/*.md` directly (that mechanism is Open Question 3).
+      With those in place, the visualiser
+      E2E/integration suites pass against the relocated, refactored crate and
+      `mise run` is green end-to-end (the aggregate gate).
 
 ## Open Questions
 
-- Whether the frontend's own toolchain checks (Biome/vitest/Playwright) move under
-  a `cli/visualiser/frontend` task path or stay as-is — decided during
-  implementation.
+1. Whether the frontend's own toolchain checks (Biome/vitest/Playwright) move under
+   a `cli/visualiser/frontend` task path or stay as-is — decided during
+   implementation.
+2. Does the server keep an async façade over the sync `corpus-adapters` store (via
+   `spawn_blocking`), or do the store primitives gain an async variant?
+3. Once `launch-server.sh` is retired, does the server read `.accelerator/*.md`
+   directly via `config`/`config-adapters`, or does the launcher resolve config and
+   pass it in (replacing the emitted `config.json`)?
 
 ## Dependencies
 
-- Blocked by: 0166 (shared crates the server refactors onto), 0164 (launcher
-  dispatch).
-- Relates to: 0165 (the visualiser joins the multi-binary release).
+- Blocked by: 0179 (delivers the `corpus`/`corpus-adapters`/`document` crates the
+  server refactors onto, resting transitively on 0178 for `config`/`config-adapters`),
+  0164 (launcher dispatch). All three — 0179, its transitive dependency 0178, and
+  0164 — are now `done`, so the crate-refactor and dispatch prerequisites are
+  satisfied.
+- Not blocked by: 0180 (atomic-store primitives) — the fold-in reuses
+  `corpus-adapters`' existing `FileCorpusStore` write path from 0179; 0180's extra
+  JSONL/lock primitives are not on this story's path.
+- Relates to: 0165 (the visualiser joins the multi-binary release), 0166 (this
+  refactor validates the shared-crate approach 0166 described; 0166 itself built
+  nothing — see Drafting Notes).
+- Ordering constraint on the distribution cut-over (the criterion retiring
+  `launch-server.sh` + the standalone `bin/checksums.json` in favour of the unified
+  launcher's fetch/verify): that cut-over is only safe once 0165's release manifest
+  actually carries a visualiser entry — otherwise the launcher's fetch/verify path is
+  unsatisfiable. 0165 is not a hard blocker for the whole story (relocation, refactor,
+  and orchestration can land first), but its manifest entry must land before or with
+  the cut-over (mirrors the 0180 "Not blocked by" rationale above).
+- External system: the retired bespoke distribution is replaced by the unified
+  launcher fetching the pre-compiled visualiser binary from GitHub Releases, so the
+  cut-over criterion's fetch/verify path is coupled to that hosting being reachable —
+  the same external dependency the launcher already carries (0164/0165), recorded
+  here for visibility.
 - Parent: epic 0136.
 
 ## Assumptions
 
 - Moving the `server`+`frontend` pair as a unit preserves the relative embed path,
-  so no literal surgery is needed (resolved Q1).
+  so no literal surgery is needed (the unit-vs-separate move was resolved in favour
+  of the unit move during extraction).
 
 ## Technical Notes
 
-- Existing seam: `file_driver.rs` already defines a `FileDriver` port trait.
-- The server has no production TLS (loopback + guards); the launcher's rustls is the
-  only production TLS.
+Duplicated server modules retire onto shared items:
+
+- `docs.rs` (`DocTypeKey`, 14 variants) → `corpus::doc_type::DocTypeKey`.
+- `slug.rs` (`derive`, `humanise_slug`, `title_case_segment`) → `corpus::slug`;
+  `title_case_segment` is documented there as the retire target.
+- `frontmatter.rs` (`fence_offsets`, `parse`) → `document::fence_offsets` +
+  `corpus_adapters::document::parse`.
+- `patcher.rs` (`patch_status`) → `corpus_adapters::patcher::patch_status`.
+- `typed_ref.rs` (`parse_typed_ref`) → `corpus::typed_ref`.
+- `config.rs` (`WorkItemConfig` ID logic) → `corpus::WorkItemIdScheme` + injected
+  `IdScanner`.
+- `file_driver.rs` (`atomic_write_preserving_perms`) →
+  `corpus_adapters::FileCorpusStore` (`AtomicWrite`).
+- linkage/cluster logic (`related.rs`, `clusters.rs`, `lifecycle.rs`) →
+  `corpus::linkage` (`parse_document`, `TYPE_PAIRS`, `Band`).
+
+Reconciliation tensions to resolve during implementation:
+
+- Async vs sync: the server's `FileDriver`/atomic-write and the axum/tokio stack are
+  async; `corpus`/`corpus-adapters` are sync. The domain/parsing code moves out; the
+  async I/O boundary (spawn_blocking or a thin async façade) stays in this crate.
+- Frontmatter engine swap: `gray_matter` + `serde_yml` → the `document` crate
+  (serde-saphyr, confined to `document`). Server wire types derive serde (kebab-case
+  for the API); `corpus::DocTypeKey` is serde-free, so the wire mapping must be
+  re-homed in a thin server view type over `wire_str`/`from_wire_str`.
+- No `infer` matcher today: the server keys doc type off which root a path sits under
+  (`LocalFileDriver::kind_for_canonical_path`), whereas `corpus` exposes a pure
+  `doc_type::infer(path, table)` longest-segment matcher — pick one during the
+  refactor.
+- Version inheritance: `server/Cargo.toml` hand-copies the version literal; as a
+  workspace member it should use `version.workspace = true`.
+
+Retained / unchanged:
+
+- Existing seam: `file_driver.rs` already defines an (async) `FileDriver` port trait.
+- The server has no production TLS (loopback + Host/Origin guards); the launcher's
+  rustls is the only production TLS.
 
 ## Drafting Notes
 
 - Treated as the Phase 5 story; it is both a fold-in and the validation that the
-  shared crates (0166) actually absorb the visualiser's duplicated logic.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+  shared crates delivered by 0179 actually absorb the visualiser's duplicated logic.
+- Kept as a single story rather than split into a relocate-plus-dispatch story and a
+  refactor story, despite the two streams being notionally separable. The reason is
+  that the relocation is the point at which the visualiser becomes a workspace member
+  and can `use corpus`/`use document` at all: relocating without refactoring would
+  leave the duplicated modules compiling in their new home only to be deleted days
+  later, and refactoring without relocating is impossible while the crate lives
+  outside the workspace. Delivering them as one increment avoids a throwaway
+  intermediate state and lets the fold-in double as the "first on-demand sub-binary"
+  proof for the launcher (0164) in a single validated step. The per-stream acceptance
+  criteria remain individually checkable, so partial progress is still visible.
+- Reconciled the stale "0166" shared-crates citation: 0166 is the draft umbrella
+  story that built nothing, so the precise blocker is 0179 (transitively 0178). The
+  canonical `blocks: 0168` edges already live on 0179 and 0164, so they were not
+  duplicated into this item's `blocked_by`.
 
 ## References
 

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -5,14 +5,16 @@ title: "VCS Subdomain and Hooks Migration"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
+status: ready
 kind: story
-priority: medium
+priority: high
 parent: "work-item:0136"
-blocked_by: ["work-item:0166", "work-item:0167", "work-item:0179"]
+blocked_by: ["work-item:0164", "work-item:0166", "work-item:0167", "work-item:0179"]
+blocks: ["work-item:0172", "work-item:0174"]
+relates_to: ["work-item:0172", "work-item:0174"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, vcs, hooks, migration]
-last_updated: "2026-07-11T12:40:21+00:00"
+last_updated: "2026-07-20T09:34:16+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-190"
@@ -21,80 +23,134 @@ external_id: "PP-190"
 # 0169: VCS Subdomain and Hooks Migration
 
 **Kind**: Story
-**Status**: Draft
-**Priority**: Medium
+**Status**: Ready
+**Priority**: High
 **Author**: Toby Clemson
 
 ## Summary
 
 Build the `accelerator-vcs` subdomain (detection/status/log/guard) and migrate the
-SessionStart/PreToolUse hook logic into the CLI (ADR-0048), registering the
+SessionStart and PreToolUse hook logic into the CLI (ADR-0048), registering the
 universal bash wrapper in `hooks.json` to invoke domain subcommands with a
-`--format=hook` envelope rather than a hook-specific subcommand.
+`--format=hook` envelope rather than a hook-specific subcommand. The SessionStart
+migration covers VCS detection and config detection only (the latter via a
+cross-subdomain `accelerator config detect` port); the migration-discoverability
+reminder is deferred to 0172.
 
 ## Context
 
 `scripts/vcs-common.sh` (the `.jj`-wins dispatch, the load-bearing
 `classify_checkout` arm ordering) backs both the VCS skills and the hooks. ADR-0048
-says hook logic moves into the CLI; the hooks are currently four bare `.sh` paths in
-`hooks.json` honouring the Claude Code hook I/O protocol. Resolved Q4 fixes the
-mechanism: register the universal wrapper invoking domain subcommands, with the hook
-I/O envelope produced by a CLI `--format=hook` switch.
+says hook logic moves into the CLI; consolidating it there removes the parallel bash
+implementation the hooks and skills currently share and unblocks the remaining
+epic-0136 shell retirement (0172, 0174) — the goal this story ultimately serves. The
+hooks are currently four bare `.sh` paths in `hooks.json` honouring the Claude Code
+hook I/O protocol. The invocation mechanism
+(resolved during refinement of the parent epic 0136) is fixed: register the
+universal wrapper invoking domain subcommands, with the hook I/O envelope produced
+by a CLI `--format=hook` switch. The SessionStart hook
+currently fans out to VCS detection, config detection, and a migration-discoverability
+reminder; this story ports the first two and leaves the migration reminder to land
+with the migration subdomain (0172).
 
 ## Requirements
 
 - Implement `accelerator-vcs` as a hexagon: `vcs detect`, `vcs status`, `vcs log`,
-  `vcs guard`, porting `vcs-common.sh` semantics (jj-outranks-git dispatch, the
-  6-line `classify_checkout` record with its first-match-wins arm order, worktree/
-  submodule/bare/`GIT_DIR` handling). External tools (`jj`, `git`) behind an
-  outbound port.
-- Migrate hook logic into the CLI: `hooks.json` registers the universal bash
-  wrapper (which fetches `accelerator` on first use, then execs it) invoking domain
-  subcommands — SessionStart → `accelerator vcs detect` / `accelerator config detect`
-  / `accelerator migrate discoverability`; PreToolUse(`Bash`) → `accelerator vcs
-  guard`. No hook-specific subcommand.
+  `vcs guard`, over the `vcs`/`vcs-adapters` crates delivered by 0179 — porting
+  `vcs-common.sh` semantics (jj-outranks-git dispatch, the 6-line `classify_checkout`
+  record with its first-match-wins arm order, worktree/submodule/bare/`GIT_DIR`
+  handling) and extending those crates with the full `classify_checkout` taxonomy.
+  "Full taxonomy" here means reproducing the shell's existing classification set
+  (worktree, submodule, bare, `GIT_DIR`, plain) as typed variants — not adding
+  classifications beyond what the shell produces. External tools (`jj`, `git`)
+  behind an outbound port.
+- Migrate the VCS and config hook logic into the CLI: `hooks.json` registers the
+  universal bash wrapper (which fetches `accelerator` on first use, then execs it)
+  invoking domain subcommands — SessionStart → `accelerator vcs detect` +
+  `accelerator config detect`; PreToolUse(`Bash`) → `accelerator vcs guard`. No
+  hook-specific subcommand. The SessionStart migration-discoverability reminder is
+  out of scope here and remains its existing bash hook until 0172.
 - Add a `--format=hook` switch producing the Claude Code hook I/O envelope, so one
   domain operation serves both its skill-injection caller (plain) and its hook
   caller (envelope).
-- Decide built-in vs `accelerator-vcs` sub-binary for the hot PreToolUse guard
-  (lean built-in to avoid a per-Bash-call sub-binary fetch); keep the wrapper
-  bash-3.2-safe.
+- Serve the hot PreToolUse guard as the `accelerator-vcs` sub-binary invoked through
+  the wrapper, relying on the 0164 fetch-verify-cache model so the sub-binary fetch
+  is a first-use-only cost amortised by the warmed cache — no per-Bash-call fetch
+  after warm-up. Keep the wrapper bash-3.2-safe.
 
 ## Acceptance Criteria
 
-- [ ] `accelerator vcs detect|status|log|guard` reproduce the shell behaviours,
-      verified against the repointed `hooks/test-vcs-detect.sh` parity gate.
+- [ ] `accelerator vcs detect` reproduces the shell detection behaviour, verified
+      against the repointed `hooks/test-vcs-detect.sh` parity gate.
+- [ ] `accelerator vcs status` and `accelerator vcs log` reproduce the shell
+      behaviours, each verified against a golden-output test asserting the same
+      output as the corresponding `vcs-common.sh` path across a fixture-repo set
+      covering, at minimum: clean git, dirty git, git ahead/behind, detached-HEAD
+      git, clean jj, and dirty jj.
+- [ ] `accelerator vcs guard` reproduces the shell guard behaviour, verified
+      against an allow/deny fixture set that covers each Bash-call class the shell
+      guard distinguishes — the blocked git/jj mutation patterns and the
+      allowed read-only/non-VCS patterns — not merely one allow and one deny.
+- [ ] `classify_checkout` is verified by a fixture covering each arm (worktree,
+      submodule, bare, `GIT_DIR`, plain) and asserting first-match-wins precedence
+      for at least one ambiguous checkout, so the load-bearing arm order cannot
+      regress silently.
+- [ ] `accelerator config detect` reproduces the SessionStart config-detection
+      behaviour of `config-detect.sh`, verified against its hook test.
 - [ ] `hooks.json` registers the wrapper invoking domain subcommands; SessionStart
-      injects the VCS/config/migrate context and PreToolUse guards Bash calls, both
-      emitting the correct hook I/O envelope via `--format=hook`.
-- [ ] The PreToolUse guard path does not trigger a sub-binary fetch on every Bash
-      call (built-in, or warmed cache).
-- [ ] The hook `.sh` files (`vcs-detect.sh`, `vcs-guard.sh`, `config-detect.sh`,
-      `migrate-discoverability.sh`) are removed and the hooks suite floor adjusted
-      in the same change.
+      injects the VCS and config context and PreToolUse guards Bash calls, both
+      emitting the hook I/O envelope via `--format=hook`, verified against a golden
+      envelope fixture per hook type (SessionStart, PreToolUse) that pins the
+      Claude Code hook I/O protocol fields.
+- [ ] After first use, the PreToolUse guard resolves `accelerator vcs guard` from the
+      warmed cache — verified by asserting zero sub-binary fetch invocations against
+      a stubbed/instrumented fetcher across repeated guard calls after the cache is
+      warm.
+- [ ] The wrapper passes the bash-3.2 gate — `scripts/lint-bashisms.sh` (and the
+      standard shfmt/ShellCheck checks) report no findings against it.
+- [ ] The `vcs-detect.sh`, `vcs-guard.sh`, and `config-detect.sh` hook scripts are
+      removed and the hooks suite floor adjusted in the same change;
+      `migrate-discoverability.sh` is left in place for 0172.
 
 ## Open Questions
 
-- Whether `config detect` and `migrate discoverability` are fully covered here or
-  partly deferred to 0167 (config) / 0172 (migrate) — sequence at implementation.
+- None outstanding — the config-detect / migrate-discoverability scope boundary was
+  resolved during refinement (config detect in scope here; migrate discoverability
+  deferred to 0172).
 
 ## Dependencies
 
-- Blocked by: 0166 (shared crates), 0167 (the wrapper + invocation contract), 0179
-  (the `vcs`/`vcs-adapters` crates this subdomain consumes and extends with the
-  full `classify_checkout` taxonomy).
+- Blocked by: 0164 (the fetch-verify-cache model the warmed-cache guard relies on —
+  AC "guard resolves from the warmed cache with no per-Bash-call fetch" is not
+  validatable until 0164 lands), 0166 (shared crates — complete), 0167 (the wrapper
+  + invocation contract, and the built-in `config` command this story extends with
+  `config detect` — in progress, expected complete before this is picked up),
+  0179 (the `vcs`/`vcs-adapters` crates this subdomain consumes and extends —
+  complete on the feature branch).
+- Blocks: 0172 (its final migrate-discoverability hook migration builds on this
+  story's `hooks.json` rewrite), 0174 (retires the wrapper/shell tail left precisely
+  because this story removes only three of the four hook scripts).
+- Related: 0172, 0174 (see Blocks — both consume this story's `hooks.json` output).
 - Parent: epic 0136.
 
 ## Assumptions
 
-- The four target platforms are Unix; the guard's per-Bash-call cost is comparable
-  to today's `vcs-guard.sh` spawn.
+- The four target platforms (the epic 0136 target triples per
+  `tasks/shared/targets.py`: `aarch64`/`x86_64-apple-darwin` and
+  `aarch64`/`x86_64-unknown-linux-musl`) are all Unix.
+- After the first-use fetch, the guard's warmed-cache per-Bash-call cost is
+  comparable to today's `vcs-guard.sh` spawn. Only the absence of a per-call fetch
+  is gated by an acceptance criterion; per-call latency parity is an assumption, not
+  a verified bound.
 
 ## Technical Notes
 
 - Source bash: `scripts/vcs-common.sh`, `hooks/vcs-detect.sh`, `hooks/vcs-guard.sh`,
-  `hooks/config-detect.sh`, `hooks/migrate-discoverability.sh`, `hooks/hooks.json`,
-  and the `hooks/test-fixtures/vcs-detect/` fixtures.
+  `hooks/config-detect.sh`, `hooks/hooks.json`, and the
+  `hooks/test-fixtures/vcs-detect/` fixtures. (`hooks/migrate-discoverability.sh` is
+  deliberately out of scope — it ports with the migration subdomain in 0172.)
+- The `vcs`/`vcs-adapters` crates land in 0179; this story extends them with the full
+  `classify_checkout` taxonomy rather than defining them from scratch.
 - `classify_checkout` arm ordering is load-bearing — preserve first-match-wins
   semantics exactly.
 
@@ -102,13 +158,18 @@ I/O envelope produced by a CLI `--format=hook` switch.
 
 - Treated as the Phase 6 story; bundles the VCS subdomain with the hooks migration
   because the hooks are the VCS subdomain's primary consumer.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+- Scope boundary confirmed with the author: `config detect` is migrated here; the
+  SessionStart migrate-discoverability reminder is deferred to 0172, so this story
+  removes three hook scripts, not four.
+- The built-in-vs-sub-binary question was closed: the guard is served as the
+  `accelerator-vcs` sub-binary, and the fetch cost is a first-use-only hit amortised
+  by the 0164 warmed cache — so it is not carried as an open question.
+- Priority raised medium → high: this is a critical-path Phase 6 story that gates the
+  hooks migration for epic 0136.
 
 ## References
 
 - Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
 - Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Related: 0166, 0167, 0172, 0174, 0179
 - ADRs: ADR-0048, ADR-0053

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -62,8 +62,11 @@ with the migration subdomain (0172).
   handling) and extending those crates with the full `classify_checkout` taxonomy.
   "Full taxonomy" here means reproducing the shell's existing classification set
   (worktree, submodule, bare, `GIT_DIR`, plain) as typed variants — not adding
-  classifications beyond what the shell produces. External tools (`jj`, `git`)
-  behind an outbound port.
+  classifications beyond what the shell produces. External VCS state (`jj`,
+  `git`) is read through in-process Rust libraries — `gix` (gitoxide) for git
+  and `jj-lib` for jujutsu — bound behind the outbound port, not by spawning
+  `jj`/`git` subprocesses; a per-query shell fallback behind the same port is
+  permitted only where no library equivalent exists.
 - Migrate the VCS and config hook logic into the CLI: `hooks.json` registers the
   universal bash wrapper (which fetches `accelerator` on first use, then execs it)
   invoking domain subcommands — SessionStart → `accelerator vcs detect` +
@@ -95,6 +98,11 @@ with the migration subdomain (0172).
       submodule, bare, `GIT_DIR`, plain) and asserting first-match-wins precedence
       for at least one ambiguous checkout, so the load-bearing arm order cannot
       regress silently.
+- [ ] The `accelerator-vcs` adapters read VCS state through the `gix` and
+      `jj-lib` libraries rather than by spawning `jj`/`git` subprocesses —
+      verified by asserting zero `jj`/`git` process spawns across the
+      detect/status/log/guard paths under an instrumented process launcher; any
+      shell fallback is explicit, per-query, and covered by its own test.
 - [ ] `accelerator config detect` reproduces the SessionStart config-detection
       behaviour of `config-detect.sh`, verified against its hook test.
 - [ ] `hooks.json` registers the wrapper invoking domain subcommands; SessionStart
@@ -153,6 +161,50 @@ with the migration subdomain (0172).
   `classify_checkout` taxonomy rather than defining them from scratch.
 - `classify_checkout` arm ordering is load-bearing — preserve first-match-wins
   semantics exactly.
+- **Implementation approach — bind VCS libraries, don't shell out.** The adapters
+  should drive git and jujutsu through in-process Rust libraries — `gix`
+  (gitoxide) for git and `jj-lib` for jujutsu — bound behind the outbound VCS
+  ports, rather than spawning `jj`/`git` child processes. This departs from the
+  current `CommandProbe` adapter (`cli/vcs-adapters/src/lib.rs:48-196`), which
+  runs `jj log`/`git rev-parse` as subprocesses; the port abstraction
+  (`cli/vcs/src/lib.rs:48-55`) already allows swapping in a library-backed
+  adapter without touching the domain.
+  - Git queries `classify_checkout` needs map to `gix`: bare check
+    (`git rev-parse --is-bare-repository`, `vcs-common.sh:207`), worktree
+    detection (`--git-dir` vs `--git-common-dir`, `vcs-common.sh:217-219`), and
+    superproject/submodule resolution (`--show-superproject-working-tree`,
+    `vcs-common.sh:140-146`).
+  - jj queries map to `jj-lib`: workspace-root resolution and the
+    main-vs-secondary distinction (`.jj/repo` dir vs file,
+    `vcs-common.sh:74-81`), plus revision reads.
+  - Risk to validate early: `jj-lib`'s public API is explicitly unstable and
+    pins to the jj release; confirm its workspace/repo-loading surface covers
+    the secondary-workspace and colocated cases before committing. `gix` is the
+    more mature of the two. Where a query has no library equivalent, a per-query
+    shell fallback *behind the same port* is acceptable, but library-first is
+    the default.
+- Behavioural reference (`path:line`):
+  - jj-outranks-git dispatch — a command-set selector, not a topology (git's
+    index lags jj's working copy in colocated): `scripts/vcs-common.sh:27-36`.
+  - `classify_checkout` contract + six-line `KEY=VALUE` record:
+    `scripts/vcs-common.sh:157-176`; body `:177-280`.
+  - Load-bearing arm cascade (first-match-wins) — `colocated` must precede the
+    `nested-*` arms: `scripts/vcs-common.sh:240-272`.
+  - Hook I/O envelopes to reproduce under `--format=hook`: SessionStart
+    `{hookSpecificOutput:{hookEventName,additionalContext}}` + optional
+    `systemMessage` (`hooks/vcs-detect.sh:177-181`); PreToolUse guard
+    `{decision:block,reason}` (pure-jj) vs
+    `{decision:allow,hookSpecificOutput}}` (colocated)
+    (`hooks/vcs-guard.sh:97-108`).
+  - Guard command-parsing (a separate behaviour from detection): compound-command
+    split on `&& || ; |` then git-subcommand pattern match
+    (`hooks/vcs-guard.sh:44-108`); `gh`/`rtk` unconditionally allowed.
+  - Rust starting point: `vcs`/`vcs-adapters` today model corpus `RepoFacts`
+    (root/name/kind/revision), *not* the hook taxonomy —
+    `cli/vcs/src/lib.rs:32-78`; parity tests assert facts only
+    (`cli/vcs-adapters/tests/detection.rs`). The launcher dispatches any new
+    `accelerator-vcs` external subcommand with no launcher changes
+    (`cli/launcher/src/launch/inbound/cli.rs:15-22`).
 
 ## Drafting Notes
 

--- a/meta/work/0180-atomic-store-primitives-corpus-adapters.md
+++ b/meta/work/0180-atomic-store-primitives-corpus-adapters.md
@@ -5,7 +5,7 @@ title: "Atomic-Store Primitives in corpus-adapters"
 date: "2026-07-06T22:27:35+00:00"
 author: Toby Clemson
 producer: refine-work-item
-status: ready
+status: done
 kind: task
 priority: high
 parent: "work-item:0166"


### PR DESCRIPTION

# [0168/0169] Refine work items

## Summary

Grooms the next tranche of the Rust CLI migration epic (0136): refines work items **0168** (fold the visualiser into the `cli/` workspace) and **0169** (VCS subdomain + hooks migration) to *ready* through a review pass, and marks **0166** and **0180** *done*. This is a documentation-only PR — no code changes.

## Changes

- **0169 — VCS subdomain & hooks migration**: reviewed (five lenses, REVISE → APPROVE) and refined to *ready*. Key refinement: VCS access is now specified as **library-based** — `gix` (gitoxide) for git and `jj-lib` for jujutsu, read in-process behind the outbound VCS port, rather than spawning `jj`/`git` subprocesses (a per-query shell fallback stays behind the same port). Flags `jj-lib`'s unstable public API as an early-validation risk.
- **0168 — fold visualiser into `cli/` workspace**: reviewed (REVISE → APPROVE) and refined to *ready*; relocates `accelerator-visualiser` onto the shared `config`/`corpus` crates and moves start/stop/status under `accelerator visualiser …` as the first on-demand sub-binary (ADR-0054).
- **Status transitions**: 0166 (shared config/corpus/store crates) moved draft → *done*, and 0180 (atomic-store primitives) moved ready → *done*.
- Adds the work-item review artifacts for 0168 and 0169.

## Context

- Epic **0136** — Rust CLI migration (`parent`).
- Refines **0168** (`PP-189`) and **0169** (`PP-190`); marks **0166** and **0180** (`PP-704`) done.
- Relates to **0172** (migration engine subdomain) — 0169 blocks it, and the SessionStart migration-discoverability reminder is deferred to it.
- Stacked on `0180-atomic-store-primitives` (PR #23), which carries the corpus/atomic-store code this grooming refers to.

## Testing

- [x] No executable surface — the changes are work-item and review markdown; verification is limited to frontmatter well-formedness and internal linkage consistency, both confirmed by inspection.

## Notes for Reviewers

- The load-bearing decision to confirm is **0169's library-based VCS access** (`gix` + `jj-lib` in-process vs subprocess shell-out) — it departs from the earlier `CommandProbe` shell-out assumption and hinges on `jj-lib`'s unstable API, which the work item calls out for early validation.
- Both work-item reviews resolved from an initial **REVISE** (driven by breadth, not weakness) to **APPROVE**; the review docs are included for the audit trail.
