### PR TITLE
[0182] Plugin root rename and terminal invocation surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .idea
 .playwright-mcp/
 .pytest_cache/
+.venv/
 __pycache__/
 meta/eval-workspaces/
 cli/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **The CLI can be run from an ordinary terminal.** A new `SessionStart` hook
+  keeps a fixed path inside the plugin's data directory pointing at the current
+  installation's launcher, so a symlink you create once on your `$PATH` keeps
+  working across plugin upgrades. Setup, platform support and the trust-chain
+  caveats are documented under Terminal Invocation in `docs/internals.md`.
+
 ### Changed
 
 - **Interactive option panels replace typed confirmations across 15 skills.**

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Code compatibility, see [Releases & Compatibility](docs/releases-and-compatibili
   implement spine in detail, including the plan review/stress-test cycle.
 - [Visualiser](docs/visualiser.md) — the browser-based companion view of `meta/`.
 - [Internals](docs/internals.md) — the `meta/` directory deep-dive, the agent
-  roster, and VCS detection.
+  roster, VCS detection, and running the CLI from a terminal.
 - [Configuration](docs/configuration.md) — config files, templates, per-skill
   customisation, and custom review lenses.
 - [Migrations](docs/migrations.md) — upgrading a repo with `/accelerator:migrate`.

--- a/bin/accelerator
+++ b/bin/accelerator
@@ -113,7 +113,6 @@ readonly plugin_root
 unverified_log="${ACCELERATOR_CACHE_DIR:-${plugin_root}/bin}/.accelerator-unverified.log"
 
 export ACCELERATOR_PLUGIN_ROOT="${plugin_root}"
-export CLAUDE_PLUGIN_ROOT="${plugin_root}"
 
 # The case arms must stay in sync with tasks/shared/targets.py (coherence test).
 host_arch="${ACCELERATOR_UNAME_M:-$(uname -m)}"

--- a/cli/config-adapters/src/store.rs
+++ b/cli/config-adapters/src/store.rs
@@ -21,6 +21,11 @@ use crate::document;
 /// suppresses the uniform legacy-layout refusal, and — when the current-layout
 /// pair is absent — falls back to reading the legacy `.claude/accelerator.md`
 /// and `.claude/accelerator.local.md` pair.
+///
+/// The policy is a caller-supplied flag, never an environment read. The shell
+/// migration runner still exports `ACCELERATOR_MIGRATION_MODE` into every
+/// migration child, and this layer deliberately ignores it — the bypass is
+/// requested explicitly or not at all.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum LegacyPolicy {
     Reject,

--- a/cli/config-adapters/src/store.rs
+++ b/cli/config-adapters/src/store.rs
@@ -59,10 +59,27 @@ impl FileConfigStore {
         self
     }
 
+    /// An empty path is dropped: it would resolve plugin content relative to
+    /// the process working directory. Every composer inherits the rule here.
     #[must_use]
     pub fn with_plugin_root(mut self, plugin_root: Option<PathBuf>) -> Self {
-        self.plugin_root = plugin_root;
+        self.plugin_root =
+            plugin_root.filter(|root| !root.as_os_str().is_empty());
         self
+    }
+
+    /// The installation root, required: this read cannot be synthesised without
+    /// it.
+    fn require_plugin_root(&self) -> Result<&Path, ConfigError> {
+        self.plugin_root
+            .as_deref()
+            .ok_or(ConfigError::PluginRootUnavailable)
+    }
+
+    /// The installation root when known. Callers here degrade a hint or a
+    /// warning rather than an answer, so an absent root is tolerated.
+    fn plugin_root_if_known(&self) -> Option<&Path> {
+        self.plugin_root.as_deref()
     }
 
     fn absolutise(&self, path: &str) -> PathBuf {
@@ -80,7 +97,7 @@ impl FileConfigStore {
         if let Ok(relative) = path.strip_prefix(&self.root) {
             return relative.display().to_string();
         }
-        if let Some(plugin) = &self.plugin_root {
+        if let Some(plugin) = self.plugin_root_if_known() {
             if let Ok(relative) = path.strip_prefix(plugin) {
                 return format!("<plugin>/{}", relative.display());
             }
@@ -284,7 +301,7 @@ impl ReadLensCatalogue for FileConfigStore {
     }
 
     fn known_skill_names(&self) -> Result<Vec<String>, ConfigError> {
-        let Some(plugin) = &self.plugin_root else {
+        let Some(plugin) = self.plugin_root_if_known() else {
             return Ok(Vec::new());
         };
         let skills = plugin.join("skills");
@@ -345,25 +362,22 @@ impl ReadTemplate for FileConfigStore {
                 warning,
             )?));
         }
-        if let Some(plugin) = &self.plugin_root {
-            let default = plugin.join("templates").join(format!("{name}.md"));
-            if default.is_file() {
-                return Ok(Some(self.resolved(
-                    TemplateSource::PluginDefault,
-                    &default,
-                    warning,
-                )?));
-            }
+        let plugin = self.require_plugin_root()?;
+        let default = plugin.join("templates").join(format!("{name}.md"));
+        if default.is_file() {
+            return Ok(Some(self.resolved(
+                TemplateSource::PluginDefault,
+                &default,
+                warning,
+            )?));
         }
         Ok(None)
     }
 
-    fn template_names(&self) -> Vec<String> {
-        let Some(plugin) = &self.plugin_root else {
-            return Vec::new();
-        };
+    fn template_names(&self) -> Result<Vec<String>, ConfigError> {
+        let plugin = self.require_plugin_root()?;
         let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
         let mut files: Vec<String> = entries
             .filter_map(Result::ok)
@@ -374,21 +388,20 @@ impl ReadTemplate for FileConfigStore {
             })
             .collect();
         files.sort();
-        files
+        Ok(files
             .into_iter()
             .filter_map(|name| name.strip_suffix(".md").map(str::to_owned))
-            .collect()
+            .collect())
     }
 
     fn plugin_default(
         &self,
         name: &str,
     ) -> Result<Option<ResolvedTemplate>, ConfigError> {
-        let Some(path) =
-            self.plugin_template_path(name).filter(|p| p.is_file())
-        else {
+        let path = self.plugin_template_path(name)?;
+        if !path.is_file() {
             return Ok(None);
-        };
+        }
         Ok(Some(self.resolved(
             TemplateSource::PluginDefault,
             &path,
@@ -415,10 +428,11 @@ impl FileConfigStore {
         })
     }
 
-    fn plugin_template_path(&self, name: &str) -> Option<PathBuf> {
-        self.plugin_root
-            .as_ref()
-            .map(|plugin| plugin.join("templates").join(format!("{name}.md")))
+    fn plugin_template_path(&self, name: &str) -> Result<PathBuf, ConfigError> {
+        Ok(self
+            .require_plugin_root()?
+            .join("templates")
+            .join(format!("{name}.md")))
     }
 }
 
@@ -431,15 +445,14 @@ impl TemplateOverride for FileConfigStore {
         dry_run: bool,
     ) -> Result<EjectResult, ConfigError> {
         let key = name.to_owned();
-        let Some(source) =
-            self.plugin_template_path(name).filter(|p| p.is_file())
-        else {
+        let source = self.plugin_template_path(name)?;
+        if !source.is_file() {
             return Ok(EjectResult {
                 outcome: EjectOutcome::NoDefault,
                 key,
                 display: String::new(),
             });
-        };
+        }
         let target = self.absolutise(templates_dir).join(format!("{name}.md"));
         let display = self.display_path(&target);
         let exists = target.is_file();

--- a/cli/config/src/error.rs
+++ b/cli/config/src/error.rs
@@ -63,6 +63,28 @@ pub enum ConfigError {
         path: String,
     },
     LegacyLayout,
+    PluginRootUnavailable,
+}
+
+impl ConfigError {
+    /// Whether `--fail-safe` must not absorb this failure.
+    ///
+    /// Exhaustive inside the defining crate, so a new variant does not compile
+    /// until it is classified — `#[non_exhaustive]` would otherwise let a
+    /// caller's wildcard default it to degradable.
+    #[must_use]
+    pub const fn is_refusal(&self) -> bool {
+        match self {
+            Self::Invalid { .. } | Self::PluginRootUnavailable => true,
+            Self::NotFound { .. }
+            | Self::PathConflict { .. }
+            | Self::MalformedFrontmatter { .. }
+            | Self::Io { .. }
+            | Self::InvalidKey { .. }
+            | Self::UnsafePath { .. }
+            | Self::LegacyLayout => false,
+        }
+    }
 }
 
 impl Display for ConfigError {
@@ -105,6 +127,12 @@ impl Display for ConfigError {
                 "Accelerator: legacy config detected at \
                  .claude/accelerator.md.\n\
                  Run /accelerator:migrate to update the layout, then retry."
+            ),
+            Self::PluginRootUnavailable => write!(
+                formatter,
+                "the plugin installation root is unknown: set \
+                 ACCELERATOR_PLUGIN_ROOT, or invoke accelerator through \
+                 bin/accelerator, which derives it"
             ),
         }
     }
@@ -215,6 +243,28 @@ mod tests {
         assert!(rendered.contains(".claude/accelerator.md"));
         assert!(rendered.contains("/accelerator:migrate"));
         assert_eq!(rendered.lines().count(), 2);
+    }
+
+    #[test]
+    fn plugin_root_unavailable_names_the_variable_and_the_bootstrap() {
+        let rendered = ConfigError::PluginRootUnavailable.to_string();
+        assert!(rendered.contains("ACCELERATOR_PLUGIN_ROOT"));
+        assert!(rendered.contains("bin/accelerator"));
+    }
+
+    #[test]
+    fn a_missing_plugin_root_is_a_refusal_and_a_read_failure_is_not() {
+        assert!(ConfigError::PluginRootUnavailable.is_refusal());
+        assert!(!ConfigError::LegacyLayout.is_refusal());
+        assert!(!ConfigError::Io {
+            path: ".accelerator/config.md".to_owned(),
+            detail: "permission denied".to_owned(),
+        }
+        .is_refusal());
+        assert!(ConfigError::Invalid {
+            detail: "bad".to_owned()
+        }
+        .is_refusal());
     }
 
     #[test]

--- a/cli/config/src/service.rs
+++ b/cli/config/src/service.rs
@@ -325,14 +325,21 @@ pub trait ReadTemplate {
 
     /// The template names available from the plugin templates directory,
     /// sorted.
-    fn template_names(&self) -> Vec<String>;
+    ///
+    /// # Errors
+    ///
+    /// [`ConfigError::PluginRootUnavailable`] when the plugin root is unknown:
+    /// this enumeration cannot be synthesised without it, unlike
+    /// [`ReadLensCatalogue::known_skill_names`], which stays empty.
+    fn template_names(&self) -> Result<Vec<String>, ConfigError>;
 
     /// The plugin default template for `name`, or `None` when the plugin ships
     /// no default for it.
     ///
     /// # Errors
     ///
-    /// A [`ConfigError`] when a present default cannot be read.
+    /// [`ConfigError::PluginRootUnavailable`] when the plugin root is unknown,
+    /// or a [`ConfigError`] when a present default cannot be read.
     fn plugin_default(
         &self,
         name: &str,

--- a/cli/corpus-adapters/tests/parity.rs
+++ b/cli/corpus-adapters/tests/parity.rs
@@ -82,7 +82,7 @@ fn bash_records(script: &Path, file: &Path) -> Result<Vec<String>, TestError> {
     // linkage-parser.sh sources doc-type-table.sh, whose resolver is
     // `${ACCELERATOR_BIN:-…/bin/accelerator} config paths --doc-types`. Point it
     // at the compiled launcher so the oracle never falls through to the
-    // bootstrap (which needs CLAUDE_PLUGIN_ROOT or a signed release).
+    // bootstrap (which needs ACCELERATOR_PLUGIN_ROOT or a signed release).
     let output = Command::new(script)
         .arg(file)
         .env("ACCELERATOR_BIN", launcher_binary()?)

--- a/cli/launcher/src/config_command/core/template.rs
+++ b/cli/launcher/src/config_command/core/template.rs
@@ -40,7 +40,7 @@ pub fn list(
     templates: &dyn ReadTemplate,
 ) -> Result<Vec<ListRow>, ConfigError> {
     let mut rows = Vec::new();
-    for key in templates.template_names() {
+    for key in templates.template_names()? {
         let (source, display_path) = match resolve(config, templates, &key)? {
             Some(resolved) => {
                 (resolved.source.label().to_owned(), resolved.display_path)
@@ -57,9 +57,13 @@ pub fn list(
 }
 
 /// The comma-joined available names, for the not-found diagnostic.
+///
+/// A failed enumeration degrades the hint to empty rather than propagating: the
+/// error it decorates carries the real signal, and constructing an error must
+/// not itself be fallible.
 #[must_use]
 pub fn available(templates: &dyn ReadTemplate) -> String {
-    templates.template_names().join(", ")
+    templates.template_names().unwrap_or_default().join(", ")
 }
 
 /// The comma-joined available names, or `(none found)` when there are none —

--- a/cli/launcher/src/config_command/inbound/cli.rs
+++ b/cli/launcher/src/config_command/inbound/cli.rs
@@ -415,15 +415,16 @@ fn run_instructions(
 enum Failure {
     /// A read/IO failure the fail-safe boundary may absorb.
     Read(ConfigError),
-    /// A validation refusal that stays fail-closed regardless of `--fail-safe`.
+    /// A failure `--fail-safe` must never absorb.
     Refusal(ConfigError),
 }
 
 impl From<ConfigError> for Failure {
     fn from(error: ConfigError) -> Self {
-        match error {
-            ConfigError::Invalid { .. } => Self::Refusal(error),
-            _ => Self::Read(error),
+        if error.is_refusal() {
+            Self::Refusal(error)
+        } else {
+            Self::Read(error)
         }
     }
 }
@@ -436,8 +437,8 @@ enum Degrade {
 }
 
 /// Renders a scalar view to stdout-plus-warnings and dispatches it through
-/// [`finish`] with the scalar suppression policy. A [`ConfigError::Invalid`]
-/// stays a fail-closed refusal via [`From<ConfigError>`].
+/// [`finish`] with the scalar suppression policy. A refusing [`ConfigError`]
+/// stays fail-closed via [`From<ConfigError>`].
 fn finish_scalar(
     view: Result<ScalarView, ConfigError>,
     on_failure: OnFailure,
@@ -538,7 +539,7 @@ fn eject_all(
     let available = template_view::available_or_none(stack.templates());
     let mut had_error = false;
     let mut had_exists = false;
-    for key in stack.templates().template_names() {
+    for key in stack.templates().template_names()? {
         let result = stack.overrides().eject(&key, dir, force, dry_run)?;
         let text = template_render::eject_text(
             result.outcome,

--- a/cli/launcher/src/launch/outbound/resolve/cache_root.rs
+++ b/cli/launcher/src/launch/outbound/resolve/cache_root.rs
@@ -131,7 +131,13 @@ mod tests {
         let result = resolve(&config());
         assert!(result.is_err(), "expected an ACCELERATOR_PLUGIN_ROOT error");
         if let Err(error) = result {
-            assert!(error.to_string().contains("ACCELERATOR_PLUGIN_ROOT"));
+            let message = error.to_string();
+            assert!(message.contains("ACCELERATOR_PLUGIN_ROOT"));
+            // Distinguishes this step from the config layer's plugin-root
+            // refusal, which also names the variable.
+            assert!(
+                message.contains("no ACCELERATOR_CACHE_DIR override was given")
+            );
         }
     }
 

--- a/cli/launcher/src/launch/outbound/resolve/cache_root.rs
+++ b/cli/launcher/src/launch/outbound/resolve/cache_root.rs
@@ -1,6 +1,6 @@
 //! Resolves the runtime cache directory.
 //!
-//! `${CLAUDE_PLUGIN_ROOT}/bin` when writable and exec-capable, else the
+//! `${ACCELERATOR_PLUGIN_ROOT}/bin` when writable and exec-capable, else the
 //! `ACCELERATOR_CACHE_DIR` override, else a named error. No XDG fallback — an
 //! XDG-resident binary would break the plugin-root `allowed-tools` glob match.
 //! Read-only/noexec roots are probed.
@@ -23,7 +23,7 @@ impl CacheRootConfig {
             cache_dir_override: std::env::var_os("ACCELERATOR_CACHE_DIR")
                 .filter(|value| !value.is_empty())
                 .map(PathBuf::from),
-            plugin_root: std::env::var_os("CLAUDE_PLUGIN_ROOT")
+            plugin_root: std::env::var_os("ACCELERATOR_PLUGIN_ROOT")
                 .filter(|value| !value.is_empty())
                 .map(PathBuf::from),
         }
@@ -35,7 +35,7 @@ impl CacheRootConfig {
 /// # Errors
 ///
 /// [`ResolutionError::CacheRootUnavailable`] when no candidate is usable — an
-/// unset `CLAUDE_PLUGIN_ROOT` with no override, or a candidate failing the
+/// unset `ACCELERATOR_PLUGIN_ROOT` with no override, or a candidate failing the
 /// write+exec probe (with no XDG fallback).
 pub fn resolve(config: &CacheRootConfig) -> Result<PathBuf, ResolutionError> {
     if let Some(override_dir) = &config.cache_dir_override {
@@ -57,7 +57,7 @@ pub fn resolve(config: &CacheRootConfig) -> Result<PathBuf, ResolutionError> {
 
     let plugin_root = config.plugin_root.as_ref().ok_or_else(|| {
         ResolutionError::CacheRootUnavailable {
-            detail: "CLAUDE_PLUGIN_ROOT is not set and no \
+            detail: "ACCELERATOR_PLUGIN_ROOT is not set and no \
                      ACCELERATOR_CACHE_DIR override was given"
                 .to_owned(),
         }
@@ -129,9 +129,9 @@ mod tests {
     #[test]
     fn unset_plugin_root_with_no_override_is_a_named_error() {
         let result = resolve(&config());
-        assert!(result.is_err(), "expected a CLAUDE_PLUGIN_ROOT error");
+        assert!(result.is_err(), "expected an ACCELERATOR_PLUGIN_ROOT error");
         if let Err(error) = result {
-            assert!(error.to_string().contains("CLAUDE_PLUGIN_ROOT"));
+            assert!(error.to_string().contains("ACCELERATOR_PLUGIN_ROOT"));
         }
     }
 

--- a/cli/launcher/src/main.rs
+++ b/cli/launcher/src/main.rs
@@ -170,10 +170,13 @@ fn compose_stack(
     ))
 }
 
-/// The plugin root from `CLAUDE_PLUGIN_ROOT`, for resolving plugin-default
-/// templates; `None` when unset (template defaults are then unavailable).
+/// The plugin root from `ACCELERATOR_PLUGIN_ROOT`, for resolving plugin-default
+/// templates; `None` when unset or empty (template defaults are then
+/// unavailable).
 fn plugin_root() -> Option<PathBuf> {
-    std::env::var_os("CLAUDE_PLUGIN_ROOT").map(PathBuf::from)
+    std::env::var_os("ACCELERATOR_PLUGIN_ROOT")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
 }
 
 /// The directory config resolution starts from — the `config paths --doc-types`

--- a/cli/launcher/src/main.rs
+++ b/cli/launcher/src/main.rs
@@ -171,12 +171,10 @@ fn compose_stack(
 }
 
 /// The plugin root from `ACCELERATOR_PLUGIN_ROOT`, for resolving plugin-default
-/// templates; `None` when unset or empty (template defaults are then
-/// unavailable).
+/// templates; `None` when unset. `with_plugin_root` drops an empty value, so
+/// the launcher and the visualiser server inherit that rule from one place.
 fn plugin_root() -> Option<PathBuf> {
-    std::env::var_os("ACCELERATOR_PLUGIN_ROOT")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+    std::env::var_os("ACCELERATOR_PLUGIN_ROOT").map(PathBuf::from)
 }
 
 /// The directory config resolution starts from — the `config paths --doc-types`

--- a/cli/launcher/tests/config_read.rs
+++ b/cli/launcher/tests/config_read.rs
@@ -1239,6 +1239,142 @@ fn an_empty_plugin_root_behaves_as_an_unset_plugin_root() -> TestResult {
         "an empty root resolved templates from the cwd: {:?}",
         String::from_utf8_lossy(&empty.stdout)
     );
+    assert_ne!(code(&empty), 0);
+    assert!(empty.stdout.is_empty());
+    assert_names_the_plugin_root(&empty);
+    Ok(())
+}
+
+fn assert_names_the_plugin_root(output: &Output) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "stderr does not name the plugin root variable: {stderr}"
+    );
+}
+
+/// The refusal signature: non-zero, nothing on stdout so no answer can be
+/// spliced into a prompt, and a diagnostic naming what the caller must supply.
+fn assert_refuses_without_a_plugin_root(output: &Output) {
+    assert_ne!(code(output), 0);
+    assert!(
+        output.stdout.is_empty(),
+        "stdout was not empty: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert_names_the_plugin_root(output);
+}
+
+#[test]
+fn templates_list_with_no_plugin_root_is_a_named_refusal_not_an_empty_table(
+) -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let output = run_in(&fixture.root, &["config", "templates", "list"])?;
+    assert_refuses_without_a_plugin_root(&output);
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("| Template |"));
+    Ok(())
+}
+
+/// The refusal classification is what makes these two identical: a read failure
+/// would degrade to `## Template Unavailable` on stdout at exit 0.
+#[test]
+fn a_missing_plugin_root_refuses_identically_with_and_without_fail_safe(
+) -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    for args in [
+        vec!["config", "templates", "list"],
+        vec!["config", "template", "demo"],
+        vec!["config", "templates", "show", "demo"],
+    ] {
+        let loud = run_in(&fixture.root, &args)?;
+        let mut flagged = args.clone();
+        flagged.push("--fail-safe");
+        let degraded = run_in(&fixture.root, &flagged)?;
+        assert_refuses_without_a_plugin_root(&loud);
+        assert_refuses_without_a_plugin_root(&degraded);
+        assert_eq!(code(&degraded), code(&loud), "{args:?}");
+        assert_eq!(degraded.stderr, loud.stderr, "{args:?}");
+    }
+    Ok(())
+}
+
+#[test]
+fn templates_eject_all_with_no_plugin_root_writes_nothing() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let output =
+        run_in(&fixture.root, &["config", "templates", "eject", "--all"])?;
+    assert_refuses_without_a_plugin_root(&output);
+    assert!(
+        !fixture.root.join(".accelerator/templates").exists(),
+        "eject --all created the override directory without a plugin root"
+    );
+    Ok(())
+}
+
+/// `eject <name>`, `diff` and `reset` carry no `--fail-safe`, so their exit code
+/// is 1 either way and the diagnostic is the only observable.
+#[test]
+fn the_unflagged_template_commands_name_the_variable_with_no_plugin_root(
+) -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    for args in [
+        vec!["config", "templates", "eject", "demo"],
+        vec!["config", "templates", "diff", "demo"],
+        vec!["config", "templates", "reset", "demo"],
+    ] {
+        let output = run_in(&fixture.root, &args)?;
+        assert_ne!(code(&output), 0, "{args:?}");
+        assert_names_the_plugin_root(&output);
+    }
+    Ok(())
+}
+
+/// Pins the plugin-default check being at the third tier rather than hoisted to
+/// the top of `resolve_template`: hoisting would refuse this override too.
+#[test]
+fn a_user_override_still_resolves_with_no_plugin_root() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    fs::create_dir_all(fixture.root.join(".accelerator/templates"))?;
+    fs::write(
+        fixture.root.join(".accelerator/templates/demo.md"),
+        "# Mine\n",
+    )?;
+    let output = run_in(&fixture.root, &["config", "template", "demo"])?;
+    assert_eq!(output.stdout, b"```markdown\n# Mine\n```\n");
+    assert_eq!(code(&output), 0);
+    Ok(())
+}
+
+/// A root that is set but is not an installation still succeeds-with-nothing:
+/// `template_names` swallows the failed `read_dir`. Deliberate residue, tracked
+/// as its own work item rather than folded in here.
+#[test]
+fn a_root_without_a_templates_directory_still_renders_an_empty_table(
+) -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    assert_eq!(
+        output.stdout,
+        b"| Template | Source | Path |\n|----------|--------|------|\n"
+    );
+    assert_eq!(code(&output), 0);
+    Ok(())
+}
+
+#[test]
+fn the_root_independent_families_still_succeed_with_no_plugin_root(
+) -> TestResult {
+    let workspace = workspace("summary")?;
+    for args in [vec!["config", "paths"], vec!["config", "summary"]] {
+        let output = run_in(&workspace, &args)?;
+        assert_eq!(code(&output), 0, "{args:?}");
+        assert!(!output.stdout.is_empty(), "{args:?} printed nothing");
+    }
     Ok(())
 }
 

--- a/cli/launcher/tests/config_read.rs
+++ b/cli/launcher/tests/config_read.rs
@@ -6,6 +6,7 @@
 //! compare `output.stdout` directly, never through `from_utf8_lossy`.
 
 use std::error::Error;
+use std::ffi::OsStr;
 use std::fs;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
@@ -59,7 +60,7 @@ fn run_in(cwd: &Path, args: &[&str]) -> Result<Output, Box<dyn Error>> {
     let mut command = Command::new(env!("CARGO_BIN_EXE_accelerator"));
     command.current_dir(cwd);
     command.env_remove("ACCELERATOR_LOG");
-    command.env_remove("CLAUDE_PLUGIN_ROOT");
+    command.env_remove("ACCELERATOR_PLUGIN_ROOT");
     command.env_remove("ACCELERATOR_CACHE_DIR");
     command.env_remove("ACCELERATOR_RELEASE_BASE_URL");
     command.args(args);
@@ -1166,7 +1167,7 @@ fn summary_hook_keeps_the_unrecognised_skill_warning_off_stdout() -> TestResult
     command.env_remove("ACCELERATOR_LOG");
     command.env_remove("ACCELERATOR_CACHE_DIR");
     command.env_remove("ACCELERATOR_RELEASE_BASE_URL");
-    command.env("CLAUDE_PLUGIN_ROOT", &plugin);
+    command.env("ACCELERATOR_PLUGIN_ROOT", &plugin);
     command.args(["config", "summary", "--format", "hook"]);
     let output = command.output()?;
 
@@ -1197,14 +1198,48 @@ fn run_with_plugin(
     cwd: &Path,
     args: &[&str],
 ) -> Result<Output, Box<dyn Error>> {
+    run_with_plugin_root(cwd, plugin_root().as_os_str(), args)
+}
+
+fn run_with_plugin_root(
+    cwd: &Path,
+    root: &OsStr,
+    args: &[&str],
+) -> Result<Output, Box<dyn Error>> {
     let mut command = Command::new(env!("CARGO_BIN_EXE_accelerator"));
     command.current_dir(cwd);
     command.env_remove("ACCELERATOR_LOG");
     command.env_remove("ACCELERATOR_CACHE_DIR");
     command.env_remove("ACCELERATOR_RELEASE_BASE_URL");
-    command.env("CLAUDE_PLUGIN_ROOT", plugin_root());
+    command.env("ACCELERATOR_PLUGIN_ROOT", root);
     command.args(args);
     Ok(command.output()?)
+}
+
+/// Without the empty-string filter an empty value becomes `PathBuf::from("")`,
+/// which resolves plugin templates relative to the current directory — so the
+/// cwd is seeded with a `templates/` tree the assertion would otherwise see.
+#[test]
+fn an_empty_plugin_root_behaves_as_an_unset_plugin_root() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    fs::create_dir_all(fixture.root.join("templates"))?;
+    fs::write(fixture.root.join("templates/decoy.md"), "# decoy\n")?;
+
+    let unset = run_in(&fixture.root, &["config", "templates", "list"])?;
+    let empty = run_with_plugin_root(
+        &fixture.root,
+        OsStr::new(""),
+        &["config", "templates", "list"],
+    )?;
+
+    assert_eq!(empty.stdout, unset.stdout);
+    assert_eq!(code(&empty), code(&unset));
+    assert!(
+        !String::from_utf8_lossy(&empty.stdout).contains("decoy"),
+        "an empty root resolved templates from the cwd: {:?}",
+        String::from_utf8_lossy(&empty.stdout)
+    );
+    Ok(())
 }
 
 #[test]

--- a/cli/launcher/tests/version.rs
+++ b/cli/launcher/tests/version.rs
@@ -19,7 +19,7 @@ fn run(args: &[&str], env: &[(&str, &str)]) -> Result<Output, Box<dyn Error>> {
     let mut command = Command::new(env!("CARGO_BIN_EXE_accelerator"));
     command.env_remove("ACCELERATOR_LOG");
     // Hermetic: no inherited plugin root, cache override, or release URL.
-    command.env_remove("CLAUDE_PLUGIN_ROOT");
+    command.env_remove("ACCELERATOR_PLUGIN_ROOT");
     command.env_remove("ACCELERATOR_CACHE_DIR");
     command.env_remove("ACCELERATOR_RELEASE_BASE_URL");
     command.args(args);
@@ -176,7 +176,7 @@ fn an_unresolvable_subcommand_exits_non_zero_with_a_named_step(
     );
     let stderr = String::from_utf8(output.stderr)?;
     assert!(
-        stderr.contains("CLAUDE_PLUGIN_ROOT"),
+        stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
         "stderr missing the named resolution step: {stderr:?}"
     );
     Ok(())

--- a/cli/launcher/tests/version.rs
+++ b/cli/launcher/tests/version.rs
@@ -175,8 +175,11 @@ fn an_unresolvable_subcommand_exits_non_zero_with_a_named_step(
         "expected a non-zero exit for an unresolvable subcommand"
     );
     let stderr = String::from_utf8(output.stderr)?;
+    // The clause is unique to CacheRootUnavailable: asserting the variable name
+    // alone would also match the plugin-root refusal, so the two named errors
+    // would be interchangeable to this test.
     assert!(
-        stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
+        stderr.contains("no ACCELERATOR_CACHE_DIR override was given"),
         "stderr missing the named resolution step: {stderr:?}"
     );
     Ok(())

--- a/cli/visualiser/frontend/e2e/start-server.mjs
+++ b/cli/visualiser/frontend/e2e/start-server.mjs
@@ -95,7 +95,7 @@ const child = spawn(bin, ["serve", "--owner-pid", "0"], {
   cwd: project,
   env: {
     ...process.env,
-    CLAUDE_PLUGIN_ROOT: project,
+    ACCELERATOR_PLUGIN_ROOT: project,
     FIXTURES_PATH: fixturesDir,
   },
   stdio: "inherit",

--- a/cli/visualiser/server/src/compose.rs
+++ b/cli/visualiser/server/src/compose.rs
@@ -154,7 +154,7 @@ fn resolve_templates(
     let user_root = safe_dir(project_root, templates_rel, "paths.templates")?;
     let plugin_templates = plugin_root.join("templates");
     let mut map = HashMap::new();
-    for name in store.template_names() {
+    for name in store.template_names()? {
         let res = service
             .effective(&Key::parse(&format!("templates.{name}"))?, None)?;
         let configured =

--- a/cli/visualiser/server/src/main.rs
+++ b/cli/visualiser/server/src/main.rs
@@ -66,8 +66,8 @@ fn resolve_host() -> String {
 }
 
 fn run_serve(owner_pid: i32, owner_start_time: Option<u64>) -> ExitCode {
-    let Some(plugin_root) = std::env::var_os("CLAUDE_PLUGIN_ROOT") else {
-        eprintln!("CLAUDE_PLUGIN_ROOT is not set");
+    let Some(plugin_root) = std::env::var_os("ACCELERATOR_PLUGIN_ROOT") else {
+        eprintln!("ACCELERATOR_PLUGIN_ROOT is not set");
         return ExitCode::from(2);
     };
     let plugin_root = PathBuf::from(plugin_root);

--- a/cli/visualiser/server/tests/api_smoke.rs
+++ b/cli/visualiser/server/tests/api_smoke.rs
@@ -29,7 +29,7 @@ async fn api_surface_is_fully_reachable_against_fixture_meta() {
     let mut child = Command::new(bin)
         .args(["serve", "--owner-pid", "0"])
         .current_dir(project)
-        .env("CLAUDE_PLUGIN_ROOT", project)
+        .env("ACCELERATOR_PLUGIN_ROOT", project)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .kill_on_drop(true)

--- a/cli/visualiser/server/tests/compose_contract.rs
+++ b/cli/visualiser/server/tests/compose_contract.rs
@@ -180,3 +180,23 @@ fn unconfigured_project_uses_catalogue_defaults() {
     assert_eq!(work_item.scan_regex, "^([0-9]+)-");
     assert!(work_item.default_project_code.is_none());
 }
+
+/// The emptiness rule lives in `with_plugin_root`, so the server inherits it:
+/// an empty root refuses rather than resolving plugin templates against cwd.
+#[test]
+fn an_empty_plugin_root_refuses_to_compose() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_project(tmp.path());
+    let error = load(Params {
+        cwd: tmp.path().to_path_buf(),
+        plugin_root: PathBuf::new(),
+        owner_pid: 0,
+        owner_start_time: None,
+        host: "127.0.0.1".to_string(),
+    })
+    .expect_err("an empty plugin root composed a config");
+    assert!(
+        error.to_string().contains("ACCELERATOR_PLUGIN_ROOT"),
+        "the error does not name the variable: {error}"
+    );
+}

--- a/cli/visualiser/server/tests/orchestration_lifecycle.rs
+++ b/cli/visualiser/server/tests/orchestration_lifecycle.rs
@@ -52,7 +52,7 @@ fn seed_project(dir: &Path, config_body: &str) {
 fn cli(project: &Path) -> Command {
     let mut cmd = Command::cargo_bin("accelerator-visualiser").unwrap();
     cmd.current_dir(project)
-        .env("CLAUDE_PLUGIN_ROOT", repo_root());
+        .env("ACCELERATOR_PLUGIN_ROOT", repo_root());
     cmd
 }
 
@@ -291,7 +291,7 @@ fn serve_without_plugin_root_exits_2() {
     Command::cargo_bin("accelerator-visualiser")
         .unwrap()
         .current_dir(tmp.path())
-        .env_remove("CLAUDE_PLUGIN_ROOT")
+        .env_remove("ACCELERATOR_PLUGIN_ROOT")
         .args(["serve", "--owner-pid", "0"])
         .assert()
         .code(2);

--- a/cli/visualiser/server/tests/shutdown.rs
+++ b/cli/visualiser/server/tests/shutdown.rs
@@ -16,7 +16,7 @@ fn spawn_serve(project: &Path) -> tokio::process::Child {
     tokio::process::Command::new(env!("CARGO_BIN_EXE_accelerator-visualiser"))
         .args(["serve", "--owner-pid", "0"])
         .current_dir(project)
-        .env("CLAUDE_PLUGIN_ROOT", project)
+        .env("ACCELERATOR_PLUGIN_ROOT", project)
         .spawn()
         .expect("spawn serve")
 }

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -85,6 +85,144 @@ detection covers three modes:
 | **jj (colocated)** | `.jj/` and `.git/` | `jj`              |
 | **jj (pure)**      | `.jj/` only        | `jj`              |
 
+## Terminal Invocation
+
+Accelerator's CLI can be run from an ordinary terminal, not only from inside a
+Claude Code session. Because the plugin is installed into a version-scoped
+directory that moves on every upgrade, the supported route is a two-hop chain:
+
+```
+~/.local/bin/accelerator                # you create this, once
+  -> <plugin data>/bin/accelerator      # a SessionStart hook refreshes this
+    -> <plugin root>/bin/accelerator    # version-pinned, moves on upgrade
+```
+
+The hop you create points at a target that never moves, so it never needs
+re-running. The hop that must track the version is owned by
+`hooks/launcher-link-refresh.sh`, which refreshes it at every session start.
+This requires Claude Code **v2.1.78 or later** (the release that added the
+plugin data directory). Below that, link `<plugin root>/bin/accelerator`
+directly and re-run the link after each upgrade.
+
+**Supported platforms**: macOS or Linux (including WSL) on x86-64 or arm64. The
+CLI refuses anything else, so Git Bash, Cygwin, armv7, riscv64 and ppc64le are
+out of scope. The Linux artifacts are statically linked (musl), so there is no
+glibc floor. Under WSL the plugin data directory must sit on the Linux
+filesystem — a `/mnt/<drive>` DrvFs path cannot hold symlinks.
+
+### Setting it up
+
+First, find the path the hook maintains. It is printed by the hook whenever it
+re-points the link, and otherwise discoverable:
+
+```bash
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+ls -d "$CLAUDE_DIR"/plugins/data/*accelerator*/bin/accelerator
+```
+
+Typical results, one per channel:
+
+| Channel     | Typical path                                                       |
+|-------------|--------------------------------------------------------------------|
+| Stable      | `~/.claude/plugins/data/accelerator-atomic-innovation/bin/accelerator` |
+| Prerelease  | `~/.claude/plugins/data/accelerator-atomic-innovation-prerelease/bin/accelerator` |
+
+These are examples rather than a contract: `~/.claude` moves with
+`CLAUDE_CONFIG_DIR`, and the directory name is derived from the plugin
+identifier. Prefer the discovery command, or the path the hook printed.
+
+Verify it exists and points somewhere real before linking anything:
+
+```bash
+ls -l <discovered path>
+```
+
+If it is missing, the hook has not run — start a Claude Code session first, and
+check your Claude Code version against the floor above.
+
+Then create your own hop:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sfn <discovered path> ~/.local/bin/accelerator
+```
+
+The `mkdir -p` is not optional; `~/.local/bin` frequently does not exist, and
+`ln` then fails with `No such file or directory`. Prefer a directory you own
+that is not group-writable: this command fetches and executes signed binaries,
+so its `PATH` entry is part of the trust chain, and Homebrew-managed
+`/usr/local/bin` is often group-writable.
+
+`~/.local/bin` is not on `PATH` by default on macOS, and some Linux
+distributions add it only in a login shell. Open a new shell and check:
+
+```bash
+command -v accelerator
+```
+
+If that prints nothing, the directory is not on your `PATH`. In a POSIX shell:
+
+```bash
+case ":$PATH:" in *":$HOME/.local/bin:"*) echo on ;; *) echo missing ;; esac
+```
+
+Add it in your shell profile. In fish the diagnostic above is a syntax error and
+the fix is `fish_add_path ~/.local/bin`.
+
+If you track both channels, link the second under a different name — for
+example `accelerator-pre` — so the two do not collide.
+
+### Which installation am I running?
+
+The link is opaque, so ask the CLI:
+
+```bash
+accelerator version                          # the resolved installation
+readlink ~/.local/bin/accelerator            # your hop
+readlink "$(readlink ~/.local/bin/accelerator)"   # the plugin-owned hop
+```
+
+This matters because the plugin-owned hop is **channel-global with
+last-session-wins semantics**. A session started before an upgrade re-points it
+to the older installation for every terminal user and every concurrent session,
+not just itself — and what it selects is the whole installation: the bootstrap,
+the vendored verifier, the release key and the launcher cache. So a stale
+session can put your terminal command back on an installation old enough to
+predate a security fix, for as long as Claude Code retains the old directory
+(observed at roughly two weeks, though that is Claude Code's behaviour rather
+than something this plugin controls). `/reload-plugins` corrects it immediately;
+the next session corrects it anyway.
+
+### Offline, mirrored and read-only installs
+
+The terminal surface assumes a cache already populated by a Claude Code session.
+A first run against an empty cache needs network access to the artifact host and
+has no degraded mode. Two environment variables cover the awkward cases:
+
+| Variable                       | Effect                                          |
+|--------------------------------|-------------------------------------------------|
+| `ACCELERATOR_CACHE_DIR`        | Where the launcher is staged and executed from  |
+| `ACCELERATOR_RELEASE_BASE_URL` | Where release artifacts are fetched from        |
+
+Both are trust-root inputs rather than ordinary conveniences. The cache
+directory is where the bootstrap writes and *executes* a probe file, so point it
+at a directory you own and that is not group-writable. The release base URL
+should be a host you trust not to serve an older signed release: the cache key
+carries no content hash, so a mirror can hand back an older validly-signed
+launcher for the current version.
+
+`ACCELERATOR_PLUGIN_ROOT` is **exported by** the bootstrap for the launcher it
+runs; it is never read as an input. Setting it has no effect.
+
+### Removing it
+
+Uninstalling the plugin stops the hook that maintains the second hop, but leaves
+your own link behind as a broken `accelerator` on `PATH`. Remove it yourself:
+
+```bash
+rm ~/.local/bin/accelerator
+```
+
 ---
 
 [← Visualiser](visualiser.md) · [Docs home](../README.md#documentation) · [Configuration →](configuration.md)

--- a/docs/releases-and-compatibility.md
+++ b/docs/releases-and-compatibility.md
@@ -28,6 +28,12 @@ marketplace:
 /plugin install accelerator@atomic-innovation
 ```
 
+If you have linked the CLI onto your `$PATH`, re-point your own link at the
+other channel's plugin data directory — it is per-plugin-id, so switching
+channels leaves the old link resolving to the uninstalled channel. The same
+applies when uninstalling entirely: remove your link. See
+[Terminal Invocation](internals.md#terminal-invocation).
+
 ## Claude Code compatibility
 
 This plugin relies on Claude Code's subagent `skills:` preload mechanism

--- a/docs/visualiser.md
+++ b/docs/visualiser.md
@@ -20,8 +20,8 @@ load-error pages.
 ## Launching
 
 ```bash
-/visualise            # from inside a Claude Code session
-accelerator-visualiser            # CLI wrapper — optionally symlink onto $PATH
+/visualise                  # from inside a Claude Code session
+accelerator visualiser      # from a terminal — see internals.md
 ```
 
 The server binds to `localhost` on a dynamic port. It has no authentication
@@ -35,7 +35,7 @@ returns the same URL.
 /visualise stop       # SIGTERM, escalating to SIGKILL after 2s
 ```
 
-Both subcommands also work via the `accelerator-visualiser` CLI wrapper.
+Both subcommands also work via the `accelerator visualiser` CLI.
 The server auto-exits after 8 hours idle or when the process that
 launched it exits, so explicit `stop` is rarely necessary.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -27,6 +27,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/migrate-discoverability.sh"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/launcher-link-refresh.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/hooks/launcher-link-refresh.sh
+++ b/hooks/launcher-link-refresh.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -uo pipefail
+CDPATH=
+
+# SessionStart hook: keep ${CLAUDE_PLUGIN_DATA}/bin/accelerator pointing at the
+# current installation's launcher, so a user's own PATH symlink survives plugin
+# upgrades without being re-created. Exits 0 in all cases.
+#
+# The root is self-located, never taken from the environment: this hook
+# publishes a persistent, channel-global pointer, so a stale ambient value would
+# poison the terminal command until someone noticed. Two of the four sibling
+# hooks are env-first; both use the value transiently and then exec. This one
+# is invoked by its own absolute path, so its location already *is* the value
+# an ambient root would have supplied.
+#
+# Accumulated rather than emitted inline: at most one JSON object may reach
+# stdout, and two conditions can hold in one run.
+NOTICE=""
+
+finish() {
+  [ -n "$1" ] && printf '[accelerator] %s\n' "$1" >&2
+  if [ -n "${NOTICE}" ]; then
+    jq -n --arg m "[accelerator] ${NOTICE}" '{systemMessage: $m}' 2>/dev/null ||
+      printf '[accelerator] %s\n' "${NOTICE}" >&2
+  fi
+  exit 0
+}
+
+SCRIPT_DIR=$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+PLUGIN_ROOT=$(cd -P -- "${SCRIPT_DIR}/.." && pwd -P)
+LAUNCHER="${PLUGIN_ROOT}/bin/accelerator"
+
+# Read before the CLAUDE_PLUGIN_DATA guard: a trust-chain signal must not be
+# suppressed on the Claude Code versions that lack a convenience feature.
+UNVERIFIED_LOG="${ACCELERATOR_CACHE_DIR:-${PLUGIN_ROOT}/bin}/.accelerator-unverified.log"
+if [ -s "${UNVERIFIED_LOG}" ]; then
+  NOTICE="an unverified launcher was recorded in ${UNVERIFIED_LOG}"
+fi
+
+case "${CLAUDE_PLUGIN_DATA:-}" in
+  /*) ;;
+  *) finish "CLAUDE_PLUGIN_DATA unavailable; no terminal link refreshed. See docs/internals.md#terminal-invocation" ;;
+esac
+
+[ -x "${LAUNCHER}" ] ||
+  finish "launcher not executable: ${LAUNCHER}; leaving the terminal link alone"
+
+DATA_BIN="${CLAUDE_PLUGIN_DATA}/bin"
+LINK="${DATA_BIN}/accelerator"
+STAGED="${LINK}.new.$$"
+
+# Before mkdir -p, which would otherwise fail first for a regular file and
+# follow a dangling symlink out of the tree for the other flavour.
+if [ -L "${DATA_BIN}" ] || { [ -e "${DATA_BIN}" ] && [ ! -d "${DATA_BIN}" ]; }; then
+  finish "${DATA_BIN} is not a plain directory; remove it to let Accelerator manage the terminal link"
+fi
+# shellcheck disable=SC2174 # deliberate: -m must apply to DATA_BIN only. If CLAUDE_PLUGIN_DATA itself must be created it is Claude Code's directory to own, so it takes the umask-derived mode.
+mkdir -p -m 0700 "${DATA_BIN}" ||
+  finish "could not create ${DATA_BIN}; a terminal 'accelerator' command may be stale"
+
+# mv -f onto a symlink-to-directory writes *inside* it and reports success, so
+# the temp-plus-rename dance needs this clear to stay correct.
+if [ -L "${LINK}" ] && [ -d "${LINK}" ]; then
+  rm -f "${LINK}" ||
+    finish "could not clear ${LINK}; a terminal 'accelerator' command may be stale"
+fi
+if [ -e "${LINK}" ] && [ ! -L "${LINK}" ]; then
+  NOTICE="${NOTICE}${NOTICE:+; }${LINK} exists and is not a symlink, so the terminal 'accelerator' command will not be updated. Remove it to let Accelerator manage the link."
+  finish ""
+fi
+
+# ln -sfn onto a *real* directory succeeds, linking inside it, so a stale
+# staging directory on a recycled pid would rename a directory onto LINK.
+if [ -e "${STAGED}" ] || [ -L "${STAGED}" ]; then
+  finish "stale staging path ${STAGED} is in the way; remove it and start a new session"
+fi
+trap 'rm -rf "${STAGED}" 2>/dev/null || true' EXIT
+
+PREVIOUS=$(readlink "${LINK}" 2>/dev/null || true)
+ln -sfn "${LAUNCHER}" "${STAGED}" ||
+  finish "could not stage ${STAGED}; a terminal 'accelerator' command may be stale"
+mv -f "${STAGED}" "${LINK}" ||
+  finish "could not install ${LINK}; a terminal 'accelerator' command may be stale"
+[ -L "${LINK}" ] ||
+  finish "${LINK} is not a symlink after refresh; remove it and start a new session"
+
+if [ -n "${PREVIOUS}" ] && [ "${PREVIOUS}" != "${LAUNCHER}" ]; then
+  finish "terminal link re-pointed: ${PREVIOUS} -> ${LAUNCHER}"
+fi
+finish ""

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -14,7 +14,7 @@ derived_from:
 tags: [plan, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
 revision: "e56fb165ea4b7591de3586bc43e96cb8bf7ab6df"
 repository: "accelerator"
-last_updated: "2026-07-28T10:52:00+00:00"
+last_updated: "2026-07-29T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -272,16 +272,15 @@ rename:
 |---|---|---|---|
 | 0 | Determinations — no code | yes, no predecessor | **done** 2026-07-28 |
 | **1a** | Bootstrap self-locates, `--fail-safe`-aware `fail()`, exports **both** names; new tests, 2 deletions | **yes — and independently releasable** | **done** 2026-07-28 |
-| **1c** | Work-item seam re-point + the `build:cli:dev` edge | **yes, today** — needs neither 1a nor 1b | not started |
+| **1c** | Work-item seam re-point + the `build:cli:dev` edge | **yes, today** — needs neither 1a nor 1b | **done** 2026-07-29 |
 | **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | not started |
 | 2 | The `CLAUDE_*` boundary guard | after 1b | not started |
 | 3 | Terminal invocation surface | after 1a | not started |
 | 4 | `!`-site conformance suite | after 1a | not started |
 | 5 | Named error for a missing plugin root | after 1b | not started |
 
-**Progress — 2026-07-28.** Phases 0 and 1a are implemented, verified and
-committed; `mise run` is green end-to-end (three consecutive runs). 1c is next
-in the merge order. Five commits carry the work:
+**Progress — 2026-07-29.** Phases 0, 1a and 1c are implemented, verified and
+committed. 1b is next in the merge order. Six commits carry the work:
 
 | Commit | Content |
 |---|---|
@@ -290,6 +289,7 @@ in the merge order. Five commits carry the work:
 | `Cover rootless invocation, symlink chases and fail-safe aborts` | 1a commit 2 |
 | `Derive the installation root from the bootstrap's own location` | 1a commit 3 |
 | `Stop three suites failing on wall-clock noise under parallel load` | out of scope — see below |
+| `Force the work-item template fallback through ACCELERATOR_BIN` | Phase 1c |
 
 Two things a later phase inherits:
 
@@ -1257,6 +1257,8 @@ file is on Phase 2's permitted-residue list.
 
 ## Phase 1c: The Work-Item Seam and the Build Edge
 
+> **Done 2026-07-29.**
+
 ### Overview
 
 Two changes that are green **today**, independent of 1a and 1b: the seam re-point
@@ -1362,19 +1364,26 @@ CI needs no edit: `test-unit` and `test-integration` already carry the
 
 #### Automated Verification
 
-- [ ] Work-item shell suites pass: `mise run test:integration:work`
-- [ ] The exhaustive edge assertion passes:
-      `uv run pytest tests/unit/tasks/test_mise.py -v`
-- [ ] `mise run check` exits 0
+- [x] Work-item shell suites pass: `mise run test:integration:work` *(242 passed
+      in the work-item suite; 0 failed across the subtree)*
+- [x] The exhaustive edge assertion passes:
+      `uv run pytest tests/unit/tasks/test_mise.py -v` *(18 passed)*
+- [x] `mise run check` exits 0
 
 #### Manual Verification
 
-- [ ] Temporarily removing `hardcoded_fallback`'s `status)` arm turns the
+- [x] Temporarily removing `hardcoded_fallback`'s `status)` arm turns the
       re-pointed seam assertions red. (It also reddens Test 7 at `:1071` and both
       tripwire comparisons, so the mutation is a sanity check on the pair rather
-      than an isolating one.)
-- [ ] Adding a `test:integration:*` task to neither `_LAUNCHER_DEPENDENTS` nor
-      `_NO_LAUNCHER_NEEDED` turns `test_mise.py` red
+      than an isolating one.) **Confirmed**: 4 failures, including both
+      `returns hardcoded status values` and `seam forces the hardcoded fallback`,
+      while `a working CLI reads the override` stayed green — the pair is
+      falsifiable in both directions as designed.
+- [x] Adding a `test:integration:*` task to neither `_LAUNCHER_DEPENDENTS` nor
+      `_NO_LAUNCHER_NEEDED` turns `test_mise.py` red. **Confirmed**: a temporary
+      `test:integration:probe` leaf fails
+      `test_every_integration_task_declares_its_launcher_need` with
+      `Extra items in the left set: 'test:integration:probe'`.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -273,14 +273,15 @@ rename:
 | 0 | Determinations — no code | yes, no predecessor | **done** 2026-07-28 |
 | **1a** | Bootstrap self-locates, `--fail-safe`-aware `fail()`, exports **both** names; new tests, 2 deletions | **yes — and independently releasable** | **done** 2026-07-28 |
 | **1c** | Work-item seam re-point + the `build:cli:dev` edge | **yes, today** — needs neither 1a nor 1b | **done** 2026-07-29 |
-| **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | not started |
+| **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | **done** 2026-07-29 |
 | 2 | The `CLAUDE_*` boundary guard | after 1b | not started |
 | 3 | Terminal invocation surface | after 1a | not started |
 | 4 | `!`-site conformance suite | after 1a | not started |
 | 5 | Named error for a missing plugin root | after 1b | not started |
 
-**Progress — 2026-07-29.** Phases 0, 1a and 1c are implemented, verified and
-committed. 1b is next in the merge order. Six commits carry the work:
+**Progress — 2026-07-29.** Phases 0, 1a, 1c and 1b are implemented, verified
+and committed. Phase 2 is next in the merge order. Seven commits carry the
+work:
 
 | Commit | Content |
 |---|---|
@@ -290,6 +291,7 @@ committed. 1b is next in the merge order. Six commits carry the work:
 | `Derive the installation root from the bootstrap's own location` | 1a commit 3 |
 | `Stop three suites failing on wall-clock noise under parallel load` | out of scope — see below |
 | `Force the work-item template fallback through ACCELERATOR_BIN` | Phase 1c |
+| `Rename the plugin root onto ACCELERATOR_PLUGIN_ROOT` | Phase 1b |
 
 Two things a later phase inherits:
 
@@ -1153,7 +1155,7 @@ one-off check that never runs again:
 
 ## Phase 1b: The Rename
 
-> **Lands after Phase 1c**, which follows this section. 1c is green today and
+> **Done 2026-07-29**, after Phase 1c as sequenced. 1c is green today and
 > independent, but the rename makes its seam vacuous if it goes first — see the
 > mergeability table in *Implementation Approach* and Phase 1c's Overview.
 
@@ -1233,25 +1235,36 @@ file is on Phase 2's permitted-residue list.
 
 #### Automated Verification
 
-- [ ] `cli/` workspace tests pass: `mise run test:unit:cli`
-- [ ] The empty-string case is asserted:
-      `cargo test -p accelerator-launcher --test config_read empty_plugin_root`
-- [ ] Entrypoint suite still passes: `uv run pytest tests/integration/entrypoint -v`
-- [ ] Work-item shell suites pass: `mise run test:integration:work`
-- [ ] Dev-task integration tests pass: `mise run test:integration:dev`
-- [ ] Visualiser integration tests pass: `mise run test:integration:visualiser`
-- [ ] Build-system unit tests pass: `mise run test:unit:tasks`
-- [ ] No `CLAUDE_` string remains in `bin/accelerator`:
+- [x] `cli/` workspace tests pass: `mise run test:unit:cli`
+- [x] The empty-string case is asserted:
+      `cargo test -p accelerator --test config_read empty_plugin_root` — note
+      the package is `accelerator`, not `accelerator-launcher`. The case seeds a
+      `templates/decoy.md` in the cwd, so an unfiltered empty value (which
+      becomes `PathBuf::from("")`) is *observable* rather than merely equal:
+      confirmed red without the filter, listing `decoy` as a plugin default.
+- [x] Entrypoint suite still passes: `uv run pytest tests/integration/entrypoint -v`
+      *(46 passed)*
+- [x] Work-item shell suites pass: `mise run test:integration:work`
+- [x] Dev-task integration tests pass: `mise run test:integration:dev` *(17 passed)*
+- [x] Visualiser integration tests pass: `mise run test:integration:visualiser`
+- [x] Build-system unit tests pass: `mise run test:unit:tasks` *(368 passed)*
+- [x] No `CLAUDE_` string remains in `bin/accelerator`:
       `! grep -q 'CLAUDE_' bin/accelerator`
-- [ ] `mise run check` exits 0
-- [ ] `mise run` (bare default) exits 0 end-to-end
+- [x] `mise run check` exits 0
+- [x] `mise run` (bare default) exits 0 end-to-end
 
 #### Manual Verification
 
-- [ ] `mise run dev:*` still starts the visualiser server (the renamed
-      `tasks/dev.py` writer feeds its hard-exit reader)
-- [ ] A freshly built launcher, invoked directly with only
-      `ACCELERATOR_PLUGIN_ROOT` set, renders the plugin-default template tier
+- [x] `mise run dev:*` still starts the visualiser server (the renamed
+      `tasks/dev.py` writer feeds its hard-exit reader). **Confirmed**:
+      `mise run dev` then `dev:status` reports both server and frontend active.
+      `mise.local.toml` sets only `CLAUDE_PLUGIN_ROOT`, so the server's root can
+      only have come from the renamed writer — had the rename been one-sided the
+      let-else would have exited 2.
+- [x] A freshly built launcher, invoked directly with only
+      `ACCELERATOR_PLUGIN_ROOT` set, renders the plugin-default template tier.
+      **Confirmed** under `env -i`: 13 plugin-default rows with the variable set,
+      a header-only table without it.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -3132,7 +3132,8 @@ Two consequences for this phase:
   `a_root_without_a_templates_directory_still_renders_an_empty_table`).
 - Raise a **follow-up work item** for converting that arm's `NotFound` case into
   `PluginRootUnavailable` (keeping genuine I/O failures as `Io`), and reference its
-  id here — a prose note in a completed plan is not a work queue.
+  id here — a prose note in a completed plan is not a work queue. **Raised as
+  0184** (`meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`).
 
 #### 4. Update the tests
 
@@ -3215,47 +3216,114 @@ Hand-run criteria assume the repository root as cwd and a host-native debug buil
 `CARGO_TARGET_DIR` may be set. The hermetic equivalents are the `config_read.rs`
 cases, which pin cwd via `run_in` and are what CI actually runs.
 
-- [ ] `cli/` workspace tests pass: `mise run test:unit:cli` — including the 47
-      untouched `run_in` cases and both rootless `summary` cases
-- [ ] The new variant's `Display` names the variable, asserted as a unit test in
-      `cli/config/src/error.rs`'s existing per-variant block
-- [ ] Every `ConfigError` variant is classified: adding one without extending
-      `is_refusal()` fails to compile
-- [ ] A rootless `config templates list` is a named error rather than an empty
-      table, exiting non-zero with a diagnostic naming the variable
-- [ ] The same command **with** `--fail-safe` behaves identically — non-zero, empty
+- [x] `cli/` workspace tests pass: `mise run test:unit:cli` — including the 47
+      untouched `run_in` cases and both rootless `summary` cases *(586 passed)*
+- [x] The new variant's `Display` names the variable, asserted as a unit test in
+      `cli/config/src/error.rs`'s existing per-variant block —
+      `plugin_root_unavailable_names_the_variable_and_the_bootstrap`
+- [x] Every `ConfigError` variant is classified: adding one without extending
+      `is_refusal()` fails to compile. **Confirmed** by adding a throwaway variant
+      mid-phase: `error[E0004]: non-exhaustive patterns` at the `is_refusal`
+      match. Classification of the four variants the plan's snippet omitted
+      (`PathConflict`, `MalformedFrontmatter`, `InvalidKey`, `UnsafePath`) follows
+      the wildcard it replaced — degradable — so no existing behaviour moved.
+- [x] A rootless `config templates list` is a named error rather than an empty
+      table, exiting non-zero with a diagnostic naming the variable —
+      `templates_list_with_no_plugin_root_is_a_named_refusal_not_an_empty_table`
+- [x] The same command **with** `--fail-safe` behaves identically — non-zero, empty
       stdout, diagnostic on stderr — because the failure is a `Refusal`
-- [ ] `config template adr` with no root still exits non-zero with and without
-      `--fail-safe`, as it does today, with a better message
-- [ ] A rootless `config templates eject --all` is a named error and writes no
-      file, where today it exits 0 having ejected nothing
-- [ ] **A rootless `config template <name>` still resolves a user override** — the
-      criterion that pins the tier check being in place rather than hoisted
-- [ ] A root that exists but has no `templates/` still renders a header-only table
-      at exit 0 (characterisation — the deferred residue, visible not implicit)
-- [ ] The root-independent families still succeed rootless, `config summary` among
+- [x] `config template adr` with no root still exits non-zero with and without
+      `--fail-safe`, as it does today, with a better message. Both this and the
+      criterion above are one parametrised case,
+      `a_missing_plugin_root_refuses_identically_with_and_without_fail_safe`,
+      covering `templates list`, `template <name>` and `templates show` and
+      asserting **byte-identical stderr** across the flag — which is the property
+      that separates the `Refusal` classification from a `Read` one.
+- [x] A rootless `config templates eject --all` is a named error and writes no
+      file, where today it exits 0 having ejected nothing —
+      `templates_eject_all_with_no_plugin_root_writes_nothing`, plus
+      `the_unflagged_template_commands_name_the_variable_with_no_plugin_root` for
+      `eject <name>`, `diff` and `reset`
+- [x] **A rootless `config template <name>` still resolves a user override** — the
+      criterion that pins the tier check being in place rather than hoisted:
+      `a_user_override_still_resolves_with_no_plugin_root`
+- [x] A root that exists but has no `templates/` still renders a header-only table
+      at exit 0 (characterisation — the deferred residue, visible not implicit) —
+      `a_root_without_a_templates_directory_still_renders_an_empty_table`
+- [x] The root-independent families still succeed rootless, `config summary` among
       them: `config paths` and `config summary` both exit 0 with non-empty stdout,
-      run against a stated fixture project
-- [ ] `version` with no root still exits 0
-- [ ] An external subcommand with no root fails at the **cache-root** step, pinned
-      by a substring only that error emits
-- [ ] An empty-string root behaves identically to an absent one, for the launcher
-      **and** the visualiser server (one filter in `with_plugin_root`)
-- [ ] Architecture rules hold: `mise run pup:check`
-- [ ] The Phase 4 conformance suite still passes:
-      `mise run test:integration:skill-invocation`
-- [ ] `mise run check` exits 0 — including `missing_errors_doc` on the newly
+      run against a stated fixture project — the `summary` fixture, in
+      `the_root_independent_families_still_succeed_with_no_plugin_root`
+- [x] `version` with no root still exits 0 — already covered: `version.rs`'s `run`
+      helper strips `ACCELERATOR_PLUGIN_ROOT` from every case in the file
+- [x] An external subcommand with no root fails at the **cache-root** step, pinned
+      by a substring only that error emits — `no ACCELERATOR_CACHE_DIR override
+      was given`, tightened at `version.rs`'s
+      `an_unresolvable_subcommand_exits_non_zero_with_a_named_step` and at
+      `cache_root.rs`'s `unset_plugin_root_with_no_override_is_a_named_error`
+- [x] An empty-string root behaves identically to an absent one, for the launcher
+      **and** the visualiser server (one filter in `with_plugin_root`) —
+      `an_empty_plugin_root_behaves_as_an_unset_plugin_root` (strengthened to the
+      named refusal) and the server's `an_empty_plugin_root_refuses_to_compose`
+- [x] Architecture rules hold: `mise run pup:check`
+- [x] The Phase 4 conformance suite still passes:
+      `mise run test:integration:skill-invocation` *(128 passed)*
+- [x] `mise run check` exits 0 — including `missing_errors_doc` on the newly
       fallible port
-- [ ] `mise run` (bare default) exits 0 end-to-end
+- [x] `mise run` (bare default) exits 0 end-to-end
 
 #### Manual Verification
 
-- [ ] A rootless launcher reached via `ACCELERATOR_BIN` prints a diagnostic naming
-      `ACCELERATOR_PLUGIN_ROOT` for `templates list` instead of an empty table
-- [ ] Nothing reaches stdout on that path, so no resolved path could be spliced
-      into a prompt
-- [ ] A `!` site still cannot reach this failure, because the bootstrap always
-      exports a root — confirm by checking one skill loads normally after the change
+- [x] A rootless launcher reached via `ACCELERATOR_BIN` prints a diagnostic naming
+      `ACCELERATOR_PLUGIN_ROOT` for `templates list` instead of an empty table.
+      **Confirmed**: exit 1 with `the plugin installation root is unknown: set
+      ACCELERATOR_PLUGIN_ROOT, or invoke accelerator through bin/accelerator,
+      which derives it`, run from a bare `mktemp -d` with both variables stripped.
+- [x] Nothing reaches stdout on that path, so no resolved path could be spliced
+      into a prompt. **Confirmed**: 0 bytes, with and without `--fail-safe`.
+- [x] A `!` site still cannot reach this failure, because the bootstrap always
+      exports a root — confirm by checking one skill loads normally after the
+      change. **Discharged by automation instead**: Phase 4's conformance suite
+      runs all 122 distinct `config` `!`-site commands through the real bootstrap
+      with both variables removed from the environment, and all 128 cases stay
+      green. That covers every skill rather than one, so a hand check adds
+      nothing.
+
+### Implementation notes
+
+Four departures from the section above.
+
+- **`is_refusal` is `pub`, not `pub(crate)`.** The section's snippet says
+  `pub(crate)`, but its sole consumer — `From<ConfigError> for Failure` — lives in
+  the `accelerator` launcher crate, so `pub(crate)` on a method of `config` makes
+  it unreachable and the delegation cannot compile. The property the section
+  actually wants is *exhaustiveness inside the defining crate*, which the
+  `match` provides regardless of the visibility of the method wrapping it.
+- **Nine variants to classify, not five.** The snippet omits `PathConflict`,
+  `MalformedFrontmatter`, `InvalidKey` and `UnsafePath`. All four take the
+  `false` arm, which is what the wildcard they replace already gave them, so no
+  existing classification moved and no existing test changed. `UnsafePath` is
+  the one worth naming: it *reads* like a refusal, and
+  `paths_doc_types_stays_fail_closed_on_escape_with_fail_safe` proves that path
+  is already fail-closed — but via `ConfigError::Invalid` raised in
+  `config::paths`, not via `UnsafePath`, so classifying it `true` would have
+  been a behaviour change dressed as a tidy-up.
+- **`plugin_default`'s and `eject`'s rewrites take the `if !path.is_file()`
+  shape the section predicts, but `plugin_template_path` keeps no `Option`
+  seam at all** — it is `Result<PathBuf, ConfigError>` outright, so the two
+  consumers each read `let path = self.plugin_template_path(name)?;`. The
+  `EjectOutcome::NoDefault` consequence the section flags is real and now
+  observable: with no root, `eject` refuses before it can report it.
+- **The server's half of the empty-root criterion is a `compose_contract.rs`
+  case, not a subprocess test.** `an_empty_plugin_root_refuses_to_compose`
+  calls `compose::load` with `PathBuf::new()` and asserts the error names the
+  variable. The server's own `var_os` at `main.rs:69` is left unfiltered as the
+  section intends — `store.template_names()?` refuses first, so `load` fails
+  before `plugin_root.join("templates")` can become a cwd-relative path. Absent
+  and empty are therefore not byte-identical at the server: absent exits 2 at
+  `main.rs` naming the variable, empty exits 2 via `failed to compose config`
+  also naming it. Both refuse to start; only the launcher achieves literal
+  identity.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -14,7 +14,7 @@ derived_from:
 tags: [plan, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
 revision: "e56fb165ea4b7591de3586bc43e96cb8bf7ab6df"
 repository: "accelerator"
-last_updated: "2026-07-29T00:00:00+00:00"
+last_updated: "2026-07-29T10:34:58+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -276,11 +276,11 @@ rename:
 | **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | **done** 2026-07-29 |
 | 2 | The `CLAUDE_*` boundary guard | after 1b | **done** 2026-07-29 |
 | 3 | Terminal invocation surface | after 1a | **done** 2026-07-29 |
-| 4 | `!`-site conformance suite | after 1a | not started |
+| 4 | `!`-site conformance suite | after 1a | **done** 2026-07-29 |
 | 5 | Named error for a missing plugin root | after 1b | not started |
 
-**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b, 2 and 3 are implemented,
-verified and committed. Phase 4 is next in the merge order. Thirteen commits
+**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b, 2, 3 and 4 are implemented,
+verified and committed. Phase 5 and the closing step remain. Fifteen commits
 carry the work:
 
 | Commit | Content |
@@ -298,6 +298,8 @@ carry the work:
 | `Keep a terminal-reachable link to the current launcher` | 3 commit 1 |
 | `Give every shell-suite subtree a discovery floor` | 3 commit 2 |
 | `Document running the accelerator CLI from a terminal` | 3 commit 3 |
+| `Extract the fixture-installation apparatus for reuse` | 4 commit 1 |
+| `Run every skill's config commands in the production shape` | 4 commit 2 |
 
 Two things a later phase inherits:
 
@@ -1668,7 +1670,7 @@ previous "the gate is reachable from `cli:check`" criterion was vacuous. Add
 - [x] The leaf is pinned into `cli:check.depends`:
       `uv run pytest tests/unit/tasks/test_mise.py -v` *(21 passed)*
 - [x] `mise run cli:check` exits 0
-- [ ] The purge holds over **non-`meta/`** tracked files —
+- [x] The purge holds over **non-`meta/`** tracked files —
       `grep -rl 'CLAUDE_PLUGIN_ROOT'` honouring `.gitignore` and excluding
       `meta/` returns only `hooks/**`, `scripts/interactive-harness.sh`,
       `scripts/test-design.sh`, `skills/config/migrate/**`, migrations
@@ -1686,12 +1688,19 @@ previous "the gate is reachable from `cli:check`" criterion was vacuous. Add
       rather than coupling. Derive the list by running the grep rather than by
       enumeration, so it cannot drift from what the tree actually contains.
 
-      **Measured: 86 files, every one in the permitted set.** Two notes on the
-      list as written. `tests/integration/skill-invocation/test_skill_invocation_conformance.py`
-      does not exist yet — Phase 4 adds it. And the `hooks/**` entry covers four
-      more files than the list implies (`hooks.json`, the two hook suites and
-      `hooks/test-fixtures/vcs-detect/regenerate.sh`), which is why the criterion
-      says to derive the list rather than enumerate it.
+      **Measured at Phase 2: 86 files. Re-measured after Phases 3 and 4: 87,
+      every one in the permitted set.** Three corrections to the list as
+      written. The `hooks/**` entry covers four more files than it implies
+      (`hooks.json`, the two bash harnesses and
+      `hooks/test-fixtures/vcs-detect/regenerate.sh`). Phase 3 adds one file
+      outside that prefix —
+      `tests/integration/hooks/test_launcher_link_refresh.py`, which must name
+      the variable in order to assert the hook does *not* — and that is the only
+      addition between the two measurements. And of the "three files this work
+      adds that must name what they forbid or strip", only **two** do:
+      `tests/integration/skill-invocation/test_skill_invocation_conformance.py`
+      never names the variable, because Phase 4 promoted `PLUGIN_PREFIX` to
+      public and imports it rather than carrying a third literal copy.
 - [x] `mise run check` exits 0
 
 #### Manual Verification
@@ -2552,6 +2561,8 @@ alongside `hooks`, since the extracted helper made each one line.
 
 ## Phase 4: `!`-Site Conformance Suite
 
+> **Done 2026-07-29.** Two commits: the harness extraction, then the suite.
+
 ### Overview
 
 Prove that every `bin/accelerator config *` command the skills actually invoke
@@ -2753,30 +2764,92 @@ step and `workspaces: cli` cargo caching.
 
 #### Automated Verification
 
-- [ ] The suite passes:
-      `uv run pytest tests/integration/skill-invocation -v`
-- [ ] The structural corpus invariants hold — every SKILL.md with a `config` `!`
+- [x] The suite passes:
+      `uv run pytest tests/integration/skill-invocation -v` *(128 passed in 80s;
+      122 command cases + 6 corpus invariants)*
+- [x] The structural corpus invariants hold — every SKILL.md with a `config` `!`
       site contributes a command, the `instructions`/`context` counts equal
-      `EXPECTED_INJECTION_SKILLS`, and the declined set is empty
-- [ ] The suite is hermetic — it performs no live fetch, serving the launcher from
-      the stub release server only
-- [ ] `mise run test:integration:skill-invocation` exits 0
-- [ ] The leaf is reachable from the roll-up CI runs, and the build edge is
-      asserted: `uv run pytest tests/unit/tasks/test_mise.py -v`
-- [ ] `mise run test:integration` runs it (not just the leaf directly)
-- [ ] `mise run check` exits 0
+      `EXPECTED_INJECTION_SKILLS`, and the declined set is empty. A fourth
+      invariant was added: every skill *named* by an `instructions`/`context`
+      command must exist. The fixture derives its overrides from the corpus, so
+      without it a `!` site naming a nonexistent skill would have an override
+      helpfully created for it and pass — and neither the permissions census nor
+      the count checks would notice, since both count skills carrying an
+      injection rather than whether the name resolves.
+- [x] The suite is hermetic — it performs no live fetch, serving the launcher from
+      the stub release server only (enforced by `run_bootstrap`'s preconditions,
+      plus the session-scoped `bin/` guard)
+- [x] `mise run test:integration:skill-invocation` exits 0
+- [x] The leaf is reachable from the roll-up CI runs, and the build edge is
+      asserted: `uv run pytest tests/unit/tasks/test_mise.py -v` *(23 passed)*
+- [x] `mise run test:integration` runs it (not just the leaf directly)
+- [x] `mise run check` exits 0
 
 #### Manual Verification
 
-- [ ] Adding a new `!` site with a broken `config` command to any SKILL.md turns
-      the suite red
-- [ ] Adding a `!` site to a *new* SKILL.md that the scan fails to pick up turns
-      the suite red via the per-file invariant
-- [ ] Changing this repository's own `.accelerator/config.md` does **not** change
-      the suite's result — the fixture project is the only oracle
-- [ ] Deleting the fixture's instructions override for one skill turns exactly one
+- [x] Adding a new `!` site with a broken `config` command to any SKILL.md turns
+      the suite red. **Confirmed**: a `config template no-such-template
+      --fail-safe` site appended to `create-note` failed as its own case.
+- [x] Adding a `!` site to a *new* SKILL.md that the scan fails to pick up turns
+      the suite red via the per-file invariant. **Confirmed** with a real new
+      `skills/zzz-probe/SKILL.md` and the extractor's walk narrowed to skip it:
+      only `test_every_skill_with_a_config_site_contributes_a_command` fired.
+- [x] Changing this repository's own `.accelerator/config.md` does **not** change
+      the suite's result — the fixture project is the only oracle. **Confirmed**:
+      with `paths.work`, `paths.plans` and `agents.reviewer` all rewritten in the
+      repo config, all 128 still pass.
+- [x] Deleting the fixture's instructions override for one skill turns exactly one
       assertion red, confirming the 86 are content-discriminating rather than
-      empty-tolerant
+      empty-tolerant. **Confirmed, with a count correction**: dropping the
+      `commit` override reddens *two* cases, not one — `instructions commit` and
+      `context --skill commit`. Each configured skill contributes one command to
+      each family, so two is the correct blast radius.
+
+### Implementation notes
+
+Seven departures from the section above, each measured.
+
+- **The support extraction was not a Phase 1a deliverable after all.** Phase 1a
+  shipped with the apparatus still module-private in the entrypoint suite, so
+  this phase does the extraction itself — commit 1, with the entrypoint suite
+  refactored onto it and still 46 green.
+- **The fixture project is generated per run, not committed.** The section asks
+  for both ("the only committed fixture" *and* "generate the config file and the
+  expectations from one fixture data structure"). Generation wins: a committed
+  tree of ~84 override files would need hand-maintenance on every skill rename,
+  which is precisely the drift the single-sourcing exists to prevent. The cost
+  is that the fixture is derived from the thing under test, which is why
+  `test_every_named_skill_exists` was added — see the criterion above.
+- **The corpus module lives in `tests/integration/support/`.** A module inside
+  `tests/integration/skill-invocation/` is not importable: the directory name is
+  hyphenated. The suite directory keeps the hyphen (matching the task name); only
+  the importable module moves.
+- **The leaf gets no `build:cli:dev` edge, and goes in `_NO_LAUNCHER_NEEDED`.**
+  The section says to add both, but the suite builds the launcher in-fixture
+  through the shared `build_launcher` — which exists so a suite runs standalone —
+  and Phase 1a's own note says a build edge would then contend on cargo's target
+  lock while making the assertion inert. The two halves of the plan contradict
+  each other here; the Phase 1a reasoning is the one with a mechanism behind it.
+- **The family table's counts are off in three places.** Measured: 13 distinct
+  `template <name>` commands (19 occurrences), not 20; there is **no**
+  `templates list` command in the corpus at all; and there is a
+  `config agent <name>` family the table omits. The totals the section states —
+  204 commands, 122 distinct, 45 files, 42 injection skills each way — are all
+  exact.
+- **Every one of the 122 distinct commands renders non-empty stdout** against the
+  fixture, which is better than the section predicts. So no family needs an
+  empty-tolerant assertion: the per-skill 86 are exact content matches and
+  everything else is asserted non-empty.
+- **The suite does not name `CLAUDE_PLUGIN_ROOT`.** Phase 2's residue criterion
+  lists it among the files that "must name what they forbid or strip". It does
+  not need to: promoting `skill_permissions._PLUGIN_PREFIX` to a public
+  `PLUGIN_PREFIX` — which the section calls for anyway, to avoid a third literal
+  copy — means the substitution reads the constant instead. Phase 2's criterion
+  is corrected accordingly.
+- **One bootstrap invocation per command, not two.** The section implies separate
+  exit-code and stdout tests; merging them halves 244 subprocess runs to 122
+  (~80s for the suite). Cases are parametrised over *distinct* commands — the 204
+  occurrences carry 122 distinct texts, and a duplicate exercises nothing new.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -275,13 +275,13 @@ rename:
 | **1c** | Work-item seam re-point + the `build:cli:dev` edge | **yes, today** — needs neither 1a nor 1b | **done** 2026-07-29 |
 | **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | **done** 2026-07-29 |
 | 2 | The `CLAUDE_*` boundary guard | after 1b | **done** 2026-07-29 |
-| 3 | Terminal invocation surface | after 1a | not started |
+| 3 | Terminal invocation surface | after 1a | **done** 2026-07-29 |
 | 4 | `!`-site conformance suite | after 1a | not started |
 | 5 | Named error for a missing plugin root | after 1b | not started |
 
-**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b and 2 are implemented, verified
-and committed. Phase 3 is next in the merge order. Ten commits carry the
-work:
+**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b, 2 and 3 are implemented,
+verified and committed. Phase 4 is next in the merge order. Thirteen commits
+carry the work:
 
 | Commit | Content |
 |---|---|
@@ -295,6 +295,9 @@ work:
 | `Promote the gitignore-honouring walk to a shared primitive` | 2 commit 1 |
 | `Add a guard against CLAUDE_* coupling in the rename set` | 2 commit 2 |
 | `Wire the CLAUDE_* boundary guard into cli:check` | 2 commit 3 |
+| `Keep a terminal-reachable link to the current launcher` | 3 commit 1 |
+| `Give every shell-suite subtree a discovery floor` | 3 commit 2 |
+| `Document running the accelerator CLI from a terminal` | 3 commit 3 |
 
 Two things a later phase inherits:
 
@@ -573,9 +576,11 @@ Claude Code version tested.
       discarded, a follow-up item is raised for
       `hooks/migrate-discoverability.sh`'s advisory — it is discarded, and the
       follow-up is work item 0183
-- [ ] Phase 3's `docs/internals.md` section states the version requirement
-      locally, with the version-pinned fallback for anyone below it *(deferred to
-      Phase 3)*
+- [x] Phase 3's `docs/internals.md` section states the version requirement
+      locally, with the version-pinned fallback for anyone below it. **Done
+      2026-07-29**: the Terminal Invocation section names v2.1.78 and tells
+      anyone below it to link `<plugin root>/bin/accelerator` directly and
+      re-run after each upgrade.
 
 ---
 
@@ -1708,6 +1713,8 @@ previous "the gate is reachable from `cli:check`" criterion was vacuous. Add
 
 ## Phase 3: Terminal Invocation Surface
 
+> **Done 2026-07-29.** Three commits, as sequenced.
+
 ### Overview
 
 A fixed-path, upgrade-surviving entry for terminal use, via a two-hop chain, plus
@@ -1759,6 +1766,13 @@ should move.
 ### Changes Required
 
 #### 1. The hook test suite (written first)
+
+> **Superseded on the language, not the cases.** The suite shipped as
+> `tests/integration/hooks/test_launcher_link_refresh.py`, not a
+> `hooks/test-*.sh` harness: ADR-0048 makes Python the test language for the
+> non-Rust surfaces, shell wrappers included, and the two bash harnesses still
+> under `hooks/` predate that decision. Every *case* below is implemented; the
+> bash-specific mechanics are not. See *Implementation notes*.
 
 **File**: `hooks/test-launcher-link-refresh.sh` (new, `chmod 0755`, mode committed)
 **Changes**: Copies the structure of `hooks/test-migrate-discoverability.sh` —
@@ -2233,14 +2247,17 @@ there (it registers only `skills`), so hooks are discovered by convention.
 exec bit, so no registry entry is needed. But `hooks` has no floor count, so a
 dropped exec bit would silently remove a suite from CI.
 
-A **count** floor alone does not close that for this phase. `hooks/` holds two
-suites today and three after it, so `_EXPECTED_HOOKS_SUITES = 3` is the value — but
-`TestHooksSuiteGuard` builds its at-baseline case from the constant itself, so a
-floor left at `2` would pass every test while failing to detect the loss of the very
-suite it was added for. Add a `_REQUIRED_HOOKS_SUITES` **by-name** entry for
-`hooks/test-launcher-link-refresh.sh`, mirroring `_REQUIRED_CONFIG_SUITES` — that is
-the only shape that detects this suite specifically. Both the count and the identity
-guard get their `Exit`.
+A **count** floor alone would not have closed that for a *shell* suite: `hooks/`
+holds two suites, three with a bash link-refresh harness, and the paired guard
+builds its at-baseline case from the constant itself, so a floor left at `2` would
+pass every test while failing to detect the loss of the very suite it was added for.
+The plan therefore called for a `_REQUIRED_HOOKS_SUITES` by-name entry.
+
+**That requirement lapses with the Python port.** `_EXPECTED_HOOKS_SUITES` stays at
+`2` — the two bash harnesses — and the by-name tuple is empty, because the exec-bit
+hazard the floor exists for does not apply to a pytest file: losing one is a
+collection error, not a silently smaller run. The floor still guards the two
+harnesses that *are* exec-bit-discovered.
 
 Rather than a fifth copy of the seven-line `if len(suites) < _EXPECTED_*: raise
 Exit(...)` block (and a fifth near-identical guard class), extract one
@@ -2258,18 +2275,15 @@ subtree.)
 **Changes**: Every existing floor constant has a paired guard class here —
 `TestConfigSuiteGuard`, `TestMigrateSuiteGuard`, `TestWorkSuiteGuard`,
 `TestIntegrationsSuiteGuard` — each asserting `pytest.raises(Exit)` below baseline
-and (for most) passing at baseline built from the constant itself. Add
-`TestHooksSuiteGuard` in the `TestWorkSuiteGuard` shape. Without it the new `Exit`
-branch would be the only floor in the file with no unit coverage, so an
-off-by-one or inverted comparison would ship silently — defeating the fail-loudly
-purpose the floor exists for.
+and (for most) passing at baseline built from the constant itself. Every guarded
+task gains a case, so no `Exit` branch ships without unit coverage and an
+off-by-one or inverted comparison cannot pass silently.
 
-Both new `.sh` files are entrypoints and must **not** be added to
-`SHELL_LIBRARIES` (`tasks/lint/scripts.py:18-49`) — that would trip the
-`chmod -x` branch (`:128-129`) and break the pinned-membership test
-`tests/unit/tasks/test_exec_bits.py:288-292`. A test *runner* is an entrypoint by
-the rule in `tasks/README.md`, so no registry or pinned-list edit is needed for
-the new suite.
+The hook itself is an entrypoint and must **not** be added to `SHELL_LIBRARIES`
+(`tasks/lint/scripts.py:18-49`) — that would trip the `chmod -x` branch
+(`:128-129`) and break the pinned-membership test
+`tests/unit/tasks/test_exec_bits.py:288-292`. Only one new `.sh` file lands now
+that the suite is Python.
 
 #### 5. Documentation
 
@@ -2413,38 +2427,52 @@ the mechanism by which any of this reaches users.
 
 #### Automated Verification
 
-- [ ] The hook suite passes: `bash hooks/test-launcher-link-refresh.sh`
-- [ ] Hooks integration tests pass, including the new floor:
-      `mise run test:integration:hooks`
-- [ ] The floor's own guard passes:
-      `uv run pytest tests/unit/tasks/test_integration.py -v`
-- [ ] The existing hook suites still pass — in particular the
+- [x] The hook suite passes: `uv run pytest tests/integration/hooks`
+      *(22 tests, 0.5s — ported from the 62-assertion bash draft)*
+- [x] Hooks integration tests pass, including the new floor:
+      `mise run test:integration:hooks` *(all three suites discovered and green)*
+- [x] The floor's own guard passes:
+      `uv run pytest tests/unit/tasks/test_integration.py -v` *(17 passed)*
+- [x] The existing hook suites still pass — in particular the
       `SessionStart[0]` index assertion: `bash hooks/test-vcs-detect.sh`
-- [ ] `hooks.json` is valid and registers the hook, selected by content:
+      *(131 passed; the new group was appended at index 3)*
+- [x] `hooks.json` is valid and registers the hook, selected by content:
       `jq -e '[.hooks.SessionStart[].hooks[].command] | any(endswith("launcher-link-refresh.sh"))' hooks/hooks.json`
-- [ ] The exec-bit invariant holds: `mise run lint:scripts:check` and
-      `uv run pytest tests/unit/tasks/test_exec_bits.py -v`
-- [ ] `docs/internals.md` carries the section:
+- [x] The exec-bit invariant holds: `mise run lint:scripts:check` and
+      `uv run pytest tests/unit/tasks/test_exec_bits.py -v` *(17 passed)*
+- [x] `docs/internals.md` carries the section:
       `grep -q '^## Terminal Invocation' docs/internals.md`
-- [ ] No stale wrapper name remains:
+- [x] No stale wrapper name remains:
       `! grep -q 'accelerator-visualiser' docs/visualiser.md`
-- [ ] The competing recipe is gone:
+- [x] The competing recipe is gone:
       `! grep -q 'CLAUDE_PLUGIN_ROOT}/bin/accelerator" "\$HOME/.local/bin' skills/visualisation/visualise/SKILL.md`
-- [ ] No ad-hoc symlink advice survives in the visualiser docs:
+- [x] No ad-hoc symlink advice survives in the visualiser docs:
       `! grep -q 'symlink onto' docs/visualiser.md`
-- [ ] The documented recipe carries no unexpanded token:
+- [x] The documented recipe carries no unexpanded token:
       `! grep -q 'CLAUDE_PLUGIN_DATA}/bin/accelerator' docs/internals.md`
-- [ ] `README.md` links to it and the gloss names the new section
-- [ ] The hook emits **at most one** JSON object on stdout, asserted by the
+- [x] `README.md` links to it and the gloss names the new section
+- [x] The hook emits **at most one** JSON object on stdout, asserted by the
       both-notices-at-once case
-- [ ] With `jq` shadowed off `PATH`, the notices degrade to stderr and the hook
-      still exits 0
-- [ ] The hook reads no root from the environment:
-      `! grep -q 'CLAUDE_PLUGIN_ROOT' hooks/launcher-link-refresh.sh`
-- [ ] A re-point is reported naming both roots, and a first refresh is silent
-- [ ] `mise run check` exits 0
+- [x] With `jq` shadowed off `PATH`, the notices degrade to stderr and the hook
+      still exits 0. **Shadowed, not stripped**: macOS 15 ships `/usr/bin/jq`,
+      so dropping every directory holding a `jq` also removes `dirname`,
+      `mkdir` and `ln`, and the hook fails for an unrelated reason well before
+      the jq fallback. The case prepends a `jq` stub that exits 127 instead.
+- [x] The hook reads no root from the environment:
+      `! grep -q 'CLAUDE_PLUGIN_ROOT' hooks/launcher-link-refresh.sh` — which
+      also constrains the *header comment*: the divergence note is worded
+      without naming the variable so the bare grep stays a usable guard.
+- [x] A re-point is reported naming both roots, and a first refresh is silent
+- [x] `mise run check` exits 0
 
 #### Manual Verification
+
+All five need the hook running from an **installed** plugin, so they are
+**deferred to the release candidate** — the installed plugin is `1.24.0-pre.16`,
+which predates this hook, and Claude Code invokes `hooks.json` from the
+installation rather than the working tree. The hermetic equivalents are the 62
+suite assertions; what these add is the real `SessionStart` path and a real
+upgrade.
 
 - [ ] In a real session, the hook fires at `SessionStart` and
       `${CLAUDE_PLUGIN_DATA}/bin/accelerator` resolves to the current
@@ -2458,6 +2486,67 @@ the mechanism by which any of this reaches users.
 - [ ] Removing the plugin leaves the dangling *plugin-owned* link inside
       `${CLAUDE_PLUGIN_DATA}`; the user's own first hop is theirs to remove, as
       the documentation now says
+
+### Implementation notes
+
+**The suite is Python, not bash.** ADR-0048 makes Python the test language for
+the non-Rust surfaces, shell wrappers included; the plan drafted a
+`hooks/test-*.sh` harness by analogy with `test-migrate-discoverability.sh` and
+`test-vcs-detect.sh`, which predate that decision. Ported to
+`tests/integration/hooks/test_launcher_link_refresh.py`: 22 tests in 0.5s,
+against 62 assertions in the bash draft. Consequences:
+
+- **Most of the "tool constraints" paragraph evaporates.** `find -printf` versus
+  BSD `find`, `stat -c` versus `stat -f`, `ls -ld | cut -c1-10` to dodge macOS's
+  xattr column, `LC_ALL=C sort` for stable tree listings, `readlink 2>/dev/null`
+  for GNU's non-symlink diagnostic — every one of those exists because bash has
+  no portable primitive. `os.lstat`, `Path.readlink` and `sorted()` behave the
+  same on both legs. What survives is the constraint that *matters*: the fixture
+  root is resolved physically because the hook uses `pwd -P`, while
+  `CLAUDE_PLUGIN_DATA` is never canonicalised because the hook composes it
+  verbatim.
+- **Scrubbing becomes construction.** `run_hook`'s `env -u …` list existed
+  because a bash suite inherits the ambient environment. `subprocess.run` takes
+  an explicit `env` dict, so the leak is impossible by default rather than
+  guarded against.
+- **The channel split is asserted more precisely.** `jq -r '.systemMessage'`
+  becomes `json.loads`, and the exactly-one-JSON-object case counts objects with
+  `raw_decode` rather than trusting `jq -s 'length'`.
+- **`hooks/` now has two test languages, so its mise task runs both** — the
+  pytest directory and the two remaining bash harnesses.
+- **The floor's by-name requirement lapses**, and
+  `tests/unit/tasks/test_integration.py` has to stub `Context.run`: the `hooks`
+  task shells out to pytest before its floor check, and invoke's `@task` rejects
+  a stand-in Context, so without the stub the floor unit tests would run the
+  whole hooks suite twice.
+- **The stale-staging case is unchanged in substance**, and worth re-noting: it
+  still goes through a wrapper that `exec`s the hook, because the staging path
+  carries the hook child's pid and no language makes that knowable in advance.
+
+Four further things the plan did not anticipate, each settled by measurement:
+
+- **Fixture roots must be returned as *physical* paths.** The plan's tool
+  constraints say neither the hook nor the suite may canonicalise "the paths it
+  is handed", which is right for `CLAUDE_PLUGIN_DATA` — the hook composes that
+  verbatim — but wrong for the fixture *root*: the hook resolves its own root
+  with `pwd -P`, so on macOS it reports `/private/var/folders/…` against a
+  `mktemp -d` of `/var/folders/…` and every `readlink` comparison fails on that
+  leg. `make_root` therefore returns `cd -P … && pwd -P`, deriving the expected
+  value the same way the hook derives the actual one. Three cases were red
+  before this.
+- **The jq-absent case shadows rather than strips.** See the criterion above.
+- **The hook's header comment cannot name `CLAUDE_PLUGIN_ROOT`.** The plan asks
+  the hook to record *why* it self-locates rather than reading the variable, and
+  separately asserts `! grep -q 'CLAUDE_PLUGIN_ROOT'` over the file. Both are
+  satisfiable only if the note is worded without the literal, which it now is.
+- **Two shellcheck findings are the plan's own deliberate choices**, so both
+  carry justified disables: `SC2174` (`-m` with `-p` applies only to the deepest
+  directory — exactly the intent, since `${CLAUDE_PLUGIN_DATA}` itself is Claude
+  Code's to own) and `SC2012` (`ls -ld | cut` is the only portable mode read once
+  `stat` is banned for the GNU/BSD flag split and BSD `find` has no `-printf`).
+
+The plan's optional deferral is taken: `decisions` and `github` gained floors
+alongside `hooks`, since the extracted helper made each one line.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -14,7 +14,7 @@ derived_from:
 tags: [plan, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
 revision: "e56fb165ea4b7591de3586bc43e96cb8bf7ab6df"
 repository: "accelerator"
-last_updated: "2026-07-29T13:40:46+00:00"
+last_updated: "2026-07-29T15:21:21+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -1129,7 +1129,7 @@ names; 1b narrows it to one.
 
 #### Manual Verification
 
-- [ ] Rootless invocation by absolute path succeeds:
+- [x] Rootless invocation by absolute path succeeds:
       `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT ./bin/accelerator config templates list`
       exits 0 and lists an `adr` row with Source `plugin default`. **Manual, with a
       precondition**: it fetches the launcher for the version in
@@ -1137,9 +1137,16 @@ names; 1b narrows it to one.
       development it 404s. It passes once released *because* of the transitional
       export, since the pre-rename launcher reads the old name. The hermetic
       equivalent, and the actual CI gate, is the entrypoint suite.
-      **Deferred to the release candidate**: `1.24.0-pre.16` is the version in
-      `plugin.json` and its assets are not published, so running this now would
-      404 against the real GitHub release *and* write into the shipped `bin/`.
+      **Performed 2026-07-29 against installed `1.24.0-pre.17`** — the Phase
+      1a-only release, which still carries the transitional export — invoked by
+      absolute path from a bare `mktemp -d` with both variables stripped: exit 0
+      and `` | `adr` | plugin default | `<plugin>/templates/adr.md` | ``, no
+      `accelerator:` line on stderr. `config instructions commit --fail-safe`
+      likewise exits 0 clean. The launcher and its `.minisig` are cached in the
+      installed tree with no `.accelerator-unverified.log`, so the real
+      fetch → verify → cache chain ran. (It was deferred while `1.24.0-pre.16`
+      was current, whose assets were unpublished: running it then would have
+      404'd *and* written into the shipped `bin/`.)
 
 - [x] The Phase 1a regression tests fail when run against the pre-change
       `bin/accelerator` (stash the bootstrap change, confirm red, restore).
@@ -3367,6 +3374,12 @@ Until then this file is what supplies `CLAUDE_PLUGIN_ROOT` to the installed
 plugin's still-unfixed bootstrap in this repository, and every CLI-invoking skill
 — including the ones used to carry out this plan — depends on it.
 
+**Met 2026-07-29**: `1.24.0-pre.17` is installed and self-locates, verified by
+Phase 1a's rootless criterion above. The step is unblocked. Note the two manual
+criteria below cannot be evidenced by skill loads performed *before* the
+deletion — those still run through this file's ambient value — so the deletion
+comes first and the skill loads after.
+
 ### Why keeping it this long costs nothing
 
 The file's only hazard is masking the bug class in local test runs, and **Phase 1b
@@ -3401,21 +3414,45 @@ feeding the installed plugin's bootstrap.
 
 #### Automated Verification
 
-- [ ] The file is gone: `test ! -e mise.local.toml`
+- [x] The file is gone: `test ! -e mise.local.toml` — **done 2026-07-29**,
+      alongside the `1.24.0-pre.17` install. `mise env` now exports no plugin
+      root.
 - [x] The ignore entry landed: `grep -qx 'mise.local.toml' .gitignore` —
       `.gitignore:26`, and the file is untracked as a result
 - [x] It is on no branch that can reach CI:
       `! git cat-file -e main:mise.local.toml 2>/dev/null`
-- [ ] The shell suites still pass with no ambient root:
-      `mise run test:integration:work test:integration:config`
-- [ ] `mise run` (bare default) exits 0 end-to-end
+- [x] The shell suites still pass with no ambient root:
+      `mise run test:integration:work test:integration:config` — run as two
+      invocations, since a single `mise run` passes the second name as an
+      *argument* to the first. 404 assertions pass in the work subtree, 1692 in
+      config, each exit 0; both green again inside the clean full run below
+- [x] `mise run` (bare default) exits 0 end-to-end — run under
+      `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT`, so no ambient root
+      reached any task. All three `cli/`-scoped guards executed, and the
+      formatters changed nothing.
+
+      An earlier run of the same commit failed `test:integration:config` on a
+      teardown race in the Playwright executor cases (`rm: … Directory not
+      empty` on the fixture's `.accelerator/tmp`), not on anything root-related:
+      that suite passed standalone both before and after, and green in the clean
+      run. It belongs to the recorded config-suite flake class, not to this step.
 
 #### Manual Verification
 
-- [ ] With the file deleted, `/accelerator:commit` and one other CLI-invoking
-      skill load without error against the **installed** plugin — the direct
-      confirmation that the fix reached the artifact
-- [ ] No permission prompt appears for either skill
+- [x] With the file deleted, two CLI-invoking skills load without error against
+      the **installed** `1.24.0-pre.17` — `list-work-items` (injections
+      populated: `meta/work`, `linear`, the work-item template) and `paths` (all
+      14 configured paths resolved). Non-empty injections are what separates a
+      real read from a `--fail-safe` degradation.
+
+      Caveat on strictness: this Claude Code session's own environment still
+      carries a stale `CLAUDE_PLUGIN_ROOT` pointing at `1.24.0-pre.16`,
+      inherited at session start, so the `!` shells saw one. It is provably
+      inert — the executed path is `1.24.0-pre.17`'s own bootstrap, which never
+      *reads* either variable (its only mention is the export at `:116`) — but
+      the unconfounded confirmation is a session started outside this
+      repository's mise context, which is worth doing once.
+- [x] No permission prompt appears for either skill
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -14,7 +14,7 @@ derived_from:
 tags: [plan, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
 revision: "e56fb165ea4b7591de3586bc43e96cb8bf7ab6df"
 repository: "accelerator"
-last_updated: "2026-07-29T10:34:58+00:00"
+last_updated: "2026-07-29T13:40:46+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -88,10 +88,12 @@ one `!` site that exercises it is
 `ACCELERATOR_BIN`, so the one configuration that matters in production — correct
 path, empty environment — is never exercised. Two tests actively assert the
 faulty behaviour. No test invokes the bootstrap through a symlink.
-`mise.local.toml` — present only in the jj working-copy commit, on no pushed
-branch — sets the variable and masks the whole bug class in every local run,
-while simultaneously being the only reason the installed plugin's skills work in
-this repository at all.
+`mise.local.toml` — on no pushed branch — sets the variable and masks the whole
+bug class in every local run, while simultaneously being the only reason the
+installed plugin's skills work in this repository at all. (It was in the jj
+working-copy commit when this was written; it is now untracked, since
+`.gitignore` gained the entry the closing step calls for, so only the on-disk
+file remains.)
 
 ## Desired End State
 
@@ -277,11 +279,14 @@ rename:
 | 2 | The `CLAUDE_*` boundary guard | after 1b | **done** 2026-07-29 |
 | 3 | Terminal invocation surface | after 1a | **done** 2026-07-29 |
 | 4 | `!`-site conformance suite | after 1a | **done** 2026-07-29 |
-| 5 | Named error for a missing plugin root | after 1b | not started |
+| 5 | Named error for a missing plugin root | after 1b | **done** 2026-07-29 |
 
-**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b, 2, 3 and 4 are implemented,
-verified and committed. Phase 5 and the closing step remain. Fifteen commits
-carry the work:
+**Progress — 2026-07-29.** All eight phases — 0, 1a, 1c, 1b, 2, 3, 4 and 5 — are
+implemented, verified and committed. Only the closing step remains, and it waits
+on a precondition outside this plan (a prerelease carrying the Phase 1a fix
+installed and in use), along with the manual criteria deferred to the release
+candidate: Phase 1a's published-release check and Phase 3's five installed-hook
+checks. Sixteen commits carry the work:
 
 | Commit | Content |
 |---|---|
@@ -300,6 +305,7 @@ carry the work:
 | `Document running the accelerator CLI from a terminal` | 3 commit 3 |
 | `Extract the fixture-installation apparatus for reuse` | 4 commit 1 |
 | `Run every skill's config commands in the production shape` | 4 commit 2 |
+| `Refuse rather than answer empty when the plugin root is unknown` | Phase 5 |
 
 Two things a later phase inherits:
 
@@ -1184,9 +1190,14 @@ dev harness and the shell suites, so `mise run` would go red between them.
 #### 1. The launcher and server readers
 
 **Files**:
-- `cli/launcher/src/main.rs:173,176` — the doc comment and `var_os`. Add the
-  empty-string filter `cache_root.rs:27` already has, so an empty value does not
-  become `Some("")`.
+- `cli/launcher/src/main.rs:173,176` — the doc comment and `var_os`. An empty
+  value must not become `Some("")`, as the filter at `cache_root.rs:27` already
+  ensures for its own read. *Landed one layer down instead:
+  `FileConfigStore::with_plugin_root` (`cli/config-adapters/src/store.rs:65-69`)
+  drops an empty value, so the launcher and the visualiser server inherit the
+  rule from one place rather than each carrying a filter — `main.rs`'s `var_os`
+  is deliberately left unfiltered and its doc comment says so. Recorded in Phase
+  5's implementation notes, which also covers the server half.*
 - `cli/launcher/src/launch/outbound/resolve/cache_root.rs:3,26,38,60` — module
   doc, `var_os`, error doc, and the `CacheRootUnavailable` detail text.
 - `cli/visualiser/server/src/main.rs:69,70` — the let-else and its `eprintln!`.
@@ -1598,6 +1609,14 @@ the mandatory `depends = ["deps:install:python"]`, added to `cli:check.depends`
 `cli/`-scoped guard reachable from the bare `default` task, establishing a third
 pattern. (Closing that default-task blind spot for all three guards together is
 worth doing, but as its own change.)
+
+*Superseded 2026-07-29, at validation.* Validation measured what "as its own
+change" cost in the meantime: the bare `default` task depends on `lint:check` and
+never on `check`, so **none** of the three guards ran in a full local `mise run`
+— a `CLAUDE_*` reintroduction in the rename set was green locally and caught only
+by CI's separate `cli:check` step. All three are now in `lint:check.depends`
+*and* `cli:check.depends`, together rather than one at a time, so no third
+pattern is established. `test_mise.py`'s `_CLI_CHECK_GATES` pins both placements.
 
 **File**: `tasks/README.md`
 **Changes**: The per-component table describes `cli:check` as "format + lint
@@ -3370,21 +3389,22 @@ not touch — but it means the local masking ends at 1b, not 1a.
 **File**: `mise.local.toml`
 **Changes**: Delete, and confirm it is absent from the working-copy commit.
 
-The per-push hazard is already largely handled by mechanism rather than ritual:
-`.gitignore:26` lists `mise.local.toml`. That entry is **new in the current
-working copy** (`jj diff .gitignore` shows it as an addition), not pre-existing, so
-it is part of this work and should land with it. With it in place the file cannot
-be accidentally `git add`ed, and jj will not auto-snapshot it unless force-tracked
-— which is also the explanation for the otherwise-odd situation of a gitignored
-file being present in the working-copy commit.
+The per-push hazard is already handled by mechanism rather than ritual:
+`.gitignore:26` lists `mise.local.toml`. That entry was **new in the working copy**
+when this was written, not pre-existing, so it is part of this work — and it has
+since landed. With it in place the file cannot be accidentally `git add`ed, and
+jj no longer snapshots it: it is now untracked rather than sitting in the
+working-copy commit, so the only thing deletion still removes is the on-disk file
+feeding the installed plugin's bootstrap.
 
 ### Success Criteria
 
 #### Automated Verification
 
 - [ ] The file is gone: `test ! -e mise.local.toml`
-- [ ] The ignore entry landed: `grep -qx 'mise.local.toml' .gitignore`
-- [ ] It is on no branch that can reach CI:
+- [x] The ignore entry landed: `grep -qx 'mise.local.toml' .gitignore` —
+      `.gitignore:26`, and the file is untracked as a result
+- [x] It is on no branch that can reach CI:
       `! git cat-file -e main:mise.local.toml 2>/dev/null`
 - [ ] The shell suites still pass with no ambient root:
       `mise run test:integration:work test:integration:config`

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -274,13 +274,13 @@ rename:
 | **1a** | Bootstrap self-locates, `--fail-safe`-aware `fail()`, exports **both** names; new tests, 2 deletions | **yes — and independently releasable** | **done** 2026-07-28 |
 | **1c** | Work-item seam re-point + the `build:cli:dev` edge | **yes, today** — needs neither 1a nor 1b | **done** 2026-07-29 |
 | **1b** | The rename: 3 production + ~10 test `cli/` readers, 5 out-of-tree writers; drops the transitional export | yes, **given 1c** | **done** 2026-07-29 |
-| 2 | The `CLAUDE_*` boundary guard | after 1b | not started |
+| 2 | The `CLAUDE_*` boundary guard | after 1b | **done** 2026-07-29 |
 | 3 | Terminal invocation surface | after 1a | not started |
 | 4 | `!`-site conformance suite | after 1a | not started |
 | 5 | Named error for a missing plugin root | after 1b | not started |
 
-**Progress — 2026-07-29.** Phases 0, 1a, 1c and 1b are implemented, verified
-and committed. Phase 2 is next in the merge order. Seven commits carry the
+**Progress — 2026-07-29.** Phases 0, 1a, 1c, 1b and 2 are implemented, verified
+and committed. Phase 3 is next in the merge order. Ten commits carry the
 work:
 
 | Commit | Content |
@@ -292,6 +292,9 @@ work:
 | `Stop three suites failing on wall-clock noise under parallel load` | out of scope — see below |
 | `Force the work-item template fallback through ACCELERATOR_BIN` | Phase 1c |
 | `Rename the plugin root onto ACCELERATOR_PLUGIN_ROOT` | Phase 1b |
+| `Promote the gitignore-honouring walk to a shared primitive` | 2 commit 1 |
+| `Add a guard against CLAUDE_* coupling in the rename set` | 2 commit 2 |
+| `Wire the CLAUDE_* boundary guard into cli:check` | 2 commit 3 |
 
 Two things a later phase inherits:
 
@@ -1402,6 +1405,8 @@ CI needs no edit: `test-unit` and `test-integration` already carry the
 
 ## Phase 2: The `CLAUDE_*` Boundary Guard
 
+> **Done 2026-07-29.** Three commits, as sequenced.
+
 ### Overview
 
 Make the boundary rule non-negotiable rather than conventional: **nothing in the
@@ -1477,7 +1482,10 @@ Three details are load-bearing:
   build tree — exactly the failure the *Performance Considerations* section warns
   about. Hence `repo` plus an explicit `subtree`, rather than one conflated `root`.
 - **`prune` defaults to `_BUILD_OUTPUT` in the signature**, not to `()` with a
-  hidden additive union. A caller can then see what it gets and opt out. Without
+  hidden additive union. *Implemented with replace semantics, which is what the
+  signature default means — the plan's later test-case bullet said "adds to
+  rather than replaces", contradicting this paragraph's own rationale. A caller
+  wanting both writes `_BUILD_OUTPUT + (...)`, and the test asserts that.* A caller can then see what it gets and opt out. Without
   `dist`/`playwright-report` the guard reads the minified SPA bundle and Playwright
   traces — both present under bare `mise run`, which builds the frontend and runs
   E2E — so the result would depend on what had been run locally, and a vendored
@@ -1643,15 +1651,18 @@ previous "the gate is reachable from `cli:check`" criterion was vacuous. Add
 
 #### Automated Verification
 
-- [ ] The guard reports nothing on the real tree:
-      `mise run lint:claude-coupling:check`
-- [ ] The guard's own tests pass:
-      `uv run pytest tests/unit/tasks/test_claude_coupling.py -v`
-- [ ] The promoted walk did not regress its callers:
+- [x] The guard reports nothing on the real tree:
+      `mise run lint:claude-coupling:check` *(724 files scanned, 0 violations)*
+- [x] The guard's own tests pass:
+      `uv run pytest tests/unit/tasks/test_claude_coupling.py -v` *(16 passed)*
+- [x] The promoted walk did not regress its callers:
       `uv run pytest tests/unit/tasks/shared/test_sources.py tests/unit/tasks/test_python_coverage.py tests/unit/tasks/test_exec_bits.py -v`
-- [ ] The leaf is pinned into `cli:check.depends`:
-      `uv run pytest tests/unit/tasks/test_mise.py -v`
-- [ ] `mise run cli:check` exits 0
+      *(42 passed)*. `shell_sources()`'s real-tree output is byte-identical
+      before and after (192 entries either way) — the `.venv`/`dist` prune is
+      latent on this tree, so it is pinned by a `tmp_path` case instead.
+- [x] The leaf is pinned into `cli:check.depends`:
+      `uv run pytest tests/unit/tasks/test_mise.py -v` *(21 passed)*
+- [x] `mise run cli:check` exits 0
 - [ ] The purge holds over **non-`meta/`** tracked files —
       `grep -rl 'CLAUDE_PLUGIN_ROOT'` honouring `.gitignore` and excluding
       `meta/` returns only `hooks/**`, `scripts/interactive-harness.sh`,
@@ -1669,19 +1680,29 @@ previous "the gate is reachable from `cli:check`" criterion was vacuous. Add
       `meta/` is excluded because it records history — including this plan —
       rather than coupling. Derive the list by running the grep rather than by
       enumeration, so it cannot drift from what the tree actually contains.
-- [ ] `mise run check` exits 0
+
+      **Measured: 86 files, every one in the permitted set.** Two notes on the
+      list as written. `tests/integration/skill-invocation/test_skill_invocation_conformance.py`
+      does not exist yet — Phase 4 adds it. And the `hooks/**` entry covers four
+      more files than the list implies (`hooks.json`, the two hook suites and
+      `hooks/test-fixtures/vcs-detect/regenerate.sh`), which is why the criterion
+      says to derive the list rather than enumerate it.
+- [x] `mise run check` exits 0
 
 #### Manual Verification
 
-- [ ] Reintroducing a `CLAUDE_PLUGIN_ROOT` read into `cli/launcher/src/main.rs`
+- [x] Reintroducing a `CLAUDE_PLUGIN_ROOT` read into `cli/launcher/src/main.rs`
       turns `mise run cli:check` red with a `path:line:text` report naming the
-      variable, and the failure message names the guard file
-- [ ] Reintroducing Phase 1a's transitional `export CLAUDE_PLUGIN_ROOT` into
+      variable, and the failure message names the guard file. **Confirmed**:
+      `cli/launcher/src/main.rs:177:std::env::var_os("CLAUDE_PLUGIN_ROOT")`.
+- [x] Reintroducing Phase 1a's transitional `export CLAUDE_PLUGIN_ROOT` into
       `bin/accelerator` turns it red too — the property that makes the guard the
-      backstop for 1b's cleanup
-- [ ] The guard's scan does not descend into `cli/target/`,
+      backstop for 1b's cleanup. **Confirmed** in the same run:
+      `bin/accelerator:353:export CLAUDE_PLUGIN_ROOT="${plugin_root}"`.
+- [x] The guard's scan does not descend into `cli/target/`,
       `node_modules/` or `dist/` (observable as a sub-second run rather than a
-      multi-second one, with or without a built frontend)
+      multi-second one, with or without a built frontend). **Confirmed**: 275ms
+      against a built tree, 724 files scanned.
 
 ---
 

--- a/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
+++ b/meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md
@@ -2855,6 +2855,11 @@ Seven departures from the section above, each measured.
 
 ## Phase 5: A Missing Plugin Root Becomes a Named Error
 
+> **Done 2026-07-29.** One commit. All implementation phases are now complete;
+> what remains in this plan is the closing `mise.local.toml` step and the manual
+> criteria deferred to the release candidate (Phase 1a's published-release check
+> and Phase 3's five installed-hook checks).
+
 ### Overview
 
 Remove the design flaw the rename does not fix. `plugin_root()` returns

--- a/meta/prs/30-description.md
+++ b/meta/prs/30-description.md
@@ -26,70 +26,21 @@ schema_version: 1
 
 ## Summary
 
-PR #28 made `bin/accelerator` derive its installation root from its own
-location, unbreaking all 45 CLI-invoking skills. This is the rest of that work:
-the launcher and server layers move off `CLAUDE_PLUGIN_ROOT` onto
-`ACCELERATOR_PLUGIN_ROOT`, a lint guard makes that boundary non-negotiable, an
-unknown plugin root becomes a named refusal instead of a silently empty answer,
-and running `accelerator` from an ordinary terminal becomes a documented,
-upgrade-surviving surface.
+PR #28 made `bin/accelerator` derive its installation root from its own location, unbreaking all 45 CLI-invoking skills. This is the rest of that work: the launcher and server layers move off `CLAUDE_PLUGIN_ROOT` onto `ACCELERATOR_PLUGIN_ROOT`, a lint guard makes that boundary non-negotiable, an unknown plugin root becomes a named refusal instead of a silently empty answer, and running `accelerator` from an ordinary terminal becomes a documented, upgrade-surviving surface.
 
 ## Changes
 
-**The rename.** `cli/launcher`, `cli/visualiser/server` and the cache-root
-resolver read `ACCELERATOR_PLUGIN_ROOT`; the four out-of-tree writers
-(`tasks/dev.py`, `tasks/shared/dev/circus.py`, `tasks/test/helpers.py`,
-`tests/integration/dev/dev_integration_driver.py`) set it. `bin/accelerator`
-drops the transitional dual export it carried for one release, so nothing in the
-rename set names a `CLAUDE_*` variable any more. An empty value is now treated
-as unset, filtered once in `FileConfigStore::with_plugin_root` so the launcher
-and the server inherit the rule from one place.
+**The rename.** `cli/launcher`, `cli/visualiser/server` and the cache-root resolver read `ACCELERATOR_PLUGIN_ROOT`; the four out-of-tree writers (`tasks/dev.py`, `tasks/shared/dev/circus.py`, `tasks/test/helpers.py`, `tests/integration/dev/dev_integration_driver.py`) set it. `bin/accelerator` drops the transitional dual export it carried for one release, so nothing in the rename set names a `CLAUDE_*` variable any more. An empty value is now treated as unset, filtered once in `FileConfigStore::with_plugin_root` so the launcher and the server inherit the rule from one place.
 
-**A missing root is a named error.** `ConfigError::PluginRootUnavailable` names
-the variable and the remedy, and `is_refusal()` classifies every variant
-exhaustively — a new variant will not compile until it is classified. The
-template ports became fallible, so a rootless `config templates list` exits
-non-zero with a diagnostic instead of printing an empty table at exit 0, and
-`templates eject --all` refuses instead of silently ejecting nothing. Refusals
-are byte-identical with and without `--fail-safe`. Root-independent families —
-`paths`, `summary`, `instructions`, `context`, `work`, `review` — keep working
-without a root, and a user template override still resolves without one.
+**A missing root is a named error.** `ConfigError::PluginRootUnavailable` names the variable and the remedy, and `is_refusal()` classifies every variant exhaustively — a new variant will not compile until it is classified. The template ports became fallible, so a rootless `config templates list` exits non-zero with a diagnostic instead of printing an empty table at exit 0, and `templates eject --all` refuses instead of silently ejecting nothing. Refusals are byte-identical with and without `--fail-safe`. Root-independent families — `paths`, `summary`, `instructions`, `context`, `work`, `review` — keep working without a root, and a user template override still resolves without one.
 
-**A boundary guard.** `tasks/lint/claude_coupling.py` fails if anything in the
-rename set (`cli/**`, `bin/accelerator`, the four writers) names a `CLAUDE_*`
-variable. No allowlist: the failure message says the reference must be removed.
-It fails closed on empty discovery, on a file count below a floor, and on any
-named path that no longer resolves. The gitignore-honouring directory walk it
-needs was promoted to `tasks/shared/sources.py:walk_files` rather than copied a
-third time. The guard is wired into both `cli:check` (what CI runs) and
-`lint:check` (the only path the bare `mise run` reaches), together with the two
-pre-existing `cli/`-scoped guards, which had the same blind spot.
+**A boundary guard.** `tasks/lint/claude_coupling.py` fails if anything in the rename set (`cli/**`, `bin/accelerator`, the four writers) names a `CLAUDE_*` variable. No allowlist: the failure message says the reference must be removed. It fails closed on empty discovery, on a file count below a floor, and on any named path that no longer resolves. The gitignore-honouring directory walk it needs was promoted to `tasks/shared/sources.py:walk_files` rather than copied a third time. The guard is wired into both `cli:check` (what CI runs) and `lint:check` (the only path the bare `mise run` reaches), together with the two pre-existing `cli/`-scoped guards, which had the same blind spot.
 
-**Terminal invocation.** A new `SessionStart` hook,
-`hooks/launcher-link-refresh.sh`, keeps `${CLAUDE_PLUGIN_DATA}/bin/accelerator`
-pointing at the current installation's launcher, so a symlink you create once on
-your `$PATH` survives upgrades. It exits 0 on every path, refuses rather than
-clobbering anything it does not own, reports a re-point, and surfaces an
-unverified-launcher record from the bootstrap's durable log. `docs/internals.md`
-gains a Terminal Invocation section (discovery-first, since the data-directory
-layout is an undocumented internal); `docs/releases-and-compatibility.md` covers
-channel switches; the competing version-pinned recipe in the visualise skill and
-a stale `accelerator-visualiser` reference are gone.
+**Terminal invocation.** A new `SessionStart` hook, `hooks/launcher-link-refresh.sh`, keeps `${CLAUDE_PLUGIN_DATA}/bin/accelerator` pointing at the current installation's launcher, so a symlink you create once on your `$PATH` survives upgrades. It exits 0 on every path, refuses rather than clobbering anything it does not own, reports a re-point, and surfaces an unverified-launcher record from the bootstrap's durable log. `docs/internals.md` gains a Terminal Invocation section (discovery-first, since the data-directory layout is an undocumented internal); `docs/releases-and-compatibility.md` covers channel switches; the competing version-pinned recipe in the visualise skill and a stale `accelerator-visualiser` reference are gone.
 
-**A conformance suite for the `!` sites.** `tests/integration/skill-invocation`
-runs all 122 distinct `config` commands the skills invoke at load time through
-the real bootstrap against a fixture installation, in the production shape —
-correct absolute path, empty environment — which is the one configuration no
-other suite exercised, and the gap that let this bug ship. Plus six structural
-invariants over the corpus. The fixture-installation apparatus was extracted to
-`tests/integration/support/` and the entrypoint suite refactored onto it.
+**A conformance suite for the `!` sites.** `tests/integration/skill-invocation` runs all 122 distinct `config` commands the skills invoke at load time through the real bootstrap against a fixture installation, in the production shape — correct absolute path, empty environment — which is the one configuration no other suite exercised, and the gap that let this bug ship. Plus six structural invariants over the corpus. The fixture-installation apparatus was extracted to `tests/integration/support/` and the entrypoint suite refactored onto it.
 
-**Test-infrastructure repairs.** The work-item template seam now forces failure
-through `ACCELERATOR_BIN` rather than a bogus plugin root, with a paired test
-proving the fallback branch is actually entered — it would have passed vacuously
-after the rename. `hooks`, `decisions` and `github` gained shell-suite discovery
-floors via one extracted helper. `test_mise.py` pins which integration tasks
-need a prebuilt launcher, exhaustively, so a new task forces a decision.
+**Test-infrastructure repairs.** The work-item template seam now forces failure through `ACCELERATOR_BIN` rather than a bogus plugin root, with a paired test proving the fallback branch is actually entered — it would have passed vacuously after the rename. `hooks`, `decisions` and `github` gained shell-suite discovery floors via one extracted helper. `test_mise.py` pins which integration tasks need a prebuilt launcher, exhaustively, so a new task forces a decision.
 
 ## Context
 
@@ -101,83 +52,26 @@ need a prebuilt launcher, exhaustively, so a new task forces a decision.
 
 ## Testing
 
-- [x] `mise run` (bare default) exits 0 end-to-end, run under
-      `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT` so no ambient root
-      reached any task. The formatters changed nothing. The commits after that
-      run are documentation-only, so the tip's code is exactly what was verified.
-- [x] `mise run cli:check` exits 0; `lint:claude-coupling:check` scans 724 files
-      with 0 violations in ~230ms, and its scan descends into neither
-      `cli/target/` nor `node_modules/` nor `dist/`.
-- [x] Shell suites with no ambient plugin root: `test:integration:work` 404
-      assertions, `test:integration:config` 1692, each exit 0.
-- [x] `test:integration:skill-invocation` 128 passed (122 command cases + 6
-      corpus invariants); `test:integration:entrypoint` 46;
-      `test:integration:hooks` 22; `test:unit:tasks` 409; `test:unit:cli` green.
-- [x] Guard falsifiability: reintroducing a `CLAUDE_PLUGIN_ROOT` read into
-      `cli/launcher/src/main.rs` and the transitional export into
-      `bin/accelerator` both turn `cli:check` red with a `path:line:text` report;
-      removing the three `lint:check` entries reddens the new placement
-      assertion.
-- [x] Rootless behaviour, measured against a freshly built launcher from a bare
-      temp directory with both variables stripped: `config templates list` exits
-      1 naming `ACCELERATOR_PLUGIN_ROOT`, 0 bytes on stdout with and without
-      `--fail-safe`; `config summary` and `config path work` still exit 0.
-- [x] Against the installed `1.24.0-pre.17` (the predecessor release), rootless
-      invocation by absolute path renders the plugin-default `adr` row and the
-      originally reported `config instructions commit --fail-safe` exits 0 clean.
-- [ ] The terminal link end-to-end — hook firing at `SessionStart`, the
-      documented recipe on a machine without `~/.local/bin`, surviving an
-      upgrade, two concurrent sessions, and plugin removal. Needs a release
-      carrying the hook; `1.24.0-pre.17` predates it. The hermetic equivalents
-      are the 22 hook cases.
-- [ ] One skill load from a Claude Code session whose environment carries no
-      `CLAUDE_PLUGIN_ROOT` at all. Two skills load correctly today, but this
-      session inherited a stale value at startup, so that check currently rests
-      on the bootstrap never reading one rather than on isolation.
+- [x] `mise run` (bare default) exits 0 end-to-end, run under `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT` so no ambient root reached any task. The formatters changed nothing. The commits after that run are documentation-only, so the tip's code is exactly what was verified.
+- [x] `mise run cli:check` exits 0; `lint:claude-coupling:check` scans 724 files with 0 violations in ~230ms, and its scan descends into neither `cli/target/` nor `node_modules/` nor `dist/`.
+- [x] Shell suites with no ambient plugin root: `test:integration:work` 404 assertions, `test:integration:config` 1692, each exit 0.
+- [x] `test:integration:skill-invocation` 128 passed (122 command cases + 6 corpus invariants); `test:integration:entrypoint` 46; `test:integration:hooks` 22; `test:unit:tasks` 409; `test:unit:cli` green.
+- [x] Guard falsifiability: reintroducing a `CLAUDE_PLUGIN_ROOT` read into `cli/launcher/src/main.rs` and the transitional export into `bin/accelerator` both turn `cli:check` red with a `path:line:text` report; removing the three `lint:check` entries reddens the new placement assertion.
+- [x] Rootless behaviour, measured against a freshly built launcher from a bare temp directory with both variables stripped: `config templates list` exits 1 naming `ACCELERATOR_PLUGIN_ROOT`, 0 bytes on stdout with and without `--fail-safe`; `config summary` and `config path work` still exit 0.
+- [x] Against the installed `1.24.0-pre.17` (the predecessor release), rootless invocation by absolute path renders the plugin-default `adr` row and the originally reported `config instructions commit --fail-safe` exits 0 clean.
+- [ ] The terminal link end-to-end — hook firing at `SessionStart`, the documented recipe on a machine without `~/.local/bin`, surviving an upgrade, two concurrent sessions, and plugin removal. Needs a release carrying the hook; `1.24.0-pre.17` predates it. The hermetic equivalents are the 22 hook cases.
+- [ ] One skill load from a Claude Code session whose environment carries no `CLAUDE_PLUGIN_ROOT` at all. Two skills load correctly today, but this session inherited a stale value at startup, so that check currently rests on the bootstrap never reading one rather than on isolation.
 
 ## Notes for Reviewers
 
-**Where to look first.** `bin/accelerator`'s self-location block landed in #28;
-what is new here is the removal of its second `export`. The two files carrying
-the most judgement are `hooks/launcher-link-refresh.sh` (every guard exists for a
-measured filesystem behaviour — in particular `mv -f` onto a symlink-to-directory
-writes *inside* it, which is why the link is cleared before the rename) and
-`cli/config-adapters/src/store.rs`, where the tier check must stay below the
-user-override check or a rootless override stops resolving.
+**Where to look first.** `bin/accelerator`'s self-location block landed in #28; what is new here is the removal of its second `export`. The two files carrying the most judgement are `hooks/launcher-link-refresh.sh` (every guard exists for a measured filesystem behaviour — in particular `mv -f` onto a symlink-to-directory writes *inside* it, which is why the link is cleared before the rename) and `cli/config-adapters/src/store.rs`, where the tier check must stay below the user-override check or a rootless override stops resolving.
 
-**Bootstrap and launcher must ship together, and do.** The bootstrap no longer
-exports the old name and the launcher no longer reads it, so a new bootstrap
-paired with a pre-rename launcher would find no root. That pairing cannot occur:
-the launcher cache is version-keyed and the bootstrap fetches the launcher
-matching `plugin.json`. Worth confirming during review, since it is the obvious
-failure mode of a two-sided rename.
+**Bootstrap and launcher must ship together, and do.** The bootstrap no longer exports the old name and the launcher no longer reads it, so a new bootstrap paired with a pre-rename launcher would find no root. That pairing cannot occur: the launcher cache is version-keyed and the bootstrap fetches the launcher matching `plugin.json`. Worth confirming during review, since it is the obvious failure mode of a two-sided rename.
 
-**A changelog gap.** `Unreleased` gained the terminal-invocation entry but has
-nothing for the user-visible behaviour change in this PR — a rootless template
-command now fails loudly where it used to print an empty table at exit 0 — and no
-`Fixed` entry for the original bug. Both are arguably worth adding before
-release; I left the changelog as the branch had it rather than editing it inside
-a description pass.
+**A changelog gap.** `Unreleased` gained the terminal-invocation entry but has nothing for the user-visible behaviour change in this PR — a rootless template command now fails loudly where it used to print an empty table at exit 0 — and no `Fixed` entry for the original bug. Both are arguably worth adding before release; I left the changelog as the branch had it rather than editing it inside a description pass.
 
-**One decision overrides the plan.** The plan argued the `cli/`-scoped guards
-should ride in `cli:check` *only*, reasoning from CI. Validation measured the
-consequence: because the bare `default` task depends on `lint:check` and never on
-`check`, none of the three guards ran in a full local run, so a boundary
-violation was green locally and caught only in CI. All three are now dual-wired,
-which avoids the "third pattern" the plan was guarding against. The plan records
-the reversal at the point of the original argument.
+**One decision overrides the plan.** The plan argued the `cli/`-scoped guards should ride in `cli:check` *only*, reasoning from CI. Validation measured the consequence: because the bare `default` task depends on `lint:check` and never on `check`, none of the three guards ran in a full local run, so a boundary violation was green locally and caught only in CI. All three are now dual-wired, which avoids the "third pattern" the plan was guarding against. The plan records the reversal at the point of the original argument.
 
-**Known gaps, both recorded rather than fixed.** The conformance suite excludes
-the visualiser daemon `!` site — the only one that hard-requires the plugin root
-— because it verifies `manifest.json` against the real release key; it is covered
-at the Rust layer instead. And `test:integration:config` failed once during
-validation on a teardown race in the Playwright executor cases (`rm: … Directory
-not empty`), passing standalone before and after; it belongs to the recorded
-config-suite flake class, not to this change, but it can turn a full local run
-red at random.
+**Known gaps, both recorded rather than fixed.** The conformance suite excludes the visualiser daemon `!` site — the only one that hard-requires the plugin root — because it verifies `manifest.json` against the real release key; it is covered at the Rust layer instead. And `test:integration:config` failed once during validation on a teardown race in the Playwright executor cases (`rm: … Directory not empty`), passing standalone before and after; it belongs to the recorded config-suite flake class, not to this change, but it can turn a full local run red at random.
 
-**The hook is shell, not CLI logic**, which diverges from ADR-0048. The
-justification is circularity — the link exists to make the launcher reachable, so
-maintaining it cannot depend on the launcher being fetched, verified and cached —
-and it is recorded in the plan's Phase 3 overview rather than left as apparent
-drift.
+**The hook is shell, not CLI logic**, which diverges from ADR-0048. The justification is circularity — the link exists to make the launcher reachable, so maintaining it cannot depend on the launcher being fetched, verified and cached — and it is recorded in the plan's Phase 3 overview rather than left as apparent drift.

--- a/meta/prs/30-description.md
+++ b/meta/prs/30-description.md
@@ -1,0 +1,183 @@
+---
+type: pr-description
+id: "30"
+title: "[0182] Plugin root rename and terminal invocation surface"
+date: "2026-07-29T16:18:51+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "0182"
+parent: "work-item:0182"
+relates_to:
+  - "plan:2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename"
+  - "plan-validation:2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation"
+  - "work-item:0184"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/30"
+pr_number: 30
+tags: [pr, cli, launcher, plugin-root, hooks, lint-guards]
+revision: "517db8c33c1a7964d22dbdf982aa32270a803545"
+repository: "accelerator"
+last_updated: "2026-07-29T16:18:51+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0182] Plugin root rename and terminal invocation surface
+
+## Summary
+
+PR #28 made `bin/accelerator` derive its installation root from its own
+location, unbreaking all 45 CLI-invoking skills. This is the rest of that work:
+the launcher and server layers move off `CLAUDE_PLUGIN_ROOT` onto
+`ACCELERATOR_PLUGIN_ROOT`, a lint guard makes that boundary non-negotiable, an
+unknown plugin root becomes a named refusal instead of a silently empty answer,
+and running `accelerator` from an ordinary terminal becomes a documented,
+upgrade-surviving surface.
+
+## Changes
+
+**The rename.** `cli/launcher`, `cli/visualiser/server` and the cache-root
+resolver read `ACCELERATOR_PLUGIN_ROOT`; the four out-of-tree writers
+(`tasks/dev.py`, `tasks/shared/dev/circus.py`, `tasks/test/helpers.py`,
+`tests/integration/dev/dev_integration_driver.py`) set it. `bin/accelerator`
+drops the transitional dual export it carried for one release, so nothing in the
+rename set names a `CLAUDE_*` variable any more. An empty value is now treated
+as unset, filtered once in `FileConfigStore::with_plugin_root` so the launcher
+and the server inherit the rule from one place.
+
+**A missing root is a named error.** `ConfigError::PluginRootUnavailable` names
+the variable and the remedy, and `is_refusal()` classifies every variant
+exhaustively — a new variant will not compile until it is classified. The
+template ports became fallible, so a rootless `config templates list` exits
+non-zero with a diagnostic instead of printing an empty table at exit 0, and
+`templates eject --all` refuses instead of silently ejecting nothing. Refusals
+are byte-identical with and without `--fail-safe`. Root-independent families —
+`paths`, `summary`, `instructions`, `context`, `work`, `review` — keep working
+without a root, and a user template override still resolves without one.
+
+**A boundary guard.** `tasks/lint/claude_coupling.py` fails if anything in the
+rename set (`cli/**`, `bin/accelerator`, the four writers) names a `CLAUDE_*`
+variable. No allowlist: the failure message says the reference must be removed.
+It fails closed on empty discovery, on a file count below a floor, and on any
+named path that no longer resolves. The gitignore-honouring directory walk it
+needs was promoted to `tasks/shared/sources.py:walk_files` rather than copied a
+third time. The guard is wired into both `cli:check` (what CI runs) and
+`lint:check` (the only path the bare `mise run` reaches), together with the two
+pre-existing `cli/`-scoped guards, which had the same blind spot.
+
+**Terminal invocation.** A new `SessionStart` hook,
+`hooks/launcher-link-refresh.sh`, keeps `${CLAUDE_PLUGIN_DATA}/bin/accelerator`
+pointing at the current installation's launcher, so a symlink you create once on
+your `$PATH` survives upgrades. It exits 0 on every path, refuses rather than
+clobbering anything it does not own, reports a re-point, and surfaces an
+unverified-launcher record from the bootstrap's durable log. `docs/internals.md`
+gains a Terminal Invocation section (discovery-first, since the data-directory
+layout is an undocumented internal); `docs/releases-and-compatibility.md` covers
+channel switches; the competing version-pinned recipe in the visualise skill and
+a stale `accelerator-visualiser` reference are gone.
+
+**A conformance suite for the `!` sites.** `tests/integration/skill-invocation`
+runs all 122 distinct `config` commands the skills invoke at load time through
+the real bootstrap against a fixture installation, in the production shape —
+correct absolute path, empty environment — which is the one configuration no
+other suite exercised, and the gap that let this bug ship. Plus six structural
+invariants over the corpus. The fixture-installation apparatus was extracted to
+`tests/integration/support/` and the entrypoint suite refactored onto it.
+
+**Test-infrastructure repairs.** The work-item template seam now forces failure
+through `ACCELERATOR_BIN` rather than a bogus plugin root, with a paired test
+proving the fallback branch is actually entered — it would have passed vacuously
+after the rename. `hooks`, `decisions` and `github` gained shell-suite discovery
+floors via one extracted helper. `test_mise.py` pins which integration tasks
+need a prebuilt launcher, exhaustively, so a new task forces a decision.
+
+## Context
+
+- Work item: [`meta/work/0182-cli-derives-plugin-root-from-own-location.md`](../work/0182-cli-derives-plugin-root-from-own-location.md)
+- Plan: [`meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md`](../plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md)
+- Validation: [`meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md`](../validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md)
+- Predecessor: PR #28 (bootstrap self-location and `--fail-safe`), released as `1.24.0-pre.17`
+- Follow-up raised here: [`meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`](../work/0184-template-enumeration-swallows-a-wrong-plugin-root.md)
+
+## Testing
+
+- [x] `mise run` (bare default) exits 0 end-to-end, run under
+      `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT` so no ambient root
+      reached any task. The formatters changed nothing. The commits after that
+      run are documentation-only, so the tip's code is exactly what was verified.
+- [x] `mise run cli:check` exits 0; `lint:claude-coupling:check` scans 724 files
+      with 0 violations in ~230ms, and its scan descends into neither
+      `cli/target/` nor `node_modules/` nor `dist/`.
+- [x] Shell suites with no ambient plugin root: `test:integration:work` 404
+      assertions, `test:integration:config` 1692, each exit 0.
+- [x] `test:integration:skill-invocation` 128 passed (122 command cases + 6
+      corpus invariants); `test:integration:entrypoint` 46;
+      `test:integration:hooks` 22; `test:unit:tasks` 409; `test:unit:cli` green.
+- [x] Guard falsifiability: reintroducing a `CLAUDE_PLUGIN_ROOT` read into
+      `cli/launcher/src/main.rs` and the transitional export into
+      `bin/accelerator` both turn `cli:check` red with a `path:line:text` report;
+      removing the three `lint:check` entries reddens the new placement
+      assertion.
+- [x] Rootless behaviour, measured against a freshly built launcher from a bare
+      temp directory with both variables stripped: `config templates list` exits
+      1 naming `ACCELERATOR_PLUGIN_ROOT`, 0 bytes on stdout with and without
+      `--fail-safe`; `config summary` and `config path work` still exit 0.
+- [x] Against the installed `1.24.0-pre.17` (the predecessor release), rootless
+      invocation by absolute path renders the plugin-default `adr` row and the
+      originally reported `config instructions commit --fail-safe` exits 0 clean.
+- [ ] The terminal link end-to-end — hook firing at `SessionStart`, the
+      documented recipe on a machine without `~/.local/bin`, surviving an
+      upgrade, two concurrent sessions, and plugin removal. Needs a release
+      carrying the hook; `1.24.0-pre.17` predates it. The hermetic equivalents
+      are the 22 hook cases.
+- [ ] One skill load from a Claude Code session whose environment carries no
+      `CLAUDE_PLUGIN_ROOT` at all. Two skills load correctly today, but this
+      session inherited a stale value at startup, so that check currently rests
+      on the bootstrap never reading one rather than on isolation.
+
+## Notes for Reviewers
+
+**Where to look first.** `bin/accelerator`'s self-location block landed in #28;
+what is new here is the removal of its second `export`. The two files carrying
+the most judgement are `hooks/launcher-link-refresh.sh` (every guard exists for a
+measured filesystem behaviour — in particular `mv -f` onto a symlink-to-directory
+writes *inside* it, which is why the link is cleared before the rename) and
+`cli/config-adapters/src/store.rs`, where the tier check must stay below the
+user-override check or a rootless override stops resolving.
+
+**Bootstrap and launcher must ship together, and do.** The bootstrap no longer
+exports the old name and the launcher no longer reads it, so a new bootstrap
+paired with a pre-rename launcher would find no root. That pairing cannot occur:
+the launcher cache is version-keyed and the bootstrap fetches the launcher
+matching `plugin.json`. Worth confirming during review, since it is the obvious
+failure mode of a two-sided rename.
+
+**A changelog gap.** `Unreleased` gained the terminal-invocation entry but has
+nothing for the user-visible behaviour change in this PR — a rootless template
+command now fails loudly where it used to print an empty table at exit 0 — and no
+`Fixed` entry for the original bug. Both are arguably worth adding before
+release; I left the changelog as the branch had it rather than editing it inside
+a description pass.
+
+**One decision overrides the plan.** The plan argued the `cli/`-scoped guards
+should ride in `cli:check` *only*, reasoning from CI. Validation measured the
+consequence: because the bare `default` task depends on `lint:check` and never on
+`check`, none of the three guards ran in a full local run, so a boundary
+violation was green locally and caught only in CI. All three are now dual-wired,
+which avoids the "third pattern" the plan was guarding against. The plan records
+the reversal at the point of the original argument.
+
+**Known gaps, both recorded rather than fixed.** The conformance suite excludes
+the visualiser daemon `!` site — the only one that hard-requires the plugin root
+— because it verifies `manifest.json` against the real release key; it is covered
+at the Rust layer instead. And `test:integration:config` failed once during
+validation on a teardown race in the Playwright executor cases (`rm: … Directory
+not empty`), passing standalone before and after; it belongs to the recorded
+config-suite flake class, not to this change, but it can turn a full local run
+red at random.
+
+**The hook is shell, not CLI logic**, which diverges from ADR-0048. The
+justification is circularity — the link exists to make the launcher reachable, so
+maintaining it cannot depend on the launcher being fetched, verified and cached —
+and it is recorded in the plan's Phase 3 overview rather than left as apparent
+drift.

--- a/meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md
+++ b/meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md
@@ -1,0 +1,253 @@
+---
+type: plan-validation
+id: "2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation"
+title: "Validation Report: Bootstrap Self-Location and the ACCELERATOR_PLUGIN_ROOT Rename"
+date: "2026-07-29T13:36:14+00:00"
+author: "Toby Clemson"
+producer: validate-plan
+status: complete
+result: "partial"
+parent: "work-item:0182"
+target: "plan:2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename"
+tags: [validation, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
+last_updated: "2026-07-29T13:36:14+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Bootstrap Self-Location and the `ACCELERATOR_PLUGIN_ROOT` Rename
+
+Validated at revision `2da813f0` (working copy empty, parent `b89ff3a5`).
+Every automated criterion was re-run rather than taken from the plan's own
+annotations; every count below is measured in this session.
+
+### Implementation Status
+
+✓ Phase 0: Determinations — fully implemented
+✓ Phase 1a: Bootstrap self-location and `--fail-safe` — fully implemented
+✓ Phase 1c: Work-item seam and build edge — fully implemented
+✓ Phase 1b: The rename — fully implemented
+✓ Phase 2: The `CLAUDE_*` boundary guard — fully implemented
+✓ Phase 3: Terminal invocation surface — fully implemented
+✓ Phase 4: `!`-site conformance suite — fully implemented
+✓ Phase 5: A missing plugin root becomes a named error — fully implemented
+⚠️ Closing step (`mise.local.toml` removal) — not done, and correctly so: its
+stated precondition (a prerelease carrying the Phase 1a fix installed and in
+use) is not met. `1.24.0-pre.16` is still the installed plugin. Two of its five
+automated criteria are however *already* satisfied — see *Deviations*.
+
+Sixteen commits carry the work (`nstyplkt`…`pnynskrr` plus the pre-existing-flake
+fix), one more than the plan's progress table records.
+
+### Automated Verification Results
+
+✓ `mise run` (bare default) exits 0 end-to-end — the full local CI mirror, run
+  to completion in this session. Working copy is still empty afterwards, so the
+  in-place formatters had nothing to change.
+✓ `mise run cli:check` exits 0 — run separately, because the bare default does
+  **not** reach it (see *Potential Issues*). `lint:claude-coupling:check`
+  completes in 228ms.
+✓ The `CLAUDE_*` guard is clean and its scope is intact: `_in_scope()` discovers
+  **724** files and `violations(REPO_ROOT)` returns `[]` — reproduced directly,
+  matching the plan's measurement exactly.
+✓ Suite counts, all from the full run: `test:integration:entrypoint` 46 passed ·
+  `test:integration:hooks` 22 passed · `test:integration:skill-invocation` 128
+  passed · `test:unit:tasks` 406 passed · `test:integration:tasks` 51 passed ·
+  `test:integration:deny` 15 passed · `test:integration:dev` 17 passed ·
+  `test:unit:cli` green (89.12% line coverage) · all shell suites (`config`,
+  `work`, `migrate`, `integrations`, `decisions`, `github`) green · frontend
+  unit + E2E green.
+✓ Phase 5's named cases all executed in the run:
+  `templates_list_with_no_plugin_root_is_a_named_refusal_not_an_empty_table`,
+  `a_missing_plugin_root_refuses_identically_with_and_without_fail_safe`,
+  `a_user_override_still_resolves_with_no_plugin_root`,
+  `an_empty_plugin_root_refuses_to_compose`,
+  `plugin_root_unavailable_names_the_variable_and_the_bootstrap`,
+  `the_root_independent_families_still_succeed_with_no_plugin_root`.
+✓ `! grep -q 'CLAUDE_' bin/accelerator` — zero matches; the transitional export
+  is gone.
+✓ `! grep -q 'CLAUDE_PLUGIN_ROOT' hooks/launcher-link-refresh.sh` — zero
+  matches, header comment included.
+✓ Residue purge holds: the non-`meta/` tracked `CLAUDE_PLUGIN_ROOT` grep returns
+  **87** files, every one inside the permitted set the plan enumerates (no
+  file outside it). Re-derived by running the grep, not by transcription.
+✓ Phase 3 documentation criteria: `docs/internals.md:88` carries
+  `## Terminal Invocation`; `README.md:57-58` links it and the gloss names
+  "running the CLI from a terminal"; no unexpanded `CLAUDE_PLUGIN_DATA}/bin/…`
+  token in the docs; `accelerator-visualiser` and the competing `~/.local/bin`
+  recipe are both gone.
+✓ `hooks/hooks.json` registers `launcher-link-refresh.sh` as the **fourth**
+  `SessionStart` group (index 3), so `test-vcs-detect.sh`'s hard-coded
+  `SessionStart[0]` assertion is undisturbed; the hook is mode 0755.
+✓ Behaviour spot-check against a freshly built launcher from a bare temp dir
+  with both root variables stripped: `config templates list` exits 1 with
+  `the plugin installation root is unknown: set ACCELERATOR_PLUGIN_ROOT, or
+  invoke accelerator through bin/accelerator, which derives it`; the same command
+  with `--fail-safe` still exits non-zero with **0 bytes** on stdout;
+  `config summary` still exits 0.
+
+Nothing failed. No automated criterion in the plan was found to be overstated.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `bin/accelerator:21-115` implements the argv scan (stops at the first `--` and
+  first match), `max_hops=16`, `fail`/`fail_integrity` as two named entry points,
+  `dir_of` by parameter expansion, the `while [[ -L ]]` chase with `|| fail` on
+  every `readlink`/`cd`, `cd -P` for the `..` step, `CDPATH=`, the single-line
+  sanitiser `${1//$'\n'/ }`, and one write-only `export ACCELERATOR_PLUGIN_ROOT`.
+  The file reads no root variable at all.
+- `hooks/launcher-link-refresh.sh` matches the pinned listing line for line:
+  single `finish()` exit point, unverified-log read *above* the
+  `CLAUDE_PLUGIN_DATA` guard, `[ -L ]`/`[ ! -d ]` before `mkdir -p -m 0700`, the
+  symlink-to-directory clear before the staged `mv`, the `STAGED` pre-check with
+  an `rm -rf` trap, the post-`mv` `[ -L ]` assertion, and the `PREVIOUS`
+  comparison that reports a re-point. Both deliberate shellcheck disables carry
+  their justification.
+- `tasks/lint/claude_coupling.py` is shaped as specified: pure `violations(root)`,
+  no allowlist, decode-failure skip with `_SKIP_SUFFIXES` as a speed hint only,
+  fail-closed on empty *discovery* (`_MIN_SCANNED = 200`) **and** on any `_FILES`
+  entry that no longer resolves, `path:line:text` reporting, and a docstring
+  stating the invariant plus the out-of-scope-by-construction adapter layer.
+- `tasks/shared/sources.py:63-86` promotes `walk_files(repo, subtree, prune)`
+  with replace semantics and the root-spec-not-subtree-spec rule documented;
+  `shell_sources()` and `test_python_coverage.py`'s `_py_files` both ride it.
+- Phase 5's consumer placement is correct where it matters:
+  `FileConfigStore::resolve` checks the user override *before*
+  `require_plugin_root()`, so `a_user_override_still_resolves_with_no_plugin_root`
+  is testing a real seam rather than an accident; `is_refusal()` is an exhaustive
+  `match` (a new variant will not compile until classified) and is `pub` so the
+  launcher's `From<ConfigError> for Failure` can reach it.
+- `tests/integration/support/installation.py:301-319` enforces the hermeticity
+  preconditions inside the single funnel, with the URL check implemented as
+  `urlparse(...).hostname.endswith(".invalid")` rather than a suffix test on the
+  whole URL — the stronger form the plan argues for.
+- `tests/unit/tasks/test_mise.py` pins both `_LAUNCHER_DEPENDENTS` and an
+  exhaustive `_NO_LAUNCHER_NEEDED`, with `test:integration:skill-invocation`
+  in the latter and a reason recorded.
+- `.gitignore` covers the launcher cache, sub-binary cache, lock, unverified log
+  and staged shims, with the digest-anchored shim pattern and a comment
+  explaining why `-*-*` would have been wrong; the stale pre-0168
+  `visualise/bin/…` entry is gone.
+
+#### Deviations from Plan:
+
+- **The plan document was internally stale about its own last phase** — the
+  mergeability table said Phase 5 "not started" and the *Progress — 2026-07-29*
+  paragraph said it remained, listing fifteen commits, while Phase 5's own
+  section recorded it done and the commit (`Refuse rather than answer empty when
+  the plugin root is unknown`) existed. **Corrected in this validation pass**: the
+  table row reads done, the paragraph records all eight phases complete with only
+  the closing step and the release-candidate manual checks outstanding, and the
+  sixteenth commit is listed.
+- **The empty-string root filter landed in `with_plugin_root`**
+  (`cli/config-adapters/src/store.rs:65-69`), not at `cli/launcher/src/main.rs:176`
+  as Phase 1b §1 specified. Strictly better — one filter now serves the launcher
+  *and* the visualiser server — and Phase 5's implementation notes recorded it,
+  but Phase 1b's text did not. **Corrected in this validation pass**: Phase 1b §1
+  now names `with_plugin_root` as where the rule lives and says `main.rs`'s
+  `var_os` is deliberately left unfiltered.
+- **`violations()` gained a `min_scanned` parameter** not in the plan's signature,
+  as a seam for the guard's own tiny-tree tests. The real-tree assertion uses the
+  default, so the floor is not weakened.
+- **`.gitignore` uses `bin/.tmp-*`** where the plan specifies
+  `bin/.tmp-launcher-*` — broader than asked, harmless in a directory the plugin
+  ships from.
+- **Two closing-step criteria are already met but unticked**: `.gitignore:26`
+  carries `mise.local.toml`, and the file is absent from `main`. Beyond that,
+  `mise.local.toml` is no longer tracked in the working-copy commit at all
+  (`jj file list mise.local.toml` returns nothing), so the *Current State
+  Analysis* claim that it "exists only in the current jj working-copy commit" is
+  already out of date — only the on-disk, untracked file remains, and its sole
+  remaining effect is the one the plan describes: supplying `CLAUDE_PLUGIN_ROOT`
+  to the still-unfixed installed bootstrap.
+- Phase 3's suite shipped as Python (`tests/integration/hooks/test_launcher_link_refresh.py`,
+  22 cases) rather than a `hooks/test-*.sh` harness, and Phase 4 did the support
+  extraction Phase 1a was supposed to leave behind. Both are recorded in the
+  phases' own *Implementation notes*; noted here only for completeness.
+
+#### Potential Issues:
+
+- **The three `cli/`-scoped guards were unreachable from `mise run`.** Measured
+  from the full run's task list: `lint:claude-coupling:check`,
+  `lint:store-duplication:check` and `lint:vendor-shims:check` did not execute.
+  They rode in `cli:check` only, which CI runs as its own step
+  (`.github/workflows/main.yml:257`) — so the invariant *was* enforced before
+  merge, but `CLAUDE.md`'s "done means `mise run` exits 0" was not a complete
+  local gate for it. The plan deferred this ("worth doing, but as its own
+  change") and no follow-up item covered it (0183 is the
+  `migrate-discoverability` stderr advisory, 0184 is `template_names` on a
+  known-but-wrong root).
+
+  **Closed in this validation pass, on the maintainer's decision to wire rather
+  than ticket**: all three are now in `lint:check.depends` (`mise.toml:462`) as
+  well as `cli:check.depends`, so the bare `default` task reaches them —
+  `default` depends on `lint:check`, never on `check`, which is the specific
+  reason a `cli:check`-only guard was invisible locally. A second paired
+  assertion, `test_gate_wired_into_lint_check`, pins the new placement over the
+  same constant as the `cli:check` one; falsified by removing the three entries
+  (3 failed, 23 passed) and green restored. `mise run lint:check` exits 0 with
+  all three executing, and `tasks/README.md` now records both placements and
+  why. `test_mise.py` 26 passed; `mise run build-system:check` exits 0.
+- **`dir_of()` assigns `dir` as a global** (`bin/accelerator:74`). Harmless today
+  — the value is recomputed on every call and nothing else in the file uses the
+  name — but the file's other helpers keep no state, so a later reader could
+  reasonably assume this one doesn't either. `local dir` is bash-3.2-safe.
+- `fail_integrity()` (`:54`) calls `dir_of()` (`:71`) defined below it. Correct at
+  runtime, and unreachable before both definitions exist, but the ordering is the
+  one thing in the header region that would break silently if a future gate moved
+  above line 71.
+- Phase 4's suite excludes the visualiser daemon `!` site by design, so
+  external-subcommand dispatch has no `!`-site-level coverage; the suite's
+  docstring records this and points at `version.rs`/`cache_root.rs`. Accepted, but
+  it means the one `!` site that *hard-requires* the plugin root is verified only
+  at the Rust layer.
+
+### Manual Testing Required:
+
+The plan's own deferrals stand, unchanged and correctly reasoned — all of them
+need the fix to be *installed*, and `1.24.0-pre.16` predates it:
+
+1. Release-candidate checks (Phase 1a, Phase 3):
+  - [ ] `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT ./bin/accelerator config templates list`
+        exits 0 and lists an `adr` row with Source `plugin default`, against a
+        published release (it 404s until then, and would write into the shipped
+        `bin/`).
+  - [ ] In a real session the hook fires at `SessionStart` and
+        `${CLAUDE_PLUGIN_DATA}/bin/accelerator` resolves to the current
+        installation.
+  - [ ] The documented recipe, followed verbatim on a machine without
+        `~/.local/bin`, yields a working `accelerator` on `PATH` in a new login
+        shell.
+  - [ ] After a plugin upgrade, a new session's link points at the new root with
+        no user action.
+  - [ ] Two concurrent sessions never leave the link absent.
+  - [ ] Removing the plugin leaves only the dangling plugin-owned link inside
+        `${CLAUDE_PLUGIN_DATA}`.
+
+2. Closing step, once a prerelease carrying Phase 1a is installed:
+  - [ ] Delete `mise.local.toml`, then `mise run test:integration:work
+        test:integration:config` and a bare `mise run` still exit 0.
+  - [ ] `/accelerator:commit` and one other CLI-invoking skill load against the
+        **installed** plugin with no error and no permission prompt.
+
+### Recommendations:
+
+- ~~Correct the plan's mergeability table and progress paragraph~~ — **done in
+  this pass**, along with the two closing-step criteria that were already
+  satisfied (now ticked, with `.gitignore:26` named) and the *Current State
+  Analysis* and *Closing step* lines about `mise.local.toml` sitting in the
+  working-copy commit (it is now untracked; only the on-disk file remains).
+- ~~Correct Phase 1b §1's text about the empty-string filter~~ — **done in this
+  pass.**
+- ~~Close the default-task blind spot~~ — **done in this pass** by wiring rather
+  than ticketing; see *Potential Issues*. Note this deliberately overrides the
+  plan's Phase 2 argument against dual-wiring (which reasoned from `cli:check`
+  being what CI runs, and did not weigh the bare `default` task's blindness).
+- **Do not flip the plan to `done` yet.** The closing step and the
+  release-candidate manual set are real remaining deliverables with an external
+  precondition; `in-progress` is the accurate status until a prerelease carrying
+  Phase 1a is installed and those checks are performed.
+- Optionally, make `dir` local in `dir_of()` while `bin/accelerator` is still
+  fresh in mind.

--- a/meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md
+++ b/meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md
@@ -10,7 +10,7 @@ result: "partial"
 parent: "work-item:0182"
 target: "plan:2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename"
 tags: [validation, cli, launcher, bootstrap, plugin-root, hooks, lint-guards]
-last_updated: "2026-07-29T13:36:14+00:00"
+last_updated: "2026-07-29T15:21:21+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -20,6 +20,10 @@ schema_version: 1
 Validated at revision `2da813f0` (working copy empty, parent `b89ff3a5`).
 Every automated criterion was re-run rather than taken from the plan's own
 annotations; every count below is measured in this session.
+
+**Amended 2026-07-29T15:21Z**, after `1.24.0-pre.17` was installed: Phase 1a's
+release-candidate manual criteria are now performed and passing against the
+published artifact. Phase 3's five remain deferred — see *Manual Testing*.
 
 ### Implementation Status
 
@@ -31,28 +35,75 @@ annotations; every count below is measured in this session.
 ✓ Phase 3: Terminal invocation surface — fully implemented
 ✓ Phase 4: `!`-site conformance suite — fully implemented
 ✓ Phase 5: A missing plugin root becomes a named error — fully implemented
-⚠️ Closing step (`mise.local.toml` removal) — not done, and correctly so: its
-stated precondition (a prerelease carrying the Phase 1a fix installed and in
-use) is not met. `1.24.0-pre.16` is still the installed plugin. Two of its five
-automated criteria are however *already* satisfied — see *Deviations*.
+✓ Closing step (`mise.local.toml` removal) — **done 2026-07-29**, every criterion
+performed. The file was already absent when the deletion was attempted (removed
+alongside the `1.24.0-pre.17` install, outside this session), and `mise env` now
+exports no plugin root. Details under *Closing Step Results*.
+
+**The installed artifact is the Phase 1a-only release**, which is the plan's
+independent-releasability claim confirmed in the field rather than argued:
+`1.24.0-pre.17`'s `bin/accelerator` carries the self-location block
+(`BASH_SOURCE`, `max_hops=16`, `export ACCELERATOR_PLUGIN_ROOT`) **and** the
+transitional `export CLAUDE_PLUGIN_ROOT` at `:116` that Phase 1b deletes — so it
+predates 1b, and it works because the shipped launcher still reads the old name.
+Phase 3's hook is absent from it, which is why those checks cannot yet run.
 
 Sixteen commits carry the work (`nstyplkt`…`pnynskrr` plus the pre-existing-flake
 fix), one more than the plan's progress table records.
+
+### Closing Step Results
+
+Performed 2026-07-29, after `1.24.0-pre.17` was installed.
+
+✓ `test ! -e mise.local.toml` — the file was **already gone** when deletion was
+  attempted (`rm` reported "No such file or directory"), removed outside this
+  session alongside the plugin update. `mise env` exports no plugin root.
+✓ `.gitignore:26` carries the entry, and the file is absent from `main`.
+✓ Shell suites with **no ambient root**: `test:integration:work` 404 assertions
+  pass, `test:integration:config` 1692, each exit 0. Run as two separate
+  invocations — a single `mise run a b` passes `b` as an *argument* to `a`, which
+  fails with invoke's "No idea what … is!" rather than running the second task.
+✓ `mise run` (bare default) exits 0 end-to-end under
+  `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT`, with all three
+  `cli/`-scoped guards executing and the formatters changing nothing.
+⚠️ An earlier full run of the same commit failed `test:integration:config` on a
+  teardown race in the Playwright executor cases — `rm: … Directory not empty` on
+  the fixture's `.accelerator/tmp`. Not root-related and not caused by the
+  deletion: that suite passed standalone both before and after, and green inside
+  the clean run. It belongs to the recorded config-suite flake class. Worth its
+  own item if it recurs, since it turns a full local run red at random.
+✓ Two CLI-invoking skills load against installed `1.24.0-pre.17` with no error
+  and no permission prompt: `list-work-items` (injections populated — `meta/work`,
+  `linear`, the work-item template) and `paths` (all 14 configured paths
+  resolved). Non-empty injections are what distinguishes a real read from a
+  `--fail-safe` degradation.
+
+  **Caveat on that last one.** This session's own environment still carries a
+  stale `CLAUDE_PLUGIN_ROOT` pointing at `1.24.0-pre.16`, inherited at session
+  start, so the `!` shells did see one. It is provably inert — the executed path
+  is `pre.17`'s own bootstrap, whose only mention of the variable is the
+  transitional `export` at `:116`, with no read anywhere — but the unconfounded
+  version of this check is a session started outside this repository's mise
+  context. Worth doing once; it is the only check here resting on an argument
+  rather than on an isolated environment.
 
 ### Automated Verification Results
 
 ✓ `mise run` (bare default) exits 0 end-to-end — the full local CI mirror, run
   to completion in this session. Working copy is still empty afterwards, so the
   in-place formatters had nothing to change.
-✓ `mise run cli:check` exits 0 — run separately, because the bare default does
-  **not** reach it (see *Potential Issues*). `lint:claude-coupling:check`
-  completes in 228ms.
+✓ `mise run cli:check` exits 0. At the time of the first pass this had to be run
+  separately, because the bare default did **not** reach it; the wiring described
+  under *Potential Issues* has since fixed that, and the clean closing-step run
+  shows all three guards executing inside `mise run`.
+  `lint:claude-coupling:check` completes in 228ms.
 ✓ The `CLAUDE_*` guard is clean and its scope is intact: `_in_scope()` discovers
   **724** files and `violations(REPO_ROOT)` returns `[]` — reproduced directly,
   matching the plan's measurement exactly.
 ✓ Suite counts, all from the full run: `test:integration:entrypoint` 46 passed ·
   `test:integration:hooks` 22 passed · `test:integration:skill-invocation` 128
-  passed · `test:unit:tasks` 406 passed · `test:integration:tasks` 51 passed ·
+  passed · `test:unit:tasks` 406 passed, 409 after the guard-wiring cases ·
+  `test:integration:tasks` 51 passed ·
   `test:integration:deny` 15 passed · `test:integration:dev` 17 passed ·
   `test:unit:cli` green (89.12% line coverage) · all shell suites (`config`,
   `work`, `migrate`, `integrations`, `decisions`, `github`) green · frontend
@@ -206,14 +257,31 @@ Nothing failed. No automated criterion in the plan was found to be overstated.
 
 ### Manual Testing Required:
 
-The plan's own deferrals stand, unchanged and correctly reasoned — all of them
-need the fix to be *installed*, and `1.24.0-pre.16` predates it:
+Phase 1a's deferrals are **discharged**; Phase 3's still stand, because the hook
+is not in the installed artifact.
 
-1. Release-candidate checks (Phase 1a, Phase 3):
-  - [ ] `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT ./bin/accelerator config templates list`
-        exits 0 and lists an `adr` row with Source `plugin default`, against a
-        published release (it 404s until then, and would write into the shipped
-        `bin/`).
+1. Phase 1a, performed 2026-07-29 against installed `1.24.0-pre.17`, invoked by
+   absolute path from a bare `mktemp -d` with **both** root variables stripped:
+  - [x] `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT <root>/bin/accelerator config templates list`
+        exits 0 and renders
+        `` | `adr` | plugin default | `<plugin>/templates/adr.md` | `` — a real
+        plugin-default row, not the empty table this bug produced — with **zero**
+        `accelerator:` lines on stderr.
+  - [x] The originally reported failing command,
+        `config instructions commit --fail-safe`, exits 0 with no `accelerator:`
+        diagnostic. Empty stdout is correct here, as the plan records.
+  - [x] The genuine fetch → verify → cache chain ran against the real release:
+        `bin/accelerator-launcher-1.24.0-pre.17-darwin-arm64` and its `.minisig`
+        are cached in the installed tree, and no
+        `.accelerator-unverified.log` exists — so nothing degraded to an
+        unverified path.
+
+2. Phase 3, still deferred — `hooks/launcher-link-refresh.sh` is **absent** from
+   `1.24.0-pre.17`, so a release carrying Phase 3 is needed. Current machine
+   state, recorded as the pre-condition baseline: `${CLAUDE_PLUGIN_DATA}` resolves
+   to `~/.claude/plugins/data/accelerator-atomic-innovation-prerelease/` (the
+   `data/<plugin>-<marketplace>` shape the documentation describes as *typical*),
+   it holds no `bin/`, and there is no `~/.local/bin/accelerator`.
   - [ ] In a real session the hook fires at `SessionStart` and
         `${CLAUDE_PLUGIN_DATA}/bin/accelerator` resolves to the current
         installation.
@@ -226,11 +294,12 @@ need the fix to be *installed*, and `1.24.0-pre.16` predates it:
   - [ ] Removing the plugin leaves only the dangling plugin-owned link inside
         `${CLAUDE_PLUGIN_DATA}`.
 
-2. Closing step, once a prerelease carrying Phase 1a is installed:
-  - [ ] Delete `mise.local.toml`, then `mise run test:integration:work
-        test:integration:config` and a bare `mise run` still exit 0.
-  - [ ] `/accelerator:commit` and one other CLI-invoking skill load against the
-        **installed** plugin with no error and no permission prompt.
+3. Closing step — **done**, see *Closing Step Results* above. One optional
+   follow-up remains:
+  - [ ] Re-confirm a CLI-invoking skill load from a Claude Code session whose
+        environment carries no `CLAUDE_PLUGIN_ROOT` at all (start it outside this
+        repository's mise context), so the check rests on isolation rather than
+        on the inertness argument.
 
 ### Recommendations:
 
@@ -245,9 +314,14 @@ need the fix to be *installed*, and `1.24.0-pre.16` predates it:
   than ticketing; see *Potential Issues*. Note this deliberately overrides the
   plan's Phase 2 argument against dual-wiring (which reasoned from `cli:check`
   being what CI runs, and did not weigh the bare `default` task's blindness).
-- **Do not flip the plan to `done` yet.** The closing step and the
-  release-candidate manual set are real remaining deliverables with an external
-  precondition; `in-progress` is the accurate status until a prerelease carrying
-  Phase 1a is installed and those checks are performed.
+- ~~Do the closing step~~ — **done in this pass**, all five automated and both
+  manual criteria performed; see *Closing Step Results*.
+- **Do not flip the plan to `done` yet.** Phase 3's five checks still need a
+  release carrying `hooks/launcher-link-refresh.sh`, which `1.24.0-pre.17` does
+  not have; `in-progress` stays accurate until then. That, plus the optional
+  clean-session skill load, is all that is left.
+- **Consider an item for the config-suite teardown race** if it recurs — it turned
+  one full local run red at random during this pass, and a flake in the gate that
+  defines "done" costs more than its size suggests.
 - Optionally, make `dir` local in `dir_of()` while `bin/accelerator` is still
   fresh in mind.

--- a/meta/work/0182-cli-derives-plugin-root-from-own-location.md
+++ b/meta/work/0182-cli-derives-plugin-root-from-own-location.md
@@ -5,13 +5,13 @@ title: "bin/accelerator requires CLAUDE_PLUGIN_ROOT in the environment (never ex
 date: "2026-07-26T21:28:26+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: ready
+status: in-progress
 kind: bug
 priority: high
-relates_to: ["work-item:0164", "work-item:0167", "work-item:0136", "work-item:0183", "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface"]
+relates_to: ["work-item:0164", "work-item:0167", "work-item:0136", "work-item:0183", "work-item:0184", "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface"]
 source: "issue-research:2026-07-26-cli-requires-claude-plugin-root-env-var"
 tags: [bug, cli, launcher, bootstrap, plugin-root, skills]
-last_updated: "2026-07-28T09:14:02+00:00"
+last_updated: "2026-07-29T00:00:00+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -455,7 +455,7 @@ still holds for the suites that need a real compiled launcher.
       still resolve under the real installation root and no row resolves under the
       injected path. (Consistent with R4, which no longer relies on the bootstrap
       honouring an ambient root at all.)
-- [ ] Given the R4 seam is re-pointed at `ACCELERATOR_BIN="/nonexistent/accelerator"`,
+- [x] Given the R4 seam is re-pointed at `ACCELERATOR_BIN="/nonexistent/accelerator"`,
       when the four assertions in `test-work-item-scripts.sh` run, then they still
       exercise the hardcoded-fallback path in
       `work-item-template-field-hints.sh` — demonstrated by their failing if that
@@ -466,24 +466,44 @@ still holds for the suites that need a real compiled launcher.
       pre-verified binary the bootstrap uses to check the launcher's signature),
       when `--fail-safe` is in argv, then the bootstrap exits 0 with empty stdout
       and one diagnostic line on stderr; without the flag it exits non-zero.
-- [ ] Given `hooks/shim-refresh.sh` is run with `CLAUDE_PLUGIN_DATA=<tmp>/data`
+**Met 2026-07-29** — the hook criteria below are satisfied by
+`tests/integration/hooks/test_launcher_link_refresh.py` (22 cases). Two naming
+deviations from this list, both settled during implementation: the hook ships as
+`hooks/launcher-link-refresh.sh`, not `shim-refresh.sh`; and "prints that
+refreshed path" is narrowed to the **re-point** case — a first refresh is silent
+on both channels, since the resolved Open Question above establishes that a
+routine `SessionStart` stderr line reaches nobody, so only a *change* of target
+is worth naming.
+
+- [x] Given `hooks/shim-refresh.sh` is run with `CLAUDE_PLUGIN_DATA=<tmp>/data`
       and `CLAUDE_PLUGIN_ROOT=<tmp>/v1`, then `<tmp>/data/bin/accelerator` is a
       symlink to `<tmp>/v1/bin/accelerator` and the hook prints that refreshed
       path; when re-run with `CLAUDE_PLUGIN_ROOT=<tmp>/v2` it re-points there,
       and a pre-existing `<tmp>/userbin/accelerator → <tmp>/data/bin/accelerator`
       link — whose own target did not move — still executes.
-- [ ] Given `hooks/shim-refresh.sh` is run with `CLAUDE_PLUGIN_DATA` unset, then
+      (`test_a_first_refresh_creates_the_link_and_says_nothing` and
+      `test_a_second_root_repoints_the_link_and_names_both`, the latter executing
+      the user's own hop after the re-point.)
+- [x] Given `hooks/shim-refresh.sh` is run with `CLAUDE_PLUGIN_DATA` unset, then
       it exits 0 and creates nothing (in particular no `/bin` entry).
-- [ ] Given `hooks/shim-refresh.sh` alone is run with `HOME` and
+      (`test_an_unset_plugin_data_is_inert`, plus
+      `test_a_relative_plugin_data_is_inert` for a value that would compose a
+      cwd-relative path.)
+- [x] Given `hooks/shim-refresh.sh` alone is run with `HOME` and
       `CLAUDE_PLUGIN_DATA` pointed into a temp tree, when that tree is snapshotted
       before and after and diffed, then the only paths created or modified lie
       inside `${CLAUDE_PLUGIN_DATA}`, and `<HOME>/.local/bin` does not exist.
       (Scoped to this hook alone — the other `SessionStart` hooks legitimately
       write config and migration state elsewhere.)
-- [ ] No tracked source file under `cli/` contains the string `CLAUDE_`, as
+      (`test_nothing_outside_plugin_data_is_created_or_modified`.)
+- [x] No tracked source file under `cli/` contains the string `CLAUDE_`, as
       enforced by the R7 lint task (honouring `.gitignore`, so `cli/target/` and
       `cli/visualiser/frontend/node_modules/` are excluded), and that guard has a
       negative test proving it fails when a reference is reintroduced.
+      **Met 2026-07-29**: `mise run lint:claude-coupling:check` (28 packages,
+      clean) with `tests/unit/tasks/test_claude_coupling.py` carrying the negative
+      cases — a `var_os` read, a comment mention, any `CLAUDE_`-prefixed name, and
+      reintroduction into both the bootstrap and an out-of-tree writer.
 - [ ] `mise.local.toml` is absent from the repo, and `grep -rl
       'CLAUDE_PLUGIN_ROOT'` over the working tree (honouring `.gitignore`)
       returns **only**: `hooks/**`, `scripts/interactive-harness.sh`,
@@ -503,17 +523,27 @@ still holds for the suites that need a real compiled launcher.
       `_BARE_LAUNCHER` probe — the matcher *model*, which is why R7 is a separate
       guard), `.shellcheckrc:51` and `CLAUDE.md:65` (comment and prose); and it
       listed `agents/**`, which has **zero** occurrences.
-- [ ] The renamed diagnostics name `ACCELERATOR_PLUGIN_ROOT`, asserted by the
+- [x] The renamed diagnostics name `ACCELERATOR_PLUGIN_ROOT`, asserted by the
       existing message-text tests at `launcher/tests/version.rs:179` and
-      `cache_root.rs:132,134`.
-- [ ] `hooks/hooks.json` registers `shim-refresh.sh` as a `SessionStart` entry
+      `cache_root.rs:132,134`. Both were **tightened further** on 2026-07-29: the
+      config layer's new `PluginRootUnavailable` also names the variable, so a
+      variable-name-only assertion no longer distinguishes the cache-root step
+      from it. Each now additionally matches `no ACCELERATOR_CACHE_DIR override
+      was given`, a clause only `CacheRootUnavailable` emits.
+- [x] `hooks/hooks.json` registers `shim-refresh.sh` as a `SessionStart` entry
       (without it the hook never fires and R9's upgrade-survival property is
       absent, while every other hook criterion — which invokes the script
-      directly — would still pass).
-- [ ] `docs/internals.md` contains a "Terminal invocation" section stating the
+      directly — would still pass). **Met 2026-07-29**, as
+      `launcher-link-refresh.sh` at index 3 — appended, so
+      `test-vcs-detect.sh`'s hard-coded `SessionStart[0]` assertion still holds —
+      and asserted by `test_the_hook_is_a_session_start_group` and
+      `test_the_group_holds_exactly_one_command_hook`.
+- [x] `docs/internals.md` contains a "Terminal invocation" section stating the
       one-line `ln -s` recipe, the macOS `~/.local/bin`-not-on-`PATH` caveat, the
       per-channel shim paths with the second-channel note, and the mid-session
       upgrade caveat; and the Documentation list in `README.md` links to it.
+      **Met 2026-07-29** as "Terminal Invocation" (`docs/internals.md:88`),
+      linked from `README.md:58`.
 - [x] R11's result is recorded in this item's Open Questions, naming the Claude
       Code version tested (v2.1.220) and its basis. **Met 2026-07-27.**
 - [x] R12's floor determination is recorded, and either the declared floor is
@@ -524,7 +554,7 @@ still holds for the suites that need a real compiled launcher.
       decision was not to introduce one, so those two sites are the target rather
       than `plugin.json`. **Met 2026-07-28**: the variable landed in v2.1.78, so
       the floor is unchanged and both prose sites are untouched.
-- [ ] **Automated** — every `bin/accelerator config *` command extracted from a
+- [x] **Automated** — every `bin/accelerator config *` command extracted from a
       `!` block in any `skills/**/SKILL.md` exits 0 **and** emits no
       `accelerator:` diagnostic line on stderr, with a per-family stdout
       assertion (below). The harness performs Claude Code's own textual
@@ -556,6 +586,17 @@ still holds for the suites that need a real compiled launcher.
         `skill_permissions.py` point 3). Note the 20 `config template <name>`
         sites are **fail-closed regardless** of that flag (R4), so they are the
         subset that stays loud rather than degrading.
+
+      **Met 2026-07-29** by `tests/integration/skill-invocation/` (128 cases: 122
+      distinct commands plus 6 corpus invariants), run as
+      `mise run test:integration:skill-invocation`. Three counts above are off, as
+      measured during implementation: **13** distinct `template <name>` commands
+      (19 occurrences), not 20; there is **no** `templates list` command in the
+      corpus at all; and a `config agent <name>` family is missing from the list.
+      The totals — 204 commands, 122 distinct, 45 files, 42 injection skills each
+      way — are exact. Better than predicted: **every** one of the 122 renders
+      non-empty stdout against the fixture, so no family needs an empty-tolerant
+      assertion.
 - [ ] **Manual, pre-release** — on a clean install of the release artifact, with
       no `mise.local.toml` and neither variable exported into the shell, in
       permission mode `default` with no broad Bash allow rules: invoke
@@ -569,9 +610,15 @@ still holds for the suites that need a real compiled launcher.
       If a prompt appears, the `${CLAUDE_SKILL_DIR}` migration item is raised and
       the **prerelease** is gated on it (see Dependencies — this item still closes
       on its own criteria).
-- [ ] `mise run` (bare default task) exits 0 end-to-end.
-- [ ] The regression test from R5 fails against the current `bin/accelerator` and
-      passes after the fix.
+- [x] `mise run` (bare default task) exits 0 end-to-end. **Met 2026-07-29** with
+      every phase landed.
+- [x] The regression test from R5 fails against the current `bin/accelerator` and
+      passes after the fix. **Met 2026-07-28**: confirmed at the intermediate
+      commit with the bootstrap change stashed — 18 of the new entrypoint cases
+      red, every one with `accelerator: CLAUDE_PLUGIN_ROOT is not set`. The three
+      that pass pre-change are the ones predicted: the symlink-cycle case (which
+      characterises the kernel's `ELOOP`) and the two scan-window cases (a gate
+      fires either way).
 
 ## Open Questions
 

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -1,0 +1,104 @@
+---
+type: work-item
+id: "0184"
+title: "template_names succeeds-with-nothing on a plugin root that is not an installation"
+date: "2026-07-29T00:00:00+00:00"
+author: Toby Clemson
+producer: implement-plan
+status: draft
+kind: bug
+priority: low
+relates_to: ["work-item:0182"]
+tags: [bug, cli, config, templates, plugin-root]
+last_updated: "2026-07-29T00:00:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0184: template_names succeeds-with-nothing on a plugin root that is not an installation
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Low
+**Author**: Toby Clemson
+
+## Summary
+
+`FileConfigStore::template_names`
+([`cli/config-adapters/src/store.rs`](../../cli/config-adapters/src/store.rs))
+now refuses when the plugin root is *unknown*, but still succeeds with an empty
+list when the root is *known and wrong*:
+
+```rust
+let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
+    return Ok(Vec::new());
+};
+```
+
+That arm swallows every `read_dir` failure alike — a root pointing at a
+directory that is not an Accelerator installation, a root pointing at a deleted
+path, and a genuine permission or I/O error. The observable is a header-only
+`config templates list` table at exit 0: the same silent-wrong-answer mode 0182
+closed for the unknown-root case, surviving one step further out.
+
+## Context
+
+0182 Phase 5 converted a missing root into `ConfigError::PluginRootUnavailable`
+at the three plugin-content consumers, and deliberately left this arm alone so
+the phase stayed scoped to the root's *presence*. The surviving behaviour is
+pinned as a characterisation test —
+`a_root_without_a_templates_directory_still_renders_an_empty_table` in
+`cli/launcher/tests/config_read.rs` — so it is visible rather than implicit, and
+that test is what this item would change.
+
+A wrong root became newly plausible in the same change: the bootstrap derives
+the root from its own location, and a directly-invoked launcher passes no
+`plugin.json` gate that would catch a root pointing somewhere unexpected.
+
+## Requirements
+
+- Distinguish the `read_dir` failure kinds instead of collapsing them:
+  `ErrorKind::NotFound` (the root carries no `templates/` directory, so it is
+  not an installation) becomes `ConfigError::PluginRootUnavailable`; every other
+  error becomes `ConfigError::Io` naming the path, matching the treatment the
+  other enumerators in this file already give (`custom_lenses`, `skill_names`).
+- Decide whether the same reasoning applies to `resolve_template`'s
+  plugin-default tier and to `plugin_template_path`, which today test
+  `is_file()` and fall through — a wrong root there yields "not found" for every
+  template name, which is a better message than an empty table but still names
+  the template rather than the root.
+- Keep the root-independent families and project-local overrides working: a
+  wrong root must not break `config template <name>` when a user override
+  resolves, which is the property
+  `a_user_override_still_resolves_with_no_plugin_root` pins for the absent-root
+  case.
+
+## Acceptance Criteria
+
+- [ ] `config templates list` against a root that exists but carries no
+      `templates/` directory exits non-zero with a diagnostic naming
+      `ACCELERATOR_PLUGIN_ROOT`, replacing the header-only table at exit 0.
+- [ ] A genuine I/O failure on a present `templates/` directory (e.g. mode
+      `0o000`) yields a `ConfigError::Io` naming the path, not the plugin-root
+      refusal — the two are distinguishable from the message alone.
+- [ ] The characterisation test named above is replaced by its inverse rather
+      than deleted, so the change of behaviour is recorded at the same site.
+- [ ] A user override still resolves against a wrong root.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- Blocked by: 0182 (introduces `PluginRootUnavailable` and the two named
+  accessors this builds on).
+
+## Assumptions
+
+- Every Accelerator installation ships a `templates/` directory, so its absence
+  is a reliable signal that the root is not an installation. Worth confirming
+  against the release artifact's file list before relying on it.
+
+## References
+
+- `meta/work/0182-cli-derives-plugin-root-from-own-location.md`
+- `meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md`
+  — Phase 5 §3, "What this does and does not buy"

--- a/mise.toml
+++ b/mise.toml
@@ -404,9 +404,14 @@ description = "Guard against regressing to the bash config cluster: no SKILL.md 
 depends = ["deps:install:python"]
 run = "invoke lint.call-site-migration.check"
 
+[tasks."lint:claude-coupling:check"]
+description = "Guard the rename set (cli/, bin/accelerator, the dev-env writers) against naming any CLAUDE_* variable"
+depends = ["deps:install:python"]
+run = "invoke lint.claude-coupling.check"
+
 [tasks."cli:check"]
 description = "Run all cli/ workspace format and lint checks (workspace-wide rustfmt + clippy + vendored-shim drift guard; read-only, no tests)"
-depends = ["format:cli:check", "lint:cli:check", "lint:vendor-shims:check", "lint:store-duplication:check"]
+depends = ["format:cli:check", "lint:cli:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check"]
 
 [tasks."deny:check"]
 description = "Check the cli/ workspace dependency graph with cargo-deny (advisories, licenses, bans, sources)"

--- a/mise.toml
+++ b/mise.toml
@@ -181,6 +181,11 @@ description = "Run bin/accelerator entry-point tests (stubbed fetch, real minisi
 depends = ["deps:install:python"]
 run = "invoke test.integration.entrypoint"
 
+[tasks."test:integration:skill-invocation"]
+description = "Extract every bin/accelerator config !-site command from skills/**/SKILL.md and run it through the real bootstrap with an empty environment"
+depends = ["deps:install:python"]
+run = "invoke test.integration.skill-invocation"
+
 [tasks."test:integration:config"]
 description = "Run config integration tests"
 depends = ["build:cli:dev"]
@@ -231,6 +236,7 @@ depends = [
     "test:integration:visualiser",
     "test:integration:dev",
     "test:integration:entrypoint",
+    "test:integration:skill-invocation",
     "test:integration:config",
     "test:integration:deny",
     "test:integration:decisions",

--- a/mise.toml
+++ b/mise.toml
@@ -459,7 +459,7 @@ depends = ["format:frontend:check", "lint:frontend:check", "types:frontend:check
 
 [tasks."lint:check"]
 description = "Run all lint checks"
-depends = ["lint:frontend:check", "lint:server:check", "lint:cli:check", "lint:build-system:check", "lint:scripts:check", "lint:skill-permissions:check", "lint:call-site-migration:check"]
+depends = ["lint:frontend:check", "lint:server:check", "lint:cli:check", "lint:build-system:check", "lint:scripts:check", "lint:skill-permissions:check", "lint:call-site-migration:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check"]
 
 [tasks."lint:fix"]
 description = "Apply all safe lint fixes (shell has no autofixer — run `mise run scripts:check` for remaining shell findings)"

--- a/skills/visualisation/visualise/SKILL.md
+++ b/skills/visualisation/visualise/SKILL.md
@@ -156,9 +156,9 @@ visualiser:
 ---
 ```
 
-To run the visualiser from a terminal, symlink the accelerator CLI onto
-your `$PATH` and invoke `accelerator visualiser [stop | status]`:
-
-**Install command**: !`printf 'ln -s "%s" "%s"' "${CLAUDE_PLUGIN_ROOT}/bin/accelerator" "$HOME/.local/bin/accelerator"`
+To run the visualiser from a terminal, link the accelerator CLI onto your
+`$PATH` and invoke `accelerator visualiser [stop | status]`. The link is a
+two-hop chain so it survives plugin upgrades — see the Terminal Invocation
+section of `docs/internals.md` for the setup steps.
 
 !`${CLAUDE_PLUGIN_ROOT}/bin/accelerator config instructions visualise --fail-safe`

--- a/skills/work/scripts/test-work-item-scripts.sh
+++ b/skills/work/scripts/test-work-item-scripts.sh
@@ -1044,13 +1044,12 @@ OUTPUT=$(cd "$REPO" && bash "$FIELD_HINTS" status)
 EXPECTED=$(printf "open\nclosed\nwontfix")
 assert_eq "returns custom status values" "$EXPECTED" "$OUTPUT"
 
-# Test 6: config-read-template failure → hardcoded fallback for known fields
+# Test 6: CLI failure → hardcoded fallback for known fields
 echo "Test: Template read failure falls back to hardcoded defaults"
-# Create a repo with no template at all and set PLUGIN_ROOT to a nonexistent
-# plugin to force config-read-template.sh to fail
+# A repo with no template of its own, with ACCELERATOR_BIN pointed at a path
+# that does not exist so the template read fails.
 REPO=$(setup_repo)
-# Override PLUGIN_ROOT to simulate failure — run in subshell with modified env
-OUTPUT=$(cd "$REPO" && CLAUDE_PLUGIN_ROOT="/nonexistent/plugin" bash "$FIELD_HINTS" status 2>/dev/null) || true
+OUTPUT=$(cd "$REPO" && ACCELERATOR_BIN="/nonexistent/accelerator" bash "$FIELD_HINTS" status 2>/dev/null) || true
 EXPECTED=$(printf "draft\nready\nin-progress\nreview\ndone\nblocked\nabandoned")
 assert_eq "returns hardcoded status values" "$EXPECTED" "$OUTPUT"
 
@@ -1083,7 +1082,7 @@ while IFS= read -r token; do
   token=$(echo "$token" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   [ -n "$token" ] && SHIPPING_VALUES="${SHIPPING_VALUES}${SHIPPING_VALUES:+$'\n'}${token}"
 done < <(echo "$STATUS_COMMENT" | tr '|' '\n')
-HARDCODED_VALUES=$(cd /tmp && CLAUDE_PLUGIN_ROOT="/nonexistent" bash "$FIELD_HINTS" status 2>/dev/null) || true
+HARDCODED_VALUES=$(cd /tmp && ACCELERATOR_BIN="/nonexistent/accelerator" bash "$FIELD_HINTS" status 2>/dev/null) || true
 assert_eq "hardcoded status matches shipping template" "$SHIPPING_VALUES" "$HARDCODED_VALUES"
 
 KIND_LINE=$(grep "^kind:" "$SHIPPING_TEMPLATE")
@@ -1093,7 +1092,7 @@ while IFS= read -r token; do
   token=$(echo "$token" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   [ -n "$token" ] && SHIPPING_VALUES="${SHIPPING_VALUES}${SHIPPING_VALUES:+$'\n'}${token}"
 done < <(echo "$KIND_COMMENT" | tr '|' '\n')
-HARDCODED_VALUES=$(cd /tmp && CLAUDE_PLUGIN_ROOT="/nonexistent" bash "$FIELD_HINTS" kind 2>/dev/null) || true
+HARDCODED_VALUES=$(cd /tmp && ACCELERATOR_BIN="/nonexistent/accelerator" bash "$FIELD_HINTS" kind 2>/dev/null) || true
 assert_eq "hardcoded kind matches shipping template" "$SHIPPING_VALUES" "$HARDCODED_VALUES"
 
 PRIORITY_LINE=$(grep "^priority:" "$SHIPPING_TEMPLATE")
@@ -1103,8 +1102,30 @@ while IFS= read -r token; do
   token=$(echo "$token" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
   [ -n "$token" ] && SHIPPING_VALUES="${SHIPPING_VALUES}${SHIPPING_VALUES:+$'\n'}${token}"
 done < <(echo "$PRIORITY_COMMENT" | tr '|' '\n')
-HARDCODED_VALUES=$(cd /tmp && CLAUDE_PLUGIN_ROOT="/nonexistent" bash "$FIELD_HINTS" priority 2>/dev/null) || true
+HARDCODED_VALUES=$(cd /tmp && ACCELERATOR_BIN="/nonexistent/accelerator" bash "$FIELD_HINTS" priority 2>/dev/null) || true
 assert_eq "hardcoded priority matches shipping template" "$SHIPPING_VALUES" "$HARDCODED_VALUES"
+
+# Test 9: The seam is provably what forces the fallback. Against a repo whose
+# own template carries values no fallback can produce, the seam still yields
+# the hardcoded set and a working CLI yields the override's.
+echo "Test: Seam forces the fallback against a distinguishable template"
+REPO=$(setup_repo)
+mkdir -p "$REPO/.accelerator/templates"
+cat >"$REPO/.accelerator/templates/work-item.md" <<'FIXTURE'
+---
+work_item_id: NNNN
+status: draft                                  # alpha | beta | gamma
+---
+
+# NNNN: Title
+FIXTURE
+OUTPUT=$(cd "$REPO" && ACCELERATOR_BIN="/nonexistent/accelerator" bash "$FIELD_HINTS" status 2>/dev/null) || true
+EXPECTED=$(printf "draft\nready\nin-progress\nreview\ndone\nblocked\nabandoned")
+assert_eq "seam forces the hardcoded fallback" "$EXPECTED" "$OUTPUT"
+
+OUTPUT=$(cd "$REPO" && bash "$FIELD_HINTS" status)
+EXPECTED=$(printf "alpha\nbeta\ngamma")
+assert_eq "a working CLI reads the override" "$EXPECTED" "$OUTPUT"
 
 echo ""
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -29,7 +29,11 @@ members join enforcement with no per-member wiring. `format:cli:*` and
 rust `components` field is silently skipped for an already-present toolchain, so
 rustfmt/clippy are provisioned explicitly. `lint:cli:fix` applies only clippy's
 machine-rewritable subset (lints such as `unwrap_used` cannot be auto-fixed), so
-`cli:check` must still be run for the remainder. Beyond `cli:check`, Rust
+`cli:check` must still be run for the remainder. It also folds three Python
+guards over the same tree — `lint:vendor-shims:check`,
+`lint:store-duplication:check` and `lint:claude-coupling:check` — which ride
+here rather than in `lint:check` because they are `cli/`-scoped and `cli:check`
+is what CI runs. Beyond `cli:check`, Rust
 enforcement also spans standalone entity tasks wired directly into the top-level
 `check` (they sit outside the `cli:` roll-up, mirroring `version:*` /
 `github:*`): `deny:check` (cargo-deny supply-chain) and `pup:check` (cargo-pup

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -31,9 +31,11 @@ rustfmt/clippy are provisioned explicitly. `lint:cli:fix` applies only clippy's
 machine-rewritable subset (lints such as `unwrap_used` cannot be auto-fixed), so
 `cli:check` must still be run for the remainder. It also folds three Python
 guards over the same tree — `lint:vendor-shims:check`,
-`lint:store-duplication:check` and `lint:claude-coupling:check` — which ride
-here rather than in `lint:check` because they are `cli/`-scoped and `cli:check`
-is what CI runs. Beyond `cli:check`, Rust
+`lint:store-duplication:check` and `lint:claude-coupling:check`. Those three are
+wired into `lint:check` as well: `cli:check` is what CI runs, but the bare
+`default` task depends on `lint:check` and not on `check`, so a `cli:check`-only
+guard stays green in a full local run however badly its invariant is broken.
+`tests/unit/tasks/test_mise.py` pins both placements. Beyond `cli:check`, Rust
 enforcement also spans standalone entity tasks wired directly into the top-level
 `check` (they sit outside the `cli:` roll-up, mirroring `version:*` /
 `github:*`): `deny:check` (cargo-deny supply-chain) and `pup:check` (cargo-pup

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -111,6 +111,9 @@ ns_lint.add_collection(
 ns_lint.add_collection(
     Collection.from_module(lint.call_site_migration)
 )  # lint.call-site-migration.check
+ns_lint.add_collection(
+    Collection.from_module(lint.claude_coupling)
+)  # lint.claude-coupling.check
 ns.add_collection(ns_lint)
 
 ns_types = Collection("types")

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -42,10 +42,10 @@ _DIAGNOSTIC_LOG = _DEV_DIR / "dev.log"
 def _server_env() -> dict[str, str]:
     """Env for the arbiter and the detached daemon.
 
-    The resolved PATH lets the daemon find node; CLAUDE_PLUGIN_ROOT lets the
-    Model-1 server resolve plugin templates.
+    The resolved PATH lets the daemon find node; ACCELERATOR_PLUGIN_ROOT lets
+    the Model-1 server resolve plugin templates.
     """
-    return {**os.environ, "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT)}
+    return {**os.environ, "ACCELERATOR_PLUGIN_ROOT": str(REPO_ROOT)}
 
 
 def _dev_deps(context: Context) -> DevDeps:

--- a/tasks/lint/__init__.py
+++ b/tasks/lint/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     build_system,
     call_site_migration,
+    claude_coupling,
     cli,
     frontend,
     scripts,
@@ -14,6 +15,7 @@ from . import (
 __all__ = [
     "build_system",
     "call_site_migration",
+    "claude_coupling",
     "cli",
     "frontend",
     "scripts",

--- a/tasks/lint/claude_coupling.py
+++ b/tasks/lint/claude_coupling.py
@@ -1,0 +1,108 @@
+"""Guard: no plugin entry point may require a ``CLAUDE_*`` variable.
+
+``CLAUDE_PLUGIN_ROOT`` is Claude Code's to define, and it is substituted into
+skill content rather than exported to the Bash tool or the ``!`` preprocessor.
+A launcher-layer reader of it therefore works only when some caller happens to
+have set it — which is what broke every CLI-invoking skill. The rename set —
+``cli/**``, the ``bin/accelerator`` entry point, and the four out-of-tree
+writers that feed those readers — names ``ACCELERATOR_PLUGIN_ROOT`` instead,
+and this makes that non-negotiable.
+
+Everything outside the rename set is out of scope by construction, not by
+exemption: the adapter layer (``hooks/``, ``skills/config/migrate/**``, the
+interactive harnesses), the Claude Code matcher model in
+``skill_permissions.py``, and the SKILL.md substitution tokens all legitimately
+name the variable. That is why there is no allowlist — the first exemption
+added under pressure could be the very file the bug was in.
+"""
+
+import re
+from pathlib import Path
+
+from invoke import Context, Exit, task
+
+from tasks.shared.sources import repo_root, walk_files
+
+_SHAPE = re.compile(r"CLAUDE_[A-Z0-9_]*")
+
+# Speed only; the correctness rule is the decode below.
+_SKIP_SUFFIXES = (".png", ".ico", ".woff2", ".lock", ".snap", ".bin")
+
+_SUBTREES = ("cli",)
+_FILES = (
+    "bin/accelerator",
+    "tasks/dev.py",
+    "tasks/shared/dev/circus.py",
+    "tasks/test/helpers.py",
+    "tests/integration/dev/dev_integration_driver.py",
+)
+
+# A silently-emptied scan reads as cleanliness in both the lint task and the
+# paired `violations(REPO_ROOT) == []` assertion, so the discovered set has a
+# floor. cli/ alone carries several hundred text files.
+_MIN_SCANNED = 200
+
+
+def _in_scope(root: Path) -> list[Path]:
+    """Absolute paths in the rename set, with unreadable suffixes skipped."""
+    paths: list[Path] = []
+    for subtree in _SUBTREES:
+        paths.extend(
+            root / rel
+            for rel in walk_files(root, subtree=subtree)
+            if not rel.endswith(_SKIP_SUFFIXES)
+        )
+    for rel in _FILES:
+        path = root / rel
+        if not path.is_file():
+            raise Exit(
+                f"{rel} is named in tasks/lint/claude_coupling.py but is not "
+                f"a file under {root} — it was renamed, moved or split, and "
+                f"has silently dropped out of the guard's scope",
+                code=1,
+            )
+        paths.append(path)
+    return paths
+
+
+def violations(root: Path, min_scanned: int = _MIN_SCANNED) -> list[str]:
+    """Repo-relative ``path:line:text`` for every CLAUDE_* reference in scope.
+
+    Files that cannot be decoded as UTF-8 are skipped: the rule is "in scope
+    unless it is unreadable as text", so a binary asset landing under ``cli/``
+    must not turn the check into a traceback.
+
+    ``min_scanned`` is lowered only by this guard's own tests, which build
+    deliberately tiny trees; the real-tree floor is ``_MIN_SCANNED``.
+    """
+    paths = _in_scope(root)
+    if len(paths) < min_scanned:
+        raise Exit(
+            f"only {len(paths)} files matched — scope discovery is broken "
+            f"(expected at least {min_scanned})",
+            code=1,
+        )
+    found: list[str] = []
+    for path in sorted(set(paths)):
+        try:
+            text = path.read_text(encoding="utf-8", errors="strict")
+        except UnicodeDecodeError:
+            continue
+        rel = path.relative_to(root).as_posix()
+        for number, line in enumerate(text.splitlines(), start=1):
+            if _SHAPE.search(line):
+                found.append(f"{rel}:{number}:{line.strip()}")
+    return found
+
+
+@task
+def check(context: Context) -> None:
+    """Fail if anything in the rename set names a CLAUDE_* variable."""
+    offenders = violations(repo_root())
+    if offenders:
+        raise Exit(
+            "the rename set must not name a CLAUDE_* variable — remove the "
+            "reference (see tasks/lint/claude_coupling.py for the "
+            "invariant):\n  " + "\n  ".join(offenders),
+            code=1,
+        )

--- a/tasks/lint/skill_permissions.py
+++ b/tasks/lint/skill_permissions.py
@@ -52,7 +52,9 @@ _CONFIG_MARKER = "/bin/accelerator config "
 _CONTEXT_SKILL = "/bin/accelerator config context --skill "
 _CONTEXT_ANY = "/bin/accelerator config context"
 _INSTRUCTIONS = "/bin/accelerator config instructions "
-_PLUGIN_PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
+# Public: the conformance suite substitutes this prefix the way Claude Code
+# does, and a second literal copy could desynchronise from this guard.
+PLUGIN_PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
 _NAME_TOKEN = re.compile(r"([a-z0-9][a-z0-9-]*)")
 
 
@@ -98,7 +100,7 @@ def preprocessor_commands(text: str) -> list[str]:
 
 def is_plugin_invocation(command: str) -> bool:
     """Return whether a command invokes a plugin script or the launcher."""
-    return command.startswith(_PLUGIN_PREFIX)
+    return command.startswith(PLUGIN_PREFIX)
 
 
 def covered_by(command: str, pattern: str) -> bool:

--- a/tasks/shared/dev/circus.py
+++ b/tasks/shared/dev/circus.py
@@ -40,9 +40,9 @@ def render_circus_ini(spec: ArbiterSpec) -> str:
 
     The server watcher runs ``serve`` from ``working_dir`` (the project root) so
     the Model-1 server discovers ``.accelerator/`` and reads config directly;
-    ``copy_env`` propagates ``CLAUDE_PLUGIN_ROOT`` (and the resolved PATH so npm
-    finds node) from the arbiter env. ``--owner-pid 0`` disables owner-based
-    auto-shutdown for the dev path.
+    ``copy_env`` propagates ``ACCELERATOR_PLUGIN_ROOT`` (and the resolved PATH
+    so npm finds node) from the arbiter env. ``--owner-pid 0`` disables
+    owner-based auto-shutdown for the dev path.
 
     Logging note (forced by the server binary): the Rust server initialises
     ``tracing`` to its composed log path (``<project>/.accelerator/tmp/

--- a/tasks/shared/sources.py
+++ b/tasks/shared/sources.py
@@ -1,22 +1,29 @@
 """Shared source-file discovery for the format and lint task families.
 
-Both families scan an identical set of shell files (`*.sh`, minus `workspaces/`
-(jj checkouts), plus the explicitly-listed extensionless CLI script) so format
-and lint never disagree about what is in scope.
+`walk_files` is the shared traversal: a gitignore-honouring walk that prunes
+ignored and build-output directories in place. Suffix filtering, subtree scoping
+and per-caller keep rules stay with the callers, so one function does not become
+the single point of change for several unrelated discovery policies.
 
-Discovery is a filesystem walk that honours the repository-root `.gitignore`,
-deliberately VCS-agnostic: `git ls-files` is blind inside a jj workspace (git
-resolves to the parent repo, whose index does not track the workspace), which
-silently emptied the scan and let unformatted scripts reach CI. A plain walk
-behaves identically under git checkouts (CI) and jj workspaces (local).
+Discovery is a filesystem walk rather than a VCS query, deliberately: `git
+ls-files` is blind inside a jj workspace (git resolves to the parent repo, whose
+index does not track the workspace), which silently emptied the scan and let
+unformatted scripts reach CI. A plain walk behaves identically under git
+checkouts (CI) and jj workspaces (local).
 
-Only the root `.gitignore` is honoured, not nested ones — sufficient here
-because every ignored shell script lives under a root-ignored tree (e.g.
-`node_modules/`). Revisit with per-directory spec layering if a nested
-`.gitignore` ever needs to hide a `.sh` file.
+Only the root `.gitignore` is honoured, not nested ones. That is why `prune`
+carries build output the root file misses: `dist/` and `playwright-report/` are
+ignored only by `cli/visualiser/frontend/.gitignore` (the root file's `/dist/`
+is root-anchored), and `.venv` is ignored nowhere. Revisit with per-directory
+spec layering if a nested `.gitignore` ever needs to hide a source file.
+
+`shell_sources` layers the shell policy on top: `*.sh`, minus `workspaces/` (jj
+checkouts), plus the explicitly-listed extensionless CLI script, so format and
+lint never disagree about what is in scope.
 """
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pathspec
@@ -48,6 +55,49 @@ def _ignore_spec(repo: Path) -> pathspec.GitIgnoreSpec:
     return pathspec.GitIgnoreSpec.from_lines(lines)
 
 
+_BUILD_OUTPUT = (
+    "dist",
+    ".venv",
+    "node_modules",
+    "playwright-report",
+    "coverage",
+)
+
+
+def walk_files(
+    repo: Path,
+    subtree: str | None = None,
+    prune: tuple[str, ...] = _BUILD_OUTPUT,
+) -> Iterator[str]:
+    """Repo-relative paths, gitignore-honouring, pruning ignored dirs in place.
+
+    The ignore spec is always read from ``repo`` and matched repo-relative,
+    whatever ``subtree`` scopes the walk to — the root ``.gitignore``'s entries
+    are root-anchored (``cli/target/``), so reading a spec at a subtree would
+    silently match nothing.
+
+    ``prune`` names directories to skip wherever they appear, and it *replaces*
+    the default rather than adding to it, so a caller sees exactly what it gets.
+    To keep the defaults and add to them, pass ``_BUILD_OUTPUT + (...)``.
+    """
+    spec = _ignore_spec(repo)
+    start = repo / subtree if subtree else repo
+    for dirpath, dirnames, filenames in os.walk(start):
+        rel_dir = Path(dirpath).relative_to(repo)
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d not in prune
+            and not spec.match_file(
+                f"{d}/" if rel_dir == Path() else f"{rel_dir / d}/"
+            )
+        ]
+        for filename in filenames:
+            rel = filename if rel_dir == Path() else str(rel_dir / filename)
+            if not spec.match_file(rel):
+                yield rel
+
+
 # The plugin entry point is a bash script with no .sh extension (Claude Code
 # invokes the bare command), so the walk's `.sh` filter never matches it.
 # Include it explicitly so it is linted/formatted like any other script;
@@ -58,38 +108,20 @@ _EXTRA_SHELL_SOURCES = ("bin/accelerator",)
 def shell_sources(root: Path | None = None) -> list[str]:
     """`.sh` files (repo-relative, sorted) with the exclusion set applied.
 
-    Walks the tree, pruning gitignored directories in place so large ignored
-    trees (e.g. `node_modules`) are never descended into, then keeps `.sh`
-    files that are neither gitignored nor excluded by `_keep`. The extensionless
-    extras in `_EXTRA_SHELL_SOURCES` are appended afterwards (the walk's `.sh`
-    filter never matches them).
+    Keeps `.sh` files from `walk_files` that are not excluded by `_keep`. The
+    extensionless extras in `_EXTRA_SHELL_SOURCES` are appended afterwards (the
+    walk's `.sh` filter never matches them), which needs its own `_ignore_spec`
+    since `walk_files` does not expose the one it built.
     """
     repo = root or repo_root()
-    spec = _ignore_spec(repo)
-    out: list[str] = []
-    for dirpath, dirnames, filenames in os.walk(repo):
-        rel_dir = Path(dirpath).relative_to(repo)
-        dirnames[:] = [
-            d
-            for d in dirnames
-            if not spec.match_file(
-                f"{d}/" if rel_dir == Path() else f"{rel_dir / d}/"
-            )
-        ]
-        for filename in filenames:
-            if not filename.endswith(".sh"):
-                continue
-            rel = filename if rel_dir == Path() else str(rel_dir / filename)
-            if spec.match_file(rel):
-                continue
-            if _keep(rel):
-                out.append(rel)
-    # Append the extensionless CLI script(s) — they escape the `.sh` walk
-    # filter.
+    out = [
+        rel for rel in walk_files(repo) if rel.endswith(".sh") and _keep(rel)
+    ]
     # Gate on existence under `repo` (so a tmp_path test root that lacks them
     # does not pick up the literal) and still respect gitignore + _keep
     # (defensive: a future workspaces-relative extra would be filtered, though
     # the current literal never is).
+    spec = _ignore_spec(repo)
     out.extend(
         s
         for s in _EXTRA_SHELL_SOURCES

--- a/tasks/shared/sources.py
+++ b/tasks/shared/sources.py
@@ -14,8 +14,13 @@ checkouts (CI) and jj workspaces (local).
 Only the root `.gitignore` is honoured, not nested ones. That is why `prune`
 carries build output the root file misses: `dist/` and `playwright-report/` are
 ignored only by `cli/visualiser/frontend/.gitignore` (the root file's `/dist/`
-is root-anchored), and `.venv` is ignored nowhere. Revisit with per-directory
-spec layering if a nested `.gitignore` ever needs to hide a source file.
+is root-anchored). Revisit with per-directory spec layering if a nested
+`.gitignore` ever needs to hide a source file.
+
+`prune` deliberately overlaps the root file for `.venv` and `node_modules`,
+which it also lists. The walk is called with `tmp_path` roots that carry no
+`.gitignore` at all, so the prune is the only thing keeping a vendored tree out
+of those scans.
 
 `shell_sources` layers the shell policy on top: `*.sh`, minus `workspaces/` (jj
 checkouts), plus the explicitly-listed extensionless CLI script, so format and

--- a/tasks/test/helpers.py
+++ b/tasks/test/helpers.py
@@ -15,25 +15,30 @@ def repo_root() -> Path:
 
 
 def accelerator_env() -> dict[str, str]:
-    """Return the ACCELERATOR_BIN/CLAUDE_PLUGIN_ROOT overlay for the suites.
+    """Return the ACCELERATOR_BIN/ACCELERATOR_PLUGIN_ROOT overlay.
 
     Repointed production shell scripts read config through
     ``"${ACCELERATOR_BIN:-$PLUGIN_ROOT/bin/accelerator}" config …``. This
     overlay is layered onto a child process via ``context.run(env=...)`` — it is
     *not* written into this process's environment — so it keeps a subtree's
     suites on the compiled binary rather than the signed-release bootstrap with
-    no global side effect. CLAUDE_PLUGIN_ROOT is included for template lookup.
+    no global side effect. ACCELERATOR_PLUGIN_ROOT is included for template
+    lookup: the suites invoke the launcher directly, bypassing the bootstrap
+    that would otherwise export it.
 
     The launcher itself is produced by the ``build:cli:dev`` mise dependency of
     the test tasks, so build ordering lives in the task graph rather than in an
-    ad-hoc cargo call here. A caller-supplied ACCELERATOR_BIN/CLAUDE_PLUGIN_ROOT
-    (a stub or a release build) is honoured.
+    ad-hoc cargo call here. A caller-supplied
+    ACCELERATOR_BIN/ACCELERATOR_PLUGIN_ROOT (a stub or a release build) is
+    honoured.
     """
     repo = repo_root()
     default_bin = str(repo / "cli" / "target" / "debug" / "accelerator")
     return {
         "ACCELERATOR_BIN": os.environ.get("ACCELERATOR_BIN", default_bin),
-        "CLAUDE_PLUGIN_ROOT": os.environ.get("CLAUDE_PLUGIN_ROOT", str(repo)),
+        "ACCELERATOR_PLUGIN_ROOT": os.environ.get(
+            "ACCELERATOR_PLUGIN_ROOT", str(repo)
+        ),
     }
 
 

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -118,7 +118,12 @@ def decisions(context: Context) -> None:
 
 @task
 def hooks(context: Context) -> None:
-    """Integration tests for the hooks/ subtree."""
+    """Integration tests for the hooks/ subtree.
+
+    Two halves: the pytest suites (ADR-0048 — Python is the test language for
+    the non-Rust surfaces) and the two bash harnesses that predate it.
+    """
+    context.run("uv run pytest tests/integration/hooks -v")
     run_shell_suites(context, "hooks")
 
 

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -114,6 +114,12 @@ def entrypoint(context: Context) -> None:
 
 
 @task
+def skill_invocation(context: Context) -> None:
+    """Run every SKILL.md `!`-site config command in the production shape."""
+    context.run("uv run pytest tests/integration/skill-invocation -v")
+
+
+@task
 def deny(context: Context) -> None:
     """cargo-deny native-tls/OpenSSL ban regression (offline fixtures)."""
     context.run("uv run pytest tests/integration/deny -v")

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -40,6 +40,43 @@ _REQUIRED_CONFIG_SUITES = (
     "scripts/test-validate-corpus-frontmatter.sh",
 )
 
+# The three previously-unguarded subtrees, each at its current size. hooks/
+# holds only the two bash harnesses that predate ADR-0048; the link-refresh
+# suite is pytest, where a lost file is a collection error rather than a
+# silently smaller run, so no by-name entry is needed.
+_EXPECTED_HOOKS_SUITES = 2
+_EXPECTED_DECISIONS_SUITES = 1
+_EXPECTED_GITHUB_SUITES = 3
+
+
+def _require_suite_floor(
+    suites: list[str],
+    floor: int,
+    required: tuple[str, ...],
+    subject: str,
+) -> None:
+    """Fail loudly when discovery shrinks below its floor or loses a gate.
+
+    An exec bit dropped on an exec-bit-lossy filesystem, or a suite renamed off
+    the ``test-*.sh`` convention, otherwise removes a regression net from CI
+    while every task still exits 0.
+    """
+    if len(suites) < floor:
+        raise Exit(
+            f"Expected at least {floor} {subject} shell suites, found "
+            f"{len(suites)}: {suites}. An exec bit may have been dropped — a "
+            f"regression suite is missing from CI.",
+            code=1,
+        )
+    missing = [s for s in required if s not in suites]
+    if missing:
+        raise Exit(
+            f"Required {subject} shell suite(s) not discovered by name: "
+            f"{missing} (found {suites}). A gate may have lost its exec bit or "
+            f"been renamed off the test-*.sh convention.",
+            code=1,
+        )
+
 
 @task
 def visualiser(context: Context) -> None:
@@ -92,28 +129,16 @@ def pup(context: Context) -> None:
 def config(context: Context) -> None:
     """Integration tests for the plugin-wide config scripts."""
     suites = run_shell_suites(context, "scripts", accelerator_env())
-    if len(suites) < _EXPECTED_CONFIG_SUITES:
-        raise Exit(
-            f"Expected at least {_EXPECTED_CONFIG_SUITES} config shell "
-            f"suites, found {len(suites)}: {suites}. An exec bit may have "
-            f"been dropped — a fail-closed gate (e.g. the corpus validator) is "
-            f"missing from CI.",
-            code=1,
-        )
-    missing = [s for s in _REQUIRED_CONFIG_SUITES if s not in suites]
-    if missing:
-        raise Exit(
-            f"Required config shell suite(s) not discovered by name: {missing} "
-            f"(found {suites}). A fail-closed gate may have lost its exec bit "
-            f"or been renamed off the test-*.sh convention.",
-            code=1,
-        )
+    _require_suite_floor(
+        suites, _EXPECTED_CONFIG_SUITES, _REQUIRED_CONFIG_SUITES, "config"
+    )
 
 
 @task
 def decisions(context: Context) -> None:
     """Integration tests for the decisions skill scripts."""
-    run_shell_suites(context, "skills/decisions", accelerator_env())
+    suites = run_shell_suites(context, "skills/decisions", accelerator_env())
+    _require_suite_floor(suites, _EXPECTED_DECISIONS_SUITES, (), "decisions")
 
 
 @task
@@ -124,39 +149,31 @@ def hooks(context: Context) -> None:
     the non-Rust surfaces) and the two bash harnesses that predate it.
     """
     context.run("uv run pytest tests/integration/hooks -v")
-    run_shell_suites(context, "hooks")
+    suites = run_shell_suites(context, "hooks")
+    _require_suite_floor(suites, _EXPECTED_HOOKS_SUITES, (), "hooks")
 
 
 @task
 def github(context: Context) -> None:
     """Integration tests for the github skills (shell harnesses)."""
-    run_shell_suites(context, "skills/github")
+    suites = run_shell_suites(context, "skills/github")
+    _require_suite_floor(suites, _EXPECTED_GITHUB_SUITES, (), "github")
 
 
 @task
 def work(context: Context) -> None:
     """Integration tests for the work-management skill scripts."""
     suites = run_shell_suites(context, "skills/work", accelerator_env())
-    if len(suites) < _EXPECTED_WORK_SUITES:
-        raise Exit(
-            f"Expected at least {_EXPECTED_WORK_SUITES} work shell suites, "
-            f"found {len(suites)}: {suites}. An exec bit may have been "
-            f"dropped — a work-management regression suite is missing from CI.",
-            code=1,
-        )
+    _require_suite_floor(suites, _EXPECTED_WORK_SUITES, (), "work")
 
 
 @task
 def integrations(context: Context) -> None:
     """Integration tests for the jira/linear integration scripts."""
     suites = run_shell_suites(context, "skills/integrations", accelerator_env())
-    if len(suites) < _EXPECTED_INTEGRATIONS_SUITES:
-        raise Exit(
-            f"Expected at least {_EXPECTED_INTEGRATIONS_SUITES} integration "
-            f"shell suites, found {len(suites)}: {suites}. An exec bit may "
-            f"have been dropped — a create/auth suite is missing from CI.",
-            code=1,
-        )
+    _require_suite_floor(
+        suites, _EXPECTED_INTEGRATIONS_SUITES, (), "integrations"
+    )
 
 
 @task
@@ -165,10 +182,4 @@ def migrate(context: Context) -> None:
     suites = run_shell_suites(
         context, "skills/config/migrate", accelerator_env()
     )
-    if len(suites) < _EXPECTED_MIGRATE_SUITES:
-        raise Exit(
-            f"Expected at least {_EXPECTED_MIGRATE_SUITES} migrate shell "
-            f"suites, found {len(suites)}: {suites}. An exec bit may have "
-            f"been dropped — the migrate regression net is incomplete.",
-            code=1,
-        )
+    _require_suite_floor(suites, _EXPECTED_MIGRATE_SUITES, (), "migrate")

--- a/tests/integration/dev/dev_integration_driver.py
+++ b/tests/integration/dev/dev_integration_driver.py
@@ -135,7 +135,7 @@ def _build_deps(workspace: Path, opts: dict) -> DevDeps:
     server_info_path = state_dir / "server-info.json"
 
     env = os.environ.copy()
-    env["CLAUDE_PLUGIN_ROOT"] = str(workspace)
+    env["ACCELERATOR_PLUGIN_ROOT"] = str(workspace)
     if opts.get("strip_path"):
         # Only the venv bin (for circusd) — NOT the fake npm's dir. The frontend
         # watcher must still resolve npm via the absolute path rendered into the

--- a/tests/integration/entrypoint/test_accelerator_entrypoint.py
+++ b/tests/integration/entrypoint/test_accelerator_entrypoint.py
@@ -1,238 +1,82 @@
-"""Hermetic tests for the `bin/accelerator` plugin entry point.
-
-Ports the former `scripts/test-accelerator-entrypoint.sh` to Python (ADR-0048:
-Python is the test language for the non-Rust surfaces, shell wrappers included).
-
-The bootstrap is exercised end-to-end with its documented test seams: fetches
-are stubbed via `ACCELERATOR_BOOTSTRAP_DOWNLOADER` (a script that copies from a
-local server dir and logs each requested URL), host detection is forced via the
-injected `ACCELERATOR_UNAME_S`/`_M`, and signatures are *real* minisign
-signatures verified by the *real* `accelerator-verify` shim built from `cli/`.
-
-Every subprocess runs under an explicit, minimal environment (mirroring the
-shell suite's `env -i`) so an ambient variable can't mask a bug. `cargo` and
-`minisign` are mise-provisioned, so a missing tool is a CI provisioning
-regression (fail) rather than a local convenience skip.
-"""
-
 import concurrent.futures
-import contextlib
 import hashlib
-import json
 import os
 import platform
 import shutil
 import subprocess
-import tempfile
-import urllib.parse
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
+from tests.integration.support.installation import (
+    BASH as _BASH,
+)
+from tests.integration.support.installation import (
+    LAUNCHER_STUB_SRC as _LAUNCHER_SRC,
+)
+from tests.integration.support.installation import (
+    REPO_BIN as _REPO_BIN,
+)
+from tests.integration.support.installation import (
+    REPO_BOOTSTRAP as _REPO_BOOTSTRAP,
+)
+from tests.integration.support.installation import (
+    REPO_ROOT as _REPO_ROOT,
+)
+from tests.integration.support.installation import (
+    VERSION as _VERSION,
+)
+from tests.integration.support.installation import (
+    Installation as Harness,
+)
+from tests.integration.support.installation import (
+    build_launcher,
+    build_shim,
+    copy_bootstrap,
+    download_log,
+    dumped_env,
+    generate_keys,
+    make_installation,
+    run_bootstrap,
+    serve_launcher,
+    write_downloader,
+)
+from tests.integration.support.installation import (
+    host_platform as _resolve_host_platform,
+)
+
 _HERE = Path(__file__).resolve().parent
-_REPO_ROOT = _HERE.parents[2]
-_REPO_BOOTSTRAP = _REPO_ROOT / "bin/accelerator"
-_REPO_BIN = _REPO_ROOT / "bin"
 
-# The system interpreter, not whatever `bash` resolves to: macOS ships 3.2 and
-# the bootstrap is held to that floor, so a contributor with Homebrew bash 5 on
-# PATH would otherwise run the whole suite off-floor and green.
-_BASH = "/bin/bash" if Path("/bin/bash").exists() else "bash"
-
-# The harness pins a synthetic version so cache paths are deterministic and the
-# real GitHub release base URL is never contacted (overridden to .invalid).
-_VERSION = "9.9.9-test"
-
-# Marks a fixture root's own templates/adr.md, so a resolved installation root
-# is provable from the launcher's stdout rather than from a rendered path.
-_SENTINEL = "FIXTURE-ADR-SENTINEL-{label}"
-
-# Stand-in for the fetched launcher binary: records its argv (one per line) to
-# LAUNCHER_ARGS_OUT, its whole environment as JSON to LAUNCHER_ENV_OUT, and
-# exits with LAUNCHER_EXIT. Signed by minisign like a real release asset; its
-# content is opaque to verification.
-_LAUNCHER_SRC = """\
-#!/usr/bin/env python3
-import json
-import os
-import sys
-
-out = os.environ.get("LAUNCHER_ARGS_OUT")
-if out:
-    with open(out, "w") as handle:
-        for arg in sys.argv[1:]:
-            handle.write(arg + "\\n")
-env_out = os.environ.get("LAUNCHER_ENV_OUT")
-if env_out:
-    with open(env_out, "w") as handle:
-        json.dump(dict(os.environ), handle)
-sys.exit(int(os.environ.get("LAUNCHER_EXIT", "0")))
-"""
-
-# Injected downloader: copies "${SERVER_DIR}/<basename>" to the destination and
-# appends each requested URL to ${DL_LOG}, so a test can assert what was (or was
-# not) fetched. Exits 22 (curl's "HTTP error") when the asset is absent.
-_DOWNLOADER_SRC = """\
-#!/usr/bin/env python3
-import os
-import shutil
-import sys
-
-url, dest = sys.argv[1], sys.argv[2]
-with open(os.environ["DL_LOG"], "a") as log:
-    log.write(url + "\\n")
-src = os.path.join(os.environ["SERVER_DIR"], os.path.basename(url))
-if os.path.isfile(src):
-    shutil.copy(src, dest)
-    sys.exit(0)
-sys.exit(22)
-"""
-
-
-def _in_ci() -> bool:
-    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
-
-
-def _require(name: str) -> None:
-    if shutil.which(name):
-        return
-    message = f"{name} not on PATH"
-    if _in_ci():
-        pytest.fail(f"{message} — provisioning regression in CI")
-    pytest.skip(message)
-
-
-def _sig_path(binary: Path) -> Path:
-    return binary.with_name(binary.name + ".minisig")
-
-
-def _sign(secret_key: Path, target: Path) -> None:
-    subprocess.run(
-        [
-            "minisign",
-            "-S",
-            "-s",
-            str(secret_key),
-            "-m",
-            str(target),
-            "-x",
-            str(_sig_path(target)),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-
-def _serve_launcher(
-    server: Path, alias: str, secret_key: Path, source: Path | None = None
-) -> None:
-    """Serve a launcher under the given target alias and sign it.
-
-    With no `source` the stub above is written; with one, that binary is copied
-    verbatim. Serving the real compiled launcher is what lets a test assert on
-    launcher-rendered stdout while still traversing the genuine fetch → verify
-    → cache → exec chain, with no network and no dev override.
-    """
-    launcher = server / f"accelerator-{alias}"
-    if source is None:
-        launcher.write_text(_LAUNCHER_SRC)
-    else:
-        shutil.copy(source, launcher)
-    launcher.chmod(0o755)
-    _sign(secret_key, launcher)
+_serve_launcher = serve_launcher
+_run_bootstrap = run_bootstrap
+_dumped_env = dumped_env
+_dl_lines = download_log
 
 
 @pytest.fixture(scope="module")
 def host_platform() -> str:
-    arch = {
-        "arm64": "arm64",
-        "aarch64": "arm64",
-        "x86_64": "x64",
-        "amd64": "x64",
-    }.get(platform.machine())
-    system = {"Darwin": "darwin", "Linux": "linux"}.get(platform.system())
-    if arch is None or system is None:
-        pytest.skip(
-            f"unsupported host: {platform.system()}/{platform.machine()}"
-        )
-    return f"{system}-{arch}"
+    return _resolve_host_platform()
 
 
 @pytest.fixture(scope="module")
 def shim_bin() -> Path:
-    """Build and return the real `accelerator-verify` shim from `cli/`."""
-    _require("cargo")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "--quiet",
-            "-p",
-            "accelerator-verify",
-            "--manifest-path",
-            str(_REPO_ROOT / "cli/Cargo.toml"),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    shim = _REPO_ROOT / "cli/target/debug/accelerator-verify"
-    if not (shim.exists() and os.access(shim, os.X_OK)):
-        pytest.fail(f"shim not built: {shim}")
-    return shim
+    return build_shim()
 
 
 @pytest.fixture(scope="module")
 def launcher_bin() -> Path:
-    """Build and return the real launcher from `cli/`.
-
-    Built in-fixture rather than behind a `mise` build edge, mirroring
-    `shim_bin`, so `uv run pytest tests/integration/entrypoint` still works
-    standalone. `test:integration:entrypoint` must therefore *not* gain a
-    `build:cli:dev` dependency: the two would contend on cargo's target lock.
-    """
-    _require("cargo")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "--quiet",
-            "--bin",
-            "accelerator",
-            "--manifest-path",
-            str(_REPO_ROOT / "cli/Cargo.toml"),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    launcher = _REPO_ROOT / "cli/target/debug/accelerator"
-    if not (launcher.exists() and os.access(launcher, os.X_OK)):
-        pytest.fail(f"launcher not built: {launcher}")
-    return launcher
+    return build_launcher()
 
 
 @pytest.fixture(scope="session")
 def bootstrap_src(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """A copy of `bin/accelerator`, outside the working tree.
-
-    Naming the repo's own bootstrap as a runnable path is the trap this suite
-    must not leave reachable: with self-location it resolves the real repo
-    root, passes every gate, and fetches the real release over the network into
-    the working tree's `bin/`.
-    """
-    copy = tmp_path_factory.mktemp("bootstrap") / "accelerator"
-    shutil.copy(_REPO_BOOTSTRAP, copy)
-    copy.chmod(0o755)
-    return copy
+    return copy_bootstrap(tmp_path_factory.mktemp("bootstrap") / "accelerator")
 
 
 @pytest.fixture(scope="session", autouse=True)
 def repo_bin_is_untouched() -> Iterator[None]:
-    """Backstop for anything that bypasses the `_run_bootstrap` funnel.
+    """Backstop for anything that bypasses the `run_bootstrap` funnel.
 
     Fires after egress rather than preventing it, which is why the funnel's own
     preconditions exist as well.
@@ -245,41 +89,12 @@ def repo_bin_is_untouched() -> Iterator[None]:
 
 @pytest.fixture(scope="module")
 def keys(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """A dir holding passwordless release + attacker minisign keypairs."""
-    _require("minisign")
-    key_dir = tmp_path_factory.mktemp("keys")
-    for name in ("release", "attacker"):
-        subprocess.run(
-            [
-                "minisign",
-                "-G",
-                "-W",
-                "-f",
-                "-p",
-                str(key_dir / f"{name}.pub"),
-                "-s",
-                str(key_dir / f"{name}.key"),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    return key_dir
+    return generate_keys(tmp_path_factory.mktemp("keys"))
 
 
 @pytest.fixture
 def downloader(tmp_path: Path) -> Path:
-    script = tmp_path / "downloader.py"
-    script.write_text(_DOWNLOADER_SRC)
-    script.chmod(0o755)
-    return script
-
-
-@dataclass(frozen=True)
-class Harness:
-    root: Path
-    server: Path
-    sentinel: str
+    return write_downloader(tmp_path / "downloader.py")
 
 
 @pytest.fixture
@@ -291,17 +106,7 @@ def make_harness(
     host_platform: str,
     bootstrap_src: Path,
 ) -> Callable[..., Harness]:
-    """Factory: build a plugin root + release server, return a `Harness`.
-
-    The release public key is always the real one; `secret` only chooses the
-    key the served launcher is *signed* with, so `secret="attacker"` models an
-    asset signed by a non-release key (verification must refuse it).
-
-    `label` names the root in its own `templates/adr.md` sentinel, so a test
-    with two roots proves which one resolved from stdout rather than from the
-    factory's call order. `real_launcher` serves the compiled launcher instead
-    of the stub, for the tests that assert on launcher-rendered output.
-    """
+    """Factory: build a plugin root + release server, return an installation."""
     counter = {"n": 0}
 
     def _make(
@@ -311,117 +116,22 @@ def make_harness(
         real_launcher: bool = False,
     ) -> Harness:
         counter["n"] += 1
-        root = tmp_path / f"root{counter['n']}"
-        (root / ".claude-plugin").mkdir(parents=True)
-        (root / "keys").mkdir()
-        (root / "bin").mkdir()
-        (root / "templates").mkdir()
-        (root / ".claude-plugin/plugin.json").write_text(
-            f'{{\n  "name": "accelerator",\n  "version": "{_VERSION}"\n}}\n'
-        )
-        sentinel = _SENTINEL.format(label=label)
-        (root / "templates/adr.md").write_text(
-            f"# ADR template\n\n{sentinel}\n"
-        )
-        shutil.copy(keys / "release.pub", root / "keys/accelerator-release.pub")
-        bootstrap = root / "bin/accelerator"
-        shutil.copy(bootstrap_src, bootstrap)
-        bootstrap.chmod(0o755)
-        shim = root / f"bin/accelerator-verify-{host_platform}"
-        shutil.copy(shim_bin, shim)
-        shim.chmod(0o755)
-
-        server = tmp_path / f"server{counter['n']}"
-        server.mkdir()
         source = (
             request.getfixturevalue("launcher_bin") if real_launcher else None
         )
-        _serve_launcher(
-            server, host_platform, keys / f"{secret}.key", source=source
+        return make_installation(
+            tmp_path / f"root{counter['n']}",
+            tmp_path / f"server{counter['n']}",
+            keys=keys,
+            shim=shim_bin,
+            bootstrap=bootstrap_src,
+            alias=host_platform,
+            label=label,
+            secret=secret,
+            launcher_source=source,
         )
-        return Harness(root=root, server=server, sentinel=sentinel)
 
     return _make
-
-
-def _assert_hermetic(env: dict[str, str], entry: Path) -> None:
-    """Preconditions enforced at the single funnel every invocation passes.
-
-    An autouse fixture cannot carry these: `_run_bootstrap` composes a complete
-    explicit environment, so nothing set on `os.environ` reaches the child.
-    """
-    assert "ACCELERATOR_BOOTSTRAP_DOWNLOADER" in env, (
-        "the bootstrap must never reach a real downloader"
-    )
-    base_url = env.get("ACCELERATOR_RELEASE_BASE_URL", "")
-    host = urllib.parse.urlparse(base_url).hostname or ""
-    assert host.endswith(".invalid"), (
-        f"the release base URL must be unresolvable, got {base_url!r}"
-    )
-    assert entry.absolute() != _REPO_BOOTSTRAP, (
-        "running the repo's own bootstrap fetches the real release into bin/"
-    )
-    with contextlib.suppress(OSError):
-        assert entry.resolve() != _REPO_BOOTSTRAP, (
-            "the entry path resolves to the repo's own bootstrap"
-        )
-
-
-def _run_bootstrap(
-    root: Path,
-    server: Path,
-    downloader: Path,
-    *,
-    args: tuple[str, ...] = (),
-    extra_env: dict[str, str] | None = None,
-    path: str | None = None,
-    entry: Path | None = None,
-    cwd: Path | None = None,
-    timeout: float | None = None,
-) -> subprocess.CompletedProcess[str]:
-    """Run the harness's `bin/accelerator` under a minimal, explicit env.
-
-    Neither root variable is injected: the bootstrap self-locates from `entry`,
-    which defaults to the harness root's own copy. `cwd` defaults to an empty
-    directory, since the launcher's `config` family reads project config from
-    the working directory.
-    """
-    env = {
-        "PATH": path or os.environ["PATH"],
-        "HOME": os.environ.get("HOME", "/tmp"),
-        "ACCELERATOR_BOOTSTRAP_DOWNLOADER": str(downloader),
-        "ACCELERATOR_RELEASE_BASE_URL": f"https://example.invalid/v{_VERSION}",
-        "SERVER_DIR": str(server),
-        "DL_LOG": str(server / "dl.log"),
-    }
-    if extra_env:
-        env.update(extra_env)
-    entry = entry or root / "bin/accelerator"
-    with contextlib.ExitStack() as stack:
-        if cwd is None:
-            cwd = Path(stack.enter_context(tempfile.TemporaryDirectory()))
-        _assert_hermetic(env, cwd / entry)
-        try:
-            return subprocess.run(
-                [_BASH, str(entry), *args],
-                capture_output=True,
-                text=True,
-                env=env,
-                cwd=str(cwd),
-                timeout=timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired:
-            pytest.fail(f"the bootstrap did not terminate: {entry}")
-
-
-def _dumped_env(path: Path) -> dict[str, str]:
-    return json.loads(path.read_text())
-
-
-def _dl_lines(server: Path) -> list[str]:
-    log = server / "dl.log"
-    return log.read_text().splitlines() if log.exists() else []
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/hooks/test_launcher_link_refresh.py
+++ b/tests/integration/hooks/test_launcher_link_refresh.py
@@ -1,0 +1,467 @@
+"""Tests for `hooks/launcher-link-refresh.sh`.
+
+Python rather than a `hooks/test-*.sh` harness, per ADR-0048: Python is the test
+language for the non-Rust surfaces, shell wrappers included. The two bash suites
+still under `hooks/` predate that decision.
+
+The hook self-locates unconditionally, so there is no environment seam for the
+plugin root — the root under test is wherever the *hook file* sits. Each case
+that needs a particular root therefore builds a fixture installation and copies
+the hook into it, which is more setup than exporting a variable and better
+fidelity: it exercises the resolution production actually performs.
+
+`_run` builds a complete explicit environment rather than inheriting one. That
+matters even though the hook never reads a plugin root: a leaked
+`ACCELERATOR_CACHE_DIR` would redirect the unverified-log path, and a leaked
+`CLAUDE_PLUGIN_DATA` would defeat the inertness cases.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HOOK = REPO_ROOT / "hooks/launcher-link-refresh.sh"
+HOOKS_JSON = REPO_ROOT / "hooks/hooks.json"
+
+HOOK_COMMAND = "${CLAUDE_PLUGIN_ROOT}/hooks/launcher-link-refresh.sh"
+
+_BASH = "/bin/bash" if Path("/bin/bash").exists() else "bash"
+
+
+@dataclass(frozen=True)
+class Result:
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def notice(self) -> str:
+        """The `systemMessage` from the single JSON object on stdout."""
+        return json.loads(self.stdout)["systemMessage"]
+
+    @property
+    def stdout_objects(self) -> int:
+        decoder = json.JSONDecoder()
+        text, count, index = self.stdout.strip(), 0, 0
+        while index < len(text):
+            _, index = decoder.raw_decode(text, index)
+            count += 1
+            while index < len(text) and text[index].isspace():
+                index += 1
+        return count
+
+
+def make_root(path: Path) -> Path:
+    """A fixture installation carrying its own copy of the hook.
+
+    The *physical* path is returned because the hook resolves its own root with
+    `pwd -P`: on macOS `tmp_path` is under /private/var while its logical form
+    is /var, so a logical path here would fail every link comparison on that
+    leg alone. `CLAUDE_PLUGIN_DATA` is deliberately never canonicalised — the
+    hook composes it verbatim, and so must the assertions.
+    """
+    (path / "hooks").mkdir(parents=True)
+    (path / "bin").mkdir()
+    shutil.copy(HOOK, path / "hooks/launcher-link-refresh.sh")
+    launcher = path / "bin/accelerator"
+    launcher.write_text("#!/bin/sh\nexit 0\n")
+    launcher.chmod(0o755)
+    return path.resolve()
+
+
+def _run(root: Path, *, plugin_data: str | None = None, **env: str) -> Result:
+    """Invoke the hook under a minimal, explicit environment."""
+    composed = {"PATH": env.pop("PATH", os.environ["PATH"])}
+    if plugin_data is not None:
+        composed["CLAUDE_PLUGIN_DATA"] = plugin_data
+    composed.update(env)
+    completed = subprocess.run(
+        [_BASH, str(root / "hooks/launcher-link-refresh.sh")],
+        capture_output=True,
+        text=True,
+        env=composed,
+        cwd=env.get("_CWD", str(root)),
+        check=False,
+    )
+    return Result(completed.returncode, completed.stdout, completed.stderr)
+
+
+def snapshot(tree: Path) -> list[str]:
+    """One line per entry plus its link target.
+
+    A name-only listing cannot see a re-pointed symlink or a rewritten file,
+    which is exactly what "created **or modified**" has to cover.
+    """
+    out = []
+    for path in [*sorted(tree.rglob("*")), tree]:
+        target = str(path.readlink()) if path.is_symlink() else ""
+        digest = ""
+        if path.is_file() and not path.is_symlink():
+            digest = path.read_bytes().hex()
+        out.append(f"{path}|{target}|{digest}")
+    return sorted(out)
+
+
+def mode_of(path: Path) -> int:
+    return stat.S_IMODE(path.lstat().st_mode)
+
+
+def link_target(path: Path) -> str:
+    return str(path.readlink()) if path.is_symlink() else ""
+
+
+class TestRefresh:
+    def test_a_first_refresh_creates_the_link_and_says_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        root = make_root(tmp_path / "v1")
+        result = _run(root, plugin_data=str(tmp_path / "data"))
+
+        assert result.returncode == 0
+        assert link_target(tmp_path / "data/bin/accelerator") == str(
+            root / "bin/accelerator"
+        )
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+    def test_a_second_root_repoints_the_link_and_names_both(
+        self, tmp_path: Path
+    ) -> None:
+        v1 = make_root(tmp_path / "v1")
+        v2 = make_root(tmp_path / "v2")
+        data = tmp_path / "data"
+        _run(v1, plugin_data=str(data))
+
+        userbin = tmp_path / "userbin"
+        userbin.mkdir()
+        (userbin / "accelerator").symlink_to(data / "bin/accelerator")
+
+        result = _run(v2, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert link_target(data / "bin/accelerator") == str(
+            v2 / "bin/accelerator"
+        )
+        assert str(v1 / "bin/accelerator") in result.stderr
+        assert str(v2 / "bin/accelerator") in result.stderr
+        # The two-hop design's central claim: the user's own hop never moved,
+        # so it still executes after the plugin-owned hop was re-pointed.
+        assert (
+            subprocess.run(
+                [str(userbin / "accelerator")], check=False
+            ).returncode
+            == 0
+        )
+
+
+class TestDestinationGuards:
+    def test_a_regular_file_is_refused_and_left_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        (data / "bin/accelerator").write_text("user content\n")
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert (data / "bin/accelerator").read_text() == "user content\n"
+        # An actionable, persistent state the hook cannot repair, so it must
+        # arrive as a systemMessage rather than on stderr.
+        assert "is not a symlink" in result.notice
+        assert "[accelerator]" not in result.stderr
+
+    def test_a_symlink_to_a_directory_is_replaced_not_written_into(
+        self, tmp_path: Path
+    ) -> None:
+        # `mv -f` onto a symlink-to-directory writes *inside* it and reports
+        # success, so this is the case that fails if the clear step is dropped.
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (data / "bin/accelerator").symlink_to(elsewhere)
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert link_target(data / "bin/accelerator") == str(
+            root / "bin/accelerator"
+        )
+        assert list(elsewhere.iterdir()) == []
+
+    def test_a_stale_staging_path_is_refused(self, tmp_path: Path) -> None:
+        # The staging path carries the hook child's pid, unknowable in advance,
+        # so the hook is invoked through a wrapper that execs it — the child
+        # then inherits a pid the fixture chose and can seed the path first.
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        wrapper = tmp_path / "wrapper.sh"
+        wrapper.write_text(
+            "#!/usr/bin/env bash\n"
+            ': >"$2/bin/accelerator.new.$$"\n'
+            'exec bash "$1"\n'
+        )
+
+        completed = subprocess.run(
+            [
+                _BASH,
+                str(wrapper),
+                str(root / "hooks/launcher-link-refresh.sh"),
+                str(data),
+            ],
+            capture_output=True,
+            text=True,
+            env={"PATH": os.environ["PATH"], "CLAUDE_PLUGIN_DATA": str(data)},
+            check=False,
+        )
+
+        assert completed.returncode == 0
+        assert "stale staging path" in completed.stderr
+        assert not (data / "bin/accelerator").exists()
+
+
+class TestDataBinGuards:
+    def test_a_symlink_to_a_directory_is_refused(self, tmp_path: Path) -> None:
+        # The flavour matters: a dangling symlink or a regular file reaches the
+        # mkdir guard instead and produces a different diagnostic.
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        data.mkdir()
+        real_bin = tmp_path / "real-bin"
+        real_bin.mkdir()
+        (data / "bin").symlink_to(real_bin)
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert "is not a plain directory" in result.stderr
+        assert list(real_bin.iterdir()) == []
+
+    def test_a_regular_file_is_refused(self, tmp_path: Path) -> None:
+        # Without this case the guard's second clause has no coverage.
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        data.mkdir()
+        (data / "bin").write_text("not a directory\n")
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert "is not a plain directory" in result.stderr
+        assert (data / "bin").read_text() == "not a directory\n"
+
+    def test_an_existing_directory_keeps_its_mode(self, tmp_path: Path) -> None:
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        (data / "bin").chmod(0o700)
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert mode_of(data / "bin") == 0o700
+
+    @pytest.mark.skipif(
+        os.getuid() == 0, reason="mode bits are advisory for uid 0"
+    )
+    def test_an_unwritable_directory_reports_and_stages_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        root = make_root(tmp_path / "v1")
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        (data / "bin").chmod(0o555)
+        try:
+            result = _run(root, plugin_data=str(data))
+
+            assert result.returncode == 0
+            assert "may be stale" in result.stderr
+            assert list((data / "bin").iterdir()) == []
+        finally:
+            # Restore before tmp_path teardown, which cannot remove it either.
+            (data / "bin").chmod(0o755)
+
+
+class TestLauncherValidation:
+    def test_a_removed_launcher_is_refused(self, tmp_path: Path) -> None:
+        # The state after an upgrade deletes the old directory.
+        root = make_root(tmp_path / "v1")
+        (root / "bin/accelerator").unlink()
+
+        result = _run(root, plugin_data=str(tmp_path / "data"))
+
+        assert result.returncode == 0
+        assert "launcher not executable" in result.stderr
+        assert not (tmp_path / "data/bin/accelerator").exists()
+
+    def test_a_non_executable_launcher_is_refused(self, tmp_path: Path) -> None:
+        root = make_root(tmp_path / "v1")
+        (root / "bin/accelerator").chmod(0o644)
+
+        result = _run(root, plugin_data=str(tmp_path / "data"))
+
+        assert result.returncode == 0
+        assert "launcher not executable" in result.stderr
+
+
+class TestInertness:
+    def test_an_unset_plugin_data_is_inert(self, tmp_path: Path) -> None:
+        # Asserted on the hook's decision, not on the absence of a /bin entry:
+        # / is unwritable on both CI legs and SIP-protected on macOS, so an
+        # absence assertion would pass whether or not the guard exists.
+        root = make_root(tmp_path / "v1")
+
+        result = _run(root)
+
+        assert result.returncode == 0
+        assert "CLAUDE_PLUGIN_DATA unavailable" in result.stderr
+        assert result.stdout == ""
+
+    def test_a_relative_plugin_data_is_inert(self, tmp_path: Path) -> None:
+        # Composing against a relative value would put the link inside the
+        # user's project directory.
+        root = make_root(tmp_path / "v1")
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        before = snapshot(cwd)
+
+        result = _run(root, plugin_data="./data", _CWD=str(cwd))
+
+        assert result.returncode == 0
+        assert "CLAUDE_PLUGIN_DATA unavailable" in result.stderr
+        assert snapshot(cwd) == before
+
+
+class TestUnverifiedLog:
+    def _seed(self, root: Path) -> Path:
+        log = root / "bin/.accelerator-unverified.log"
+        log.write_text("2026-01-01T00:00:00Z pid=1 bad signature\n")
+        return log
+
+    def test_a_non_empty_log_is_reported(self, tmp_path: Path) -> None:
+        root = make_root(tmp_path / "v1")
+        log = self._seed(root)
+
+        result = _run(root, plugin_data=str(tmp_path / "data"))
+
+        assert result.returncode == 0
+        assert str(log) in result.notice
+        assert "[accelerator]" not in result.stderr
+
+    def test_an_absent_log_produces_no_notice(self, tmp_path: Path) -> None:
+        root = make_root(tmp_path / "v1")
+
+        assert _run(root, plugin_data=str(tmp_path / "data")).stdout == ""
+
+    def test_a_zero_length_log_produces_no_notice(self, tmp_path: Path) -> None:
+        root = make_root(tmp_path / "v1")
+        (root / "bin/.accelerator-unverified.log").touch()
+
+        assert _run(root, plugin_data=str(tmp_path / "data")).stdout == ""
+
+    def test_two_notices_emit_exactly_one_json_object(
+        self, tmp_path: Path
+    ) -> None:
+        # Two systemMessage objects would be invalid output, so this is the
+        # case that pins the NOTICE accumulator.
+        root = make_root(tmp_path / "v1")
+        self._seed(root)
+        data = tmp_path / "data"
+        (data / "bin").mkdir(parents=True)
+        (data / "bin/accelerator").write_text("user content\n")
+
+        result = _run(root, plugin_data=str(data))
+
+        assert result.returncode == 0
+        assert result.stdout_objects == 1
+        assert "an unverified launcher was recorded" in result.notice
+        assert "is not a symlink" in result.notice
+
+    def test_without_jq_the_notices_degrade_to_stderr(
+        self, tmp_path: Path
+    ) -> None:
+        # Shadowed rather than stripped from PATH: macOS 15 ships /usr/bin/jq,
+        # so dropping every directory holding a jq also drops dirname, mkdir
+        # and ln, and the hook would fail before reaching the jq fallback.
+        root = make_root(tmp_path / "v1")
+        self._seed(root)
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        (shadow / "jq").write_text("#!/bin/sh\nexit 127\n")
+        (shadow / "jq").chmod(0o755)
+
+        result = _run(
+            root,
+            plugin_data=str(tmp_path / "data"),
+            PATH=f"{shadow}:{os.environ['PATH']}",
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert "an unverified launcher was recorded" in result.stderr
+
+
+def test_nothing_outside_plugin_data_is_created_or_modified(
+    tmp_path: Path,
+) -> None:
+    root = make_root(tmp_path / "v1")
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    before = snapshot(home) + snapshot(cwd)
+
+    result = _run(
+        root,
+        plugin_data=str(tmp_path / "data"),
+        HOME=str(home),
+        _CWD=str(cwd),
+    )
+
+    assert result.returncode == 0
+    assert snapshot(home) + snapshot(cwd) == before
+    assert not (home / ".local").exists()
+
+
+class TestRegistration:
+    """Selected by command content, never by index.
+
+    `hooks/test-vcs-detect.sh` already hard-codes `SessionStart[0]`; that is the
+    only positional coupling in the repository and this must not add a second.
+    """
+
+    def _group(self) -> dict:
+        registered = json.loads(HOOKS_JSON.read_text())
+        groups = [
+            group
+            for group in registered["hooks"]["SessionStart"]
+            if any(hook["command"] == HOOK_COMMAND for hook in group["hooks"])
+        ]
+        assert len(groups) == 1, groups
+        return groups[0]
+
+    def test_the_hook_is_a_session_start_group(self) -> None:
+        assert self._group()["matcher"] == ""
+
+    def test_the_group_holds_exactly_one_command_hook(self) -> None:
+        hooks = self._group()["hooks"]
+        assert len(hooks) == 1
+        assert hooks[0]["type"] == "command"
+        # The full literal: a bare endswith match would pass for a relative or
+        # wrongly-prefixed command.
+        assert hooks[0]["command"] == HOOK_COMMAND
+
+
+def test_the_hook_reads_no_plugin_root_from_the_environment() -> None:
+    assert "CLAUDE_PLUGIN_ROOT" not in HOOK.read_text()

--- a/tests/integration/skill-invocation/test_skill_invocation_conformance.py
+++ b/tests/integration/skill-invocation/test_skill_invocation_conformance.py
@@ -1,0 +1,202 @@
+"""Every `config` command the skills invoke, run in the production shape.
+
+Production shape means the correct absolute path with an *empty* environment —
+the one configuration that matters in practice and the one no other suite
+exercises, because they all inject `ACCELERATOR_BIN` or a plugin root. That gap
+is what let the bootstrap ship requiring a variable Claude Code never exports to
+a `!` shell.
+
+The commands run through the real bootstrap against a fixture installation: the
+freshly built launcher served by the stubbed release server, traversing the
+genuine fetch → verify → cache → exec chain with no network. Substituting the
+prefix to the *repo* root instead would self-locate there, pass every gate, and
+fetch the real GitHub release for a version that is not yet published.
+
+Scope: the 204 `config` commands, not all 206 `!`-site launcher invocations.
+Both remainders are in `skills/visualisation/visualise/SKILL.md` — one is a
+`printf` rendering a recipe rather than invoking anything, and the other starts
+the visualiser daemon. That one stays excluded: with
+`ACCELERATOR_VISUALISER_BIN` set the resolver short-circuits before the cache
+root is consulted, and without it it verifies `manifest.json` against the real
+release key compiled into the launcher, which a locally signed fixture manifest
+cannot satisfy. External-subcommand dispatch is therefore a known gap here,
+covered instead by `cli/launcher/tests/version.rs` and `cache_root.rs`.
+"""
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from tasks.lint.skill_permissions import EXPECTED_INJECTION_SKILLS
+from tests.integration.support import skill_corpus as corpus
+from tests.integration.support.installation import (
+    REPO_BIN,
+    REPO_ROOT,
+    Installation,
+    build_launcher,
+    build_shim,
+    copy_bootstrap,
+    generate_keys,
+    host_platform,
+    make_installation,
+    run_bootstrap,
+    write_downloader,
+)
+
+_SKILLS = REPO_ROOT / "skills"
+
+# Collected at import time because parametrisation needs it before fixtures
+# run. One case per *distinct* command: the 204 occurrences carry 122 distinct
+# texts, and re-running a duplicate exercises nothing new at ~0.1s a go.
+_ALL = corpus.extract(_SKILLS)
+_DISTINCT = sorted({c.raw: c for c in _ALL}.values(), key=lambda c: c.tail)
+
+
+@pytest.fixture(scope="module")
+def commands() -> list[corpus.Command]:
+    return _ALL
+
+
+@pytest.fixture(scope="session", autouse=True)
+def repo_bin_is_untouched() -> Iterator[None]:
+    before = {entry.name for entry in REPO_BIN.iterdir()}
+    yield
+    added = sorted({entry.name for entry in REPO_BIN.iterdir()} - before)
+    assert not added, f"the suite wrote into the shipped bin/: {added}"
+
+
+@pytest.fixture(scope="module")
+def installation(tmp_path_factory: pytest.TempPathFactory) -> Installation:
+    base = tmp_path_factory.mktemp("conformance")
+    keys = base / "keys"
+    keys.mkdir()
+    return make_installation(
+        base / "root",
+        base / "server",
+        keys=generate_keys(keys),
+        shim=build_shim(),
+        bootstrap=copy_bootstrap(base / "bootstrap-accelerator"),
+        alias=host_platform(),
+        launcher_source=build_launcher(),
+        templates=REPO_ROOT / "templates",
+    )
+
+
+@pytest.fixture(scope="module")
+def project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return corpus.write_project(
+        tmp_path_factory.mktemp("conformance-project"), _ALL
+    )
+
+
+@pytest.fixture(scope="module")
+def invoke(
+    tmp_path_factory: pytest.TempPathFactory,
+    installation: Installation,
+    project: Path,
+) -> Callable[[corpus.Command], object]:
+    downloader = write_downloader(
+        tmp_path_factory.mktemp("downloader") / "downloader.py"
+    )
+
+    def _invoke(command: corpus.Command):
+        argv = command.argv(installation.root)
+        assert argv[0] == str(installation.root / "bin/accelerator"), argv
+        return run_bootstrap(
+            installation.root,
+            installation.server,
+            downloader,
+            args=tuple(argv[1:]),
+            cwd=project,
+        )
+
+    return _invoke
+
+
+class TestCorpusIntegrity:
+    """Structural invariants, not a magic floor.
+
+    A `>= 200` floor fires on routine consolidation while staying quiet on the
+    loss it exists to detect: dropping one skill's two commands still clears 200
+    if skills are added elsewhere.
+    """
+
+    def test_every_skill_with_a_config_site_contributes_a_command(
+        self, commands: list[corpus.Command]
+    ) -> None:
+        # Derived by a second, line-level scan rather than by reusing the
+        # extractor, so a file the extractor's walk or filter drops is visible.
+        # It must not simply grep for the marker: `allowed-tools` rules and
+        # documentation code blocks name the command without invoking it.
+        assert corpus.source_files(commands) == corpus.files_with_config_sites(
+            _SKILLS
+        )
+
+    def test_instructions_count_matches_the_injection_census(
+        self, commands: list[corpus.Command]
+    ) -> None:
+        # Cross-checked against a constant that is already single-sourced and
+        # already an exact equality — asserting the family is merely non-empty
+        # would be satisfied by one command while 41 vanished.
+        assert (
+            len(corpus.instructions_skills(commands))
+            == EXPECTED_INJECTION_SKILLS
+        )
+
+    def test_context_count_matches_the_injection_census(
+        self, commands: list[corpus.Command]
+    ) -> None:
+        assert len(corpus.context_skills(commands)) == EXPECTED_INJECTION_SKILLS
+
+    def test_every_named_skill_exists(
+        self, commands: list[corpus.Command]
+    ) -> None:
+        # The fixture derives its overrides from the corpus, so without this a
+        # `!` site naming a nonexistent skill would have an override created
+        # for it and pass.
+        named = corpus.instructions_skills(commands) | corpus.context_skills(
+            commands
+        )
+        assert named <= corpus.declared_skill_names(_SKILLS)
+
+    def test_nothing_is_declined(self, commands: list[corpus.Command]) -> None:
+        # The permissions guard already forbids shell metacharacters in a `!`
+        # command, so a non-empty decline list means the corpus changed shape.
+        assert [c.raw for c in commands if c.declined] == []
+
+    def test_the_corpus_size_is_reported(
+        self, commands: list[corpus.Command], capsys: pytest.CaptureFixture
+    ) -> None:
+        # A shrinking scan should be visible as well as fatal.
+        with capsys.disabled():
+            print(
+                f"\ncorpus: {len(commands)} commands, "
+                f"{len({c.raw for c in commands})} distinct, "
+                f"{len(corpus.source_files(commands))} SKILL.md files"
+            )
+        assert commands
+
+
+@pytest.mark.parametrize("command", _DISTINCT, ids=[c.tail for c in _DISTINCT])
+def test_command_runs_in_the_production_shape(
+    invoke: Callable[[corpus.Command], object], command: corpus.Command
+) -> None:
+    result = invoke(command)
+    assert result.returncode == 0, (
+        f"{command.tail} exited {result.returncode}\n{result.stderr}"
+    )
+    # `accelerator:` is `fail()`'s own prefix, so this detects bootstrap-layer
+    # aborts specifically — the launcher's diagnostics carry no such prefix.
+    assert "accelerator:" not in result.stderr, result.stderr
+
+    expected = corpus.expected_stdout(command)
+    if expected is None:
+        # Every other family renders a plugin or built-in default, so an empty
+        # answer means a degraded read rather than a legitimate blank.
+        assert result.stdout.strip(), f"{command.tail} rendered nothing"
+    else:
+        assert expected in result.stdout, (
+            f"{command.tail} did not render the fixture override\n"
+            f"{result.stdout!r}"
+        )

--- a/tests/integration/support/installation.py
+++ b/tests/integration/support/installation.py
@@ -257,6 +257,7 @@ def make_installation(
     label: str = "self",
     secret: str = "release",
     launcher_source: Path | None = None,
+    templates: Path | None = None,
 ) -> Installation:
     """Build a plugin root plus its stub release server.
 
@@ -267,11 +268,18 @@ def make_installation(
     `label` names the root in its own `templates/adr.md` sentinel, so a caller
     with two roots proves which one resolved from stdout rather than from
     construction order.
+
+    `templates` copies a whole template tree in first, for callers that need
+    the plugin-default tier to resolve by name. The sentinel `adr.md` is
+    written afterwards either way, so it always wins.
     """
     (root / ".claude-plugin").mkdir(parents=True)
     (root / "keys").mkdir()
     (root / "bin").mkdir()
-    (root / "templates").mkdir()
+    if templates is None:
+        (root / "templates").mkdir()
+    else:
+        shutil.copytree(templates, root / "templates")
     (root / ".claude-plugin/plugin.json").write_text(
         f'{{\n  "name": "accelerator",\n  "version": "{VERSION}"\n}}\n'
     )

--- a/tests/integration/support/installation.py
+++ b/tests/integration/support/installation.py
@@ -1,0 +1,370 @@
+"""Shared fixture-installation apparatus for suites that run the bootstrap.
+
+Building a runnable installation means reproducing the whole trust chain: a
+`.claude-plugin/plugin.json`, a verify shim named for the running host, a
+generated release keypair, a signed launcher served through a stubbed
+downloader, and a writable cache. Encoding that twice would give two
+independent copies of the release asset-naming and signing contract, which
+would drift the next time `tasks/shared/targets.py` or the shim naming changes.
+
+None of it is committed. The shim is platform-specific and would skip or fail
+one CI leg; the keypair is generated per run with `*.key` gitignored, so a
+committed public key could never match a signature produced here; and a
+committed shim would put a second, unguarded copy of a trust-root binary under
+`tests/`.
+
+`run_bootstrap` is the single funnel every invocation passes, and it carries the
+network and working-tree preconditions — a caller cannot opt out of them by
+constructing its own `subprocess.run`.
+"""
+
+import contextlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REPO_BOOTSTRAP = REPO_ROOT / "bin/accelerator"
+REPO_BIN = REPO_ROOT / "bin"
+
+# The system interpreter, not whatever `bash` resolves to: macOS ships 3.2 and
+# the bootstrap is held to that floor, so a contributor with Homebrew bash 5 on
+# PATH would otherwise run a suite off-floor and green.
+BASH = "/bin/bash" if Path("/bin/bash").exists() else "bash"
+
+# A synthetic version, so cache paths are deterministic and the real GitHub
+# release base URL is never contacted (overridden to .invalid).
+VERSION = "9.9.9-test"
+
+# Marks a fixture root's own templates/adr.md, so a resolved installation root
+# is provable from the launcher's stdout rather than from a rendered path.
+SENTINEL = "FIXTURE-ADR-SENTINEL-{label}"
+
+# Stand-in for the fetched launcher binary: records its argv (one per line) to
+# LAUNCHER_ARGS_OUT, its whole environment as JSON to LAUNCHER_ENV_OUT, and
+# exits with LAUNCHER_EXIT. Signed by minisign like a real release asset; its
+# content is opaque to verification.
+LAUNCHER_STUB_SRC = """\
+#!/usr/bin/env python3
+import json
+import os
+import sys
+
+out = os.environ.get("LAUNCHER_ARGS_OUT")
+if out:
+    with open(out, "w") as handle:
+        for arg in sys.argv[1:]:
+            handle.write(arg + "\\n")
+env_out = os.environ.get("LAUNCHER_ENV_OUT")
+if env_out:
+    with open(env_out, "w") as handle:
+        json.dump(dict(os.environ), handle)
+sys.exit(int(os.environ.get("LAUNCHER_EXIT", "0")))
+"""
+
+# Injected downloader: copies "${SERVER_DIR}/<basename>" to the destination and
+# appends each requested URL to ${DL_LOG}, so a test can assert what was (or was
+# not) fetched. Exits 22 (curl's "HTTP error") when the asset is absent.
+DOWNLOADER_SRC = """\
+#!/usr/bin/env python3
+import os
+import shutil
+import sys
+
+url, dest = sys.argv[1], sys.argv[2]
+with open(os.environ["DL_LOG"], "a") as log:
+    log.write(url + "\\n")
+src = os.path.join(os.environ["SERVER_DIR"], os.path.basename(url))
+if os.path.isfile(src):
+    shutil.copy(src, dest)
+    sys.exit(0)
+sys.exit(22)
+"""
+
+
+def in_ci() -> bool:
+    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
+
+
+def require(name: str) -> None:
+    """Skip locally, fail in CI: a missing tool there is a provisioning bug."""
+    if shutil.which(name):
+        return
+    message = f"{name} not on PATH"
+    if in_ci():
+        pytest.fail(f"{message} — provisioning regression in CI")
+    pytest.skip(message)
+
+
+def host_platform() -> str:
+    """The running host's release-asset alias, e.g. ``darwin-arm64``."""
+    arch = {
+        "arm64": "arm64",
+        "aarch64": "arm64",
+        "x86_64": "x64",
+        "amd64": "x64",
+    }.get(platform.machine())
+    system = {"Darwin": "darwin", "Linux": "linux"}.get(platform.system())
+    if arch is None or system is None:
+        pytest.skip(
+            f"unsupported host: {platform.system()}/{platform.machine()}"
+        )
+    return f"{system}-{arch}"
+
+
+def _cargo_build(package: str, binary: str) -> Path:
+    require("cargo")
+    subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--quiet",
+            *package.split(),
+            "--manifest-path",
+            str(REPO_ROOT / "cli/Cargo.toml"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    built = REPO_ROOT / "cli/target/debug" / binary
+    if not (built.exists() and os.access(built, os.X_OK)):
+        pytest.fail(f"not built: {built}")
+    return built
+
+
+def build_shim() -> Path:
+    """Build and return the real `accelerator-verify` shim from `cli/`."""
+    return _cargo_build("-p accelerator-verify", "accelerator-verify")
+
+
+def build_launcher() -> Path:
+    """Build and return the real launcher from `cli/`.
+
+    Built here rather than behind a `mise` build edge so a suite using it still
+    runs standalone under a bare `uv run pytest`. A suite that calls this must
+    therefore *not* also gain a `build:cli:dev` dependency: the two would
+    contend on cargo's target lock and the asserted edge would be inert.
+    """
+    return _cargo_build("--bin accelerator", "accelerator")
+
+
+def generate_keys(key_dir: Path) -> Path:
+    """Generate passwordless release + attacker minisign keypairs."""
+    require("minisign")
+    for name in ("release", "attacker"):
+        subprocess.run(
+            [
+                "minisign",
+                "-G",
+                "-W",
+                "-f",
+                "-p",
+                str(key_dir / f"{name}.pub"),
+                "-s",
+                str(key_dir / f"{name}.key"),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    return key_dir
+
+
+def write_downloader(path: Path) -> Path:
+    path.write_text(DOWNLOADER_SRC)
+    path.chmod(0o755)
+    return path
+
+
+def copy_bootstrap(destination: Path) -> Path:
+    """Copy `bin/accelerator` to a runnable path outside the working tree.
+
+    Naming the repo's own bootstrap as a runnable path is the trap these suites
+    must not leave reachable: with self-location it resolves the real repo root,
+    passes every gate, and fetches the real release over the network into the
+    working tree's `bin/`.
+    """
+    shutil.copy(REPO_BOOTSTRAP, destination)
+    destination.chmod(0o755)
+    return destination
+
+
+def sig_path(binary: Path) -> Path:
+    return binary.with_name(binary.name + ".minisig")
+
+
+def sign(secret_key: Path, target: Path) -> None:
+    subprocess.run(
+        [
+            "minisign",
+            "-S",
+            "-s",
+            str(secret_key),
+            "-m",
+            str(target),
+            "-x",
+            str(sig_path(target)),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def serve_launcher(
+    server: Path, alias: str, secret_key: Path, source: Path | None = None
+) -> None:
+    """Serve a launcher under the given target alias and sign it.
+
+    With no `source` the stub above is written; with one, that binary is copied
+    verbatim. Serving the real compiled launcher is what lets a test assert on
+    launcher-rendered stdout while still traversing the genuine fetch → verify
+    → cache → exec chain, with no network and no dev override.
+    """
+    launcher = server / f"accelerator-{alias}"
+    if source is None:
+        launcher.write_text(LAUNCHER_STUB_SRC)
+    else:
+        shutil.copy(source, launcher)
+    launcher.chmod(0o755)
+    sign(secret_key, launcher)
+
+
+@dataclass(frozen=True)
+class Installation:
+    root: Path
+    server: Path
+    sentinel: str
+
+
+def make_installation(
+    root: Path,
+    server: Path,
+    *,
+    keys: Path,
+    shim: Path,
+    bootstrap: Path,
+    alias: str,
+    label: str = "self",
+    secret: str = "release",
+    launcher_source: Path | None = None,
+) -> Installation:
+    """Build a plugin root plus its stub release server.
+
+    The release public key placed in the root is always the real one; `secret`
+    only chooses the key the served launcher is *signed* with, so
+    `secret="attacker"` models an asset signed by a non-release key.
+
+    `label` names the root in its own `templates/adr.md` sentinel, so a caller
+    with two roots proves which one resolved from stdout rather than from
+    construction order.
+    """
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / "keys").mkdir()
+    (root / "bin").mkdir()
+    (root / "templates").mkdir()
+    (root / ".claude-plugin/plugin.json").write_text(
+        f'{{\n  "name": "accelerator",\n  "version": "{VERSION}"\n}}\n'
+    )
+    sentinel = SENTINEL.format(label=label)
+    (root / "templates/adr.md").write_text(f"# ADR template\n\n{sentinel}\n")
+    shutil.copy(keys / "release.pub", root / "keys/accelerator-release.pub")
+    copy_bootstrap(root / "bin/accelerator")
+    installed_shim = root / f"bin/accelerator-verify-{alias}"
+    shutil.copy(shim, installed_shim)
+    installed_shim.chmod(0o755)
+
+    server.mkdir(exist_ok=True)
+    serve_launcher(
+        server, alias, keys / f"{secret}.key", source=launcher_source
+    )
+    return Installation(root=root, server=server, sentinel=sentinel)
+
+
+def assert_hermetic(env: dict[str, str], entry: Path) -> None:
+    """Preconditions enforced at the single funnel every invocation passes.
+
+    An autouse fixture cannot carry these: `run_bootstrap` composes a complete
+    explicit environment, so nothing set on `os.environ` reaches the child.
+    """
+    assert "ACCELERATOR_BOOTSTRAP_DOWNLOADER" in env, (
+        "the bootstrap must never reach a real downloader"
+    )
+    base_url = env.get("ACCELERATOR_RELEASE_BASE_URL", "")
+    host = urllib.parse.urlparse(base_url).hostname or ""
+    assert host.endswith(".invalid"), (
+        f"the release base URL must be unresolvable, got {base_url!r}"
+    )
+    assert entry.absolute() != REPO_BOOTSTRAP, (
+        "running the repo's own bootstrap fetches the real release into bin/"
+    )
+    with contextlib.suppress(OSError):
+        assert entry.resolve() != REPO_BOOTSTRAP, (
+            "the entry path resolves to the repo's own bootstrap"
+        )
+
+
+def run_bootstrap(
+    root: Path,
+    server: Path,
+    downloader: Path,
+    *,
+    args: tuple[str, ...] = (),
+    extra_env: dict[str, str] | None = None,
+    path: str | None = None,
+    entry: Path | None = None,
+    cwd: Path | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run an installation's `bin/accelerator` under a minimal, explicit env.
+
+    Neither root variable is injected: the bootstrap self-locates from `entry`,
+    which defaults to the installation root's own copy. `cwd` defaults to an
+    empty directory, since the launcher's `config` family reads project config
+    from the working directory.
+    """
+    env = {
+        "PATH": path or os.environ["PATH"],
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "ACCELERATOR_BOOTSTRAP_DOWNLOADER": str(downloader),
+        "ACCELERATOR_RELEASE_BASE_URL": f"https://example.invalid/v{VERSION}",
+        "SERVER_DIR": str(server),
+        "DL_LOG": str(server / "dl.log"),
+    }
+    if extra_env:
+        env.update(extra_env)
+    entry = entry or root / "bin/accelerator"
+    with contextlib.ExitStack() as stack:
+        if cwd is None:
+            cwd = Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        assert_hermetic(env, cwd / entry)
+        try:
+            return subprocess.run(
+                [BASH, str(entry), *args],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=str(cwd),
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(f"the bootstrap did not terminate: {entry}")
+
+
+def dumped_env(path: Path) -> dict[str, str]:
+    return json.loads(path.read_text())
+
+
+def download_log(server: Path) -> list[str]:
+    log = server / "dl.log"
+    return log.read_text().splitlines() if log.exists() else []

--- a/tests/integration/support/skill_corpus.py
+++ b/tests/integration/support/skill_corpus.py
@@ -1,0 +1,195 @@
+"""The `!`-site command corpus and the fixture project it is run against.
+
+Extraction reuses `tasks/lint/skill_permissions`'s own public machinery rather
+than a second regex, so the population here cannot drift from the population the
+permissions guard checks.
+
+The fixture project and the expectations are generated from one data structure,
+so the oracle stays single-sourced as skills are renamed. Configuring an
+override for *every* skill in the corpus is the point: with only a token few
+configured, the ~84 remaining per-skill expectations reduce to ``stdout == ""``,
+which is byte-identical to a read failure degrading under the ``--fail-safe``
+that every one of these commands carries. Two fifths of the suite would be
+unable to tell success from silent degradation.
+"""
+
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from tasks.lint.skill_permissions import (
+    PLUGIN_PREFIX,
+    frontmatter_name,
+    is_plugin_invocation,
+    preprocessor_commands,
+)
+
+CONFIG_MARKER = "/bin/accelerator config "
+INSTRUCTIONS_MARKER = "/bin/accelerator config instructions "
+CONTEXT_MARKER = "/bin/accelerator config context --skill "
+
+# Shell metacharacters. The corpus is entirely static literals today, so a
+# command carrying one of these means the corpus changed shape — it is declined
+# rather than executed, because `shell=True` over markdown-derived strings would
+# make any SKILL.md an execution vector inside the test process.
+METACHARACTERS = ("&&", "||", ";", "|", "$(", "`", "<(", ">(", ">", "<")
+
+# A `!` site whose command names the config surface, on one line.
+_INLINE_SITE = re.compile(r"!`[^`]*/bin/accelerator config ")
+
+INSTRUCTIONS_BODY = "FIXTURE-INSTRUCTIONS-{skill}"
+CONTEXT_BODY = "FIXTURE-CONTEXT-{skill}"
+
+# Values the non-per-skill families read. Only `agents` and `work` need seeding;
+# the `paths`/`path`/`review`/`template` families all have plugin or built-in
+# defaults that render without any project configuration.
+FIXTURE_CONFIG = """\
+---
+agents:
+  reviewer: fixture-reviewer
+work:
+  integration: linear
+  default_project_code: FIX
+  id_pattern: 'FIX-[0-9]+'
+---
+
+Fixture team context.
+"""
+
+
+@dataclass(frozen=True)
+class Command:
+    """One `!`-site invocation, with the SKILL.md it was extracted from."""
+
+    source: str
+    raw: str
+
+    @property
+    def tail(self) -> str:
+        """The command text after the `config` marker, e.g. `template adr`."""
+        return self.raw.split(CONFIG_MARKER, 1)[1]
+
+    @property
+    def family(self) -> str:
+        return self.tail.split()[0]
+
+    @property
+    def declined(self) -> bool:
+        return any(token in self.raw for token in METACHARACTERS)
+
+    def argv(self, plugin_root: Path) -> list[str]:
+        """Claude Code's own textual substitution, then a shell-free split."""
+        substituted = self.raw.replace(PLUGIN_PREFIX, f"{plugin_root}/", 1)
+        return shlex.split(substituted)
+
+
+def extract(skills_dir: Path) -> list[Command]:
+    """Every `bin/accelerator config` `!` command under `skills/`.
+
+    `is_plugin_invocation` alone matches every plugin *script* invocation too,
+    some of which write into `meta/` or call remote trackers, so the marker
+    filter is not optional.
+    """
+    found: list[Command] = []
+    for path in sorted(skills_dir.rglob("SKILL.md")):
+        source = path.as_posix()
+        found.extend(
+            Command(source=source, raw=command)
+            for command in preprocessor_commands(path.read_text())
+            if is_plugin_invocation(command) and CONFIG_MARKER in command
+        )
+    return found
+
+
+def source_files(commands: list[Command]) -> set[str]:
+    return {command.source for command in commands}
+
+
+def files_with_config_sites(skills_dir: Path) -> set[str]:
+    """SKILL.md paths carrying a `config` command inside a `!` site.
+
+    A line-level scan, independent of `extract`'s walk-and-filter, so a file
+    that extraction drops shows up as a mismatch. Matching the marker alone
+    would over-count: `allowed-tools` rules and documentation code blocks name
+    the command without invoking it.
+    """
+    found: set[str] = set()
+    for path in skills_dir.rglob("SKILL.md"):
+        for line in path.read_text().splitlines():
+            if _INLINE_SITE.search(line):
+                found.add(path.as_posix())
+                break
+    return found
+
+
+def declared_skill_names(skills_dir: Path) -> set[str]:
+    """Every `name:` declared in a `skills/**/SKILL.md` frontmatter.
+
+    The fixture derives its overrides from the corpus, so a `!` site naming a
+    skill that does not exist would otherwise have an override helpfully
+    created for it and pass. Neither the permissions census nor this suite's
+    count checks would catch that — they count skills carrying an injection,
+    not whether the name resolves.
+    """
+    return {
+        name
+        for path in skills_dir.rglob("SKILL.md")
+        if (name := frontmatter_name(path.read_text()))
+    }
+
+
+def _named_skill(command: Command, marker: str) -> str | None:
+    if marker not in command.raw:
+        return None
+    return command.raw.split(marker, 1)[1].split()[0]
+
+
+def instructions_skills(commands: list[Command]) -> set[str]:
+    return {
+        name
+        for command in commands
+        if (name := _named_skill(command, INSTRUCTIONS_MARKER))
+    }
+
+
+def context_skills(commands: list[Command]) -> set[str]:
+    return {
+        name
+        for command in commands
+        if (name := _named_skill(command, CONTEXT_MARKER))
+    }
+
+
+def expected_stdout(command: Command) -> str | None:
+    """The exact stdout a per-skill command must produce, else `None`.
+
+    `None` means the family is asserted non-empty rather than by content.
+    """
+    if name := _named_skill(command, INSTRUCTIONS_MARKER):
+        return INSTRUCTIONS_BODY.format(skill=name)
+    if name := _named_skill(command, CONTEXT_MARKER):
+        return CONTEXT_BODY.format(skill=name)
+    return None
+
+
+def write_project(root: Path, commands: list[Command]) -> Path:
+    """Materialise the fixture project the corpus is run against."""
+    accelerator = root / ".accelerator"
+    accelerator.mkdir(parents=True)
+    # A boundary marker, so project-root discovery stops inside the fixture
+    # rather than escaping into the real working tree.
+    (root / ".git").mkdir()
+    (accelerator / "config.md").write_text(FIXTURE_CONFIG)
+    for skill in sorted(
+        instructions_skills(commands) | context_skills(commands)
+    ):
+        skill_dir = accelerator / "skills" / skill
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "instructions.md").write_text(
+            INSTRUCTIONS_BODY.format(skill=skill) + "\n"
+        )
+        (skill_dir / "context.md").write_text(
+            CONTEXT_BODY.format(skill=skill) + "\n"
+        )
+    return root

--- a/tests/unit/tasks/shared/test_sources.py
+++ b/tests/unit/tasks/shared/test_sources.py
@@ -1,11 +1,94 @@
 from pathlib import Path
 
-from tasks.shared.sources import _keep, shell_sources
+from tasks.shared.sources import _BUILD_OUTPUT, _keep, shell_sources, walk_files
 
 
 def _write(path: Path, text: str = "#!/usr/bin/env bash\n") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text)
+
+
+class TestWalkFiles:
+    def test_yields_every_suffix_repo_relative(self, tmp_path: Path):
+        # Suffix filtering belongs to the caller, not the walk.
+        _write(tmp_path / "a.sh")
+        _write(tmp_path / "pkg/b.py", "x\n")
+        _write(tmp_path / "pkg/c.md", "x\n")
+
+        assert sorted(walk_files(tmp_path)) == ["a.sh", "pkg/b.py", "pkg/c.md"]
+
+    def test_prunes_gitignored_directories(self, tmp_path: Path):
+        _write(tmp_path / ".gitignore", "cli/target/\n")
+        _write(tmp_path / "keep.sh")
+        _write(tmp_path / "cli/target/debug/build.sh")
+
+        assert sorted(walk_files(tmp_path)) == [".gitignore", "keep.sh"]
+
+    def test_prunes_gitignored_file_patterns(self, tmp_path: Path):
+        _write(tmp_path / ".gitignore", "*.generated.sh\n")
+        _write(tmp_path / "real.sh")
+        _write(tmp_path / "thing.generated.sh")
+
+        assert sorted(walk_files(tmp_path)) == [".gitignore", "real.sh"]
+
+    def test_prunes_every_build_output_entry_without_a_gitignore(
+        self, tmp_path: Path
+    ):
+        # No .gitignore is written, so any survivor proves the prune tuple —
+        # not the ignore spec — is what removed these.
+        _write(tmp_path / "keep.sh")
+        for name in _BUILD_OUTPUT:
+            _write(tmp_path / name / "nested" / "x.sh")
+
+        assert sorted(walk_files(tmp_path)) == ["keep.sh"]
+
+    def test_prunes_the_frontend_dist_bundle_at_its_real_depth(
+        self, tmp_path: Path
+    ):
+        # The built SPA is ignored only by cli/visualiser/frontend/.gitignore,
+        # which _ignore_spec never reads — the root file's `/dist/` is
+        # root-anchored and does not match at this depth.
+        _write(tmp_path / ".gitignore", "/dist/\n")
+        _write(
+            tmp_path / "cli/visualiser/frontend/dist/assets/bundle.js", "x\n"
+        )
+        _write(tmp_path / "cli/visualiser/frontend/src/main.ts", "x\n")
+
+        assert sorted(walk_files(tmp_path)) == [
+            ".gitignore",
+            "cli/visualiser/frontend/src/main.ts",
+        ]
+
+    def test_prune_replaces_rather_than_extends_the_defaults(
+        self, tmp_path: Path
+    ):
+        _write(tmp_path / "dist/x.sh")
+        _write(tmp_path / "custom/y.sh")
+
+        assert sorted(walk_files(tmp_path, prune=("custom",))) == ["dist/x.sh"]
+        assert (
+            sorted(walk_files(tmp_path, prune=(*_BUILD_OUTPUT, "custom"))) == []
+        )
+
+    def test_subtree_scopes_the_walk_but_not_the_ignore_spec(
+        self, tmp_path: Path
+    ):
+        # The spec must still be read at `repo` and matched repo-relative: a
+        # spec read at the subtree would test `target/` against `cli/target/`,
+        # match nothing, and descend into the whole build tree.
+        _write(tmp_path / ".gitignore", "cli/target/\n")
+        _write(tmp_path / "outside.sh")
+        _write(tmp_path / "cli/keep.sh")
+        _write(tmp_path / "cli/target/debug/build.sh")
+
+        assert sorted(walk_files(tmp_path, subtree="cli")) == ["cli/keep.sh"]
+
+    def test_never_descends_into_vcs_metadata(self, tmp_path: Path):
+        _write(tmp_path / "keep.sh")
+        _write(tmp_path / ".git/hooks/pre-commit.sh")
+        _write(tmp_path / ".jj/working_copy/snapshot.sh")
+
+        assert sorted(walk_files(tmp_path)) == ["keep.sh"]
 
 
 class TestKeepPredicate:
@@ -89,5 +172,19 @@ class TestShellSourcesDiscovery:
 
     def test_no_gitignore_present_is_tolerated(self, tmp_path: Path):
         _write(tmp_path / "scripts/keep.sh")
+
+        assert shell_sources(root=tmp_path) == ["scripts/keep.sh"]
+
+    def test_prunes_build_output_the_root_gitignore_misses(
+        self, tmp_path: Path
+    ):
+        # Before walk_files this yielded all six: the walk pruned only
+        # gitignored directories, and none of these five is in the root file.
+        _write(tmp_path / "scripts/keep.sh")
+        _write(tmp_path / ".venv/bin/act.sh")
+        _write(tmp_path / "cli/f/dist/b.sh")
+        _write(tmp_path / "playwright-report/t.sh")
+        _write(tmp_path / "coverage/c.sh")
+        _write(tmp_path / "node_modules/p/i.sh")
 
         assert shell_sources(root=tmp_path) == ["scripts/keep.sh"]

--- a/tests/unit/tasks/shared/test_sources.py
+++ b/tests/unit/tasks/shared/test_sources.py
@@ -178,8 +178,9 @@ class TestShellSourcesDiscovery:
     def test_prunes_build_output_the_root_gitignore_misses(
         self, tmp_path: Path
     ):
-        # Before walk_files this yielded all six: the walk pruned only
-        # gitignored directories, and none of these five is in the root file.
+        # This root carries no .gitignore, so the prune is the only thing
+        # keeping the five vendored trees out — which is why the prune list
+        # overlaps the root file rather than deferring to it.
         _write(tmp_path / "scripts/keep.sh")
         _write(tmp_path / ".venv/bin/act.sh")
         _write(tmp_path / "cli/f/dist/b.sh")

--- a/tests/unit/tasks/test_bootstrap_coverage.py
+++ b/tests/unit/tasks/test_bootstrap_coverage.py
@@ -6,6 +6,7 @@ floor. It is also one half of the plugin's trust root, which must stay
 byte-identical to what the launcher embeds. These tests pin both.
 """
 
+import re
 from pathlib import Path
 
 from tasks.shared.paths import vendored_shim_path
@@ -18,6 +19,7 @@ _KEY = "keys/accelerator-release.pub"
 _BASHISMS = _REPO_ROOT / "scripts/lint-bashisms.sh"
 _BUILD_RS = _REPO_ROOT / "cli/launcher/build.rs"
 _BOOTSTRAP_SRC = _REPO_ROOT / "bin/accelerator"
+_PLUGIN_ROOT = "ACCELERATOR_PLUGIN_ROOT"
 _LAUNCHER_MAIN = _REPO_ROOT / "cli/launcher/src/main.rs"
 _CACHE_ROOT = (
     _REPO_ROOT / "cli/launcher/src/launch/outbound/resolve/cache_root.rs"
@@ -49,27 +51,29 @@ def test_launcher_and_bootstrap_reference_the_same_committed_key() -> None:
     assert (_REPO_ROOT / _KEY).is_file()
 
 
-def test_bootstrap_exports_the_names_the_launcher_reads() -> None:
+def test_bootstrap_exports_the_one_plugin_root_the_launcher_reads() -> None:
     # A one-sided rename otherwise surfaces as a missing sentinel deep in an
-    # integration suite rather than here, in seconds.
-    bootstrap = _BOOTSTRAP_SRC.read_text()
-    exported = {
-        name
-        for name in ("ACCELERATOR_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
-        if f"export {name}=" in bootstrap
-    }
-    read = set()
-    for source in (_LAUNCHER_MAIN, _CACHE_ROOT):
-        text = source.read_text()
-        read |= {
-            name
-            for name in ("ACCELERATOR_PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT")
-            if f'var_os("{name}")' in text
-        }
-    assert read, "the launcher must read a plugin-root variable"
-    assert read <= exported, (
-        f"read but never exported: {sorted(read - exported)}"
+    # integration suite rather than here, in seconds. Exact equality on both
+    # sides also catches a second, transitional export left behind.
+    exported = set(
+        re.findall(
+            r"^export ([A-Z0-9_]*PLUGIN_ROOT)=",
+            _BOOTSTRAP_SRC.read_text(),
+            re.MULTILINE,
+        )
     )
+    assert exported == {_PLUGIN_ROOT}, (
+        f"the bootstrap exports {sorted(exported)}, not just {_PLUGIN_ROOT}"
+    )
+    for source in (_LAUNCHER_MAIN, _CACHE_ROOT):
+        read = set(
+            re.findall(
+                r'var_os\("([A-Z0-9_]*PLUGIN_ROOT)"\)', source.read_text()
+            )
+        )
+        assert read == {_PLUGIN_ROOT}, (
+            f"{source.name} reads {sorted(read)}, not {_PLUGIN_ROOT}"
+        )
 
 
 def test_the_committed_vendored_shims_are_not_gitignored() -> None:

--- a/tests/unit/tasks/test_claude_coupling.py
+++ b/tests/unit/tasks/test_claude_coupling.py
@@ -1,0 +1,172 @@
+"""Tests for the CLAUDE_* boundary guard.
+
+Every probe stays in ``tmp_path``. A sentinel written into the live tree would
+make the checks flake: ``test:unit:tasks`` runs concurrently with ``cli:check``
+under ``mise run``, and the guard rides in the latter.
+"""
+
+from pathlib import Path
+
+import pytest
+from invoke import Exit
+
+from tasks.lint.claude_coupling import (
+    _FILES,
+    _MIN_SCANNED,
+    _in_scope,
+    violations,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_READ = 'std::env::var_os("CLAUDE_PLUGIN_ROOT")\n'
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _tree(root: Path) -> Path:
+    """A minimal in-scope tree: every _FILES entry plus one cli/ source."""
+    for rel in _FILES:
+        _write(root / rel, "clean\n")
+    _write(root / "cli/launcher/src/main.rs", "fn main() {}\n")
+    return root
+
+
+def _found(root: Path) -> list[str]:
+    return violations(root, min_scanned=1)
+
+
+class TestFlagging:
+    def test_flags_a_var_os_read_under_cli(self, tmp_path: Path):
+        _tree(tmp_path)
+        _write(tmp_path / "cli/launcher/src/main.rs", _READ)
+
+        found = _found(tmp_path)
+        assert found == ["cli/launcher/src/main.rs:1:" + _READ.strip()]
+
+    def test_flags_a_comment_mention(self, tmp_path: Path):
+        _tree(tmp_path)
+        _write(tmp_path / "cli/x/src/lib.rs", "// needs CLAUDE_PLUGIN_ROOT\n")
+
+        assert any("lib.rs" in hit for hit in _found(tmp_path))
+
+    def test_flags_an_mjs_injection(self, tmp_path: Path):
+        _tree(tmp_path)
+        _write(tmp_path / "cli/f/e2e/start.mjs", "CLAUDE_PLUGIN_ROOT: p,\n")
+
+        assert any("start.mjs" in hit for hit in _found(tmp_path))
+
+    def test_flags_a_markdown_and_a_shell_file_under_cli(self, tmp_path: Path):
+        # Scan-by-default: nothing narrows the guard to source suffixes.
+        _tree(tmp_path)
+        _write(tmp_path / "cli/README.md", "Set CLAUDE_PLUGIN_ROOT first.\n")
+        _write(tmp_path / "cli/run.sh", 'echo "$CLAUDE_PLUGIN_ROOT"\n')
+
+        hits = " ".join(_found(tmp_path))
+        assert "cli/README.md" in hits
+        assert "cli/run.sh" in hits
+
+    def test_flags_a_read_reintroduced_into_the_bootstrap(self, tmp_path: Path):
+        # The entry point the bug was in, and where the transitional export
+        # lived — the reason the guard's scope is the rename set, not cli/.
+        _tree(tmp_path)
+        _write(tmp_path / "bin/accelerator", 'export CLAUDE_PLUGIN_ROOT="$r"\n')
+
+        assert any("bin/accelerator" in hit for hit in _found(tmp_path))
+
+    def test_flags_a_read_reintroduced_into_an_out_of_tree_writer(
+        self, tmp_path: Path
+    ):
+        _tree(tmp_path)
+        _write(tmp_path / "tasks/dev.py", 'env["CLAUDE_PLUGIN_ROOT"] = r\n')
+
+        assert any("tasks/dev.py" in hit for hit in _found(tmp_path))
+
+    def test_reports_path_line_and_text(self, tmp_path: Path):
+        _tree(tmp_path)
+        _write(tmp_path / "cli/x/src/lib.rs", f"fn a() {{}}\n{_READ}")
+
+        assert _found(tmp_path) == [
+            "cli/x/src/lib.rs:2:" + _READ.strip(),
+        ]
+
+    def test_flags_any_claude_prefixed_name_not_only_the_plugin_root(
+        self, tmp_path: Path
+    ):
+        _tree(tmp_path)
+        _write(tmp_path / "cli/x/src/lib.rs", 'var("CLAUDE_CONFIG_DIR")\n')
+
+        assert any("CLAUDE_CONFIG_DIR" in hit for hit in _found(tmp_path))
+
+
+class TestScopeBoundaries:
+    def test_does_not_descend_into_gitignored_build_trees(self, tmp_path: Path):
+        # cli/target/ is gitignored; node_modules/ is too. Both need the
+        # .gitignore written into tmp_path — _ignore_spec reads only that file.
+        _tree(tmp_path)
+        _write(tmp_path / ".gitignore", "cli/target/\nnode_modules/\n")
+        _write(tmp_path / "cli/target/debug/build.rs", _READ)
+        _write(tmp_path / "cli/f/node_modules/p/index.js", _READ)
+
+        assert _found(tmp_path) == []
+
+    def test_does_not_descend_into_unconditionally_pruned_build_output(
+        self, tmp_path: Path
+    ):
+        # dist/ and playwright-report/ are pruned by walk_files regardless of
+        # any .gitignore, which is what keeps the minified SPA bundle out.
+        _tree(tmp_path)
+        _write(tmp_path / "cli/f/dist/assets/bundle.js", _READ)
+        _write(tmp_path / "cli/f/playwright-report/trace.txt", _READ)
+
+        assert _found(tmp_path) == []
+
+    def test_does_not_flag_the_matcher_model_or_the_adapter_layer(
+        self, tmp_path: Path
+    ):
+        # Both legitimately name the variable and are outside the rename set.
+        _tree(tmp_path)
+        _write(tmp_path / "tasks/lint/skill_permissions.py", _READ)
+        _write(tmp_path / "hooks/config-detect.sh", _READ)
+
+        assert _found(tmp_path) == []
+
+
+class TestFailClosed:
+    def test_a_scan_below_the_floor_raises(self, tmp_path: Path):
+        # A silently-emptied scan otherwise reads as cleanliness in both the
+        # lint task and the `violations(REPO_ROOT) == []` assertion.
+        _tree(tmp_path)
+
+        with pytest.raises(Exit, match="scope discovery is broken"):
+            violations(tmp_path)
+
+    def test_a_missing_named_file_raises(self, tmp_path: Path):
+        _tree(tmp_path)
+        (tmp_path / "tasks/test/helpers.py").unlink()
+
+        with pytest.raises(Exit, match="silently dropped out"):
+            _found(tmp_path)
+
+    def test_undecodable_bytes_are_skipped_rather_than_raising(
+        self, tmp_path: Path
+    ):
+        # An unlisted suffix, so _SKIP_SUFFIXES cannot be what saves it — the
+        # strict decode is.
+        _tree(tmp_path)
+        (tmp_path / "cli/asset.dat").write_bytes(b"\xff\xfe\x00binary")
+
+        assert _found(tmp_path) == []
+
+
+class TestRealTree:
+    def test_the_scanned_set_clears_its_floor(self):
+        # Guards the guard: a silently-emptied scan otherwise reads as a clean
+        # tree in the assertion below.
+        assert len(_in_scope(REPO_ROOT)) >= _MIN_SCANNED
+
+    def test_the_real_tree_is_clean(self):
+        assert violations(REPO_ROOT) == []

--- a/tests/unit/tasks/test_integration.py
+++ b/tests/unit/tasks/test_integration.py
@@ -1,11 +1,12 @@
 """Tests for the suite-count guards in ``tasks/test/integration.py``.
 
-The ``config`` and ``migrate`` tasks assert an at-least floor on the number of
-discovered shell suites, so a dropped exec bit (which makes a fail-closed gate
-silently vanish from CI) turns the build red instead of shrinking the
-regression net. These tests cover both halves: that ``run_shell_suites``
-discovery actually shrinks when an exec bit is dropped, and that the guard
-fires when discovery falls below the baseline.
+Every guarded task asserts an at-least floor on the number of discovered shell
+suites, and some additionally require named gates, so a dropped exec bit (which
+makes a fail-closed gate silently vanish from CI) turns the build red instead of
+shrinking the regression net. These tests cover all three halves: that
+``run_shell_suites`` discovery actually shrinks when an exec bit is dropped,
+that the guard fires below the baseline, and that a named gate cannot be lost
+while the count floor still passes on filler.
 """
 
 import pytest
@@ -21,6 +22,10 @@ def _stub_accelerator_env(mocker):
     the suites; stub it to an empty overlay so the guard logic is tested without
     touching a real launcher path."""
     mocker.patch.object(integration, "accelerator_env", return_value={})
+    # `hooks` shells out to pytest before its floor check, and invoke's @task
+    # rejects a stand-in Context, so the real one has `run` stubbed instead —
+    # otherwise these unit tests would run the whole hooks suite twice.
+    mocker.patch.object(Context, "run")
 
 
 class _FakeContext:
@@ -52,75 +57,56 @@ class TestRunShellSuitesExecBit:
         assert len(reduced) == 1, "exec-bit drop must shrink the discovered set"
 
 
-class TestConfigSuiteGuard:
-    def test_guard_fires_when_below_baseline(self, mocker):
-        mocker.patch.object(
-            integration, "run_shell_suites", return_value=["scripts/test-x.sh"]
-        )
-        with pytest.raises(Exit):
-            integration.config(Context())
-
-    def test_guard_passes_at_baseline(self, mocker):
-        # The required-by-name gates must be present, with generic filler making
-        # up the rest of the count floor.
-        required = list(integration._REQUIRED_CONFIG_SUITES)
-        filler = [
-            f"scripts/test-{i}.sh"
-            for i in range(integration._EXPECTED_CONFIG_SUITES - len(required))
-        ]
-        suites = required + filler
-        mocker.patch.object(
-            integration, "run_shell_suites", return_value=suites
-        )
-        integration.config(Context())  # must not raise
+# (task name, floor constant, required-by-name tuple). Every guarded task
+# appears here, so a new floor without a paired case is a visible omission
+# rather than an untested Exit branch.
+_GUARDED = [
+    ("config", "_EXPECTED_CONFIG_SUITES", "_REQUIRED_CONFIG_SUITES"),
+    ("hooks", "_EXPECTED_HOOKS_SUITES", None),
+    ("decisions", "_EXPECTED_DECISIONS_SUITES", None),
+    ("github", "_EXPECTED_GITHUB_SUITES", None),
+    ("work", "_EXPECTED_WORK_SUITES", None),
+    ("integrations", "_EXPECTED_INTEGRATIONS_SUITES", None),
+    ("migrate", "_EXPECTED_MIGRATE_SUITES", None),
+]
 
 
-class TestMigrateSuiteGuard:
-    def test_guard_fires_when_below_baseline(self, mocker):
-        mocker.patch.object(
-            integration, "run_shell_suites", return_value=["x/test-a.sh"]
-        )
-        with pytest.raises(Exit):
-            integration.migrate(Context())
+def _at_baseline(floor_name: str, required_name: str | None) -> list[str]:
+    """A discovered set exactly at the floor, including any by-name gates."""
+    required = (
+        list(getattr(integration, required_name)) if required_name else []
+    )
+    floor = getattr(integration, floor_name)
+    filler = [f"x/test-{i}.sh" for i in range(floor - len(required))]
+    return required + filler
 
 
-class TestWorkSuiteGuard:
-    def test_guard_fires_when_below_baseline(self, mocker):
-        mocker.patch.object(
-            integration,
-            "run_shell_suites",
-            return_value=["skills/work/test-a.sh"],
-        )
-        with pytest.raises(Exit):
-            integration.work(Context())
-
-    def test_guard_passes_at_baseline(self, mocker):
-        suites = [
-            f"skills/work/test-{i}.sh"
-            for i in range(integration._EXPECTED_WORK_SUITES)
-        ]
-        mocker.patch.object(
-            integration, "run_shell_suites", return_value=suites
-        )
-        integration.work(Context())  # must not raise
+@pytest.mark.parametrize(("name", "floor_name", "required_name"), _GUARDED)
+def test_guard_fires_below_baseline(mocker, name, floor_name, required_name):
+    below = _at_baseline(floor_name, required_name)[:-1]
+    mocker.patch.object(integration, "run_shell_suites", return_value=below)
+    with pytest.raises(Exit):
+        getattr(integration, name)(Context())
 
 
-class TestIntegrationsSuiteGuard:
-    def test_guard_fires_when_below_baseline(self, mocker):
-        mocker.patch.object(
-            integration,
-            "run_shell_suites",
-            return_value=["skills/integrations/test-a.sh"],
-        )
-        with pytest.raises(Exit):
-            integration.integrations(Context())
+@pytest.mark.parametrize(("name", "floor_name", "required_name"), _GUARDED)
+def test_guard_passes_at_baseline(mocker, name, floor_name, required_name):
+    suites = _at_baseline(floor_name, required_name)
+    mocker.patch.object(integration, "run_shell_suites", return_value=suites)
+    getattr(integration, name)(Context())  # must not raise
 
-    def test_guard_passes_at_baseline(self, mocker):
-        suites = [
-            f"skills/integrations/test-{i}.sh"
-            for i in range(integration._EXPECTED_INTEGRATIONS_SUITES)
-        ]
-        mocker.patch.object(
-            integration, "run_shell_suites", return_value=suites
-        )
-        integration.integrations(Context())  # must not raise
+
+@pytest.mark.parametrize(
+    ("name", "floor_name", "required_name"),
+    [g for g in _GUARDED if g[2] is not None],
+)
+def test_guard_fires_when_a_named_gate_is_missing(
+    mocker, name, floor_name, required_name
+):
+    # At the count floor but with the by-name gates swapped for filler: the
+    # count alone cannot detect a renamed or exec-bit-stripped gate.
+    floor = getattr(integration, floor_name)
+    suites = [f"x/test-{i}.sh" for i in range(floor)]
+    mocker.patch.object(integration, "run_shell_suites", return_value=suites)
+    with pytest.raises(Exit):
+        getattr(integration, name)(Context())

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -17,9 +17,39 @@ MISE_TOML = REPO_ROOT / "mise.toml"
 # Gates that MUST be reachable from the aggregate `check` task.
 _CHECK_GATES = ["cli:check", "deny:check", "pup:check"]
 
+_LAUNCHER = "build:cli:dev"
+_INTEGRATION_PREFIX = "test:integration:"
+
+# Integration tasks that reach the compiled launcher and so MUST carry the
+# build:cli:dev edge. All six drive shell suites through accelerator_env().
+_LAUNCHER_DEPENDENTS = [
+    "test:integration:config",
+    "test:integration:decisions",
+    "test:integration:migrate",
+    "test:integration:work",
+    "test:integration:integrations",
+    "test:integration:visualiser",
+]
+
+# Integration tasks that deliberately need no prebuilt launcher, each with a
+# reason. Every test:integration:* task must appear in exactly one of the two.
+_NO_LAUNCHER_NEEDED = {
+    "test:integration:entrypoint": "builds it in-fixture, mirroring shim_bin",
+    "test:integration:tasks": "pytest over the invoke task modules",
+    "test:integration:dev": "drives circusd with Python fake processes",
+    "test:integration:deny": "cargo-deny over offline fixtures",
+    "test:integration:pup": "cargo-pup, built through build:frontend:stub",
+    "test:integration:hooks": "shell suites run with no accelerator_env",
+    "test:integration:github": "shell suites run with no accelerator_env",
+}
+
 
 def _task_depends(mise: dict, task: str) -> list[str]:
     return mise["tasks"][task].get("depends", [])
+
+
+def _integration_tasks(mise: dict) -> set[str]:
+    return {t for t in mise["tasks"] if t.startswith(_INTEGRATION_PREFIX)}
 
 
 @pytest.fixture
@@ -33,3 +63,31 @@ def test_gate_wired_into_check(mise, gate):
         f"{gate} is not in check.depends — the gate is unwired from the "
         f"read-only CI-mirror"
     )
+
+
+@pytest.mark.parametrize("task", _LAUNCHER_DEPENDENTS)
+def test_launcher_dependent_carries_the_build_edge(mise, task):
+    assert _LAUNCHER in _task_depends(mise, task), (
+        f"{task} reaches the compiled launcher but does not depend on "
+        f"{_LAUNCHER} — it would run against a stale or absent binary"
+    )
+
+
+@pytest.mark.parametrize("task", sorted(_NO_LAUNCHER_NEEDED))
+def test_task_needing_no_launcher_omits_the_build_edge(mise, task):
+    assert _LAUNCHER not in _task_depends(mise, task), (
+        f"{task} is recorded as needing no prebuilt launcher "
+        f"({_NO_LAUNCHER_NEEDED[task]}) but depends on {_LAUNCHER}"
+    )
+
+
+def test_every_integration_task_declares_its_launcher_need(mise):
+    classified = set(_LAUNCHER_DEPENDENTS) | set(_NO_LAUNCHER_NEEDED)
+    assert _integration_tasks(mise) == classified, (
+        "every test:integration:* task must appear in exactly one of "
+        "_LAUNCHER_DEPENDENTS or _NO_LAUNCHER_NEEDED"
+    )
+
+
+def test_the_two_launcher_sets_are_disjoint():
+    assert not set(_LAUNCHER_DEPENDENTS) & set(_NO_LAUNCHER_NEEDED)

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -17,9 +17,11 @@ MISE_TOML = REPO_ROOT / "mise.toml"
 # Gates that MUST be reachable from the aggregate `check` task.
 _CHECK_GATES = ["cli:check", "deny:check", "pup:check"]
 
-# cli/-scoped Python guards ride in cli:check rather than lint:check — that is
-# what CI runs. Nothing else pins their placement, so the roll-up would
-# otherwise happily lose one.
+# cli/-scoped Python guards ride in cli:check, which is what CI runs, *and* in
+# lint:check, which is the only path the bare `default` task reaches: `default`
+# depends on lint:check but not on check, so a cli:check-only guard is green
+# locally however badly the invariant is broken. Nothing else pins their
+# placement, so either roll-up would otherwise happily lose one.
 _CLI_CHECK_GATES = [
     "lint:vendor-shims:check",
     "lint:store-duplication:check",
@@ -80,6 +82,14 @@ def test_gate_wired_into_cli_check(mise, gate):
     assert gate in _task_depends(mise, "cli:check"), (
         f"{gate} is not in cli:check.depends — the guard is unwired from the "
         f"roll-up CI runs"
+    )
+
+
+@pytest.mark.parametrize("gate", _CLI_CHECK_GATES)
+def test_gate_wired_into_lint_check(mise, gate):
+    assert gate in _task_depends(mise, "lint:check"), (
+        f"{gate} is not in lint:check.depends — the guard is unreachable from "
+        f"the bare `default` task, which depends on lint:check and not on check"
     )
 
 

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -17,6 +17,15 @@ MISE_TOML = REPO_ROOT / "mise.toml"
 # Gates that MUST be reachable from the aggregate `check` task.
 _CHECK_GATES = ["cli:check", "deny:check", "pup:check"]
 
+# cli/-scoped Python guards ride in cli:check rather than lint:check — that is
+# what CI runs. Nothing else pins their placement, so the roll-up would
+# otherwise happily lose one.
+_CLI_CHECK_GATES = [
+    "lint:vendor-shims:check",
+    "lint:store-duplication:check",
+    "lint:claude-coupling:check",
+]
+
 _LAUNCHER = "build:cli:dev"
 _INTEGRATION_PREFIX = "test:integration:"
 
@@ -62,6 +71,14 @@ def test_gate_wired_into_check(mise, gate):
     assert gate in _task_depends(mise, "check"), (
         f"{gate} is not in check.depends — the gate is unwired from the "
         f"read-only CI-mirror"
+    )
+
+
+@pytest.mark.parametrize("gate", _CLI_CHECK_GATES)
+def test_gate_wired_into_cli_check(mise, gate):
+    assert gate in _task_depends(mise, "cli:check"), (
+        f"{gate} is not in cli:check.depends — the guard is unwired from the "
+        f"roll-up CI runs"
     )
 
 

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -44,6 +44,7 @@ _LAUNCHER_DEPENDENTS = [
 # reason. Every test:integration:* task must appear in exactly one of the two.
 _NO_LAUNCHER_NEEDED = {
     "test:integration:entrypoint": "builds it in-fixture, mirroring shim_bin",
+    "test:integration:skill-invocation": "builds it in-fixture, same harness",
     "test:integration:tasks": "pytest over the invoke task modules",
     "test:integration:dev": "drives circusd with Python fake processes",
     "test:integration:deny": "cargo-deny over offline fixtures",
@@ -108,3 +109,19 @@ def test_every_integration_task_declares_its_launcher_need(mise):
 
 def test_the_two_launcher_sets_are_disjoint():
     assert not set(_LAUNCHER_DEPENDENTS) & set(_NO_LAUNCHER_NEEDED)
+
+
+# test:integration.depends is curated rather than derived, so membership is an
+# explicit decision — and an omission means a whole suite ships green and never
+# runs. Each exclusion carries its reason.
+_NOT_IN_INTEGRATION_ROLLUP = {
+    "test:integration:pup": "needs the isolated nightly toolchain lane",
+}
+
+
+def test_every_integration_task_is_in_the_rollup_or_excluded_with_a_reason(
+    mise,
+):
+    rollup = set(_task_depends(mise, "test:integration"))
+    assert rollup | set(_NOT_IN_INTEGRATION_ROLLUP) == _integration_tasks(mise)
+    assert not rollup & set(_NOT_IN_INTEGRATION_ROLLUP)

--- a/tests/unit/tasks/test_python_coverage.py
+++ b/tests/unit/tasks/test_python_coverage.py
@@ -20,7 +20,6 @@ The walk is VCS-agnostic (the same gitignore-honouring approach as
 making this guard vacuous/spurious locally.
 """
 
-import os
 import shutil
 import subprocess
 import tomllib
@@ -28,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-from tasks.shared.sources import _ignore_spec, repo_root
+from tasks.shared.sources import repo_root, walk_files
 
 REPO = repo_root()
 MOCK_JIRA = "skills/integrations/jira/scripts/test-helpers/mock-jira-server.py"
@@ -70,28 +69,10 @@ def _py_files() -> set[str]:
 
     Mirrors what ruff/pyrefly discover — ruff excludes `.venv` by default and
     pyrefly is scoped to `tasks/` via `project-includes`, but `.venv` is not in
-    `.gitignore`, so it is pruned here explicitly alongside the
-    gitignore-matched directories.
+    `.gitignore`, so `walk_files` prunes it alongside the gitignore-matched
+    directories.
     """
-    spec = _ignore_spec(REPO)
-    out: set[str] = set()
-    for dirpath, dirnames, filenames in os.walk(REPO):
-        rel_dir = Path(dirpath).relative_to(REPO)
-        dirnames[:] = [
-            d
-            for d in dirnames
-            if d != ".venv"
-            and not spec.match_file(
-                f"{d}/" if rel_dir == Path() else f"{rel_dir / d}/"
-            )
-        ]
-        for name in filenames:
-            if not name.endswith(".py"):
-                continue
-            rel = name if rel_dir == Path() else str(rel_dir / name)
-            if not spec.match_file(rel):
-                out.add(rel)
-    return out
+    return {rel for rel in walk_files(REPO) if rel.endswith(".py")}
 
 
 def _tool(name: str) -> str:
@@ -124,6 +105,9 @@ class TestInScopeSet:
         assert MOCK_LINEAR in py
         # workspaces/ is gitignored, so the walk never surfaces it.
         assert not any(p.startswith("workspaces/") for p in py)
+        # .venv is gitignored nowhere, so only the explicit prune keeps the
+        # thousands of vendored .py files out of the in-scope set.
+        assert not any(p.startswith(".venv/") for p in py)
         ruff_in_scope = py - {MOCK_JIRA, MOCK_LINEAR}
         assert ruff_in_scope, "ruff in-scope set is empty after excludes"
         assert MOCK_JIRA not in ruff_in_scope

--- a/tests/unit/tasks/test_python_coverage.py
+++ b/tests/unit/tasks/test_python_coverage.py
@@ -68,9 +68,8 @@ def _py_files() -> set[str]:
     """Repo-relative `.py` paths: gitignore-honoured, `.venv` pruned.
 
     Mirrors what ruff/pyrefly discover — ruff excludes `.venv` by default and
-    pyrefly is scoped to `tasks/` via `project-includes`, but `.venv` is not in
-    `.gitignore`, so `walk_files` prunes it alongside the gitignore-matched
-    directories.
+    pyrefly is scoped to `tasks/` via `project-includes`. `.venv` is kept out
+    twice over, by `.gitignore` and by `walk_files`' prune list.
     """
     return {rel for rel in walk_files(REPO) if rel.endswith(".py")}
 
@@ -105,8 +104,8 @@ class TestInScopeSet:
         assert MOCK_LINEAR in py
         # workspaces/ is gitignored, so the walk never surfaces it.
         assert not any(p.startswith("workspaces/") for p in py)
-        # .venv is gitignored nowhere, so only the explicit prune keeps the
-        # thousands of vendored .py files out of the in-scope set.
+        # .venv holds thousands of vendored .py files; either the gitignore
+        # entry or walk_files' prune alone is enough to keep them out.
         assert not any(p.startswith(".venv/") for p in py)
         ruff_in_scope = py - {MOCK_JIRA, MOCK_LINEAR}
         assert ruff_in_scope, "ruff in-scope set is empty after excludes"


### PR DESCRIPTION
# [0182] Plugin root rename and terminal invocation surface

## Summary

PR #28 made `bin/accelerator` derive its installation root from its own location, unbreaking all 45 CLI-invoking skills. This is the rest of that work: the launcher and server layers move off `CLAUDE_PLUGIN_ROOT` onto `ACCELERATOR_PLUGIN_ROOT`, a lint guard makes that boundary non-negotiable, an unknown plugin root becomes a named refusal instead of a silently empty answer, and running `accelerator` from an ordinary terminal becomes a documented, upgrade-surviving surface.

## Changes

**The rename.** `cli/launcher`, `cli/visualiser/server` and the cache-root resolver read `ACCELERATOR_PLUGIN_ROOT`; the four out-of-tree writers (`tasks/dev.py`, `tasks/shared/dev/circus.py`, `tasks/test/helpers.py`, `tests/integration/dev/dev_integration_driver.py`) set it. `bin/accelerator` drops the transitional dual export it carried for one release, so nothing in the rename set names a `CLAUDE_*` variable any more. An empty value is now treated as unset, filtered once in `FileConfigStore::with_plugin_root` so the launcher and the server inherit the rule from one place.

**A missing root is a named error.** `ConfigError::PluginRootUnavailable` names the variable and the remedy, and `is_refusal()` classifies every variant exhaustively — a new variant will not compile until it is classified. The template ports became fallible, so a rootless `config templates list` exits non-zero with a diagnostic instead of printing an empty table at exit 0, and `templates eject --all` refuses instead of silently ejecting nothing. Refusals are byte-identical with and without `--fail-safe`. Root-independent families — `paths`, `summary`, `instructions`, `context`, `work`, `review` — keep working without a root, and a user template override still resolves without one.

**A boundary guard.** `tasks/lint/claude_coupling.py` fails if anything in the rename set (`cli/**`, `bin/accelerator`, the four writers) names a `CLAUDE_*` variable. No allowlist: the failure message says the reference must be removed. It fails closed on empty discovery, on a file count below a floor, and on any named path that no longer resolves. The gitignore-honouring directory walk it needs was promoted to `tasks/shared/sources.py:walk_files` rather than copied a third time. The guard is wired into both `cli:check` (what CI runs) and `lint:check` (the only path the bare `mise run` reaches), together with the two pre-existing `cli/`-scoped guards, which had the same blind spot.

**Terminal invocation.** A new `SessionStart` hook, `hooks/launcher-link-refresh.sh`, keeps `${CLAUDE_PLUGIN_DATA}/bin/accelerator` pointing at the current installation's launcher, so a symlink you create once on your `$PATH` survives upgrades. It exits 0 on every path, refuses rather than clobbering anything it does not own, reports a re-point, and surfaces an unverified-launcher record from the bootstrap's durable log. `docs/internals.md` gains a Terminal Invocation section (discovery-first, since the data-directory layout is an undocumented internal); `docs/releases-and-compatibility.md` covers channel switches; the competing version-pinned recipe in the visualise skill and a stale `accelerator-visualiser` reference are gone.

**A conformance suite for the `!` sites.** `tests/integration/skill-invocation` runs all 122 distinct `config` commands the skills invoke at load time through the real bootstrap against a fixture installation, in the production shape — correct absolute path, empty environment — which is the one configuration no other suite exercised, and the gap that let this bug ship. Plus six structural invariants over the corpus. The fixture-installation apparatus was extracted to `tests/integration/support/` and the entrypoint suite refactored onto it.

**Test-infrastructure repairs.** The work-item template seam now forces failure through `ACCELERATOR_BIN` rather than a bogus plugin root, with a paired test proving the fallback branch is actually entered — it would have passed vacuously after the rename. `hooks`, `decisions` and `github` gained shell-suite discovery floors via one extracted helper. `test_mise.py` pins which integration tasks need a prebuilt launcher, exhaustively, so a new task forces a decision.

## Context

- Work item: [`meta/work/0182-cli-derives-plugin-root-from-own-location.md`](../work/0182-cli-derives-plugin-root-from-own-location.md)
- Plan: [`meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md`](../plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md)
- Validation: [`meta/validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md`](../validations/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename-validation.md)
- Predecessor: PR #28 (bootstrap self-location and `--fail-safe`), released as `1.24.0-pre.17`
- Follow-up raised here: [`meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`](../work/0184-template-enumeration-swallows-a-wrong-plugin-root.md)

## Testing

- [x] `mise run` (bare default) exits 0 end-to-end, run under `env -u CLAUDE_PLUGIN_ROOT -u ACCELERATOR_PLUGIN_ROOT` so no ambient root reached any task. The formatters changed nothing. The commits after that run are documentation-only, so the tip's code is exactly what was verified.
- [x] `mise run cli:check` exits 0; `lint:claude-coupling:check` scans 724 files with 0 violations in ~230ms, and its scan descends into neither `cli/target/` nor `node_modules/` nor `dist/`.
- [x] Shell suites with no ambient plugin root: `test:integration:work` 404 assertions, `test:integration:config` 1692, each exit 0.
- [x] `test:integration:skill-invocation` 128 passed (122 command cases + 6 corpus invariants); `test:integration:entrypoint` 46; `test:integration:hooks` 22; `test:unit:tasks` 409; `test:unit:cli` green.
- [x] Guard falsifiability: reintroducing a `CLAUDE_PLUGIN_ROOT` read into `cli/launcher/src/main.rs` and the transitional export into `bin/accelerator` both turn `cli:check` red with a `path:line:text` report; removing the three `lint:check` entries reddens the new placement assertion.
- [x] Rootless behaviour, measured against a freshly built launcher from a bare temp directory with both variables stripped: `config templates list` exits 1 naming `ACCELERATOR_PLUGIN_ROOT`, 0 bytes on stdout with and without `--fail-safe`; `config summary` and `config path work` still exit 0.
- [x] Against the installed `1.24.0-pre.17` (the predecessor release), rootless invocation by absolute path renders the plugin-default `adr` row and the originally reported `config instructions commit --fail-safe` exits 0 clean.
- [ ] The terminal link end-to-end — hook firing at `SessionStart`, the documented recipe on a machine without `~/.local/bin`, surviving an upgrade, two concurrent sessions, and plugin removal. Needs a release carrying the hook; `1.24.0-pre.17` predates it. The hermetic equivalents are the 22 hook cases.
- [ ] One skill load from a Claude Code session whose environment carries no `CLAUDE_PLUGIN_ROOT` at all. Two skills load correctly today, but this session inherited a stale value at startup, so that check currently rests on the bootstrap never reading one rather than on isolation.

## Notes for Reviewers

**Where to look first.** `bin/accelerator`'s self-location block landed in #28; what is new here is the removal of its second `export`. The two files carrying the most judgement are `hooks/launcher-link-refresh.sh` (every guard exists for a measured filesystem behaviour — in particular `mv -f` onto a symlink-to-directory writes *inside* it, which is why the link is cleared before the rename) and `cli/config-adapters/src/store.rs`, where the tier check must stay below the user-override check or a rootless override stops resolving.

**Bootstrap and launcher must ship together, and do.** The bootstrap no longer exports the old name and the launcher no longer reads it, so a new bootstrap paired with a pre-rename launcher would find no root. That pairing cannot occur: the launcher cache is version-keyed and the bootstrap fetches the launcher matching `plugin.json`. Worth confirming during review, since it is the obvious failure mode of a two-sided rename.

**A changelog gap.** `Unreleased` gained the terminal-invocation entry but has nothing for the user-visible behaviour change in this PR — a rootless template command now fails loudly where it used to print an empty table at exit 0 — and no `Fixed` entry for the original bug. Both are arguably worth adding before release; I left the changelog as the branch had it rather than editing it inside a description pass.

**One decision overrides the plan.** The plan argued the `cli/`-scoped guards should ride in `cli:check` *only*, reasoning from CI. Validation measured the consequence: because the bare `default` task depends on `lint:check` and never on `check`, none of the three guards ran in a full local run, so a boundary violation was green locally and caught only in CI. All three are now dual-wired, which avoids the "third pattern" the plan was guarding against. The plan records the reversal at the point of the original argument.

**Known gaps, both recorded rather than fixed.** The conformance suite excludes the visualiser daemon `!` site — the only one that hard-requires the plugin root — because it verifies `manifest.json` against the real release key; it is covered at the Rust layer instead. And `test:integration:config` failed once during validation on a teardown race in the Playwright executor cases (`rm: … Directory not empty`), passing standalone before and after; it belongs to the recorded config-suite flake class, not to this change, but it can turn a full local run red at random.

**The hook is shell, not CLI logic**, which diverges from ADR-0048. The justification is circularity — the link exists to make the launcher reachable, so maintaining it cannot depend on the launcher being fetched, verified and cached — and it is recorded in the plan's Phase 3 overview rather than left as apparent drift.
