### PR TITLE
Trim derivable content from CLAUDE.md and scope gotchas per directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,3 @@
-This file provides guidance to Claude Code (claude.ai/code) when working with 
-code in this repository.
-
 ## What this repo is
 
 Accelerator is a **Claude Code plugin** — not a conventional application. The
@@ -43,27 +40,17 @@ mise run check` yourself before pushing.
 ### Running a single test
 
 The aggregate `mise run test:*` tasks have no name filter; drop to the
-underlying runner for one test:
-
-- **Python (tasks/):** `uv run pytest tests/unit/tasks/test_x.py::test_y -v`
-- **Rust (server):** `cd cli/visualiser/server && cargo test <name>`
-- **Frontend (Vitest):** `cd cli/visualiser/frontend && npx vitest run -t "<name>"`
-- **Shell:** the suites are standalone scripts — run e.g.
-  `bash scripts/test-config.sh` or `bash hooks/test-vcs-detect.sh` directly.
+underlying runner for one test.
 
 ## Architecture
 
 ### Skills as the product (`skills/`, `agents/`, `templates/`, `hooks/`)
 
-Skills are grouped by category (`planning/`, `research/`, `work/`, `review/`,
-`decisions/`, `design/`, `vcs/`, `github/`, `integrations/`, `config/`, …) and
-registered in `.claude-plugin/plugin.json`. Each skill is a `SKILL.md` with YAML
-frontmatter (`name`, `description`, `argument-hint`, `allowed-tools`). The
-non-obvious mechanism: a SKILL.md body runs shell via the **`!` preprocessor**
-(``!`command` ``) at invocation time to inject live context (VCS status, config,
-per-skill context) into the prompt — see `skills/vcs/commit/SKILL.md`. Scripts
-are addressed via `${CLAUDE_PLUGIN_ROOT}` so they resolve from the installed
-plugin location.
+The non-obvious mechanism: a SKILL.md body runs shell via the **`!`
+preprocessor** (``!`command` ``) at invocation time to inject live context (VCS
+status, config, per-skill context) into the prompt — see
+`skills/vcs/commit/SKILL.md`. Scripts are addressed via `${CLAUDE_PLUGIN_ROOT}`
+so they resolve from the installed plugin location.
 
 The core design (read the README "Philosophy" section): development is split
 into phases (research → plan → implement) that communicate **through the
@@ -73,31 +60,15 @@ memory; each skill reads/writes predictable paths within it. Subagents
 summaries. Locator agents (find, no Read) are deliberately separated from
 analyser agents (Read) to keep each context bounded.
 
-### Visualiser (`cli/visualiser/`)
-
-- `server/` — Rust (axum) HTTP server. Cargo features: `embed-dist` (default,
-  bundles the built SPA via `rust-embed`) and `dev-frontend` (serves from disk).
-  `build:server:dev` builds the dev binary; release builds embed the frontend.
-- `frontend/` — React 19 + TypeScript + Vite SPA. **Biome** (not ESLint/Prettier)
-  for lint + format; `tsc -b` for types; Vitest for unit, Playwright for E2E.
-- The binary is distributed via GitHub Releases and downloaded on first use,
-  verified against the signed `manifest.json` (SHA-256 + minisign, optional SLSA
-  provenance).
-
-### Build system (`tasks/`)
-
-Python invoke tasks, type-checked with **pyrefly (strict preset)** and linted
-with **ruff (`select = ["ALL"]`)** — both version-pinned exactly in
-`pyproject.toml` because their rule sets are version-sensitive. Shared helpers
-live in `tasks/shared/`. Release/version logic enforces **version coherence**:
-`plugin.json`, the cli/ workspace `Cargo.toml`, and any version-pinned member
-manifest must agree.
+Gotchas specific to the visualiser (`cli/visualiser/`) and the build system
+(`tasks/`) live in their own `CLAUDE.md` files, loaded when you work in those
+directories.
 
 ### Shell scripts (`scripts/`, `hooks/`)
 
 A large bash library backs the skills (config reading, VCS detection, frontmatter
-parsing, migrations). Checked with shfmt + ShellCheck, plus a custom
-**bashisms** linter (`scripts/lint-bashisms.sh`) that guards a **bash 3.2 floor**
+parsing, migrations). A custom **bashisms** linter
+(`scripts/lint-bashisms.sh`) guards a **bash 3.2 floor**
 — macOS ships bash 3.2, so bash-4 constructs (associative arrays, `${var,,}`,
 etc.) are banned. Suspect the 3.2 floor first for any macOS-only shell failure.
 `hooks/` contains `SessionStart`/`PreToolUse` hooks (config detection, VCS

--- a/cli/visualiser/CLAUDE.md
+++ b/cli/visualiser/CLAUDE.md
@@ -1,0 +1,8 @@
+# Visualiser
+
+- `build:server:dev` builds the dev binary; release builds embed the frontend
+  via the `embed-dist` feature.
+- The frontend uses **Biome** (not ESLint/Prettier) for lint + format.
+- The binary is distributed via GitHub Releases and downloaded on first use,
+  verified against the signed `manifest.json` (SHA-256 + minisign, optional SLSA
+  provenance).

--- a/tasks/CLAUDE.md
+++ b/tasks/CLAUDE.md
@@ -1,0 +1,7 @@
+# Build system
+
+- pyrefly and ruff are version-pinned **exactly** in `pyproject.toml` because
+  their rule sets are version-sensitive. Shared helpers live in `tasks/shared/`.
+- Release/version logic enforces **version coherence**: `plugin.json`, the
+  `cli/` workspace `Cargo.toml`, and any version-pinned member manifest must
+  agree.


### PR DESCRIPTION
# Trim derivable content from CLAUDE.md and scope gotchas per directory

## Summary

Root `CLAUDE.md` spent most of its length restating things a session can read straight off `mise.toml`, the package manifests, and any `SKILL.md` — stack recitals, per-runner test invocations, skill registration mechanics. That content costs context on every session while earning nothing that a single `ls` or manifest read wouldn't. This PR removes it, and moves the two directory-specific gotcha sets into nested `CLAUDE.md` files so they load only when you are actually working in those trees.

Net: root goes from 51 lines of substance to 22 (40 deleted, 11 added), plus 15 lines across two new files.

## Changes

- **Root `CLAUDE.md` — removed as derivable:** the "this file provides guidance" preamble; the four per-runner single-test invocations (pytest, `cargo test`, Vitest `-t`, standalone shell suites); the skill-category enumeration, `plugin.json` registration, and `SKILL.md` frontmatter key list; the visualiser stack recital (axum, React 19, TypeScript, Vite, Vitest, Playwright); and the naming of shfmt + ShellCheck as the shell checkers.
- **New `cli/visualiser/CLAUDE.md`:** release builds embed the frontend via `embed-dist` while `build:server:dev` does not; the frontend uses **Biome**, not ESLint/Prettier; the binary ships via GitHub Releases and is verified against a signed `manifest.json` (SHA-256 + minisign, optional SLSA).
- **New `tasks/CLAUDE.md`:** pyrefly and ruff are pinned *exactly* because their rule sets are version-sensitive; shared helpers live in `tasks/shared/`; release logic enforces version coherence across `plugin.json`, the `cli/` workspace `Cargo.toml`, and any version-pinned member manifest.
- **Root keeps a one-sentence pointer** at those two files so their existence is discoverable without reading them.

What deliberately stayed at root, because it applies everywhere or is not derivable at all: the mise task model and the "done means a bare `mise run`" rule, the `<component>:check` list and the absence of a `<component>:fix` roll-up, CI-only enforcement, the `!` preprocessor and `${CLAUDE_PLUGIN_ROOT}` mechanisms, the research → plan → implement filesystem philosophy and the locator/analyser subagent split, the bash 3.2 floor, and the whole conventions block (80 columns, no shell autofixer, the executable-bit invariant, no `__init__.py` in tests, tooling pins, the Claude Code v2.1.144 floor).

## Context

No linked work item — this is standalone documentation hygiene. It follows the same instinct as the recent `.gitignore` and plugin-root cleanups (#32, #30): keep the always-loaded surface small and push specifics to where they are needed.

These are the repository's **first** nested `CLAUDE.md` files; before this PR the root file was the only one. The pattern this establishes is the main thing to agree on.

## Testing

Documentation only — no code, task, or configuration path is touched.

- [x] All CI *check* jobs green on `cddd5a0`: architecture, build system, cli, supply chain, visualiser frontend, visualiser server, scripts.
- [x] Confirmed nothing reads `CLAUDE.md`: no reference under `tests/`, `scripts/`, `hooks/`, `mise.toml`, `tasks/`, or `.github/workflows/`, and no markdown lint task exists. The change is inert to CI by construction.
- [x] Both new files are within the 80-column limit.
- [x] Verified the claims that moved are still true — `plugin.json` really does carry a `skills` array (14 category directories), and `embed-dist` is still the default server feature.
- [ ] Unit, integration, E2E, and visual-regression suites were still pending when this description was written. They exercise no path this PR touches; worth a glance before merge purely for the usual macOS/Linux flakes.

## Notes for Reviewers

**One stale path is worth fixing while we are in here.** The conventions block still says the 80-column width is duplicated by hand into `` `server/rustfmt.toml` ``. That file does not exist — the only rustfmt config is `cli/rustfmt.toml`, and it is workspace-wide, which is consistent with the same document describing `cli` as "workspace-wide rustfmt + clippy". The error predates this PR, but it got *harder* to read past it here: `server/…` used to sit in the shadow of a "### Visualiser (`cli/visualiser/`)" heading that listed `server/` as a subdirectory, and that heading is now gone. The bare path has lost its antecedent. Since this PR is an accuracy pass over exactly this file, correcting it to `cli/rustfmt.toml` belongs here.

**The `plugin.json` registration requirement is now undocumented.** The removed sentence carried a rule, not just a fact. The `skills` array holds 14 *category directories*, so adding a skill inside an existing category needs no registration — but adding a **new category** does, and nothing in the trimmed file says so. The failure mode is silent: the skill simply never loads. Narrow blast radius, but it is the one deletion I would argue is not purely derivable. A half-line under "Conventions and gotchas" would cover it.

**Nested files load lazily — that is the point, and also the cost.** The gotchas now surface only once a session touches files under `cli/visualiser/` or `tasks/`. A session *planning* visualiser work, or reasoning about the release pipeline without opening those trees, will not see them. The root pointer sentence is what keeps that from being a trap, so it is load-bearing and should not be trimmed later as filler.

**Minor: the shell paragraph needs a reflow.** The edit left `parsing, migrations). A custom **bashisms** linter` and the line after it wrapping at roughly 48 and 55 columns, against the 80-column fill used throughout. Cosmetic, but this is the file that documents the 80-column rule.

**Pre-existing long lines are not from this PR.** Lines 4, 69, and 80 sit at 81 characters, but all three are unchanged context. Flagging so they are not attributed to this change — and noting that byte-length checks will over-report here, since the file is full of em dashes.

**The least-derivable deletion was the shell test hint.** "The suites are standalone scripts — run `bash scripts/test-config.sh`" is not something `mise tasks` tells you, because the aggregate `test:*` tasks take no name filter. It is still one `ls scripts/test-*.sh` away, so I think the trim holds; noting it as the closest call among the removals.
