### PR TITLE
Split the VCS subdomain story into four independent work items

### DIFF
--- a/meta/prs/34-description.md
+++ b/meta/prs/34-description.md
@@ -1,0 +1,59 @@
+---
+type: pr-description
+id: "34"
+title: "Split the VCS subdomain story into four independent work items"
+date: "2026-08-02T18:50:13+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+relates_to: ["work-item:0136", "work-item:0169", "work-item:0185", "work-item:0186", "work-item:0187", "work-item:0188", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/34"
+pr_number: 34
+tags: [work-items, planning, vcs, hooks, rust, cli, migration]
+revision: "3b3ac9a995414cc85b78bda442322ebc3174278f"
+repository: "accelerator"
+last_updated: "2026-08-02T18:50:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Split the VCS subdomain story into four independent work items
+
+## Summary
+
+0169 had accreted four concerns with very different risk profiles — the VCS subdomain and hooks migration itself, a bash micro-fix to the bootstrap, a build-system generalisation, and the adoption of two new Rust dependency trees. Review 2 returned `REVISE` on exactly that ground, unanimously across the scope, completeness and testability lenses. This PR records the split: 0169 keeps the subdomain and hooks work, three new siblings take the separable concerns, and a fourth takes the cleanup the split defers.
+
+Documentation only — no code, no build-system changes.
+
+## Changes
+
+- **Four new work items.** 0185 (converge `corpus-adapters` on the library-backed VCS adapter), 0186 (remove the exec probe from the bootstrap warm path), 0187 (generalise the sub-binary registration surface), 0188 (library-backed VCS adapter over `gix` and `jj-lib`).
+- **0169 substantially rewritten** (679 lines changed) — scope narrowed to the `vcs detect|status|log|guard` subdomain plus the hook migration, with new Terminology, "The guard's inputs", Sequencing Constraints and Validation Results sections. Its `blocked_by` gains 0186, 0187 and 0188; its `blocks` gains 0170, 0171 and 0173.
+- **Reciprocal dependency edges recorded up front**, rather than at acceptance, so the coupling is visible from the consuming side while the blocking work is in flight: `blocked_by: 0187` plus a dated Dependencies bullet on 0170–0173, `blocks: 0187` on 0168, and `blocks: 0186` on 0182. 0170's bullet also carries the no-underscore dispatch-token constraint (`work-item`, not `work_item`, because the token derives `ACCELERATOR_<TOKEN>_BIN`).
+- **Epic 0136's decomposition annotated** — the four new children placed in their phases, the acceptance criterion widened from "0162–0174" to include 0185–0188, and a note that 0178/0179/0180 are grandchildren via 0166.
+- **Research document added** — the codebase research that drove the split.
+- **Five review documents recorded** — 0169 reviews 2 (`REVISE`) and 3 (`APPROVE`), and review 1 for each of 0186, 0187 and 0188 (all `APPROVE`).
+
+## Context
+
+- Splits `meta/work/0169-vcs-subdomain-and-hooks-migration.md`, a child of epic 0136 (Migrate Shell Scripts into a Rust CLI).
+- Driven by `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`, added here. Its four substantive findings are what forced the split: the `hooks.json` `${CLAUDE_PLUGIN_ROOT}` probe resolved in the story's favour; the PreToolUse envelope the story pinned as its golden fixture turned out to be the deprecated shape; the ~108 ms per-Bash-call cost was localised to `probe_dir` in the bootstrap rather than to the sub-binary choice; and the token `vcs` collides with the existing domain crate in both `tasks/manifest.py` and cargo-pup.
+- The `gix`/`jj-lib` feasibility risk was retired empirically in that research (§9) — the combined tree passes `bans`, `advisories` and `sources` against a verbatim copy of `cli/deny.toml`, with `uluru` (MPL-2.0) the sole licence rejection, and a binary calling both cross-compiles to a static musl ELF that `_assert_static_elf` accepts.
+
+## Testing
+
+- [x] `./scripts/validate-corpus-frontmatter.sh meta` — exit 0 across the whole corpus, covering all 18 changed files' frontmatter and typed linkage.
+- [x] Reciprocal edges checked by hand in both directions: every `blocked_by` added here has its matching `blocks` on the other item.
+- [ ] CI on this PR. No code, build-system or shell files are touched, so no language toolchain check is exercised by this change.
+
+## Notes for Reviewers
+
+**The split boundaries are the thing to review, not the prose.** Each new sibling was carved out because it carries a risk the others do not: 0186 is a bash micro-change to a file 0182 is also editing; 0187 is a build-system generalisation five stories depend on; 0188 lands two dependency trees, a workspace-wide licence exception and a pre-1.0 API bet that should be revertable on its own terms. If any boundary looks wrong, it is cheaper to move it now than after planning starts.
+
+**0188 ships unwired, and that is deliberate.** It adds an adapter without removing `CommandProbe` — no caller reaches the new code until 0169 and 0185 do the consumer work. The cost is that `vcs-adapters` carries two probe implementations until 0185 lands, and the zero-spawn guarantee holds only for the four hook paths in the interim. That trade is recorded in both items.
+
+**One dependency is knowingly left unresolved.** 0186 removes the ~108 ms exec probe but leaves the verify shim's second `sha256_file` (~11.7 ms), because three existing tests in `tests/integration/entrypoint/test_accelerator_entrypoint.py` assert the planted-stub defence it provides. That leaves the warm bootstrap near 41 ms against 0169's `G ≤ 1.1 × B` gate of ≈ 38.6 ms — so 0186 is necessary but may not be sufficient for 0169's latency criterion. Rather than hide it, a dated hand-off note in 0169's Dependencies carries the obligation, and 0169 must either relax the threshold or accept the overrun with a stated rationale before acceptance. No work item owns the residual.
+
+**0182's status changes twice across this stack.** This PR flips it `in-progress` → `ready`; PR #36 flips it `ready` → `done`. Reviewing the two in isolation makes that look like churn — it is the same closeout arriving in two steps.
+
+**Stack position.** This is the base of a three-PR stack: #34 → #35 (jj pin bump) → #36 (close out 0167/0168/0182). Nothing below depends on this PR's content, only on its commits being in the ancestry.

--- a/meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md
@@ -1,0 +1,928 @@
+---
+type: codebase-research
+id: "2026-07-29-0169-vcs-subdomain-and-hooks-migration"
+title: "Research: VCS Subdomain and Hooks Migration (0169)"
+date: "2026-07-29T16:20:46+00:00"
+author: "Toby Clemson"
+producer: research-codebase
+status: complete
+work_item_id: "0169"
+parent: "work-item:0169"
+relates_to:
+  - "codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"
+  - "codebase-research:2026-07-19-0167-config-command-and-invocation-contract-migration"
+  - "codebase-research:2026-07-11-0179-corpus-crates-parsing-conventions"
+  - "codebase-research:2026-07-03-0164-launcher-and-git-style-dispatch"
+topic: "Implementation surface for the accelerator-vcs subdomain and the SessionStart/PreToolUse hooks migration"
+tags: [research, codebase, vcs, hooks, rust, cli, migration, gix, jj-lib]
+revision: "0b2f8920ae677b141a161c78fb35d4e7bb2ae0db"
+repository: "accelerator"
+last_updated: "2026-07-30T00:00:00+00:00"
+last_updated_note: "Added empirical gix/jj-lib probe and latency measurements; recorded sub-binary, in-scope probe_dir-fix and permissionDecision-envelope decisions"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Research: VCS Subdomain and Hooks Migration (0169)
+
+**Date**: 2026-07-29 16:20 UTC
+**Author**: Toby Clemson
+**Git Commit**: `0b2f8920ae677b141a161c78fb35d4e7bb2ae0db`
+**Branch**: working copy on the `0182-plugin-root-rename-and-terminal-surface` lineage (`main` = `66abd9ce` is an ancestor; this revision is unpushed, so references below are local paths, not permalinks)
+**Repository**: accelerator
+
+## Research Question
+
+What is the implementation surface for work item 0169 — building the
+`accelerator-vcs` subdomain (`detect`/`status`/`log`/`guard`) over the
+`vcs`/`vcs-adapters` crates, and migrating the SessionStart VCS-detection and
+PreToolUse guard hook logic into the CLI behind a `--format=hook` switch?
+
+## Summary
+
+The story is well-shaped and its dependencies have all landed, but research
+surfaced **four findings that change the work** and **ten stale claims** in the
+work item text.
+
+The four substantive findings:
+
+1. **The story's central open probe is answered, in the story's favour.**
+   `hooks.json`'s `command` field *does* expand `${CLAUDE_PLUGIN_ROOT}` and *does*
+   tokenize arguments (it is handed to `sh -c`), and there is additionally an
+   *exec form* — a sibling `args` array — that passes argv tokens verbatim with no
+   shell at all. Either way, `hooks/config-detect.sh` can be deleted and the
+   wrapper is unnecessary. The last clause of the final AC is unblocked.
+
+2. **The PreToolUse envelope the story pins as its golden fixture is the
+   deprecated shape — so the story emits the current one instead.** Claude Code
+   documents `{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+   "permissionDecision":…,"permissionDecisionReason":…}}` with `systemMessage` as
+   a *top-level* field. `hooks/vcs-guard.sh:103-108` nests `systemMessage`
+   *inside* `hookSpecificOutput`, where the schema has no such field — so the
+   colocated "prefer jj" warning is almost certainly discarded today.
+   **Decision (author, 2026-07-30): emit the `permissionDecision` envelope.**
+   That makes the guard a deliberate behavioural change rather than a port, so
+   the AC splits into decision-parity plus a golden fixture on the *new* shape
+   (§4). Note `permissionDecision: "allow"` skips the permission prompt, so the
+   colocated "warn but permit" case must emit a bare top-level `systemMessage`
+   with no decision at all.
+
+3. **The per-Bash-call cost is real but lives in the bootstrap, not in the
+   sub-binary choice — and fixing it is now in scope** (measured — §12). Warm,
+   on darwin-arm64: today's `vcs-guard.sh` is **35 ms**; bootstrap + launcher is
+   **149 ms**. But the launcher binary itself is only **3 ms** and a minisign
+   verify of the 8 MB launcher only **2.3 ms**. **~108 ms is `probe_dir`**
+   (`bin/accelerator:166-180`) writing a fresh executable and running it (macOS
+   charges a first-exec check), and a further **~23 ms** is hashing the 475 K
+   verify shim twice to content-address a *same-directory* copy. Both are
+   avoidable, which would put the bootstrap near **18 ms** — below the shell
+   guard it replaces. **Decisions (author, 2026-07-30): ship the guard as a
+   sub-binary, and land the `probe_dir` fix in this story** rather than
+   deferring it, since the guard runs on every Bash call.
+
+4. **The token `vcs` collides with the existing domain crate, twice — and this
+   now matters, given the sub-binary decision.**
+   `tasks/manifest.py:56-57` would resolve the sub-binary's manifest to
+   `cli/vcs/Cargo.toml` — the pure domain crate, which has no `description` and no
+   `[[bin]]`, raising `ManifestError`. And cargo-pup's
+   `vcs_domain_imports_only_permitted` matches `^vcs($|::)` — the *whole crate
+   name* — so a binary crate named `vcs` could not import its own adapters.
+   Resolution in §8.
+
+**The `gix`/`jj-lib` risk is now retired empirically** (§9). Measured against a
+verbatim copy of `cli/deny.toml`, the combined tree passes `bans`, `advisories`
+and `sources`; the sole licence rejection is `uluru` (MPL-2.0), cleared by the
+one-line per-crate exception the repo's own policy prescribes. A binary calling
+both libraries cross-compiles to a **statically linked** musl ELF that
+`_assert_static_elf` accepts. jj-lib's workspace loader reproduces the shell's
+secondary-workspace rule exactly, and needs no `UserSettings`.
+
+The remaining understatement is scope: only ~11 of `hooks/test-vcs-detect.sh`'s
+42 cases are repointable, and `vcs guard` has **no test coverage at all** today.
+
+## Detailed Findings
+
+### 1. Current state of the `vcs` / `vcs-adapters` crates
+
+Both crates exist (delivered by 0179) and are much thinner than the story
+implies. `cli/vcs/src/lib.rs` is 193 lines with **zero dependencies**.
+
+The entire public surface:
+
+| Item | Location |
+| --- | --- |
+| `enum VcsKind { Jj, Git, None }` | `cli/vcs/src/lib.rs:14-17` |
+| `VcsKind::as_str` | `cli/vcs/src/lib.rs:22` |
+| `struct RepoFacts { root, name, kind, revision }` | `cli/vcs/src/lib.rs:38-43` |
+| `trait RepoRoot { discover, repository_root }` | `cli/vcs/src/lib.rs:46-57` |
+| `trait VcsProbe { kind, revision }` | `cli/vcs/src/lib.rs:60-67` |
+| `fn facts(start, &dyn RepoRoot, &dyn VcsProbe)` | `cli/vcs/src/lib.rs:74-91` |
+
+**There is no checkout-classification model.** The taxonomy the story must add is
+absent in every arm:
+
+- *bare* — not representable. No `.git` marker ⇒ `discover` returns `None` ⇒
+  `facts` returns `None`, indistinguishable from "no repository at all"
+  (`cli/vcs-adapters/tests/detection.rs:251-277` pins this deliberately).
+- *worktree* — a `.git` *file* is intentionally indistinguishable from a `.git`
+  directory; discovery tests existence only (`cli/vcs-adapters/src/lib.rs:38`).
+- *colocated* — collapsed into `VcsKind::Jj` by marker precedence
+  (`cli/vcs-adapters/src/lib.rs:98-104`); unobservable from `RepoFacts`.
+- *nested* — the ancestor walk stops at the first marker, with no record that
+  nesting occurred (`cli/vcs-adapters/src/lib.rs:37-42`).
+- *`GIT_DIR`* — appears only as a variable to be scrubbed
+  (`cli/vcs-adapters/src/lib.rs:141`), never read or honoured.
+- *jj secondary workspace* — the **only** topology distinction present, and not
+  as a type: it is the defaulted `RepoRoot::repository_root` hook, resolved by
+  pure file reads (no subprocess) in `jj_repository_root`
+  (`cli/vcs-adapters/src/lib.rs:57-68`).
+
+`VcsKind`'s doc comment (`cli/vcs/src/lib.rs:9-12`) already encodes the
+jj-outranks-git rationale the story wants preserved — "a colocated checkout
+carries both markers, and `Jj` wins there because git's index lags the jj
+working-copy commit".
+
+**Only two subprocesses exist today**, and all spawning funnels through one site:
+
+- `jj --color=never --no-pager log -r @ --no-graph -T commit_id` —
+  `cli/vcs-adapters/src/lib.rs:110-120`
+- `git -c color.ui=false rev-parse HEAD` — `cli/vcs-adapters/src/lib.rs:124-125`
+- the single spawn chokepoint: `command.spawn()` at
+  `cli/vcs-adapters/src/lib.rs:168`
+
+That chokepoint is the natural place to instrument the story's "zero spawns" AC.
+
+Two extension frictions worth knowing:
+
+- `vcs_adapters::facts(start)` (`cli/vcs-adapters/src/lib.rs:225-227`)
+  hard-wires `MarkerWalkRoot` + `CommandProbe::new()` with no injection variant,
+  and the sole production caller (`cli/corpus-adapters/src/metadata.rs:201`)
+  calls *that*, not `vcs::facts` — so nothing downstream can be tested against a
+  fake probe.
+- `RepoFacts.root` and `.kind` currently have **no production consumer**
+  (`corpus-adapters` reads only `.name` and `.revision` at
+  `cli/corpus-adapters/src/metadata.rs:185-186`), which gives latitude to reshape.
+
+**The `bash-parity` feature name is misleading.** Despite it,
+`cli/vcs-adapters/tests/detection.rs` never shells out to any bash helper — it
+spawns `git`/`jj` only to *build* fixtures. There is no VCS shell-parity harness
+today; genuine differential suites live in `cli/corpus-adapters/tests/parity.rs`.
+
+### 2. The shell behaviour to port — and four divergent copies of mode detection
+
+`scripts/vcs-common.sh` (280 lines) is the reference. The load-bearing parts:
+
+- `find_repo_root` (`:8-18`) — lexical ancestor walk for `.jj`/`.git`, using
+  `-e`. Note it ignores any argument and always walks from `$PWD`.
+- `vcs_mode` (`:27-36`) — `.jj`-wins command-set selector, using `-e`. Prints
+  `jj|git|none`.
+- `classify_checkout` (`:177-280`) — the six-line `KEY=VALUE` record; the
+  first-match-wins cascade at `:240-272` with the documented requirement that
+  `colocated` precede the `nested-*` arms.
+- `find_jj_main_workspace_root` (`:90-114`), `find_git_main_worktree_root`
+  (`:127-155`) — the probe layer, including `GIT_DIR` scrubbing at `:132-135`
+  and the bare-repo rejection at `:137-139`.
+
+**The hooks do not use `vcs_mode()`, and neither do the status/log scripts.**
+This is a parity trap the story does not name — there are four independent
+implementations of mode detection:
+
+| Site | Test | Values produced |
+| --- | --- | --- |
+| `scripts/vcs-common.sh:29,31` | `-e` | `jj` / `git` / `none` |
+| `hooks/vcs-detect.sh:28-29` | `-d` | `jj` / `jj-colocated` / `git` |
+| `hooks/vcs-guard.sh:22,77` | `-d` | pure-jj / colocated |
+| `scripts/vcs-status.sh:9`, `scripts/vcs-log.sh:9` | `-d` | jj-arm / git-arm |
+
+Two consequences. `vcs-detect.sh` produces a **three-valued** mode that
+`vcs_mode()`'s two-valued contract cannot express. And in a checkout where
+`.git` is a *file* rather than a directory, `hooks/vcs-guard.sh:77` classifies a
+colocated repo as `pure-jj` and **blocks** where it should warn. Porting
+"`vcs-common.sh` semantics" is therefore insufficient for hook parity — the
+hooks' own inline divergences are the real reference.
+
+### 3. The hook envelope contract as 0167 actually shipped it
+
+There is **no shared hook-envelope module**. The envelope is one hand-written
+`format!` plus a private RFC-8259 `json_escape`, in a renderer for a single
+subcommand:
+
+- `hook_envelope` — `cli/launcher/src/config_command/render/summary.rs:66-74`
+- `json_escape` — `:76-101` (private, not exported)
+- byte-exact contract test — `:112-120`
+
+It is **compact** (no pretty-printing), single-key, and deliberately not
+`serde_json` — even though the launcher already depends on `serde_json`
+(`cli/launcher/Cargo.toml:35`). The choice is architectural, per the module
+docstring at `:1-5`.
+
+The emptiness rule is a single choke point —
+`cli/launcher/src/config_command/inbound/cli.rs:290`:
+
+```rust
+let stdout = match (summary_render::body(&summary), hook) {
+    (None, _) => String::new(),
+    (Some(text), false) => format!("{text}\n"),
+    (Some(text), true) => format!("{}\n", summary_render::hook_envelope(&text)),
+};
+```
+
+`--fail-safe` maps to `OnFailure::Degrade`
+(`cli/launcher/src/launch/mod.rs:22-28`), and `summary` uses
+`Degrade::Suppress` (`inbound/cli.rs:212-216`) so a degraded run emits nothing on
+stdout — deliberately, because a `## Unavailable` notice would be spliced into
+the model's prompt. The swallow/refuse split is decided by
+`ConfigError::is_refusal()` (`cli/config/src/error.rs:76-87`), whose exhaustive
+in-crate match is a pattern worth copying: a new variant will not compile until
+it is classified.
+
+**Where a `vcs` sibling cannot simply reuse it.** cargo-pup denies
+`config_command` importing `crate::launch` (`cli/pup.ron:99-112`), and by
+symmetry a `vcs_command` hexagon must not reach across into
+`crate::config_command`. The `vcs` domain crate is restricted to
+`std`/`kernel::Error`/`crate::` (`cli/pup.ron:75-89`). The neutral homes that fit
+the existing rules are a new shared launcher module (e.g.
+`crate::hooks::envelope`) or `kernel`.
+
+**The envelope must be extended, not reused.** `vcs-detect.sh:177-181` merges an
+optional `systemMessage` into the *same* jq object as `hookSpecificOutput`;
+`render/summary.rs:68-74` has **no `systemMessage` slot**. The story acknowledges
+the sibling key at `:205-207` but no AC covers the merge.
+
+### 4. Hook protocol facts (from the Claude Code documentation)
+
+- **`command` parsing.** Shell form (no `args` key) hands the whole string to
+  `sh -c`: `${CLAUDE_PLUGIN_ROOT}` is expanded and arguments are tokenized, so
+  `"${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs detect --format=hook"` works
+  directly. Exec form adds an `args` array whose elements are passed as exact
+  argv tokens with no shell. **This resolves the story's probe.** Caveat: the docs
+  do not date the `args` field, and the plugin's floor is Claude Code v2.1.144 —
+  shell form is the safer choice if `args` postdates that.
+- **SessionStart output.** `{"hookSpecificOutput":{"hookEventName":"SessionStart",
+  "additionalContext":…}}` is current. `systemMessage` is a **top-level** field
+  and may be emitted alone. Empty stdout at exit 0 is a no-op. One JSON object
+  per invocation.
+- **PreToolUse output.** The documented shape is
+  `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":…,
+  "permissionDecisionReason":…}}`, with `permissionDecision` ∈
+  `deny|allow|ask|defer`. The top-level `{"decision":"block","reason":…}` form is
+  **not documented for PreToolUse**. Exit 2 is a blocking error whose stderr
+  becomes Claude's feedback (and where JSON is ignored).
+- **Multiple hooks per event** run in parallel; all `additionalContext` is
+  concatenated; for PreToolUse the most restrictive decision wins
+  (`deny` > `defer` > `ask` > `allow`).
+
+**Decision (author, 2026-07-30): emit the `permissionDecision` envelope, not the
+deprecated shape.** The guard's mapping from today's shell behaviour:
+
+| Case | `vcs-guard.sh` today | New envelope |
+| --- | --- | --- |
+| pure-jj + blocked git subcommand | `{"decision":"block","reason":…}` (`:97-100`) | `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":…}}` |
+| colocated + blocked git subcommand | `{"decision":"allow","hookSpecificOutput":{"systemMessage":…}}` (`:103-108`) | top-level `{"systemMessage":…}` with **no** `permissionDecision` — see below |
+| no match | exit 0, no output (`:72-74`) | unchanged |
+
+**The colocated case needs care: `permissionDecision: "allow"` is not neutral.**
+Per the documentation it *skips the interactive permission prompt* (settings-level
+deny rules still apply). The shell's intent there is "let it through but advise" —
+a warning, not a grant of auto-approval. Emitting `"allow"` would therefore be a
+privilege change smuggled in under a format migration. Emitting only a top-level
+`systemMessage` preserves the intent exactly: normal permission flow proceeds and
+the advice is surfaced. (`"ask"` would force a prompt where none is currently
+forced, so it is also not parity.)
+
+Two user-visible consequences to flag in the story:
+
+- **The colocated warning will start appearing.** `vcs-guard.sh:103-108` nests
+  `systemMessage` inside `hookSpecificOutput`, where the schema has no such
+  field, so it is almost certainly discarded today. Moving it to the top level
+  fixes a silent no-op — correct, but it is new output users have not seen.
+- **This is a behavioural change, not a port**, so the AC must split: parity on
+  *decisions* (which Bash-call classes block versus pass — the allow/deny fixture
+  set the story already asks for at `:96-99`) plus a golden fixture pinning the
+  *new* envelope. Byte-parity against the shell is explicitly not the target.
+
+### 5. `hooks.json` has five hooks, not four
+
+| Index | Script | Owner |
+| --- | --- | --- |
+| SessionStart[0] | `hooks/vcs-detect.sh` (`:9`) | **0169 removes** |
+| SessionStart[1] | `hooks/config-detect.sh` (`:18`) | 0167 re-homed; 0169 may fold in |
+| SessionStart[2] | `hooks/migrate-discoverability.sh` (`:27`) | deferred to 0172 |
+| SessionStart[3] | `hooks/launcher-link-refresh.sh` (`:36`) | **no story owns it** |
+| PreToolUse(Bash) | `hooks/vcs-guard.sh` (`:47`) | **0169 removes** |
+
+`hooks/launcher-link-refresh.sh` arrived with 0182, after 0169 was written. It
+must survive untouched. It also documents two constraints 0169 inherits, at
+`hooks/launcher-link-refresh.sh:16-17`: *"at most one JSON object may reach
+stdout, and two conditions can hold in one run"* — hence its accumulate-then-
+emit-once `finish()` pattern (`:20-27`) — and it emits a bare `{systemMessage}`
+with no `hookSpecificOutput`, a third envelope shape beyond the two the story
+enumerates.
+
+### 6. Test surface: the parity gate is only ~1/4 repointable
+
+`hooks/test-vcs-detect.sh` (712 lines, 42 cases) is a hybrid:
+
+- **~11 subprocess cases** (golden JSON `:190-252`, boundary blocks `:482-594`,
+  missing-binary `:666-709`) — repointable by editing `HOOK=` at `:20` and
+  dropping `"$BASH_BIN"` at `:161`, `:233`, `:705`.
+- **27 in-process cases** (`:256-480`) — these `source scripts/vcs-common.sh` at
+  `:254` and call `classify_checkout`, `find_repo_root`, `vcs_mode`,
+  `_jj_workspace_is_secondary`, `find_jj_main_workspace_root`,
+  `find_git_main_worktree_root` as shell functions. A binary cannot host these
+  unless a `classify`-style subcommand emits the same `KEY=VALUE` record. Since
+  `vcs-common.sh` survives this story, they stay meaningful and should be split
+  into their own suite rather than repointed.
+- **1 dead case**: `:642-664` greps the *shell file's* leading comment block for
+  four phrases (0058's AC9). Nothing to grep once it is Rust.
+- `:620-634` asserts the exact `hooks.json` command literal and hard-codes the
+  positional index `SessionStart[0]`.
+
+Fixtures: only two goldens (`hooks/test-fixtures/vcs-detect/main-jj-workspace.json`,
+`main-git-checkout.json`), compared byte-for-byte at `:209`/`:221`, plus a
+host-path-artefact guard at `:196-202`. `CAPTURE-SOURCE.txt` is written by
+`regenerate.sh:49-60` but **nothing reads it**.
+
+Crucially, the boundary-block assertions extract via
+`jq -r '.hookSpecificOutput.additionalContext'` (`:486`, `:693`) — so config's
+compact JSON versus `vcs-detect.sh`'s pretty `jq -n` output is **transparent** to
+them. Only the byte-exact goldens at `:209`/`:221` would need re-baselining.
+
+**`hooks/vcs-guard.sh` has zero test coverage** — no shell suite, no pytest, no
+Rust test. Its only reference outside `meta/` is its registration. So the story's
+allow/deny AC builds *new* coverage; there is no behaviour lock to check the
+Rust guard against, which argues for capturing the shell's current decisions as
+fixtures *before* rewriting.
+
+### 7. CI and lint machinery that must move in lockstep
+
+| Guard | Location | Effect |
+| --- | --- | --- |
+| Hooks suite floor | `tasks/test/integration.py:47` (`_EXPECTED_HOOKS_SUITES = 2`), enforced `:159` | Holds if the suite stays a `hooks/test-*.sh`; must drop to 1 if converted. Never to 0 — `tests/unit/tasks/test_integration.py:84-96` stops discriminating on an empty list. |
+| Launcher-build edge | `mise.toml:209-211`; pinned by `tests/unit/tasks/test_mise.py:47-56`, `:96-109` | `test:integration:hooks` today has **no** `build:cli:dev` dep and passes **no** env. Driving a binary requires all three of: move to `_LAUNCHER_DEPENDENTS`, add `depends`, pass `accelerator_env()` at `tasks/test/integration.py:158`. |
+| `CLAUDE_*` coupling | `tasks/lint/claude_coupling.py:12`, `:31`, `_MIN_SCANNED = 200` at `:43` | `cli/**` must never name a `CLAUDE_*` variable — the binary reads `ACCELERATOR_PLUGIN_ROOT`. The harness's `CLAUDE_PLUGIN_ROOT=` overlay at `test-vcs-detect.sh:161` must change. |
+| Exec-bit invariant | `tasks/lint/scripts.py:97-145`; `SHELL_LIBRARIES` at `:18-49` | **No edit needed** — all three files being deleted are entrypoints, not libraries. `scripts/vcs-common.sh:28` stays. |
+| Stale library entry | `tasks/lint/scripts.py:113-118` + `tests/unit/tasks/test_exec_bits.py:254` | Coupled pair; only relevant when `vcs-common.sh` eventually goes (0174). |
+| Skill permissions | `tasks/lint/skill_permissions.py:41-44`, `:183-188` | A `Bash(...)` rule must name the subcommand; an ancestor glob would pre-authorise every future sub-binary. |
+| Store duplication | `tasks/lint/store_duplication.py:38-60` | Any temp-plus-rename write under `cli/**/src` outside `cli/store/` fails unless allowlisted. |
+
+Shell-suite discovery is glob-based (`tasks/test/helpers.py:45-78`), so deleting
+a `test-*.sh` auto-drops it from the run — and the floor then fails, by design.
+
+### 8. Sub-binary distribution: registration points and the warm-path cost
+
+Dispatch: only `version` and `config` are built in
+(`cli/launcher/src/launch/inbound/cli.rs:16-29`); everything else falls to
+`#[command(external_subcommand)]` and is resolved by fetch-verify-cache. Adding a
+built-in touches five exhaustive matches (`cli/launcher/src/main.rs:98-109`,
+`:139-144`, `:182-189`, `:191-201`, and `launch/inbound/cli.rs:487`).
+
+The **warm path makes no HTTP request at all** — not even for `manifest.json`
+(`cli/launcher/src/launch/outbound/resolve/mod.rs:179-211`). But it does
+re-verify: `reverify` (`:90-109`) re-runs minisign over the cached bytes because
+the cache dir is user-writable, and `bin/accelerator:336-338` independently
+re-verifies the cached launcher on every invocation. So a PreToolUse guard served
+as a sub-binary pays, per Bash call: bash bootstrap + launcher minisign verify +
+sub-binary minisign verify + 3 execs — against one bash spawn today.
+
+Registration points for a new `accelerator-vcs`:
+
+| # | Location | Note |
+| --- | --- | --- |
+| 1 | `tasks/shared/paths.py:25` | `DISPATCHED_SUBBINARIES = ("visualiser",)` — the single allowlist; drives signing, manifest, upload, re-verify |
+| 2 | `tasks/manifest.py:51-53` | `_SUBBINARY_MANIFESTS` override — **required**, see the token collision below |
+| 3 | new crate `Cargo.toml` | `package.description` mandatory (`tasks/manifest.py:60-66`); `version.workspace = true` (else `tasks/build.py:74-101` coherence) |
+| 4 | `cli/Cargo.toml:4` | workspace members |
+| 5 | `.gitignore:37` | `bin/visualiser-*` needs a `bin/vcs-*` sibling, else warm cache entries appear untracked in the shipped `bin/` |
+| 6 | `cli/launcher/tests/fixtures/manifest.example.json` | shared golden contract, also read by `tests/unit/tasks/test_manifest.py:38` |
+| 7 | `tasks/build.py:189-208` | `validate_dispatch_coherence` is hardcoded to the visualiser — the SKILL↔producer binding would be unenforced |
+| 8 | `tasks/build.py:37` / `:290-331` | cross-compile staging; musl builds get `_assert_static_elf` (`:132-159`) |
+
+Already parameterised, needing no edit: `tasks/signing.py:50-73`,
+`tasks/github.py:218-235`, `:270-293`. Nothing in `.claude-plugin/plugin.json`
+enumerates binaries. The SLSA globs at `.github/workflows/main.yml:423-425` already
+cover `accelerator-*`.
+
+**The token collision, and how to resolve it.** `tasks/manifest.py:56-57`
+defaults a token to `cli/<token>/Cargo.toml` — for `vcs` that is the pure domain
+crate (no `description`, no `[[bin]]`), so `_read_description` raises. And
+cargo-pup's `vcs_domain_imports_only_permitted` matches `^vcs($|::)`, the whole
+crate name, so a *binary* crate named `vcs` would be restricted to
+`std`/`kernel::Error`/`crate::` and could not import `vcs_adapters`.
+
+Both dissolve if the **package** is named `accelerator-vcs` while the
+**dispatch token** stays `vcs`:
+
+- pup matches the resolved module path, and `accelerator-vcs` resolves to
+  `accelerator_vcs`, which `^vcs($|::)` does not match. No new pup rule is
+  needed for the binary; mirror rule 6 (`cli/pup.ron:99-112`) with a `denied`
+  list if you want to stop it reaching sideways into `crate::launch`.
+- the directory cannot be `cli/vcs/` (taken by the domain crate), so it needs a
+  sibling — the visualiser precedent is a nested path (`cli/visualiser/server/`,
+  package `accelerator-visualiser`, token `visualiser`), but `cli/visualiser/` is
+  not itself a crate whereas `cli/vcs/` is. A sibling directory
+  (e.g. `cli/vcs-command/`) is the clean analogue.
+- add the `_SUBBINARY_MANIFESTS` entry (`tasks/manifest.py:51-53`) mapping token
+  `vcs` → that directory's `Cargo.toml`, which is exactly what that override map
+  exists for. The user-facing `accelerator vcs detect` UX is unaffected.
+
+`derive_override_var` then yields `ACCELERATOR_VCS_BIN`
+(`cli/launcher/src/launch/core.rs:215-240`), which is legal.
+
+Env-var derivation is fine: `vcs` → `ACCELERATOR_VCS_BIN`
+(`cli/launcher/src/launch/core.rs:215-240`; a token containing `_` would be
+rejected).
+
+### 9. `gix` / `jj-lib` feasibility: measured, and it passes
+
+Neither `gix`, any `gix-*`, `gitoxide`, `jj-lib`, `git2` nor `libgit2-sys`
+appears in `cli/Cargo.lock` today — both trees would be new. There was **no
+spike**; `meta/prs/24-description.md:47` records the choice as "the load-bearing
+decision to confirm", and that PR was documentation-only.
+
+**This research ran the checks empirically** — a scratch workspace with
+`gix 0.85` + `jj-lib 0.43`, evaluated against a verbatim copy of `cli/deny.toml`:
+
+| `cargo deny` check | Verdict |
+| --- | --- |
+| `bans` | **ok** |
+| `advisories` | **ok** |
+| `sources` | **ok** |
+| `licenses` | one rejection — `uluru 3.1.0`, `MPL-2.0` |
+
+Two assumptions behind the original risk assessment proved **stale**:
+
+- **`jj-lib` 0.43 no longer depends on `git2`/`libgit2-sys`.** It has migrated to
+  `gix`. That was the principal source of C linkage and of `openssl-sys`.
+- **`gix`'s default features exclude the network transports.** Compression
+  resolves to `zlib-rs` (pure Rust). No `openssl`, `openssl-sys`, `native-tls`,
+  `curl`, `curl-sys`, `libz-sys` or `libssh2-sys` enters the graph, so the
+  `cli/deny.toml:65-70` ban is satisfied with no feature surgery.
+
+This holds because **every query 0169 needs is a local read** — classification,
+status, log, guard, and even ahead/behind (remote-tracking refs live in
+`refs/remotes`). No network transport is required at all.
+
+**Static linking is not in tension with the TLS ban — they agree.**
+`openssl-sys` is C and needs a system libssl or a vendored C build; `rustls` is
+pure Rust. The ban's own rationale (`cli/deny.toml:61-64`) is to protect the
+musl-static build. Verified end-to-end: a binary calling `gix::discover` and
+jj-lib's workspace loader cross-compiles for `aarch64-unknown-linux-musl` via
+`cargo zigbuild` and reports `ELF 64-bit LSB executable, ARM aarch64, statically
+linked, stripped`; `tasks/build.py:132-159` `_assert_static_elf` accepts it
+unmodified. The only `cc` build-dep in the graph arrives via
+`iana-time-zone-haiku` (**Haiku OS**), absent from all four target triples.
+
+**The one real finding — `uluru` is MPL-2.0.** It is `gix-pack`'s LRU object
+cache, reached through both `gix` and `jj-lib`, so it cannot be feature-gated
+away. `cli/deny.toml:35-40` legislates exactly this case ("must be justified
+per-crate via `[[licenses.exceptions]]`, never added to this blanket allow").
+Adding
+
+```toml
+[licenses]
+exceptions = [
+    { crate = "uluru", allow = ["MPL-2.0"] },
+]
+```
+
+turns the run green (verified). MPL-2.0 is file-level copyleft, so consuming it
+unmodified as a library imposes no obligation on surrounding code.
+
+**The `jj-lib` unstable-API risk is also retired.** The story asks
+(`:192-197`) to "confirm its workspace/repo-loading surface covers the
+secondary-workspace and colocated cases before committing". It does, and
+without `UserSettings`:
+
+- `jj_lib::workspace::DefaultWorkspaceLoaderFactory` is public, and the
+  `WorkspaceLoader` trait exposes `workspace_root()` and `repo_path()` with no
+  settings argument (jj-lib 0.43 `src/workspace.rs:499-545`).
+- Its private `DefaultWorkspaceLoader::new` (`src/workspace.rs:564-585`)
+  implements **precisely** the shell's secondary-workspace rule — "If .jj/repo is
+  a file, then we interpret its contents as a relative path to the actual repo
+  directory", canonicalised — i.e. `_jj_workspace_is_secondary`
+  (`scripts/vcs-common.sh:74-81`) and `find_jj_main_workspace_root` (`:90-114`)
+  in one library call.
+- Probed against four real fixtures (colocated main, secondary workspace, plain
+  git, nested subdir) plus this repo's own `workspaces/build-system` checkout,
+  the library answers **match `classify_checkout` exactly**: `workspace_root()`
+  equals `BOUNDARY`, and `repo_path()` minus `/.jj/repo` equals `JJ_PARENT`.
+
+Two caveats found while probing, both worth encoding in the adapter:
+
+- **`gix::discover` walks up *past* a jj workspace boundary.** From inside
+  `workspaces/build-system` it returned the parent repo's
+  `/Users/.../accelerator/.git`. Boundary containment is the adapter's job (the
+  reason `classify_checkout` exists); bound discovery with a ceiling rather than
+  trusting `discover` to stop.
+- **`UserSettings` is a trap for a library consumer.** Full `Workspace::load`
+  requires it, and jj-lib's own defaults (`src/config/misc.toml`) are behind a
+  private `DEFAULT_CONFIG_LAYERS` static (`src/config.rs:910-913`) — so a caller
+  must supply every required key by hand, discovered one panic at a time
+  (`user.name` → `operation.hostname` → `operation.username` →
+  `debug.randomness-seed` → `signing.behavior` → …). **Avoid `Workspace::load`
+  for detection**; the loader-only path needs none of it.
+
+Two secondary notes:
+
+- **Pin `gix` to match `jj-lib`'s** (0.85 at the time of writing). Declaring
+  `gix = "0.86"` alongside `jj-lib` yields two complete `gix` trees — only a
+  warning (`multiple-versions = "warn"`, `cli/deny.toml:57`), but it doubles the
+  closure.
+- `unknown-git = "deny"` (`:74`) matters only if jj-lib's unstable API ever
+  forces pinning an unreleased commit. Both crates are on crates.io today and
+  `sources` passes.
+
+Also: `tasks/lint/cli.py:15` runs clippy with `--locked`, so `cli/Cargo.lock`
+must be committed in the same change as the new dependencies.
+
+One genuine upside the story does not claim: going in-process **dissolves 0125's
+stated reason** for keeping the lexical fallback — that the helpers must work
+with no `git`/`jj` on `PATH`, and that probing spawns 1-3 subprocesses per call.
+Neither constraint survives a library-backed adapter.
+
+
+### 10. Patterns to build on
+
+- **Hexagon template.** `cli/config/` + `cli/config-adapters/` is the grown
+  version; the shape is domain (`lib.rs` re-export face, `error.rs`,
+  `service.rs`) + adapters (`compose.rs` as the one tested wiring helper,
+  `store.rs`, private `mod`s with a curated `pub use`). Error convention: one
+  `#[non_exhaustive]` enum per domain, hand-written `Display`, `impl Error`,
+  `From<X> for kernel::Error` → `Failed(...)` (`cli/config/src/error.rs:36-147`).
+- **Domain import style.** One item per `use`, `crate::`-qualified, never
+  braces — cargo-pup resolves grouped `use foo::{a,b}` to an empty module name
+  which matches no `allowed_only` pattern (`cli/pup.ron:93-96`). `#[cfg(test)]`
+  modules are exempt in practice.
+- **"Must never fire" assertions.** `cli/launcher/tests/crypto_provider.rs:1-56`
+  is the template: a `Cell<bool>` spy port *plus* a panicking null (`PanicExec`).
+  For exact counts, `AtomicUsize` as at `cli/corpus-adapters/src/lock.rs:211-225`.
+- **Zero-fetch assertions already exist.**
+  `cli/launcher/tests/resolution.rs:451-466` points a second resolver at
+  `http://127.0.0.1:1` and proves the warm path is offline;
+  `:214-224` asserts `hits(asset) == 1`. Per-path counters:
+  `cli/launcher/tests/common/mod.rs:82-89`.
+- **Golden output.** No `insta` anywhere. Checked-in files under
+  `tests/fixtures/<case>/*.golden`, read by a `golden()` helper and compared as
+  `Vec<u8>` against `output.stdout` (`cli/launcher/tests/config_read.rs:74-135`,
+  `:490-497`).
+- **CLI end-to-end.** `env!("CARGO_BIN_EXE_accelerator")` +
+  `std::process::Command`, with a `run_in` helper that scrubs `ACCELERATOR_*`
+  (`cli/launcher/tests/config_read.rs:59-72`). For a library crate with no bin,
+  add a test-only fixture bin under `tests/fixtures/`
+  (`cli/config-adapters/tests/fixtures/config_adapters_fixture.rs`).
+- **Fixture repos.** `cli/vcs-adapters/tests/detection.rs:21-80` — `require()`
+  hard-fails on an absent binary (Rust has no skip primitive, so an early return
+  would register PASS), labelled `tempfile::Builder` prefixes, git identity passed
+  per-invocation. Existing shapes: clean git, no-commits, bare, worktree-as-file,
+  colocated (`:144-169`), jj secondary workspace (`:171-209`).
+  **Missing and needed by AC2: dirty, detached-HEAD, ahead/behind.** Consider
+  adopting `GIT_CEILING_DIRECTORIES` from `hooks/test-vcs-detect.sh:35-40` so
+  `gix`'s own discovery cannot escape the fixture.
+
+### 11. What survives this story
+
+After deleting the two hooks, five `vcs-common.sh` functions lose **every**
+production caller — `classify_checkout` (whose only call site anywhere is
+`hooks/vcs-detect.sh:122`), `find_jj_main_workspace_root`,
+`find_git_main_worktree_root`, `_jj_workspace_is_secondary`,
+`_ancestor_has_marker`. Only `hooks/test-vcs-detect.sh` would reference them.
+
+But the lexical helpers survive with a wide surface:
+
+- `find_repo_root` — 20+ call sites, notably `scripts/config-common.sh:18`
+  (the transitive hub), `skills/work/scripts/*`,
+  `skills/integrations/{jira,linear}/scripts/*`,
+  `skills/decisions/scripts/adr-next-number.sh:37`,
+  `skills/design/inventory-design/scripts/playwright/run.sh:71`
+- `vcs_mode` — exactly one: `skills/work/scripts/work-item-file-dirty.sh:45`
+
+So `scripts/vcs-common.sh` cannot be deleted here, and the story is right not to
+try. **After 0169 there will be three implementations, not two**: the Rust
+classifier, the surviving shell probe layer, and the surviving shell lexical
+walk.
+
+The coupling that makes the SessionStart port load-bearing:
+`skills/vcs/commit/SKILL.md:43-44,54-55` instructs Claude to "refer to the
+session's VCS context" — text injected by the hook being replaced.
+
+Two latent bugs a faithful port would preserve:
+
+- `skills/planning/validate-plan/SKILL.md:56-60` instructs raw `git log` /
+  `git diff`; both are in the guard's blocked pattern
+  (`hooks/vcs-guard.sh:53`), so that skill is presumably blocked in pure-jj repos.
+- `scripts/lint-bashisms.sh:31` still enumerates via `git ls-files` — the
+  jj-workspace blindspot that `shell_sources()` was deliberately moved off.
+
+### 12. Measured hook latency, and the bootstrap fix this story must land
+
+The story carries per-call latency as an unverified assumption (`:161-164`).
+Measured on darwin-arm64, warm cache, 20 iterations each:
+
+| Path | ms/call |
+| --- | --- |
+| `hooks/vcs-guard.sh` (today's shell guard) | **35.1** |
+| `bin/accelerator version` (bootstrap + launcher, warm) | **149.1** |
+| launcher binary invoked directly, no bootstrap | **3.0** |
+| minisign verify of the 8 MB launcher | **2.3** |
+| `probe_dir` write + chmod + exec + rm | **107.9** |
+| re-exec of a *pre-existing* probe file | **10.6** |
+| one `sha256_file` of the 475 K verify shim | **11.7** |
+
+Everything the fetch-verify-cache design is usually blamed for — minisign, the
+launcher, dispatch — totals under 6 ms. The 149 ms decomposes almost entirely
+into two avoidable costs:
+
+| Warm-path step | Cost | Avoidable? |
+| --- | --- | --- |
+| `probe_dir` write+chmod+exec+rm (`bin/accelerator:166-180`, via `resolve_cache_dir:195`) | ~108 ms | **yes** |
+| `sha256_file` ×2 over the 475 K shim (`:252`, `:256`) | ~23 ms | **yes** |
+| `verify_launcher` — shim exec + minisign (`:310-312`, `:336`) | ~2.3 ms | no (trust posture) |
+| `exec "${launcher}"` (`:352`) | ~3 ms | no |
+| bash startup, `uname` ×2, `plugin.json` `sed` | ~12 ms | partly |
+
+That is **~131 ms of 149 ms addressable**, which would put the bootstrap at
+roughly 18 ms — *below* today's 35 ms shell guard rather than 4× above it.
+
+**Decision (author, 2026-07-30): the `probe_dir` fix lands as part of this
+story**, not as a follow-up. The guard runs on every Bash tool call, so the
+story cannot honestly claim warm-cache parity with `vcs-guard.sh` while the
+bootstrap costs 4× the thing it replaces.
+
+Why the two costs are safe to remove:
+
+- **`probe_dir` is redundant on the warm path.** Its purpose is to catch a
+  `noexec` mount that a write-only check would miss. But the warm path then
+  execs the shim from `cache_dir` (`verify_launcher`, `:311`) and execs the
+  launcher from `cache_dir` (`:352`) — both are *stronger* exec tests than a
+  synthetic probe, and a `noexec` dir makes `verify_launcher` fail, which falls
+  through to the cold branch where the probe still belongs. Suggested shape:
+  split `probe_dir` into `ensure_dir` (the `mkdir -p`, always) and the
+  write+chmod+exec probe, and call the latter only before fetching. Note the
+  probe's result is not used to *choose* a directory — `resolve_cache_dir`
+  (`:184-193`) has no fallback — so moving it changes only where the diagnostic
+  fires, not which path is selected.
+- **The shim staging is a same-directory copy in the default configuration.**
+  `shim_source` is `${plugin_root}/bin/accelerator-verify-${platform}` (`:158`)
+  and `cache_dir` defaults to `${plugin_root}/bin` (`:190`) — so the warm path
+  hashes 475 K twice to content-address a copy of a file into its own directory.
+  The "plugin root may be noexec" rationale (`:246-247`) only bites when
+  `ACCELERATOR_CACHE_DIR` points elsewhere. Cheapest correct fix: skip staging
+  entirely when `shim_source`'s directory and `cache_dir` resolve to the same
+  path, and keep the existing digest dance only when they differ.
+  **Open sub-question for planning:** the second hash (`:256`) also defends
+  against a planted stub being trusted by name. Running the shim from
+  `shim_source` drops that check — though an attacker able to plant a stub there
+  already owns the root of trust, and `bin/accelerator-verify.vendored.sha256`
+  pins the vendored digest. Confirm the intended trust boundary before removing
+  it; if in doubt, fix `probe_dir` alone (the ~108 ms) and leave the ~23 ms.
+
+Two further consequences:
+
+- **Built-in versus sub-binary is worth single-digit ms** (one extra in-process
+  minisign verify plus an exec). It was never a latency decision. The author
+  chose the sub-binary (2026-07-30); the parent research's "lean built-in" steer
+  (`2026-06-28-0136-...:613-615`) was reasoning from an assumed per-call fetch
+  cost the warm path does not actually pay.
+- The magnitude is **macOS-specific** — the ~97 ms delta between executing a
+  freshly written file and re-executing an existing one is macOS's first-exec
+  check. Linux has no equivalent, so quote darwin as the worst case. Both are
+  shipped platforms.
+
+Suggested acceptance criteria to add to the story:
+
+- The warm-cache bootstrap performs no write-and-exec probe: verified by
+  asserting that a warm `bin/accelerator` invocation creates no
+  `.accelerator-probe-*` path (e.g. a probe-name guard, or by asserting the
+  cold path still does).
+- Warm-path per-call latency is bounded — e.g. a warm `accelerator vcs guard`
+  costs no more than today's `hooks/vcs-guard.sh` on the same host. This
+  replaces the story's current unverified assumption at `:161-164`.
+- The `noexec` diagnostic is preserved on the cold path: a cache dir that
+  cannot execute still fails closed with the existing message, covered by its
+  own test.
+- The bootstrap remains bash-3.2 clean (`scripts/lint-bashisms.sh`), which the
+  story already requires at `:124-125`.
+
+Note this also speeds up `hooks/config-detect.sh` at every SessionStart, and
+every future CLI-backed hook, for free.
+
+
+## Code References
+
+- `scripts/vcs-common.sh:27-36` — `vcs_mode`, the `.jj`-wins command-set selector
+- `scripts/vcs-common.sh:177-280` — `classify_checkout`; cascade at `:240-272`
+- `hooks/vcs-detect.sh:28-36` — inline three-valued mode detection (not `vcs_mode`)
+- `hooks/vcs-detect.sh:177-181` — SessionStart envelope + merged `systemMessage`
+- `hooks/vcs-guard.sh:53` — the blocked git-subcommand pattern
+- `hooks/vcs-guard.sh:97-108` — the two guard envelopes (legacy shape)
+- `hooks/hooks.json:9,18,27,36,47` — all five registrations
+- `hooks/launcher-link-refresh.sh:16-27` — one-JSON-object constraint, `finish()`
+- `hooks/test-vcs-detect.sh:20` — the hard-coded `HOOK` constant
+- `hooks/test-vcs-detect.sh:254-480` — the 27 in-process library cases
+- `cli/vcs/src/lib.rs:46-67` — the two outbound ports
+- `cli/vcs-adapters/src/lib.rs:110-125` — the two subprocess arg-sets
+- `cli/vcs-adapters/src/lib.rs:168` — the single `spawn()` chokepoint
+- `cli/launcher/src/config_command/render/summary.rs:66-101` — the hook envelope
+- `cli/launcher/src/config_command/inbound/cli.rs:290` — the emptiness rule
+- `cli/launcher/src/launch/inbound/cli.rs:16-29` — built-ins vs external dispatch
+- `cli/launcher/src/launch/outbound/resolve/mod.rs:179-211` — warm path + reverify
+- `bin/accelerator:336-338` — warm launcher path, still minisign-verifies
+- `cli/pup.ron:75-89` — `vcs_domain_imports_only_permitted`
+- `cli/pup.ron:93-98` — the grouped-import gotcha
+- `cli/deny.toml:41-70` — licence allow-list and the TLS bans
+- `tasks/shared/paths.py:25` — `DISPATCHED_SUBBINARIES`
+- `tasks/manifest.py:56-66` — default manifest path + mandatory description
+- `tasks/test/integration.py:43-47,150-159` — the hooks floor and task body
+- `tests/unit/tasks/test_mise.py:47-56` — `_NO_LAUNCHER_NEEDED` pin
+- `tasks/lint/claude_coupling.py:12,31,43` — the `CLAUDE_*` prohibition on `cli/**`
+- `cli/launcher/tests/crypto_provider.rs:1-56` — spy port + panicking null
+- `cli/launcher/tests/resolution.rs:451-466` — offline warm-path proof
+
+## Architecture Insights
+
+- **The hexagon boundary is enforced mechanically, and it shapes the design.**
+  Because `cli/pup.ron:75-89` restricts the `vcs` domain to
+  `std`/`kernel::Error`/`crate::`, `gix` and `jj-lib` can only ever live in
+  `vcs-adapters`. That is the right shape, but it means the full
+  `classify_checkout` taxonomy must be expressible as plain domain values with no
+  library types leaking in — the port signatures are the design work.
+- **`--format=hook` is a rendering concern collapsed at the boundary.** 0167's
+  precedent parses a `ValueEnum` then immediately flattens it to a `bool`
+  (`cli/launcher/src/launch/mod.rs:112-117`), so the hexagon never sees a
+  "format" concept. There is no shared `Format` type — `SummaryFormat` and
+  `PathsFormat` are per-subcommand, and `PathsFormat` is parsed and ignored.
+- **Envelope-per-hook-type is correct, and the story already knows it.** There is
+  no single envelope spanning hooks: SessionStart carries `additionalContext`,
+  PreToolUse carries a permission decision, and `launcher-link-refresh` emits a
+  bare `systemMessage`. What the story does not yet reflect is that the *current*
+  documented PreToolUse shape differs from the shell's.
+- **Parity is the wrong frame for the guard's envelope.** Parity on *decisions*
+  (which commands block, which pass) is worth locking. Parity on *bytes* would
+  freeze both a deprecated schema and a probably-ineffective `systemMessage`
+  placement. These should be separate criteria.
+- **Fail-safe diagnostics currently go nowhere.** `--fail-safe` writes
+  `eprintln!("{error}")` then exits 0
+  (`cli/launcher/src/config_command/inbound/cli.rs:464`), and
+  `render/mod.rs:43-48` writes *every* warning to stderr even on success. Per
+  0183's analysis, stderr at exit 0 is discarded by Claude Code. Any new
+  hook-mode command inherits this.
+- **Fetch-verify-cache is trust-first at every step**, which is why it is not
+  free: manifest signature verified before parsing (`resolve/mod.rs:130`), exact
+  version equality as anti-rollback (`manifest.rs:103-108`), cached entries
+  re-verified on every warm hit. Latency on a hot path is the cost of that
+  posture, not an implementation defect to optimise away.
+
+## Historical Context
+
+- `meta/decisions/ADR-0048-four-toolchain-split.md:99-101` — **the story's
+  citation is correct** despite the ADR's title: *"Hooks are part of this: the
+  hook logic is implemented in the CLI, fronted by a thin shell shim only if the
+  hook entry point demands a shell command."* Corroborated by
+  `ADR-0049-bash-3.2-compatibility-floor.md:23`. There is no separate hooks ADR.
+- `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md:606-615`
+  — Open Question 4 resolved the invocation mechanism, and on built-in vs
+  sub-binary said *"lean built-in to avoid a per-Bash-call sub-binary fetch"*.
+  0169 closed it the other way (`:82-85`, `:252-254`). Deliberate, but the
+  research gives the opposite answer to anyone who reads it.
+- `.../2026-06-28-...:641-646` — Open Question 8 pinned `hooks/` at 7 tracked
+  `.sh` (4 prod). It is now 8 (5 prod), after 0182.
+- `meta/reviews/work/0169-...-review-1.md` — five lenses, REVISE → APPROVE. All
+  twelve pass-1 findings dispositioned; finding #6 is the one that produced the
+  golden-envelope AC, and its fix is what this research now shows needs
+  re-examining. Left open deliberately: the bundling scope point (`:420-423`).
+- `meta/work/0125-converge-vcs-detection-on-probe-layer.md` — **open `draft`
+  debt, not subsumed by 0169.** Two binding constraints it states are *not*
+  restated in 0169: `find_repo_root` ("where am I") must stay distinct from
+  `find_git_main_worktree_root` (canonical main) — `:96-101`; and `vcs_mode` is a
+  command-set selector, so any delegation to `classify_checkout` must map the
+  topology verdict *back* to a jj/git selector — `:102-105`. It also asks for a
+  cross-strategy characterisation test (`:131-133`) that 0169 has no AC for.
+- `meta/work/0183-session-start-hook-advisories-reach-nobody-on-stderr.md:49-55`
+  — the one-JSON-object and stdout-is-context constraints; its audit AC
+  (`:83-84`) requires every SessionStart hook to be converted or cleared.
+- `meta/work/0174-retire-shell-tooling-and-ci-guards.md:44,59,88` — removes
+  *tooling, not scripts*, and never names `vcs-common.sh` or any hook script. It
+  expects the bootstrap, hook wrapper and Playwright executor to survive.
+- `meta/work/0058-workspace-worktree-boundary-detection.md` and
+  `meta/work/0124-find-repo-root-fails-in-git-worktrees.md` — the origin of
+  `classify_checkout` and of the `-d`→`-e` fix in `find_repo_root`. Both are
+  still recorded `draft` although 0124's fix has shipped.
+- `meta/prs/24-description.md:29,47` — the `gix`/`jj-lib` refinement record,
+  flagging `jj-lib`'s unstable API for early validation. Documentation-only;
+  nothing was validated.
+
+## Related Research
+
+- `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+  — the epic's scope and architecture; Phase 6 is this story
+- `meta/research/codebase/2026-06-23-0136-shell-scripts-rust-cli-migration-surface.md`
+  — the original shell inventory sweep
+- `meta/research/codebase/2026-07-19-0167-config-command-and-invocation-contract-migration.md`
+  — the `--format=hook` contract as designed
+- `meta/research/codebase/2026-07-03-0164-launcher-and-git-style-dispatch.md`
+  — dispatch and fetch-verify-cache
+- `meta/research/codebase/2026-07-11-0179-corpus-crates-parsing-conventions.md`
+  — the crate-pair template this subdomain mirrors
+- `meta/research/codebase/2026-05-15-0058-workspace-worktree-boundary-detection.md`
+  — the `classify_checkout` design being ported
+
+## Stale Claims in the Work Item
+
+Recorded so the plan can correct them rather than inherit them.
+
+1. **`:49-50` "four bare `.sh` paths in `hooks.json`"** — there are five, since
+   0182 added `launcher-link-refresh.sh`.
+2. **`:151-152` and `:250-251` "removes three of the four hook scripts"** — it
+   removes **two of five** (three if `config-detect.sh` is folded in). The review
+   praised this invariant as consistently stated across five sections; it is now
+   inaccurate in all five.
+3. **`:146-147` and `:137-139` still say `config detect` is in scope** and that
+   0167 delivers a command "this story extends with `config detect`", contradicting
+   the Summary at `:36-40`. No `config detect` exists; the shipped surface is
+   `config summary --format=hook --fail-safe`. The config half is out of scope
+   except for the optional fold-in.
+4. **`:143-149` dependency statuses** — 0164, 0166, 0179 are `done`; 0167's code
+   has landed (verified: `cli/config/`, `cli/launcher/`, `bin/accelerator`,
+   `hooks/config-detect.sh` all exist at `main`) though its work item is still
+   `ready`. The remaining blocker is bookkeeping, not work.
+5. **`:112-119` the PreToolUse golden envelope** — pins a shape the current docs
+   do not describe for PreToolUse, and the shell it copies nests `systemMessage`
+   in a position the schema has no field for. **Superseded by the 2026-07-30
+   decision**: the AC should now require the `permissionDecision` envelope and
+   split decision-parity from envelope shape (§4).
+6. **`:228-229` "must slot into the same `additionalContext` shape"** — the 0167
+   renderer has no `systemMessage` slot, so the envelope must be *extended*. The
+   story requires the sibling key at `:205-207` but no AC covers the merge.
+7. **`:238-243` the argument-splitting probe** — resolvable from documentation;
+   both shell form and an `args` exec form work.
+8. **`:82-85` "as the `accelerator-vcs` sub-binary"** — the token collides with
+   the domain crate under both `tasks/manifest.py` and `cli/pup.ron`, and the
+   parent research leaned built-in.
+9. **`:168-171` Technical Notes source list omits `scripts/vcs-status.sh` and
+   `scripts/vcs-log.sh`** — the actual implementations behind AC2's `vcs status`
+   / `vcs log` parity claim, which cites `vcs-common.sh` instead.
+10. **`:89-90` "the repointed `hooks/test-vcs-detect.sh` parity gate"** — only
+    ~11 of 42 cases are repointable; 27 test the surviving shell library and 1 is
+    unportable.
+11. **`:168-171` Technical Notes must now also name `bin/accelerator`** — the
+    `probe_dir` fix (§12) is in scope as of 2026-07-30, so the bootstrap is a
+    modified file, not merely the invocation mechanism. It is already covered by
+    the story's bash-3.2 AC (`:124-125`), which refers to "the wrapper"; that
+    wording should be pinned to `bin/accelerator` explicitly (see stale claim 6
+    on the wrapper/bootstrap ambiguity).
+
+## Open Questions
+
+1. ~~**Built-in or sub-binary for the guard?**~~ **DECIDED 2026-07-30: sub-binary**
+   (author). Measurement (§12) supports it being a low-cost choice — the
+   built-in/sub-binary delta is single-digit ms, while ~108 ms of the 149 ms
+   bootstrap+launcher path is `probe_dir`'s write-and-exec, paid either way.
+   Consequences to carry into the plan: name the **package** `accelerator-vcs` in
+   a sibling directory (not `cli/vcs/`) with a `_SUBBINARY_MANIFESTS` entry
+   keeping the token `vcs` (§8), and register the new token in
+   `DISPATCHED_SUBBINARIES`, `.gitignore`, and the manifest fixture.
+   The story's latency *assumption* (`:161-164`) can now be replaced with the
+   measured figure rather than left unverified.
+2. ~~**Does `jj-lib` cover the secondary-workspace and colocated cases, and do
+   `gix` + `jj-lib` pass `cargo deny`?**~~ **RESOLVED 2026-07-30** by the probe
+   in §9: yes on both counts, with a single `[[licenses.exceptions]]` entry for
+   `uluru` (MPL-2.0) and a `gix` version pinned to match `jj-lib`'s. Static musl
+   linking confirmed against `_assert_static_elf`. The per-query shell fallback
+   is therefore an escape hatch, not the main path. Residual follow-ups: bound
+   `gix::discover` so it cannot escape a workspace boundary, and avoid
+   `Workspace::load` (and thus `UserSettings`) on the detection path.
+3. ~~**What is the PreToolUse envelope's target shape?**~~ **DECIDED 2026-07-30:
+   the `permissionDecision` envelope** (author). Mapping and rationale in §4. The
+   AC splits into decision-parity plus a golden fixture on the new shape. Residual
+   for planning: the colocated branch must emit a bare top-level `systemMessage`
+   (no `permissionDecision`), because `"allow"` would skip the permission prompt
+   and quietly widen privilege; and the story should note that the colocated
+   warning becomes visible for the first time.
+4. **Is the `args` exec form available at the plugin's Claude Code floor
+   (v2.1.144)?** The docs do not date it. If not, shell form is the answer.
+5. **Where should the 27 in-process library cases live?** Split into a new
+   `scripts/test-vcs-common.sh` (keeping the hooks floor at 2 without a repointed
+   suite), or re-home as Rust tests? This interacts with the floor decision at
+   `tasks/test/integration.py:47`.
+6. **Who owns `scripts/vcs-status.sh` / `scripts/vcs-log.sh` and
+   `skills/vcs/commit`?** No epic-0136 story claims `skills/vcs/**`. Unless 0169
+   also rewrites that skill's two `!`-preprocessor call sites, `vcs status` and
+   `vcs log` ship with zero consumers and two shell scripts survive unowned.
+7. **Does 0169 note or close 0125?** It currently does neither, and adds a third
+   detection implementation. At minimum the plan should state that 0125 stays
+   open and that its lexical-fallback rationale is dissolved by the in-process
+   adapter.
+8. **Does 0172 know it inherits this story's `hooks.json`?** The hand-off is
+   asserted only in 0169; 0172 has no `blocked_by: 0169` and its source list omits
+   `hooks/migrate-discoverability.sh` entirely.
+9. **Removing the shim's double hash — what is the intended trust boundary?**
+   The `probe_dir` fix is settled and in scope (§12). The adjacent ~23 ms of
+   shim hashing is also removable, but the second hash (`bin/accelerator:256`)
+   defends against a planted stub being trusted by name. Decide during planning
+   whether running the shim from `shim_source` is acceptable given that
+   `bin/accelerator-verify.vendored.sha256` already pins the vendored digest; if
+   not, take the ~108 ms and leave the ~23 ms.
+
+10. **Who owns `hooks/launcher-link-refresh.sh`?** No story does. It must survive
+   0169 and 0174, so someone should say so explicitly.

--- a/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md
+++ b/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md
@@ -1,0 +1,825 @@
+---
+type: work-item-review
+id: "0169-vcs-subdomain-and-hooks-migration-review-2"
+title: "Work Item Review: VCS Subdomain and Hooks Migration"
+date: "2026-07-31T02:03:11+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0169"
+parent: "work-item:0136"
+relates_to: ["work-item-review:0169-vcs-subdomain-and-hooks-migration-review-1"]
+work_item_id: "0169"
+reviewer: Toby Clemson
+verdict: REVISE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 2
+review_pass: 4
+tags: [rust, vcs, hooks, migration]
+last_updated: "2026-07-31T09:12:46+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: VCS Subdomain and Hooks Migration
+
+**Verdict:** REVISE
+
+0169 is a dense, unusually well-anchored work item — nearly every claim carries
+a `path:line` reference, deliberate behavioural departures are declared rather
+than smuggled in as "ports", and prior research has been visibly folded back
+(the latency assumption replaced by a measurement, the `gix`/`jj-lib`
+feasibility and sub-binary naming collision recorded as resolved). The problem
+is that it has grown substantially since `review-1` approved it on 2026-07-20,
+and the additions have outrun the criteria: the story now spans four toolchains
+and five separable deliverables under one `kind: story` with 15 acceptance
+criteria, several of which cannot fail as written, compare against instruments
+the same change deletes, or enumerate the wrong set. Nineteen major findings
+across all five lenses, no criticals.
+
+The single most important observation is structural: **`review-1` approved a
+different work item.** Its scope finding was dispositioned "defensible,
+author-justified" before the library swap, the sub-binary decision, the
+bootstrap fix and the skill repoint were added. That approval should not be
+read as covering the current bundle.
+
+### Cross-Cutting Themes
+
+- **Sub-binary distribution is real, load-bearing scope that appears nowhere in
+  Requirements or Acceptance Criteria** (flagged by: scope, completeness,
+  testability, dependency — all four) — `accelerator-vcs` is the first
+  non-visualiser dispatched sub-binary, requiring `DISPATCHED_SUBBINARIES`,
+  `_SUBBINARY_MANIFESTS`, workspace members, `package.description`,
+  `.gitignore`, the shared `manifest.example.json` fixture, cross-compile
+  staging with `_assert_static_elf`, the `uluru` MPL-2.0 licence exception and
+  the `gix` version pin. All of it lives only in Technical Notes. Nothing in the
+  definition of done proves the sub-binary is buildable, signable or
+  distributable — and this is the surface most likely to fail at release time
+  rather than test time.
+
+- **Several criteria compare against instruments this change deletes** (flagged
+  by: testability, clarity) — the `vcs status`/`vcs log` goldens name
+  `scripts/vcs-status.sh` / `scripts/vcs-log.sh` as the comparator while the
+  final criterion removes both; the latency criterion baselines against
+  `hooks/vcs-guard.sh`, also removed; and the detect parity gate's byte-exact
+  goldens can be re-baselined against the new Rust output, at which point the
+  gate asserts the implementation matches itself. No capture-before-delete step
+  is stated anywhere.
+
+- **The done-state is indeterminate in two places** (flagged by: scope,
+  completeness, testability, clarity — all four bar dependency) — the
+  `config-detect.sh` fold-in is "may fold in", the shim double-hash is "if in
+  doubt… leave this", and the hooks floor is "adjusted" with no target value.
+  A reader of a closed 0169 cannot tell whether `hooks/config-detect.sh` still
+  exists, which matters because 0172 and 0174 both inherit that `hooks.json`
+  state.
+
+- **The `classify_checkout` arm list omits the two arms whose ordering is
+  load-bearing** (flagged by: testability, clarity) — Requirements defines the
+  taxonomy as (worktree, submodule, bare, `GIT_DIR`, plain) and the matching
+  criterion verifies exactly that set, while Technical Notes states the
+  load-bearing cascade is `colocated` preceding `nested-*`. The criterion that
+  exists to stop arm order regressing silently does not require testing the pair
+  whose order matters.
+
+- **Which shell implementation is the parity reference is stated two ways, and a
+  known defect has no disposition** (flagged by: testability, clarity) —
+  Requirements pins the port to `vcs-common.sh`; Technical Notes says "Port the
+  hooks' own behaviour, not just `vcs-common.sh`'s". The same note records that
+  where `.git` is a *file* the guard blocks where it should warn, but never says
+  whether the port preserves or corrects that. "Parity" and "correct" give
+  opposite answers.
+
+- **Decisions taken on 2026-07-30 created couplings the Dependencies section
+  does not record** (flagged by: dependency) — choosing the sub-binary coupled
+  the story to 0165's release pipeline; choosing the `permissionDecision`
+  envelope coupled it to a specific Claude Code schema version. Neither appears
+  in `blocked_by` or Dependencies.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Scope + Completeness + Testability + Dependency**: Sub-binary distribution
+  and dependency-policy work is absent from Requirements and Acceptance Criteria
+  **Location**: Requirements / Acceptance Criteria
+  Registration across `DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`,
+  `.gitignore`, `manifest.example.json`, cross-compile staging, the `uluru`
+  licence exception and the `gix` pin exists only in Technical Notes. Nothing
+  proves the sub-binary ships end-to-end.
+
+- 🟡 **Testability + Clarity**: Status/log golden parity compares against scripts
+  the same change deletes, with no normalisation rule
+  **Location**: Acceptance Criteria (`vcs status` / `vcs log`)
+  The comparator is removed by the final criterion, so the assertion cannot be
+  run afterwards; and `vcs log` output carries commit ids, dates and author
+  identity that vary per fixture build, with no masking rule stated.
+
+- 🟡 **Testability + Clarity**: `classify_checkout` arm enumeration omits
+  `colocated` and `nested-*`, the arms whose ordering is load-bearing
+  **Location**: Requirements / Acceptance Criteria
+  "At least one ambiguous checkout" names no specific case, so any trivially
+  ordered pair satisfies it. The invariant can regress with all criteria green.
+
+- 🟡 **Testability**: The probe-absence criterion passes against the *unfixed*
+  bootstrap
+  **Location**: Acceptance Criteria (no write-and-exec probe)
+  `probe_dir` writes, chmods, execs and removes the file within one invocation,
+  so a post-hoc check for `.accelerator-probe-*` finds nothing either way. The
+  criterion guarding the ~108 ms regression cannot fail.
+
+- 🟡 **Clarity**: "Zero `jj`/`git` spawns" and the permitted per-query shell
+  fallback are mutually exclusive as written
+  **Location**: Requirements / Acceptance Criteria
+  A fallback exercised on any of the four paths necessarily spawns `jj` or
+  `git`. The implementer cannot tell whether the assertion is unconditional or
+  excludes declared fallbacks.
+
+- 🟡 **Testability**: Guard decision matrix is not enumerated and contradicts the
+  story's own notes
+  **Location**: Acceptance Criteria (guard decision parity)
+  The criterion says fixtures cover "the allowed read-only/non-VCS patterns",
+  but `git log` and `git diff` are *inside* the shell's blocked pattern. It also
+  names only the call-class axis, not the repo-mode axis that determines the
+  decision, and leaves the `.git`-as-file case undefined.
+
+- 🟡 **Testability**: Detect parity gate can be satisfied by re-baselining its
+  own goldens
+  **Location**: Acceptance Criteria (`vcs detect` parity gate)
+  The criterion does not say whether `hooks/test-fixtures/vcs-detect/*.json` are
+  frozen at their shell-produced content; the referenced research notes they
+  "would need re-baselining".
+
+- 🟡 **Testability**: Latency criterion lacks a statistic, tolerance and
+  enforcement mechanism, and its comparator is deleted
+  **Location**: Acceptance Criteria (warm-call latency)
+  No statistic, iteration count, tolerance, platform or CI-versus-manual
+  disposition. Two verifiers can reach opposite verdicts from the same binary.
+
+- 🟡 **Testability + Scope + Completeness + Clarity**: The final criterion is
+  optional in one clause and undetermined in another, so it cannot fail
+  **Location**: Acceptance Criteria (removals and hooks floor)
+  The floor target value is unstated and depends on an unresolved Open Question;
+  the `config-detect.sh` fold-in is "may".
+
+- 🟡 **Dependency**: Claude Code's hook I/O schema is an external dependency
+  named nowhere
+  **Location**: Dependencies / Assumptions
+  If `permissionDecision` or top-level `systemMessage` postdates the v2.1.144
+  floor, the new envelope is silently ignored on supported versions —
+  reproducing the exact failure mode the research found in the shell guard.
+
+- 🟡 **Dependency**: The sub-binary decision couples the story to 0165's release
+  pipeline, which is not a recorded blocker
+  **Location**: Dependencies / Frontmatter: `blocked_by`
+  The warm-cache criterion presupposes a first successful fetch of a published,
+  signed, manifest-listed artefact. Only 0164 is named. The coupling was created
+  by the 2026-07-30 decision, after Dependencies was written.
+
+- 🟡 **Dependency**: The `vcs-common.sh` residue is handed to 0174, whose
+  recorded scope does not cover it
+  **Location**: Technical Notes / Dependencies
+  The work item says "That residue is 0174's"; the referenced research records
+  that 0174 "removes *tooling, not scripts*, and never names `vcs-common.sh` or
+  any hook script". The story's largest residual liability has no real owner.
+
+- 🟡 **Dependency**: The 0172 hand-off is recorded in one direction only, with
+  nothing actioning the missing reciprocal edge
+  **Location**: Dependencies
+  The gap is diagnosed in prose but no requirement, criterion or follow-up
+  actions it, so anyone starting 0172 sees no blocker.
+
+- 🟡 **Dependency**: 0183's SessionStart audit and stderr-discard constraint is
+  referenced but absent from Dependencies
+  **Location**: Dependencies / References
+  This story creates a new SessionStart output path subject to 0183's
+  stdout-is-context / stderr-is-discarded finding; whichever lands first, the
+  other drifts.
+
+- 🟡 **Clarity**: Two identifiers each carry several referents
+  (`accelerator-vcs`, "launcher")
+  **Location**: Summary / Requirements / Acceptance Criteria
+  "launcher" means both `bin/accelerator` and the cached binary it execs —
+  inside the requirement that changes exec behaviour on the trust-sensitive
+  bootstrap path, where resolving to the wrong artefact means removing the wrong
+  check.
+
+- 🟡 **Clarity**: "Full `classify_checkout` taxonomy" is enumerated two
+  incompatible ways
+  **Location**: Requirements / Technical Notes
+  The definitional enumeration omits arms the Technical Notes calls
+  load-bearing and the PreToolUse guard criterion depends on.
+
+- 🟡 **Clarity**: Which shell implementation is the parity reference is stated
+  two ways, and the `.git`-as-file defect has no disposition
+  **Location**: Requirements / Acceptance Criteria / Technical Notes
+  The guard's brand-new fixtures could permanently lock in either the buggy or
+  the corrected classification without anyone noticing a choice was made.
+
+- 🟡 **Scope**: The bootstrap `probe_dir` fix is an independently deliverable
+  concern with a different risk profile
+  **Location**: Requirements / Acceptance Criteria
+  It shares no code, crate or test harness with the subdomain, carries three of
+  the story's criteria plus its own open question, and by the story's own
+  account benefits already-shipped hooks independently. *(Author has elected to
+  keep this in scope — recorded here as the reviewer's independent position.)*
+
+- 🟡 **Scope**: The story spans four toolchains and five separable deliverables
+  under a single story kind
+  **Location**: Requirements
+  Rust subdomain, two new heavyweight dependencies, sub-binary distribution,
+  bash bootstrap change, skill rewrite, and a 712-line test-suite split with
+  mise task-graph rewiring — on the epic's critical path gating 0172 and 0174.
+
+#### Minor
+
+- 🔵 **Scope**: Context claims the parallel bash implementation is removed;
+  Technical Notes says it survives and the story adds a third implementation.
+- 🔵 **Completeness**: The `config-detect.sh` fold-in is an undecided deliverable
+  not tracked in Open Questions where the story's other decisions carry defaults.
+- 🔵 **Completeness**: The Open Question on where the 27 in-process cases live
+  carries no default, unlike its two siblings, yet feeds the floor criterion.
+- 🔵 **Testability**: Missing-binary parity cases have no trigger once the
+  adapters stop spawning `jj`/`git` — and the `systemMessage` sibling key's only
+  stated producer disappears with them.
+- 🔵 **Testability**: No criterion verifies the sub-binary registration or
+  dependency-policy outcomes the Requirements make load-bearing.
+- 🔵 **Testability**: "The skill still renders" is not verified by the static
+  frontmatter/permission lints named as its instrument.
+- 🔵 **Dependency**: No ordering relationship recorded with 0168, the preceding
+  epic phase touching the same visualiser-shaped registration surface.
+- 🔵 **Dependency**: `gix`, `jj-lib` and the `deny.toml` licence exception are
+  absent from Dependencies despite being the story's only third-party couplings.
+- 🔵 **Dependency**: Frontmatter `relates_to` omits 0125, 0182 and 0183, which
+  the body names.
+- 🔵 **Dependency**: Implied ordering within the story's own workstreams is not
+  captured — notably that the shell guard's decisions must be captured as
+  fixtures *before* the rewrite, and that the `test:integration:hooks` launcher
+  edge must land before the parity suite is repointed.
+- 🔵 **Clarity**: The end state of `hooks/config-detect.sh` is indeterminate
+  across two criteria.
+- 🔵 **Clarity**: "A golden envelope fixture per hook type" under-counts — the
+  adjacent criterion mandates four shapes (SessionStart with/without
+  `systemMessage`, PreToolUse deny, PreToolUse warn-only).
+- 🔵 **Clarity**: "The hooks suite floor … adjusted" names no target state.
+- 🔵 **Clarity**: The skill call sites are written as bare relative paths, unlike
+  every other invocation in the item, and would not match the permission rule
+  the same criterion mandates.
+- 🔵 **Clarity**: "see Technical Notes" points at the wrong section — the
+  argument-splitting resolution lives in "Notes from 0167".
+- 🔵 **Clarity**: "missing-binary diagnostic" does not say which binary, and
+  "`!`-injection count … at 42" does not say what it counts or which guard
+  enforces it.
+
+#### Suggestions
+
+- 🔵 **Completeness**: Assumptions is a single bullet for a story that adopts two
+  new libraries and pins a criterion to a host-specific measurement.
+- 🔵 **Completeness**: 0183 and ADR-0053 appear in References but are explained
+  nowhere in the body.
+- 🔵 **Testability**: The `noexec` criterion names no mechanism for producing a
+  non-executable cache directory on CI.
+- 🔵 **Dependency**: The `blocked_by` edge on 0167 will not clear without an
+  out-of-band bookkeeping action that nobody is assigned.
+- 🔵 **Clarity**: "The VCS half only" implies a two-way split that Context's
+  five-hook, four-concern, three-owner enumeration contradicts.
+
+### Strengths
+
+- ✅ Nearly every factual claim is anchored to a `path:line` reference, resolving
+  referents that would otherwise be ambiguous.
+- ✅ Scope boundaries are stated explicitly and repeatedly, including what is
+  *not* in scope — the config half, migrate-discoverability,
+  `launcher-link-refresh.sh`, `vcs-common.sh`, and 0125 which it explicitly does
+  not close.
+- ✅ The PreToolUse envelope criterion is exceptionally unambiguous: it names the
+  exact JSON shape, states why `"allow"` and `"ask"` are both wrong for the
+  colocated case, and flags the user-visible consequence.
+- ✅ Deliberate behavioural departures are declared as changes rather than
+  smuggled in under a "port", so behavioural risk is visible.
+- ✅ Prior research is visibly folded back: the unverified latency assumption is
+  replaced by a measured baseline, and the `gix`/`jj-lib` feasibility and
+  sub-binary naming collision are recorded as resolved.
+- ✅ Each `Blocked by` entry carries rationale *and* live status, distinguishing
+  "code landed" from "work item still marked ready".
+- ✅ The previously-open `skills/vcs/commit` ownership question was resolved into
+  the story rather than left dangling, so `vcs status`/`vcs log` now ship with a
+  consumer in the same increment.
+- ✅ The design space is bounded — "full taxonomy" is defined inline as
+  reproducing the shell's set, explicitly not adding classifications.
+- ✅ Open Questions distinguishes resolved from open with dated strikethrough, so
+  decision state is readable without cross-referencing the research.
+- ✅ Criteria are honest about where coverage is new rather than inherited — the
+  guard has no existing suite, and AC1 states how much of the 42-case detect
+  suite actually repoints (~11).
+
+### Recommended Changes
+
+1. **Add a distribution requirement and matching criterion** (addresses: the
+   four-lens distribution theme) — cover sub-binary registration end-to-end
+   (`DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`, workspace members,
+   `package.description`, `.gitignore`, `manifest.example.json`, cross-compile
+   staging), plus `cargo deny` green with the `uluru` exception and a committed
+   `Cargo.lock`. Add 0165 to Dependencies, or state explicitly that the pipeline
+   is already token-parameterised and only `validate_dispatch_coherence` needs
+   generalising.
+
+2. **Add a capture-before-delete step** (addresses: instruments-deleted theme) —
+   state that the status/log goldens, the guard decision table and the latency
+   baseline are captured from the shell **before** those files are removed, and
+   committed as fixtures. Name the normalisation rule for volatile fields
+   (commit ids, dates, absolute paths). State that the detect goldens are frozen
+   at their shell-produced content, with any regeneration justified case by case.
+
+3. **Fix the `classify_checkout` arm list** (addresses: arm-enumeration theme) —
+   state the arm list once, including `colocated` and `nested-*`, and have both
+   the Requirements definition and the fixture criterion refer to that single
+   list. Replace "at least one ambiguous checkout" with the named case: a
+   colocated checkout nested inside another repository must classify as
+   `colocated`.
+
+4. **Make the probe criterion observable** (addresses: probe-absence finding) —
+   replace the post-hoc file check with a behavioural one, e.g. point
+   `ACCELERATOR_CACHE_DIR` at a directory that is executable but not writable and
+   assert a warm invocation still succeeds.
+
+5. **Resolve the two optional deliverables** (addresses: indeterminate-done-state
+   theme) — decide the `config-detect.sh` fold-in in or out and pin the removal
+   count; pin the hooks floor to a value per resolution of the in-process-cases
+   question ("2 if they remain a `hooks/test-*.sh` suite, else 1; never 0").
+
+6. **Name a single normative parity reference per subcommand, and dispose of the
+   `.git`-as-file defect** (addresses: parity-reference theme) — state whether
+   the colocated misclassification is preserved as parity or corrected here.
+
+7. **Record the external and newly-created dependencies** (addresses: the
+   dependency findings) — Claude Code's hook schema with the v2.1.144 floor and
+   the fields relied upon; `gix`/`jj-lib` with the version-lockstep constraint
+   and the `deny.toml` exception; 0183's constraint; and add 0125, 0182, 0183 to
+   frontmatter `relates_to`.
+
+8. **Action the two hand-offs rather than observing them** (addresses: 0172 and
+   0174 findings) — add `blocked_by: 0169` to 0172 and
+   `hooks/migrate-discoverability.sh` to its source list; and either extend
+   0174's scope to the `vcs-common.sh` residue or state plainly that the residue
+   is currently unowned debt.
+
+9. **Disambiguate `accelerator-vcs` and "launcher"** (addresses: identifier
+   overload) — reserve `accelerator-vcs` for the Cargo package, "the
+   `vcs`/`vcs-adapters` crates" for the crates, "bootstrap" for `bin/accelerator`
+   and "launcher binary" for the cached Rust binary.
+
+10. **Scope the zero-spawn assertion** (addresses: zero-spawn contradiction) —
+    either forbid fallbacks on the four paths outright, or assert "zero spawns
+    other than from fallbacks declared in ⟨named list⟩, each covered by its own
+    test".
+
+11. **Reconsider the split** (addresses: the two scope majors) — the author has
+    elected to keep the `probe_dir` fix in scope; recorded here as the reviewer's
+    independent position that (a) the bootstrap fix and (b) the subdomain-versus-
+    hooks seam are both independently deliverable, and that `review-1`'s scope
+    disposition predates four of the story's current workstreams.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: A dense, heavily anchored work item whose clarity weaknesses
+concentrate in identifiers carrying more than one referent (`accelerator-vcs`,
+"launcher") and contradictions between Requirements/Acceptance Criteria and
+Technical Notes about what the deliverable actually is — most sharply the
+`classify_checkout` taxonomy, enumerated one way as a definition and a different
+way as a load-bearing constraint.
+
+**Findings**: 5 major, 6 minor, 1 suggestion — identifier overload (high);
+taxonomy enumerated two ways (high); parity reference stated two ways with the
+`.git`-as-file defect undispositioned (high); zero-spawn versus permitted
+fallback (medium); status/log parity against deleted scripts (medium);
+`config-detect.sh` end state; envelope fixture under-count; floor with no target;
+bare relative call-site paths; mis-pointed cross-reference; undefined terms;
+"VCS half" implying a two-way split.
+
+### Completeness
+
+**Summary**: Structurally complete and unusually dense — every expected section
+present and substantively populated, frontmatter fully valid, and fifteen
+criteria each naming a verification method with `path:line` anchors. The main gap
+is distribution: several steps the story calls mandatory live only in Technical
+Notes, absent from both Requirements and Acceptance Criteria.
+
+**Findings**: 1 major, 2 minor, 2 suggestions — mandatory implementation steps
+only in Technical Notes (medium); the optional fold-in untracked in Open
+Questions (high); one Open Question with no default (medium); sparse Assumptions;
+unexplained References entries.
+
+### Dependency
+
+**Summary**: An unusually well-developed Dependencies section — each blocker
+carries rationale and live status, each Blocks entry explains the coupling
+mechanism, and it deliberately records a related item (0125) it does not close.
+The gaps are at the edges: the external Claude Code schema, the newly-created
+0165 coupling, two unilaterally-asserted hand-offs, and a frontmatter graph that
+lags the prose.
+
+**Findings**: 5 major, 4 minor, 1 suggestion — Claude Code schema unrecorded
+(high); 0165 not a recorded blocker (medium); 0172 hand-off unactioned (high);
+`vcs-common.sh` residue handed to a story that does not claim it (high); 0183
+absent from Dependencies (medium); no 0168 ordering; `gix`/`jj-lib` absent;
+`relates_to` omits three couplings; internal ordering uncaptured; the 0167
+`blocked_by` edge needs an out-of-band action.
+
+### Scope
+
+**Summary**: Thematically coherent with unusually explicit boundaries, but the
+story has accreted materially since its 2026-07-20 review: it now also carries a
+bootstrap performance/trust change, an adapter re-implementation on two new
+heavyweight dependencies, a first-of-kind sub-binary registration, a skill
+rewrite and a 712-line test suite split — spanning all four toolchains under one
+`kind: story`.
+
+**Findings**: 2 major, 3 minor — `probe_dir` independently deliverable (medium);
+four toolchains / five deliverables, and the bundle `review-1` approved is not
+the bundle that exists now (medium); two optional deliverables leaving scope
+indeterminate; Context contradicting Technical Notes on whether the parallel bash
+implementation is removed; first-of-kind distribution work unrepresented.
+
+### Testability
+
+**Summary**: Unusually strong on verification framing — most criteria name a
+concrete instrument and several replace earlier unverified assumptions with
+measured baselines. Weaknesses concentrate in criteria whose instrument is
+deleted by the same change, unobservable after the fact, optional, or enumerated
+over the wrong set.
+
+**Findings**: 6 major, 4 minor, 1 suggestion — arm enumeration omits the
+load-bearing pair (high); status/log goldens against deleted comparators with no
+normalisation (high); latency criterion lacking statistic/tolerance/mechanism
+(high); final criterion optional and undetermined so it cannot fail (high); guard
+decision matrix unenumerated and contradicting the story's own notes (medium);
+detect gate satisfiable by re-baselining (medium); missing-binary cases with no
+trigger; no criterion for sub-binary registration; "skill still renders"
+mismatched to its instrument; `noexec` mechanism unnamed.
+
+
+## Re-Review (Pass 2) — 2026-07-31
+
+**Verdict:** REVISE
+
+All five lenses re-run against the revised work item. **14 of 19 pass-1 majors are
+resolved**, and completeness and dependency cleared their pass-1 finding sets
+entirely. The verdict does not move, for one reason: testability raised the
+review's first **critical**, and it is a genuine safety hole rather than a
+documentation gap.
+
+### Previously Identified Issues
+
+**Resolved (14 majors, 17 minors/suggestions)**
+
+- 🟡 **Clarity**: identifier overload (`accelerator-vcs`, "launcher") — Resolved
+  by the new Terminology section.
+- 🟡 **Clarity**: taxonomy enumerated two incompatible ways — Resolved by the
+  authoritative arm list stated once in Requirements.
+- 🟡 **Clarity**: parity reference stated two ways; `.git`-as-file undispositioned
+  — Resolved by "Normative parity reference, per subcommand" plus "Declared
+  behavioural changes".
+- 🟡 **Clarity**: zero-spawn versus permitted fallback — Resolved; the fallback
+  allowance is withdrawn and the assertion is unconditional.
+- 🟡 **Clarity**: status/log parity against deleted scripts — Resolved by the
+  capture-before-delete criterion.
+- 🟡 **Completeness**: mandatory steps only in Technical Notes — Resolved by the
+  distribution requirement and its criterion.
+- 🟡 **Dependency**: Claude Code schema unrecorded — Resolved (External systems).
+- 🟡 **Dependency**: 0165 not a recorded dependency — Resolved.
+- 🟡 **Dependency**: `vcs-common.sh` residue misattributed to 0174 — Resolved;
+  now stated as unowned debt.
+- 🟡 **Dependency**: 0172 hand-off unactioned — Resolved by the reciprocal
+  hand-off criterion.
+- 🟡 **Testability**: arm enumeration omitted the load-bearing pair — Resolved.
+- 🟡 **Testability**: final criterion optional and undetermined — Resolved; floor
+  pinned, fold-in decided.
+- 🟡 **Scope**: two optional deliverables — Resolved.
+- 🟡 **Scope**: distribution work unrepresented — Resolved.
+- 🔵 Also resolved: Context/Technical Notes contradiction on the parallel bash
+  implementation; `config-detect.sh` fold-in decided and tracked; Open Question
+  defaults; sparse Assumptions; unexplained 0183/ADR-0053 references; envelope
+  fixture under-count; bare relative call-site paths; mis-pointed "see Technical
+  Notes"; missing-binary cases retired; sub-binary registration criterion; "skill
+  still renders" instrument split; `noexec` mechanism named; `gix`/`jj-lib` and
+  `relates_to` gaps; 0168 ordering; intra-story sequencing; 0167 bookkeeping
+  action.
+
+**Partially resolved — the fix landed but introduced a sharper successor**
+
+- 🟡 **Testability**: probe-absence criterion — the residue check was replaced by
+  a behavioural one, but the replacement **passes vacuously as root**, which
+  bypasses directory write permissions.
+- 🟡 **Testability + Clarity**: detect goldens — "frozen" is now stated, but
+  "byte-compared", "frozen" and "whitespace is the only permitted difference"
+  cannot all hold, and Technical Notes confirms the renderers differ in exactly
+  that respect.
+- 🟡 **Testability + Clarity**: latency criterion — gained a statistic (median of
+  20) but is now simultaneously "recorded, not gated" and a hard ≤ 35 ms
+  threshold.
+- 🟡 **Testability**: guard decision table — now two-axis, but defined only by
+  reference to a capture whose row set is unpinned, so a two-row table satisfies
+  both criteria.
+- 🔵 **Clarity**: the Terminology section fixed five terms but "probe" (three
+  senses) and "wrapper" (undefined) escaped it.
+
+**Still present (author decision on record)**
+
+- 🟡 **Scope**: the bootstrap `probe_dir` fix remains an independently
+  deliverable workstream — now reinforced by the story's own Sequencing
+  Constraints, which state it "can land first". Author has elected to keep the
+  bundle; scope suggests recording *why* the coupling is preferred to sequencing,
+  since the story's own text argues the other way.
+- 🔵 **Scope**: story kind stretched by a 16-criterion, four-toolchain scope —
+  downgraded from major to minor in this pass.
+
+### New Issues Introduced
+
+- 🔴 **Testability**: **no criterion verifies the envelope is honoured at the
+  v2.1.144 floor.** The criteria check that the CLI *emits* the shapes and that
+  `hooks.json` *registers* the commands; both pass while Claude Code discards the
+  output. If `permissionDecision` postdates the floor, the migrated guard silently
+  stops blocking git commands in pure-jj repos — a safety regression against the
+  shell it replaces, undetectable by the story's own test set.
+- 🟡 **Dependency**: the release-artefact host is an unnamed external dependency
+  on the hot path. `vcs guard` is now a *fetched* sub-binary on a hook that fires
+  on every Bash call; a failed first-use fetch lands in PreToolUse where non-zero
+  is a blocking error, with no fail-open posture stated.
+- 🟡 **Testability**: the zero-spawn assertion's named mechanism cannot observe
+  spawns originating *inside* `gix`/`jj-lib` — the most likely violation source.
+  A `PATH`-stub black-box test would.
+- 🟡 **Completeness**: cargo-pup is the one enforcement gate missing from the
+  distribution criterion, despite a pup rule being the reason for the package
+  naming requirement.
+- 🟡 **Completeness**: the floor-verification risk has no Open Question or
+  criterion, while the lesser `args` question has both.
+- 🟡 **Dependency**: 0170/0171/0173 inherit this story's sub-binary pathfinding
+  but are not listed as Blocks.
+- 🟡 **Dependency**: the 0183 hand-off is acknowledged but excluded from the
+  reciprocal-recording criterion that covers 0172.
+- 🟡 **Clarity**: VCS adapter failure diagnostics are routed to a stdout
+  `systemMessage` in Requirements and to a discarded `--fail-safe` stderr write in
+  Dependencies; and the `hooks.json` command string for `vcs detect` is never
+  given verbatim, so whether it carries `--fail-safe` is unstated.
+- 🔵 **Scope**: the hand-off criterion makes this story's completion contingent on
+  re-scoping 0172 and 0174 — work it does not own. It can *raise* those hand-offs,
+  not own their resolution.
+- 🔵 Further minors: `hooks.json` command strings not verbatim; `vcs detect`'s
+  plain rendering unspecified; shared hook-envelope module home undecided;
+  normalisation rule deferred; status/log fixtures omit colocated, jj-secondary
+  and no-repository; "set to 2" versus "stays at 2"; residue-owner clause
+  circular; counts asserted without enumeration; `EXPECTED_INJECTION_SKILLS` unit
+  ambiguous; `CLAUDE_PLUGIN_ROOT` versus `ACCELERATOR_PLUGIN_ROOT` boundary
+  unstated; "VCS hooks only" contradicted by the `config-detect.sh` deletion.
+
+### Assessment
+
+The revision worked: the story is materially better specified, and the classes of
+defect that dominated pass 1 — vacuous criteria, deleted comparators, ambiguous
+referents, unrecorded couplings — are largely gone. What remains splits into three
+groups.
+
+**Must fix before implementation (1):** the floor-verification critical. Until it
+is known whether `permissionDecision` and top-level `systemMessage` are honoured
+at v2.1.144, the guard migration risks trading a working shell guard for a
+silently inert Rust one. This is empirically checkable in minutes and should gate
+planning, not implementation.
+
+**Should fix (7 majors):** the fail-open posture for a fetched guard on the hot
+path; the root-bypass and gix-internal-spawn holes; the golden comparison rule;
+the guard table's row set; the latency criterion's gated-or-not ambiguity; and
+cargo-pup in the distribution gate. Each is a one-to-three-line edit.
+
+**Accepted or deferred (2):** the scope pair. The author has decided to keep the
+bundle intact, and that decision is recorded in Drafting Notes.
+
+Two observations worth carrying forward. First, three of this pass's majors are
+holes in criteria written *in response to* pass 1 — the probe test, the frozen
+goldens and the guard table each fixed the stated problem while opening a
+narrower one, which is the normal shape of tightening a specification and argues
+for one more short pass rather than a broad rewrite. Second, both of the most
+serious findings (the critical, and the fetch-failure posture) are consequences
+of decisions taken on 2026-07-30 — the `permissionDecision` envelope and the
+sub-binary — and neither was re-examined for failure modes when it was taken.
+
+
+## Re-Review (Pass 3) — 2026-07-31
+
+**Verdict:** REVISE
+
+All five lenses re-run. The pass-2 **critical is resolved** — the floor-verification
+criterion landed and is accepted. Dependency and completeness both converged
+sharply (3→1 and 2→1 majors). But the aggregate did not move: **14 majors**,
+against 15-plus-a-critical in pass 2 and 19 in pass 1.
+
+### Previously Identified Issues
+
+- 🔴 **Testability**: envelope unverified at the v2.1.144 floor — **Resolved**
+  (Sequencing Constraint 1, an Open Question with a default, and an acceptance
+  criterion requiring a real denied Bash call).
+- 🟡 **Dependency**: release-artefact host unnamed / no fail-open posture —
+  **Resolved**; `--fail-safe` on all three registrations with its own criterion.
+- 🟡 **Dependency**: 0170/0171/0173 not in Blocks — **Resolved**.
+- 🟡 **Dependency**: 0183 hand-off unactioned — **Resolved** (raised by criterion).
+- 🟡 **Completeness**: floor risk untracked; cargo-pup missing from the
+  distribution gate — **Both resolved**.
+- 🟡 **Testability**: root-bypass on the probe test — **Resolved** (hard-fails
+  rather than skips when `id -u` = 0).
+- 🟡 **Clarity**: "probe"/"wrapper" overloaded — **Resolved** via Terminology.
+- 🟡 **Scope**: hand-off criterion overreach — **Resolved** ("raising these is in
+  scope; re-scoping those items is not").
+- 🟡 **Testability + Clarity**: goldens byte-vs-whitespace — **Partially
+  resolved**; `jq -S` canonicalisation added, but "must equal" and "value changes
+  require justification" still contradict.
+- 🟡 **Testability**: guard table row set — **Partially resolved**; the blocked
+  subcommands are enumerated, but "representative allowed commands" and
+  "compound commands" are not, so the claimed derivability covers 1 of 4 axes.
+- 🟡 **Testability**: zero-spawn mechanism — **Partially resolved**; the
+  black-box `PATH`-stub test is stronger, but an absolute-path spawn
+  (`/usr/bin/git`) evades it — the exact `gix`-internal case it targets.
+- 🟡 **Testability + Clarity**: latency gated-or-not — **Partially resolved**; the
+  gate is now explicit, but a hard 35 ms conflicts with a baseline captured on
+  whatever host runs acceptance.
+- 🟡 **Scope**: the exec-probe fix and the story's span — **Still present**, with
+  the bundling rationale now recorded as requested.
+
+### New Issues Introduced
+
+Nine of the fourteen majors are consequences of the pass-2 edits themselves.
+
+- 🟡 **Clarity**: **direct contradiction within one edit** — "SessionStart
+  failures emit nothing" (fail-open Requirement) versus adapter failure
+  "produces a `systemMessage` … on stdout" (`--format=hook` Requirement), with a
+  golden required for the latter.
+- 🟡 **Clarity**: the `.git`-as-file correction is scoped to the guard, but the
+  same `-d` test is inlined in `vcs-detect.sh`, `vcs-status.sh` and
+  `vcs-log.sh`, which will share one classification port — so "Everything else is
+  parity" instructs preserving a bug on paths that cannot preserve it.
+- 🟡 **Scope + Completeness + Testability** (unanimous): the `corpus-adapters` /
+  `CommandProbe` migration was declared in scope in pass 2 — scope says it does
+  not belong (orthogonal, own risk profile, nothing in the hooks migration needs
+  it); completeness and testability say that if it stays, it has **no acceptance
+  criterion**, so `CommandProbe` could survive as a second shell-spawning
+  implementation exactly as the Requirement forbids.
+- 🟡 **Scope**: the Summary enumerates "three things" the story also lands and
+  omits the library swap — the largest of the four.
+- 🟡 **Scope**: the floor criterion's fallback branch ("raise the plugin's minimum
+  version") admits a plugin-wide compatibility decision into a VCS story.
+- 🟡 **Testability**: the fail-open Requirement names three failure classes; only
+  the unreachable-host case has a criterion. Nothing verifies a degraded
+  SessionStart emits zero bytes, or the unreadable-repository case.
+- 🟡 **Testability**: the exclusive four-rule masking list likely misses
+  abbreviated SHAs, jj change IDs and jj timestamp formats — and because the rule
+  is closed, the correct fix is barred.
+- 🟡 **Clarity**: "its existing parity suite" has two candidate referents and
+  names no path, while "parity suite" denotes three different artefacts.
+- 🟡 **Dependency**: 0182 is filed under "Completed dependencies" while its own
+  entry records `in-progress`.
+
+### Assessment
+
+**The critical is gone and that matters.** The story no longer risks trading a
+working shell guard for a silently inert Rust one without noticing.
+
+But the major count across three passes is 19 → 15 → 14, and this pass's own
+composition explains why it is not falling: **nine of fourteen majors were
+created by the previous pass's fixes.** The pattern is consistent and now
+well-evidenced:
+
+- Each fix in one section contradicts a section written at a different time
+  (fail-open versus diagnostic routing; the `.git` correction versus the shared
+  port; "three things" versus the added fourth).
+- Each tightening opens a narrower version of the same hole (probe: residue →
+  root → …; zero-spawn: port → `PATH` stubs → absolute path; goldens:
+  re-baseline → whitespace → mask coverage).
+- Each "this isn't specified" finding has been closed by **absorbing more work**
+  rather than pushing it out — which is why scope alone has moved 2 → 1 → **3**
+  while everything else converged.
+
+That is not a document-quality problem any further editing pass will fix. It is
+the signature of a work item carrying more than one artefact can hold
+consistently: six workstreams, four toolchains, twenty criteria, on the epic's
+critical path.
+
+**Recommendation.** Stop iterating the text. Take the two structural actions
+first, then re-review:
+
+1. **Revert the `corpus-adapters` expansion** — three lenses agree. Put that path
+   explicitly out of scope, name who converges it, and let the story build over
+   the existing adapter for that consumer.
+2. **Split at the two seams the work item itself names** — the exec-probe
+   bootstrap fix (Sequencing Constraint 5 already concedes it can land first) and
+   the `gix`/`jj-lib` adapter swap (which stands on the existing
+   `corpus-adapters` parity suite and has independent value: it dissolves 0125's
+   lexical-fallback rationale). 0169 then keeps subdomain + hooks + sub-binary
+   registration.
+
+The remaining specification defects — the emit-nothing contradiction, the `.git`
+correction's scope, the masking list, the guard table's unenumerated axes, the
+absolute-path spawn hole, the latency baseline, the 42-case partition — are all
+one-to-three-line fixes, and most would land in whichever child story owns them.
+Fixing them in the current single document is what has produced three passes of
+this shape.
+
+
+## Re-Review (Pass 4) — 2026-07-31
+
+**Verdict:** REVISE
+
+All five lenses re-run. Three stalled on their first attempt (a stream watchdog
+timeout while reading the referenced documents) and were relaunched with reading
+scoped to the work item alone — so clarity, completeness and scope assessed the
+document without the research and review artefacts the first batch consulted.
+Noted for fairness; it narrows scope's ability to check claims against the epic.
+
+**14 majors, no criticals — identical to pass 3.**
+
+| Pass | Majors | Criticals |
+| --- | --- | --- |
+| 1 | 19 | 0 |
+| 2 | 15 | 1 |
+| 3 | 14 | 0 |
+| 4 | **14** | 0 |
+
+### Per-lens trajectory
+
+| Lens | P1 | P2 | P3 | P4 |
+| --- | --- | --- | --- | --- |
+| completeness | 1 | 2 | 1 | **0** |
+| scope | 2 | 1 | 3 | **2** |
+| clarity | 5 | 4 | 4 | **3** |
+| dependency | 5 | 3 | 1 | **3** |
+| testability | 6 | 5+1🔴 | 5 | **6** |
+
+Completeness has converged to zero. Scope's remaining two are its standing
+split recommendation, unchanged in substance across all four passes. Clarity,
+dependency and testability have not converged.
+
+### The decisive measurement
+
+**Eleven of pass 4's fourteen majors are defects in pass 3's fixes**, not
+pre-existing problems surfacing. Only three are standing issues (scope's two
+structural findings, and testability's observation that a reachable host serving
+a manifest without `accelerator-vcs` is untested).
+
+Representative examples, all introduced by the edits made to close pass 3:
+
+- The 42-case partition was rewritten to be checkable and now **does not
+  reconcile**: 27 in-process + "the remaining 15" in three disjoint buckets, plus
+  a fourth disposition — either four buckets, or 27+15+1 = 43. Flagged
+  independently by testability and clarity.
+- The emit-nothing contradiction was fixed and became a **three-way**
+  contradiction: Requirements say adapter failure emits a `systemMessage`-bearing
+  object and that "emits nothing" never applies; the verifying criterion says the
+  same case "writes exactly zero bytes"; the unreadable-repository criterion
+  leaves the shape open, destabilising the "five in total" golden count.
+- The guard decision table was enumerated to make its row count derivable; the
+  trailing "× 4 repo modes" multiplier is ambiguous in scope, and the two
+  readings differ by roughly 2×. The count is still not stated as a number.
+- The `.git`-as-file correction was extended to all four subcommands and is
+  **tested for one** — while the detect criterion, tightened in the same edit to
+  "a value difference fails the criterion", now conflicts with the correction
+  biting on that path.
+- The `corpus-adapters` revert landed cleanly and has **no criterion asserting
+  it**, so the boundary is an intention rather than a checked fact.
+
+### Assessment
+
+Three passes of editing have moved the major count 19 → 15 → 14 → 14. The
+severity ceiling did fall — the pass-2 critical is gone and stayed gone — and the
+sections describing *what the work is* have settled: completeness is at zero and
+scope reports no section-to-section drift, crediting the adapter-swap boundary as
+"exemplary deliberate scope limitation".
+
+What has not settled is the verification and coupling surface. Each tightening
+pass produces a comparable number of new inconsistencies, because the document
+must hold six workstreams, twelve requirements and twenty-plus criteria mutually
+consistent — and every fix in one section has more surface to contradict than the
+last. That is the mechanism scope has been describing since pass 1, now visible
+as a measurement rather than an opinion.
+
+**Recommendation: stop editing this document. Split it.** Scope's pass-4
+decomposition is concrete and uses this story's own revert as its evidence — with
+`CommandProbe` now explicitly retained, the hooks can migrate over the existing
+adapter and swap afterwards behind a port that "already allows the swap without
+touching the domain":
+
+1. subdomain + hooks migration + skill repoint
+2. sub-binary distribution registration (unblocks 0170/0171/0173 independently)
+3. the `gix`/`jj-lib` library swap
+4. (already carved out) the exec-probe bootstrap fix
+
+The eleven fix-defects are individually trivial. They are not worth another pass
+against the current document, because the evidence says a fifth pass produces
+about as many again. They should be fixed inside whichever child story owns them,
+where each document has a surface small enough to keep consistent.

--- a/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-3.md
+++ b/meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-3.md
@@ -1,0 +1,200 @@
+---
+type: work-item-review
+id: "0169-vcs-subdomain-and-hooks-migration-review-3"
+title: "Work Item Review: VCS Subdomain and Hooks Migration"
+date: "2026-07-31T11:04:14+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0169"
+parent: "work-item:0136"
+relates_to: ["work-item-review:0169-vcs-subdomain-and-hooks-migration-review-2"]
+work_item_id: "0169"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 3
+review_pass: 2
+tags: [rust, vcs, hooks, migration]
+last_updated: "2026-07-31T11:10:05+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: VCS Subdomain and Hooks Migration
+
+**Verdict:** APPROVE *(changed from REVISE on 2026-07-31 — see Verdict Change)*
+
+First review of the **reduced** 0169, after the 2026-07-31 split extracted 0185,
+0186, 0187 and 0188. **13 majors and 1 critical**, against review-2 pass 4's 14
+majors and none.
+
+**The split did not reduce the finding count.** That was the explicit prediction
+behind the recommendation to split, and the measurement falsifies it.
+
+| | Majors | Criticals |
+| --- | --- | --- |
+| review-2 pass 1 | 19 | 0 |
+| review-2 pass 2 | 15 | 1 |
+| review-2 pass 3 | 14 | 0 |
+| review-2 pass 4 | 14 | 0 |
+| **review-3 (reduced story)** | **13** | **1** |
+
+### What the split did change
+
+Scope's findings changed *character* entirely. "Six workstreams", "four
+toolchains", "the library swap is separable", "review-1 approved a different
+bundle" — all resolved. In their place are two finer-grained findings that could
+not have been seen before: a **release boundary bisects the story** (the
+`hooks.json` rewrite cannot ship before a release listing `accelerator-vcs`),
+and the **hooks migration and skill repoint are two independently deliverable
+consumer threads**. Dependency independently reached the release-cut finding.
+
+So the split bought real things — independent delivery, three sibling stories
+unblocked by 0187, the pre-1.0 `jj-lib` bet isolated in 0188 — but it did not
+buy review convergence.
+
+### The critical
+
+🔴 **Testability — the `.git`-as-file case has a self-contradictory oracle.**
+The correction is declared a *departure* from shell behaviour, while the
+verification oracle is a golden *captured from the shell*, and the fixture list
+explicitly includes "`.git`-as-file colocated" among the captured goldens. A
+verifier following the criteria literally compares corrected output against buggy
+expectations and fails the case the story exists to fix.
+
+This is the clearest instance of the pattern: it is the collision of two
+individually-correct fixes made in different passes — "capture before delete"
+(pass 3) and "the correction applies to all four subcommands" (pass 4).
+
+### Cross-cutting themes
+
+- **The validate-plan motivation is contradicted by the parity requirement**
+  (clarity, completeness, testability — three lenses). Context names
+  `validate-plan` being blocked in pure-jj repos as a motivating symptom; the
+  guard's blocked set keeps `log` and `diff`, and the decision table reproduces
+  it. Passing every criterion leaves the symptom intact. The motivation was added
+  in response to a pass-3 completeness suggestion, without checking it against
+  the parity requirement.
+- **The output contract is still contradictory** (clarity, testability), in the
+  section titled "Output contract, stated once". "No context to report → zero
+  bytes" overlaps "adapter failure → `systemMessage` object" on the scenario the
+  degraded-SessionStart criterion names. Third consecutive review to find this,
+  each time narrower.
+- **The release cut has no owner or gate** (scope, dependency).
+
+### Other majors
+
+- 🟡 **Testability**: no criterion pins the corrected `.git`-as-file behaviour for
+  `vcs detect` specifically — three of four subcommands get an enumerated case.
+- 🟡 **Testability**: submodule, bare and `GIT_DIR` handling is required but no
+  criterion exercises it — they are inputs, not arms, so an arm-covering fixture
+  need never construct them.
+- 🟡 **Clarity**: the `.git` correction never states the corrected classification
+  — "the new value" is never written down.
+- 🟡 **Dependency**: 0182 is a stated prerequisite recorded only in
+  `relates_to`; 0172's blocking edge is established only at *this* story's
+  acceptance, so nothing stops 0172 landing concurrently and removing the suite
+  this story's floor criterion depends on.
+- 🟡 **Scope**: the release boundary; the two consumer threads.
+- 🟡 **Completeness**: the validate-plan gap (above).
+
+### Strengths
+
+- ✅ Terminology, the authoritative guard-input enumeration, and the derivable
+  136-row table are all credited by multiple lenses as removing whole classes of
+  ambiguity.
+- ✅ Anti-vacuity clauses are working: the closed mask set, the closed taxonomy
+  assertion, the ban on permission-based fault injection, and the
+  fixtures-precede-deletion commit ordering are each called out as unusually
+  rigorous.
+- ✅ Dependencies distinguishes blocked-by from completed-but-unlisted from
+  in-flight, and names the debt the story creates rather than hiding it.
+- ✅ Requirements and criteria map nearly one-to-one; scope reports no
+  section-to-section drift.
+
+### Assessment
+
+Five review rounds have produced genuinely valuable findings — the floor-check
+critical, the fail-open posture, the `corpus-adapters` revert, the split itself.
+But the count has not fallen: 19 → 15 → 14 → 14 → 13, with a critical returning.
+
+The size hypothesis is falsified. The residual cause is visible in the
+composition: nearly every finding is a contradiction between sections edited at
+different times, and the two longest-lived defects (the output contract, the
+`.git` oracle) are collisions between fixes that were each correct in isolation.
+That is a property of iteratively patching a prose specification, not of how much
+the specification covers.
+
+**Recommendation: stop reviewing and start planning.** A plan cannot be written
+against a contradiction — the `.git` oracle and the output contract must both
+resolve to concrete values before any test can be authored, and planning forces
+that in a way another review round demonstrably has not. Take the critical and
+the three cross-cutting themes into the plan as the first questions to settle;
+leave the remaining majors to be resolved as the plan makes them concrete.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+
+## Verdict Change (Pass 2) — 2026-07-31
+
+**Verdict:** REVISE → **APPROVE** (author decision).
+
+The critical and the three cross-cutting themes were fixed; five majors are
+**accepted rather than resolved**. Recorded so the approval is not read as "all
+findings addressed".
+
+### Fixed — the critical and 8 of 13 majors
+
+- 🔴 **`.git`-as-file oracle contradiction.** Resolved — and the fix corrected an
+  error in the work item first. The story claimed the correction "applies to all
+  four subcommands", but `vcs-status.sh:9` and `vcs-log.sh:9` branch on
+  `-d "$REPO_ROOT/.jj"` and never inspect `.git`; only `vcs-detect.sh:29` and
+  `vcs-guard.sh:77` are affected. Narrowing the scope removes the
+  captured-from-shell golden for a corrected case in status/log entirely. For the
+  two affected subcommands the correction is now stated **as concrete values**
+  (`classify_checkout` `main`→`colocated`; detect mode `jj`→`jj-colocated`; guard
+  blocks→warns), and the detect fixture's golden is authored as the new
+  expectation and marked a deliberate divergence.
+- 🟡 **Output contract** (clarity, testability). The two outcomes are now disjoint
+  *by definition* — success-with-nothing-to-report → zero bytes; adapter failure →
+  exactly one `systemMessage` object. No run is both, so the overlap that survived
+  three prior fixes is structurally impossible rather than reworded. Both are
+  pinned separately and the guard's failure output is covered.
+- 🟡 **validate-plan motivation** (clarity, completeness, testability). Stated as
+  deliberately out of scope, with the reason — changing the blocked set is a
+  user-facing policy decision that should not ride inside a parity-argued
+  migration — and a follow-up item the implementer creates.
+- 🟡 **Release cut** (scope, dependency). Now a named Dependencies entry with an
+  owner, plus an acceptance criterion gating the rewrite on a *published*
+  manifest rather than the locally generated one.
+- 🟡 **`.git` correction lacked a stated value** (clarity) and **no criterion
+  pinned it for `vcs detect`** (testability). Both closed by the above.
+
+### Accepted, not resolved — 5 majors
+
+- 🟡 **Scope**: the release boundary still bisects the story, and the hooks
+  migration and skill repoint remain two independently deliverable consumer
+  threads. A further split was declined; the boundary is at least now gated by a
+  criterion rather than only narrated.
+- 🟡 **Dependency**: 0182 remains a `relates_to` edge despite being a stated
+  prerequisite, and 0172's blocking edge is still established only at *this*
+  story's acceptance — so nothing structurally prevents 0172 landing concurrently
+  and removing the suite this story's floor criterion depends on.
+- 🟡 **Testability**: submodule, bare and `GIT_DIR` handling is required by the
+  taxonomy but no criterion exercises it — they are inputs feeding the arms, not
+  arms themselves, so an arm-covering fixture need never construct them. **This is
+  the cheapest outstanding gap and the likeliest to bite**, since those are
+  precisely the cases where a library-backed adapter diverges from the shell probe
+  layer.
+
+### Standing note
+
+Five review rounds (review-2 passes 1-4, review-3) moved the major count
+19 → 15 → 14 → 14 → 13. The split changed the *character* of the findings without
+reducing the count, and the residual cause — contradictions between sections
+edited at different times — is a property of iteratively patching a prose
+specification. This approval reflects a judgement that the remaining findings are
+better resolved by planning and implementation, which cannot proceed against a
+contradiction, than by further review rounds.

--- a/meta/reviews/work/0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md
+++ b/meta/reviews/work/0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md
@@ -1,0 +1,1259 @@
+---
+type: work-item-review
+id: "0186-remove-exec-probe-from-bootstrap-warm-path-review-1"
+title: "Work Item Review: Remove the Exec Probe from the Bootstrap Warm Path"
+date: "2026-07-31T11:19:09+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0136"
+target: "work-item:0186"
+work_item_id: "0186"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 3
+tags: [shell, performance, bootstrap]
+last_updated: "2026-08-01T12:51:32+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Remove the Exec Probe from the Bootstrap Warm Path
+
+**Verdict:** REVISE
+
+0186 is a tightly-scoped, well-evidenced task: one mechanism (`probe_dir`) in
+one file (`bin/accelerator`), a measured attribution that isolates the cost
+(107.9 ms fresh-write-and-exec against 10.6 ms re-exec), and a safety argument
+stated inline rather than assumed. Every template section bar Drafting Notes is
+substantively filled, and the criteria are unusually self-aware — AC1 names why
+a residue check would be non-discriminating and pre-empts the root-bypass false
+pass. Two structural gaps drive the REVISE: the item's headline objective (the
+~108 ms saving) is gated only by a record-the-numbers criterion with no
+threshold, so the full AC set can pass with zero latency gained; and the shim
+double-hash Open Question is simultaneously mis-costed, out of scope, and the
+owner of a residual that 0169's latency gate depends on.
+
+### Cross-Cutting Themes
+
+- **The shim double-hash Open Question is doing too much work** (flagged by:
+  clarity, dependency, scope, testability) — four lenses converged on the same
+  paragraph from different angles: its ~23 ms figure belongs to a different
+  change than the one it describes (clarity), deferring it leaves the residual
+  unowned while 0186 is declared 0169's unblocker (dependency), a "yes"
+  resolution would pull a trust-boundary change into a redundancy-removal task
+  (scope), and no criterion requires the decision to be recorded (testability).
+- **AC1's warm-path test is under-specified and non-discriminating** (flagged
+  by: clarity, testability) — warming a cache requires writing into the
+  directory the criterion makes non-writable, the setup sequence is unstated,
+  and a probe kept but made non-fatal would satisfy the assertion while
+  retaining the full cost.
+- **No target for a performance work item** (flagged by: testability,
+  completeness) — the source research recommends a comparative bound against
+  `hooks/vcs-guard.sh`; 0186 carried across only the measurement protocol, not
+  the expected result. Sibling 0169 does set a bound (`G ≤ 1.1 × B`).
+- **Test surface and harness ownership are unstated** (flagged by:
+  completeness, dependency, testability) — the criteria refer to "the test" as
+  an existing obligation, Requirements list only production changes, and the
+  warm-cache harness the criteria presuppose is currently owned by 0169, which
+  is downstream.
+- **`bin/accelerator` is contested and the line references are fragile**
+  (flagged by: dependency, clarity) — the hard sequencing constraint against
+  in-progress 0182 lives only in prose (`relates_to`, no direction, no
+  reciprocal edge, epic says "no blockers"), and several targets are pinned by
+  line number alone in a file 0182 is actively editing.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Testability / Completeness**: Latency criterion records a number but
+  defines no pass/fail threshold
+  **Location**: Acceptance Criteria (warm-path saving measured and recorded)
+  The only criterion covering the item's primary objective requires that
+  before/after medians be "measured and recorded" — no threshold, so any pair of
+  numbers satisfies it, including a zero or negative saving. The source research
+  (§12) recommends a comparative bound against today's shell guard, which was
+  not carried across.
+
+- 🟡 **Dependency / Scope**: Deferring the shim double-hash leaves the residual
+  warm-path cost unowned, yet 0186 is the declared unblocker of 0169's latency
+  gate
+  **Location**: Open Questions / Dependencies
+  Removing only the probe puts the bootstrap at roughly 41 ms by §12's own
+  decomposition, against 0169's `G ≤ 1.1 × B` gate (≈38.6 ms) *plus* a
+  sub-binary exec and verify on top. 0169 cannot pick up the residual because it
+  is downstream, and no successor item exists.
+
+- 🟡 **Dependency**: Hard sequencing constraint against in-progress 0182 is
+  recorded only as "Related", with no direction and no reciprocal edge
+  **Location**: Dependencies (Related: 0182) / Frontmatter: relates_to
+  The prose says the two "must be sequenced rather than developed concurrently"
+  — a hard ordering constraint — but `blocked_by` is empty, which goes first is
+  unstated, 0182 does not reference 0186, and parent epic 0136 annotates this
+  task as "(no blockers)".
+
+- 🟡 **Clarity / Testability**: AC1's precondition is under-specified — warming
+  a cache requires writing to the directory the criterion makes non-writable
+  **Location**: Acceptance Criteria (criterion 1)
+  The criterion never states what makes the invocation "warm", nor how a
+  non-writable directory came to hold a verified launcher. It also implicitly
+  requires the warm path to be write-free, whereas Open Questions describes
+  warm-path shim staging into `cache_dir` that this item deliberately leaves in
+  place — so a failure would not distinguish "probe still present" from "staging
+  still writes".
+
+- 🟡 **Testability**: The warm-to-cold fall-through that justifies the removal
+  is not covered by any criterion
+  **Location**: Requirements (first bullet) / Acceptance Criteria
+  The safety argument is that a `noexec` directory makes `verify_launcher` fail
+  into the cold branch, but AC2 tests an *empty* (cold) cache dir made
+  non-executable, not a *populated* cache dir that has become non-executable.
+  The load-bearing claim goes untested.
+
+- 🟡 **Testability**: No criterion verifies the cold happy path or that
+  `ensure_dir` still creates the cache dir
+  **Location**: Requirements (second bullet) / Acceptance Criteria
+  Every criterion covers the warm path (AC1, AC4) or a cold *failure* (AC2);
+  none asserts that a first run against a non-existent cache dir still creates
+  the directory, probes, fetches and succeeds — the most likely regression from
+  the split.
+
+- 🟡 **Dependency**: The warm-path behavioural criterion implies a
+  launcher-build test harness that the downstream item (0169) owns
+  **Location**: Acceptance Criteria (warm-path behavioural check)
+  A warm invocation presupposes a populated cache with a verified launcher and
+  shim, i.e. a harness able to build and stage the CLI. 0169 records that this
+  wiring does not yet exist and needs `build:cli:dev` plus an
+  `accelerator_env()`-style helper — and 0169 is downstream, so the capability
+  cannot be inherited from it.
+
+- 🟡 **Clarity**: The shim-hash question conflates two different changes and
+  quotes the saving for the larger one
+  **Location**: Open Questions
+  The question asks about removing the *second* `sha256_file` call and states
+  "~23 ms", but §12 attributes ~23 ms to `sha256_file` **×2** at ~11.7 ms each,
+  and the change it proposes for that saving is skipping shim staging when
+  `shim_source`'s directory and `cache_dir` coincide — not deleting one hash.
+  Two readings, materially different payoffs.
+
+#### Minor
+
+- 🔵 **Clarity**: First two requirements disagree on whether `probe_dir` is
+  removed or split
+  **Location**: Requirements
+  Requirement 1 says "Remove the exec probe (`probe_dir`, …)"; Requirement 2
+  says "Split `probe_dir` into `ensure_dir` … and the write-chmod-exec probe".
+  A reader skimming only Requirement 1 (or the Summary) could delete `probe_dir`
+  outright and lose the `mkdir -p` the warm path still needs.
+
+- 🔵 **Completeness**: No Drafting Notes section, despite several interpretive
+  calls baked into the item
+  **Location**: Drafting Notes (absent)
+  146 other work items carry the section. The redundancy rationale, the
+  retain-rather-than-delete choice for the cold-path probe, and the shim
+  deferral all read as settled facts rather than author calls open to challenge.
+
+- 🔵 **Clarity / Testability**: "The existing diagnostic text" is neither quoted
+  nor located, and AC2 has no privilege precondition
+  **Location**: Acceptance Criteria (criterion 2)
+  A substring assertion against an unnamed message cannot distinguish the
+  intended probe diagnostic from an unrelated write/traversal error — removing a
+  directory's execute bit also blocks writing inside it. Unlike AC1, AC2 states
+  no `id -u` guard even though root traverses regardless of the execute bit.
+
+- 🔵 **Clarity**: Line-number referents will not resolve once the sequenced
+  sibling change lands
+  **Location**: Requirements / Technical Notes / Open Questions
+  Most citations pair a line range with a function name and survive drift, but
+  `:256` and `:352` are identified by line alone — in the same file 0182 is
+  editing.
+
+- 🔵 **Completeness / Testability**: Requirements omit the test work the
+  criteria presuppose, and no suite is named
+  **Location**: Requirements / Acceptance Criteria
+  Requirements list only production changes while two criteria refer to "the
+  test" as an existing obligation. Neither names the target suite, so the new
+  coverage may land where CI does not pick it up — and a passing one-off check
+  would not prevent the probe being reintroduced later.
+
+- 🔵 **Dependency**: CI execution-environment coupling behind the
+  permission-based tests is not captured
+  **Location**: Acceptance Criteria (root hard-fail; `chmod -x` cold-path check)
+  Neither the non-root runner identity nor permission-honouring filesystem
+  semantics is recorded as a dependency. If any lane runs as root (a common
+  container default), the deliberate hard-fail turns a correct implementation
+  into a red build.
+
+- 🔵 **Dependency**: Upstream provenance of the bootstrap being modified is not
+  named
+  **Location**: Dependencies / Requirements
+  `probe_dir`, `resolve_cache_dir`, the staged verify shim and the cold/warm
+  branch structure come from 0164 (fetch-verify-cache) and 0167 (invocation
+  contract); neither id appears. 0169 records the same distinction as
+  "completed dependencies (not blocking)".
+
+- 🔵 **Scope**: The shim double-hash Open Question can pull a second,
+  independent concern into the item
+  **Location**: Open Questions
+  No Requirement or Acceptance Criterion covers the change, yet Validation
+  Results pre-commits to recording a decision. If it resolves "yes"
+  mid-implementation, a task-sized redundancy removal grows a security-relevant
+  change — the same bundling that justified extracting 0186 from 0169.
+
+- 🔵 **Testability**: AC1 is satisfiable by a probe made non-fatal rather than
+  removed
+  **Location**: Acceptance Criteria (criterion 1)
+  An implementation that keeps the write-chmod-exec probe on the warm path but
+  tolerates its failure also satisfies AC1, retaining the full ~108 ms. Combined
+  with the missing latency threshold, no criterion actually pins "the probe does
+  not run on the warm path".
+
+#### Suggestions
+
+- 🔵 **Testability**: The shim double-hash decision is not bound by any
+  acceptance criterion
+  **Location**: Open Questions / Validation Results
+  The item can close with every criterion ticked while the trust-boundary
+  decision remains unrecorded.
+
+- 🔵 **Clarity**: Project shorthands used without a definition or pointer
+  **Location**: Summary / Context / Requirements
+  Warm path / cold path — the central organising concept — is never defined and
+  is named four ways ("warm path", "warm cache", "cold path", "cold branch").
+  "Fetch-verify-cache design" and "review-2, pass 4" have no pointers, unlike
+  the bash 3.2 floor which is properly linked to ADR-0049.
+
+- 🔵 **Clarity**: Bare "the probe" collides with the sibling story's reserved
+  terminology
+  **Location**: Requirements / Technical Notes
+  0169 reserves "probe layer" for the shell VCS detection functions and states
+  it is never abbreviated to "probe".
+
+### Strengths
+
+- ✅ The Context table plus the attribution note make the causal claim
+  unambiguous: 107.9 ms against 10.6 ms isolates first-exec cost from filesystem
+  work, and the ~97 ms delta is arithmetically consistent with both rows and the
+  Summary's ~108 ms.
+- ✅ Requirements state not just what to change but why it is safe — the warm
+  path already execs the shim and launcher from `cache_dir`, and
+  `resolve_cache_dir` has no fallback, so moving the probe changes only where
+  the diagnostic fires. This pre-empts the obvious reader objection.
+- ✅ AC1 explicitly identifies why the obvious check (probe residue) is
+  non-discriminating and substitutes a behavioural test, and pre-empts the
+  root-bypass false pass with a hard-fail rather than a skip.
+- ✅ AC2 rules out silent skipping — an unrunnable check becomes a recorded
+  manual check rather than a disappeared one.
+- ✅ AC3 names the concrete gates (`scripts/lint-bashisms.sh`, shfmt,
+  ShellCheck) and AC4 fixes a reproducible measurement protocol (median of 20,
+  one darwin-arm64 host, single session, no build running).
+- ✅ Single coherent purpose in one file: the two substantive Requirements are
+  the removal and the mechanical split that enables it; bash 3.2 is a constraint
+  rather than a bundled concern.
+- ✅ The extraction rationale is stated and defensible (bash bootstrap under the
+  3.2 floor, not the Rust CLI) and the item has standalone value today via
+  `hooks/config-detect.sh`, independent of 0169.
+- ✅ Clean measurement boundary with the downstream story — 0186 records an
+  absolute before/after median while 0169 retains the host-relative parity
+  threshold; no duplicated or competing criterion.
+- ✅ The `Blocks` edge is stated with its reason and is reciprocated in 0169's
+  `blocked_by`; provenance is fully traced to the research section carrying the
+  measurements.
+- ✅ Every template section bar Drafting Notes is present and substantively
+  populated with no placeholder content, and Validation Results pre-declares a
+  slot for each pending verification.
+- ✅ The platform coupling is captured as an explicit Assumption (macOS
+  first-exec penalty, no Linux equivalent), pre-empting a false expectation of
+  equivalent savings on the other shipped platform.
+
+### Recommended Changes
+
+1. **Set a numeric latency gate on AC4** (addresses: "Latency criterion records
+   a number but defines no pass/fail threshold"; "AC1 is satisfiable by a probe
+   made non-fatal")
+   Replace "measured and recorded" with a threshold — e.g. after-median at or
+   below 60 ms on darwin-arm64 with a before-minus-after delta of at least
+   80 ms — and name the measurement tool so both numbers are produced
+   identically. This also closes the non-fatal-probe loophole numerically.
+
+2. **Resolve the shim double-hash question now, before implementation**
+   (addresses: "Deferring the shim double-hash leaves the residual warm-path
+   cost unowned"; "The shim-hash question conflates two different changes";
+   "Open Question can pull a second, independent concern into the item"; "The
+   shim double-hash decision is not bound by any acceptance criterion")
+   Split the two options with their correct figures (drop `:256` only ≈ 11.7 ms;
+   skip staging when `shim_source`'s directory and `cache_dir` coincide ≈ 23 ms),
+   then either declare it out of scope and raise the successor item now — noting
+   in Dependencies that 0186 alone may not clear 0169's `≤ 1.1 × B` gate — or
+   promote it into Requirements with its own criterion. Do not leave it as a
+   discretionary mid-implementation call.
+
+3. **Encode the 0182 ordering as a real edge** (addresses: "Hard sequencing
+   constraint against in-progress 0182 is recorded only as Related";
+   "Line-number referents will not resolve once the sequenced sibling change
+   lands")
+   State the direction in prose ("0182 lands first; this task rebases onto
+   it"), move 0182 into `blocked_by` if it must precede, add the reciprocal
+   reference on 0182, correct epic 0136's "(no blockers)" annotation, and pin
+   every code citation to an enclosing function name so the line numbers are
+   indicative rather than load-bearing.
+
+4. **Rewrite AC1 as an explicit sequence** (addresses: "AC1's precondition is
+   under-specified"; "First two requirements disagree on whether `probe_dir` is
+   removed or split")
+   Spell out: warm the cache with the directory writable, `chmod -w`, then
+   assert the second invocation exits 0 with the expected `version` output.
+   State whether the warm path is expected to be write-free after the change, or
+   scope the assertion to probe-specific writes if staging may still write.
+   While there, make Requirement 1 speak only about behaviour (the warm path
+   performs no write-chmod-exec probe) and let Requirement 2 own the mechanism.
+
+5. **Add the two missing criteria the split demands** (addresses: "The
+   warm-to-cold fall-through … is not covered"; "No criterion verifies the cold
+   happy path or that `ensure_dir` still creates the cache dir")
+   One for a *populated* cache dir subsequently made non-executable, asserting
+   the same `noexec` diagnostic (proving the fall-through into the cold branch);
+   one for a non-existent `ACCELERATOR_CACHE_DIR`, asserting the directory is
+   created and `version` exits 0.
+
+6. **Name the test surface and its prerequisites** (addresses: "Requirements
+   omit the test work the criteria presuppose"; "warm-path behavioural criterion
+   implies a launcher-build test harness that 0169 owns"; "CI
+   execution-environment coupling … is not captured")
+   Add a Requirements bullet for the new bootstrap coverage naming the target
+   suite and how it is reached from `mise run`; record in Dependencies what the
+   harness needs to pre-warm the cache (`build:cli:dev` plus an
+   `accelerator_env()`-style helper, or a stub launcher/shim) and whether that
+   wiring is a prerequisite or part of this task; and state the
+   execution-environment requirement (non-root, permission-honouring
+   filesystem) plus what happens on lanes that cannot meet it.
+
+7. **Quote the `noexec` diagnostic substring and add AC2's root guard**
+   (addresses: "The existing diagnostic text is neither quoted nor located")
+   Reproduce the exact substring, assert the specific non-zero exit code, and
+   apply AC1's non-root precondition and hard-fail-if-root rule to AC2 as well.
+
+8. **Add a Drafting Notes section and define the warm/cold vocabulary**
+   (addresses: "No Drafting Notes section"; "Project shorthands used without a
+   definition or pointer"; "Bare 'the probe' collides with the sibling story's
+   reserved terminology"; "Upstream provenance … is not named")
+   List the interpretations made during extraction; define warm path and cold
+   path once in terms of whether a verified launcher is cached and settle on one
+   name for each; keep the "exec probe" qualifier on every mention; add
+   References pointers for the fetch-verify-cache design and the 0169 review-2
+   document; and add a "Completed dependencies (not blocking)" line naming 0164
+   and 0167 with their current states.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is unusually precise for its size: the problem, the
+measured attribution, and the reason the probe is safe to move are all stated
+explicitly, and most technical referents are pinned to a named function plus
+line range. The main clarity weaknesses are an under-specified precondition in
+the first acceptance criterion (what makes the asserted invocation "warm" when
+the cache dir is deliberately non-writable), and an Open Question whose stated
+saving and stated change do not match the source it derives from — leaving two
+different interpretations of what "remove the second hash" means. Remaining
+issues are smaller: a remove-vs-split tension between the first two
+requirements, an unquoted "existing diagnostic text" referent, line-number
+citations the work item itself says a sibling change will invalidate, and a few
+project shorthands used without a pointer.
+
+**Strengths**:
+
+- The Context table plus the "Attribution evidence" note in Technical Notes make
+  the causal claim unambiguous: 107.9 ms versus 10.6 ms isolates first-exec cost
+  from filesystem work, and the ~97 ms delta in the Context prose is
+  arithmetically consistent with both rows and with the ~108 ms figure in the
+  Summary.
+- Requirements do not just state what to change but why it is safe (the warm
+  path already execs the shim and launcher from the cache dir;
+  `resolve_cache_dir` has no fallback so moving the probe changes only where the
+  diagnostic fires), pre-empting the obvious reader objection.
+- The first acceptance criterion explicitly names and rules out two ways the
+  test could pass vacuously — checking for probe residue, and running as root —
+  which is far more precise than most criteria of this kind.
+- The Open Question carries an explicit default resolution ("take the exec-probe
+  win and leave this"), so an unresolved question cannot stall delivery.
+- The Dependencies section states the concrete sequencing hazard (0182 edits the
+  same file) rather than just listing an edge, and the Assumptions section names
+  darwin as the deliberate worst case rather than leaving the platform scope
+  implicit.
+
+**Findings**:
+
+- 🟡 **major** / confidence: high — **"Warm invocation" against a non-writable
+  cache dir leaves the test precondition ambiguous**
+  *Location*: Acceptance Criteria (criterion 1)
+  Criterion 1 says to point `ACCELERATOR_CACHE_DIR` at a directory that is
+  executable but **not writable** and assert that a warm invocation still
+  succeeds — but the work item never states what makes an invocation "warm", nor
+  how a non-writable directory came to hold a verified launcher. The Technical
+  Notes and Open Questions sections both say the warm path
+  stages/content-addresses the verify shim *into* `cache_dir`, which reads as a
+  write, so it is unclear whether the intended test is (a) populate the cache,
+  then `chmod -w`, relying on staging being a no-op when the staged file already
+  exists, or (b) something else entirely.
+  **Impact**: An implementer who reads it the wrong way either writes a test
+  that fails for reasons unrelated to the exec probe, or concludes the criterion
+  is unsatisfiable and quietly weakens it — in both cases the headline
+  behavioural guarantee goes unverified.
+  **Suggestion**: State the precondition explicitly (what must already exist in
+  `cache_dir` before the `chmod`, and in which order) and state whether the warm
+  path is expected to be write-free after removal of the probe.
+
+- 🟡 **major** / confidence: medium — **The shim-hash question conflates two
+  different changes and quotes the saving for the larger one**
+  *Location*: Open Questions
+  The Open Question asks whether the verify shim's **second** `sha256_file` call
+  (`bin/accelerator:256`) should be removed and says "it costs a further ~23 ms
+  per invocation". The cited source
+  (`meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §12) attributes ~23 ms to `sha256_file` **×2** (`:252` and `:256`) at
+  ~11.7 ms per call, and the change it proposes for that saving is skipping shim
+  staging entirely when `shim_source`'s directory and `cache_dir` resolve to the
+  same path — not deleting one hash. So the question admits two readings with
+  materially different payoffs (~11.7 ms for one hash, ~23 ms for skipping
+  staging).
+  **Impact**: Since the question is framed as a cost/benefit trade-off against a
+  trust-boundary concern, a saving stated at roughly double its actual value
+  could flip the decision, and the ambiguity about which change is being
+  contemplated means a "yes" answer does not tell the implementer what to build.
+  **Suggestion**: Separate the two options and attach the correct per-option
+  figure (drop `:256` only ≈ 11.7 ms; skip staging when source and cache
+  directories coincide ≈ 23 ms), and state whether a "yes" resolution is
+  implemented inside this work item or handed to a follow-up — currently only
+  the *decision* appears in Validation Results, with no requirement or criterion
+  covering the change itself.
+
+- 🔵 **minor** / confidence: high — **First two requirements disagree on whether
+  `probe_dir` is removed or split**
+  *Location*: Requirements
+  Requirement 1 says to "Remove the exec probe (`probe_dir`,
+  `bin/accelerator:166-180`) from the warm path", naming `probe_dir` as the
+  thing removed; Requirement 2 then says to "Split `probe_dir` into `ensure_dir`
+  … and the write-chmod-exec probe (cold path only …)". Read together the intent
+  is recoverable — the probe portion moves rather than disappearing — but the
+  two bullets describe the same function's fate in incompatible verbs, and "the
+  exec probe" is used for both the whole function and just its write-chmod-exec
+  portion.
+  **Impact**: A reader skimming only Requirement 1 (or the Summary's "Remove it
+  from the warm path") could delete `probe_dir` outright and lose the `mkdir -p`
+  that the warm path still needs.
+  **Suggestion**: Make Requirement 1 speak only about the *behaviour* (the warm
+  path performs no write-chmod-exec probe) and let Requirement 2 own the
+  mechanism, using one consistent name for the write-chmod-exec step throughout.
+
+- 🔵 **minor** / confidence: medium — **"The existing diagnostic text" is not
+  reproduced or located**
+  *Location*: Acceptance Criteria (criterion 2)
+  Criterion 2 requires that a cold invocation against a non-executable cache dir
+  "exits non-zero with the existing diagnostic text, asserted as a substring",
+  but the text is neither quoted nor pinned to a line in `bin/accelerator`, and
+  no other section reproduces it.
+  **Impact**: The reader cannot tell which string the assertion will match, so
+  the criterion's meaning depends on the implementer's search of the current
+  source — and if the message is reworded during the change, nothing in the work
+  item reveals that the criterion has drifted.
+  **Suggestion**: Quote the substring to be asserted (or cite its exact
+  location) so the criterion states one specific, checkable expectation.
+
+- 🔵 **minor** / confidence: medium — **Line-number referents will not resolve
+  once the sequenced sibling change lands**
+  *Location*: Requirements / Technical Notes / Open Questions
+  The work item pins its targets to line numbers in `bin/accelerator`
+  (`:166-180`, `:184-193`, `:256`, `:310-312`, `:352`) while its own
+  Dependencies section states that 0182 "also edits `bin/accelerator`" and that
+  the two changes must be sequenced. Most citations pair a line range with a
+  function name and so survive drift, but `:256` ("the verify shim's second
+  `sha256_file` call") and `:352` ("execs the launcher binary") are identified
+  by line alone.
+  **Impact**: Whichever change lands second, the bare line references point at
+  unrelated code, and a reader has to guess which construct was meant.
+  **Suggestion**: Name the enclosing function or the distinguishing code for
+  every citation (as the other references already do) and mark the line numbers
+  as indicative-at-time-of-writing.
+
+- 🔵 **minor** / confidence: medium — **Pronoun chain in the Context's closing
+  paragraph shifts referent mid-passage**
+  *Location*: Context
+  In "Every SessionStart hook pays this today via `hooks/config-detect.sh`, and
+  every future CLI-backed hook will. It was extracted from 0169 (review-2, pass
+  4) as an independently deliverable change …", "this" refers to the ~108 ms
+  cost while the immediately following "It" refers to the work item (or the
+  change), and the final "it touches the bash bootstrap" refers to the change
+  again — three referents across two sentences with no explicit subject
+  re-stated.
+  **Impact**: A reader can briefly parse "It was extracted from 0169" as the
+  exec probe or the latency cost being extracted, which momentarily inverts the
+  sentence's meaning.
+  **Suggestion**: Name the subject once at the start of the extraction sentence
+  (e.g. "This work item was extracted from 0169 …") so no pronoun spans the
+  topic change.
+
+- 🔵 **suggestion** / confidence: medium — **Project shorthands used without a
+  definition or pointer**
+  *Location*: Summary / Context / Requirements
+  Several terms carry load-bearing meaning but have no definition or link in the
+  work item: the **warm path / cold path** distinction (the central organising
+  concept, never defined — and referred to variously as "warm path", "warm
+  cache", "cold path" and "cold branch"); the **"fetch-verify-cache design"** (a
+  design named in 0164/0165, referenced only in passing); and **"review-2, pass
+  4"** (the review that drove the split, whose file is listed in 0169's
+  References but not in this item's). By contrast the bash 3.2 floor is properly
+  linked to ADR-0049, which shows the intended standard.
+  **Impact**: A competent developer new to the launcher work has to reconstruct
+  what makes a path warm — the very axis on which every requirement and
+  criterion is stated — and cannot reach the review that justifies the item's
+  existence.
+  **Suggestion**: Define warm path and cold path once (in terms of whether a
+  verified launcher is already cached), settle on one name for each, and add
+  pointers for the fetch-verify-cache design and the review-2 document in
+  References.
+
+- 🔵 **suggestion** / confidence: low — **Bare "the probe" collides with the
+  sibling story's reserved terminology**
+  *Location*: Requirements / Technical Notes
+  This item shortens "exec probe" to "the probe" in Requirements ("where the
+  probe belongs", "the probe's result never chooses a directory") and Technical
+  Notes ("the synthetic probe"), while 0169 — the story this item blocks and
+  whose review produced it — reserves "probe layer" for the shell VCS detection
+  functions in `scripts/vcs-common.sh` and states it is "never abbreviated to
+  'probe'".
+  **Impact**: Low risk in isolation, since this item touches only
+  `bin/accelerator`, but a reader moving between the two items in the same epic
+  can read "the probe" as the VCS probe layer.
+  **Suggestion**: Keep the qualifier — "exec probe" — on every mention, matching
+  0169's terminology discipline.
+
+### Completeness
+
+**Summary**: 0186 is a densely populated task work item: every section from the
+house work-item template is present and substantively filled bar one, with no
+placeholder text, and the Context carries a measured latency table plus
+attribution evidence that makes the motivation self-evident. Kind-appropriate
+content for a task is fully satisfied — the work to be done is defined to the
+level of specific functions and line ranges, with the safety rationale for the
+removal stated inline, and the single Open Question ships with an explicit
+default-if-unresolved. The only structural gaps are the omitted Drafting Notes
+section (present in 146 other work items in this corpus) and the absence in
+Requirements of the test/verification work that the Acceptance Criteria clearly
+presuppose.
+
+**Strengths**:
+
+- Every template section except Drafting Notes is present and substantively
+  populated — no placeholder or stub content anywhere, unusual for a task-kind
+  item.
+- Context does real explanatory work: a measured 6-row latency table
+  (darwin-arm64, warm cache, 20 iterations, dated), the isolating comparison
+  that attributes the cost to macOS first-exec, and the reason it matters at
+  scale (every SessionStart hook, every future CLI-backed hook).
+- Requirements are implementer-ready for a task: exact call sites
+  (`bin/accelerator:166-180`, `:184-193`), the concrete refactor shape
+  (`probe_dir` split into `ensure_dir` plus a cold-path probe), and the
+  justification that moving the probe changes only where the diagnostic fires
+  because `resolve_cache_dir` has no fallback.
+- The Open Question about the shim's second `sha256_file` call states its cost,
+  its security rationale, and an explicit "Default if unresolved" — so the item
+  can proceed without blocking, and Validation Results reserves a slot for the
+  resulting decision.
+- Acceptance Criteria anticipate their own false-pass modes (behavioural check
+  instead of probe-residue inspection; hard-fail rather than skip when run as
+  root; manual-check fallback recorded rather than silently skipped).
+- Frontmatter is complete and internally coherent — `kind: task`,
+  `status: ready`, `priority: high`, plus typed linkage
+  (`parent: work-item:0136`, `blocks: work-item:0169`,
+  `relates_to: work-item:0182`) that matches 0169's `blocked_by` list; empty
+  template slots are correctly omitted.
+- Validation Results pre-declares exactly the three artefacts the Acceptance
+  Criteria demand (before/after medians with host and OS, cold-path check mode,
+  shim decision), so post-implementation recording has a fixed home.
+
+**Findings**:
+
+- 🔵 **minor** / confidence: high — **No Drafting Notes section, despite several
+  interpretive calls baked into the item**
+  *Location*: Drafting Notes (absent)
+  This work item omits the `## Drafting Notes` section that the work-item
+  template defines and that 146 other work items in `meta/work/` carry, even
+  though it embeds several drafting judgements a reviewer would want surfaced —
+  that the warm-path probe is redundant because the shim and launcher execs are
+  stronger exec tests, that the shim double-hash question defaults to "leave
+  it", and that the 0182 overlap is a sequencing rather than a blocking
+  relationship.
+  **Impact**: Those interpretations read as settled facts rather than as author
+  calls open to challenge, so a reviewer who disagrees with (for example) the
+  redundancy argument has no designated place to see it flagged as an assumption
+  made while drafting.
+  **Suggestion**: Add a `## Drafting Notes` section listing the interpretations
+  made during extraction from 0169 — chiefly the warm-path redundancy rationale,
+  the choice to retain rather than delete the cold-path probe, and the decision
+  to defer the shim double-hash change.
+
+- 🔵 **minor** / confidence: medium — **Requirements omit the test work that the
+  Acceptance Criteria presuppose**
+  *Location*: Requirements
+  The Requirements section lists only production changes (remove the probe from
+  the warm path, split `probe_dir` into `ensure_dir` plus a cold-path probe,
+  stay bash-3.2-safe), while two Acceptance Criteria refer to "the test" as an
+  existing obligation — a non-writable-cache-dir warm invocation test with a
+  root guard, and a `chmod -x` cold-path diagnostic test — and neither names
+  which suite these belong in or whether they are new.
+  **Impact**: An implementer reading Requirements alone would scope the change
+  as a refactor and discover the test-authoring work only when checking off
+  criteria, and without a named suite the new coverage may land somewhere CI
+  does not pick it up.
+  **Suggestion**: Add a Requirements bullet covering the new bootstrap test
+  coverage and name the target suite (or state that the criteria are satisfied
+  by extending an existing bootstrap test script), so the test surface is part
+  of the defined work rather than implied by the criteria.
+
+- 🔵 **suggestion** / confidence: medium — **The latency-bound criterion
+  recommended by the source research was not carried across**
+  *Location*: Acceptance Criteria
+  The referenced research
+  (`meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §12) recommends a criterion bounding warm-path per-call latency against
+  today's `hooks/vcs-guard.sh` on the same host; 0186's corresponding criterion
+  only requires that before/after medians be "measured and recorded" in
+  Validation Results, with no target stated anywhere in the item.
+  **Impact**: The item's stated purpose is a performance fix, yet a reader
+  cannot tell from the work item what result would count as success — an outcome
+  that recorded no improvement would still tick every box, and 0169 (which this
+  blocks) measures its own latency criterion against the assumption that this
+  landed a real saving.
+  **Suggestion**: Record the expected outcome explicitly — either the source's
+  comparative bound (warm invocation no slower than the shell guard it replaces)
+  or a concrete target derived from the Context table (e.g. warm
+  `bin/accelerator version` median at or below ~50 ms on darwin-arm64). Whether
+  the criterion is measurable in the abstract is the testability lens's concern;
+  the completeness gap is that no expected result is captured at all.
+
+### Dependency
+
+**Summary**: The work item captures its most important edges explicitly and with
+reasons: it blocks 0169 (reciprocated in 0169's `blocked_by`), names parent epic
+0136, and records the same-file collision with in-progress 0182 — plus a
+platform Assumption that bounds the measurement. The gaps are all about
+schedulability rather than awareness: the 0182 collision is recorded as
+`relates_to` with no direction and no reciprocal edge (the epic spine even lists
+0186 as "no blockers"), the Open Question's default resolution leaves ~23 ms of
+the addressable warm-path cost unowned while 0186 is declared the unblocker of
+0169's latency gate, and the warm-path behavioural criterion implies a
+test-harness prerequisite that 0169 — the downstream item — currently owns.
+
+**Strengths**:
+
+- The Blocks entry is stated with its reason ("0169 — its warm-call latency
+  criterion measures against an already-fixed bootstrap") rather than as a bare
+  id, and the edge is reciprocated: 0169's frontmatter lists 0186 in
+  `blocked_by`.
+- The same-file collision with 0182 is noticed and articulated at the function
+  level ("the two changes touch different functions but the same file"), which
+  is exactly the kind of coupling that usually goes unrecorded.
+- Provenance is fully traced — extracted from 0169 (review-2, pass 4), parented
+  to epic 0136, and pointed at the specific research section (§12) carrying the
+  measurements, so the dependency graph can be reconstructed from the record.
+- The platform coupling is captured as an explicit Assumption (macOS first-exec
+  penalty, no Linux equivalent), pre-empting a false expectation of equivalent
+  savings on the other shipped platform.
+- The Open Question carries a default-if-unresolved and an instruction to record
+  the decision, so the adjacent shim-hash concern cannot silently vanish.
+
+**Findings**:
+
+- 🟡 **major** / confidence: high — **Deferring the shim double-hash leaves the
+  residual warm-path cost unowned, yet 0186 is the declared unblocker of 0169's
+  latency gate**
+  *Location*: Open Questions
+  This task declares it blocks 0169 specifically because "its warm-call latency
+  criterion measures against an already-fixed bootstrap", but the Open
+  Question's stated default is to "take the exec-probe win and leave" the shim's
+  second `sha256_file` (~23 ms). By the referenced research's own decomposition
+  (§12: 149.1 ms total, ~108 ms probe, ~23 ms double hash, ~131 ms of 149 ms
+  addressable → ~18 ms), removing only the probe leaves the bootstrap at roughly
+  41 ms, while 0169's criterion requires a warm `accelerator vcs guard` at
+  ≤ 1.1 × the 35.1 ms shell guard (≈38.6 ms) *plus* a sub-binary exec and verify
+  on top. If the default is taken, no work item owns the residual — 0169 cannot
+  pick it up because 0169 is downstream of this task.
+  **Impact**: 0169 could be scheduled as unblocked and then fail its acceptance
+  gate on latency, with the remaining fix having no owner, no id, and no place
+  in the epic spine — the exact hidden blocker this dependency record exists to
+  prevent.
+  **Suggestion**: Either state in Dependencies that 0186 alone is insufficient
+  for 0169's ≤1.1× gate and name the follow-up that owns the ~23 ms (a new id,
+  or an explicit note that 0169 must relax the criterion), or promote the
+  shim-hash fix into this task's Requirements so the Blocks claim is honest as
+  written.
+
+- 🟡 **major** / confidence: high — **Hard sequencing constraint against
+  in-progress 0182 is recorded only as "Related", with no direction and no
+  reciprocal edge**
+  *Location*: Dependencies (Related: 0182) / Frontmatter: relates_to
+  Dependencies states that 0182 (in-progress) also edits `bin/accelerator` and
+  that "they must be sequenced rather than developed concurrently" — a hard
+  ordering constraint — yet it is captured only as
+  `relates_to: ["work-item:0182"]` with `blocked_by` empty and no statement of
+  which goes first. The constraint is also invisible from the other side and
+  from above: 0182's frontmatter does not list 0186 in its `relates_to`, and
+  parent epic 0136 annotates this task as "0186 — Remove the Exec Probe from the
+  Bootstrap Warm Path *(no blockers)*". The Requirements and Technical Notes
+  additionally pin behaviour to specific line ranges in that same file
+  (`:166-180`, `:184-193`, `:310-312`, `:352`), which 0182's in-flight edits
+  will shift.
+  **Impact**: A scheduler reading the frontmatter or the epic spine will treat
+  this task as startable immediately, so the two `bin/accelerator` changes can
+  be picked up in parallel and collide — and the line references the implementer
+  is told to work from may already be stale.
+  **Suggestion**: State the direction explicitly (e.g. "0182 lands first; this
+  task rebases onto it") and encode it as a real edge — add 0182 to `blocked_by`
+  (or the equivalent sequencing field) if it must precede, add the reciprocal
+  reference on 0182, and correct the epic's "(no blockers)" annotation.
+
+- 🟡 **major** / confidence: medium — **The warm-path behavioural criterion
+  implies a launcher-build test harness that the downstream item (0169) owns**
+  *Location*: Acceptance Criteria (warm-path behavioural check)
+  The first acceptance criterion requires exercising a *warm* invocation with
+  `ACCELERATOR_CACHE_DIR` pointed at an executable-but-not-writable directory —
+  which presupposes a populated cache containing a verified launcher binary and
+  shim, i.e. a test harness able to build and stage the CLI. The referenced 0169
+  records that this wiring does not yet exist ("Land the
+  `test:integration:hooks` launcher edge before repointing the parity gate — it
+  cannot run against a binary until the task gains `build:cli:dev` and
+  `accelerator_env()`"), and 0169 is downstream of this task, so the capability
+  cannot be inherited from it. No upstream prerequisite, owning suite, or
+  stubbing strategy is named anywhere in this work item.
+  **Impact**: The headline acceptance criterion may be unimplementable when the
+  task is picked up, forcing either an unplanned harness build inside a task
+  scoped as a bash micro-change, or a silent downgrade of the criterion to a
+  manual check.
+  **Suggestion**: Name in Dependencies which suite hosts this test and what it
+  needs to pre-warm the cache (`build:cli:dev` plus an `accelerator_env()`-style
+  helper, or a stub launcher/shim), and record whether that wiring is a
+  prerequisite of this task or is delivered by it.
+
+- 🔵 **minor** / confidence: medium — **CI execution-environment coupling behind
+  the permission-based tests is not captured**
+  *Location*: Acceptance Criteria (root hard-fail; `chmod -x` cold-path check)
+  Both behavioural criteria depend on properties of the environment the suite
+  runs in: the warm-path check asserts `id -u` ≠ 0 and "hard-fails rather than
+  skips if run as root", and the cold-path check needs `chmod -x` on a cache
+  directory to be honoured unprivileged. Neither the CI runner identity
+  (non-root) nor the filesystem's permission semantics is recorded as a
+  dependency — the item only hedges that the cold-path check may become "a
+  local/manual check".
+  **Impact**: If any lane runs the suite as root (a common container default),
+  the deliberate hard-fail turns a correct implementation into a red build, and
+  the failure will look like a defect in the change rather than an environment
+  coupling.
+  **Suggestion**: Add a line to Dependencies naming the execution-environment
+  requirement (non-root runner, permission-honouring filesystem) for the lanes
+  these tests will run in, and state what happens on lanes that cannot meet it.
+
+- 🔵 **minor** / confidence: medium — **Upstream provenance of the bootstrap
+  being modified (fetch-verify-cache, invocation contract) is not named**
+  *Location*: Dependencies / Requirements
+  The Requirements and Technical Notes depend on machinery this task did not
+  create — `probe_dir`, `resolve_cache_dir`, the staged verify shim,
+  `verify_launcher` and the cold/warm branch structure all come from the
+  fetch-verify-cache work (0164) and the bootstrap invocation contract (0167) —
+  yet `blocked_by` is empty and neither id appears in Dependencies. The
+  referenced 0169 notes that 0167's code has landed on `main` while its work
+  item is still `ready`.
+  **Impact**: A reader cannot tell from this record whether the contract being
+  edited is settled or still moving, and the "redundant once a verified launcher
+  binary is cached" argument rests on upstream design decisions with no
+  traceable owner.
+  **Suggestion**: Add a "Completed dependencies (not blocking)" line naming 0164
+  and 0167 with their current states, mirroring how 0169 records the same
+  distinction, so the provenance of the modified behaviour is visible without
+  reading the parent story.
+
+### Scope
+
+**Summary**: 0186 is a tightly-scoped, coherent unit of work: one mechanism
+(`probe_dir`) in one file (`bin/accelerator`), one measured justification
+(~108 ms of a 149 ms warm invocation), and Summary/Requirements/Acceptance
+Criteria that all describe the same change. The extraction from 0169 is
+well-argued on risk-profile grounds (bash bootstrap under the 3.2 floor vs. Rust
+CLI), it has standalone value today via `hooks/config-detect.sh`, and `task` is
+an appropriate kind given sibling conventions under epic 0136. The only scope
+softness is the shim double-hash Open Question, which opens a route for a
+second, independent concern (a trust-boundary change) to enter the item in
+flight, and leaves the adjacent ~23 ms unowned if defaulted.
+
+**Strengths**:
+
+- Single coherent purpose: all three Requirements serve one change — the two
+  substantive ones are the removal and the mechanical `ensure_dir`/probe split
+  that enables it, and the third (bash 3.2) is a constraint rather than a
+  bundled concern.
+- Summary, Requirements and Acceptance Criteria describe the same scope; no
+  section introduces work the others do not anticipate.
+- Explicit in-scope/out-of-scope boundary: the probe is retained on the cold
+  path rather than deleted, and the Technical Notes state why, so the reader can
+  say precisely what is and is not being changed.
+- The extraction rationale is stated and defensible — Context names the source
+  (0169, review-2 pass 4) and the distinguishing risk profile (bash bootstrap
+  under the 3.2 floor, not the Rust CLI), and parent epic 0136 corroborates it
+  as independently deliverable.
+- Genuine standalone value despite small size: every SessionStart hook pays the
+  cost today via `hooks/config-detect.sh`, so the item delivers benefit without
+  waiting on 0169.
+- Clean measurement boundary with the downstream story: 0186 records an absolute
+  before/after warm median, while 0169 retains the host-relative parity
+  threshold (G ≤ 1.1 × B) — no duplicated or competing latency criterion.
+- Confined to one file and one owning surface — no cross-service or cross-team
+  span, and the file-level collision with in-progress 0182 is disclosed as a
+  sequencing constraint rather than left implicit.
+
+**Findings**:
+
+- 🔵 **minor** / confidence: medium — **Shim double-hash Open Question can pull
+  a second, independent concern into the item**
+  *Location*: Open Questions
+  Work item 0186 is scoped to removing the exec probe from `bin/accelerator`'s
+  warm path, but its single Open Question asks whether the verify shim's second
+  `sha256_file` call (`bin/accelerator:256`, ~23 ms) should also be removed — a
+  change with a different character (it turns on a trust-boundary judgement
+  about a planted stub being trusted by name, not on redundancy elimination). No
+  Requirement or Acceptance Criterion covers that change, yet Validation Results
+  pre-commits to recording a "Shim double-hash decision", so the item is
+  expected to *decide* something it has not scoped.
+  **Impact**: If the question resolves "yes" mid-implementation, a task-sized
+  redundancy removal silently grows a security-relevant change with untested
+  requirements — the same kind of bundling that justified extracting 0186 out of
+  0169 in the first place.
+  **Suggestion**: Keep the stated default ("take the exec-probe win and leave
+  this") but move the decision out of 0186 — either declare the shim staging
+  explicitly out of scope and raise it as its own work item, or, if it must
+  stay, add a Requirement and Acceptance Criterion so the trust-boundary change
+  is scoped rather than discretionary.
+
+- 🔵 **suggestion** / confidence: medium — **Deferred ~23 ms becomes unowned
+  once 0186 closes**
+  *Location*: Acceptance Criteria
+  The referenced research (§12 of
+  `2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`) identifies ~131 ms of
+  149 ms as addressable — ~108 ms of exec probe plus ~23 ms of double-hashing
+  the verify shim. Work item 0186 claims only the ~108 ms and defaults to
+  leaving the rest, but no Acceptance Criterion creates a successor item for it,
+  and sibling 0169 no longer owns it (its Summary lists the exec-probe fix as
+  the extracted concern).
+  **Impact**: Once 0186 closes, a measured and diagnosed optimisation with a
+  documented fix shape has no owning work item, so it is likely to be
+  rediscovered from scratch later.
+  **Suggestion**: Add a hand-off criterion in the style 0169 already uses — if
+  the double-hash question resolves as "leave it", the implementer raises a
+  follow-up work item for the shim staging/hashing cost, referencing §12 for the
+  measurement and the proposed same-directory-skip fix.
+
+### Testability
+
+**Summary**: The criteria are unusually well-engineered for a shell performance
+refactor: AC1 names the behavioural substitute for an unobservable residue check
+and pre-empts the root-bypass false pass, AC2 forbids a silent skip, and AC3
+names the exact gates. The weak point is that the item's central objective — the
+~108 ms warm-path saving — is gated only by a record-the-numbers criterion with
+no threshold, so the whole AC set can pass with the probe still executing
+(merely made non-fatal) and zero latency gained. Two behaviours the change's own
+safety argument rests on are also uncovered: the warm-to-cold fall-through on a
+noexec populated cache, and the cold happy path after `ensure_dir` is split out.
+
+**Strengths**:
+
+- AC1 explicitly identifies why the obvious check (probe residue) is
+  non-discriminating — the probe is created and removed within one invocation —
+  and substitutes a behavioural test, which is exactly the reasoning a tester
+  would otherwise have to reconstruct.
+- AC1 pre-empts a specific false-pass mode (root bypasses directory write
+  permissions) and mandates a hard failure rather than a skip, closing the usual
+  escape hatch for permission-dependent tests.
+- AC2 rules out silent skipping: if the noexec check cannot run unprivileged on
+  CI it must be recorded in Validation Results as a manual check, keeping the
+  verification visible.
+- AC3 names the concrete gates (`scripts/lint-bashisms.sh` plus
+  shfmt/ShellCheck), giving a definitive pass/fail with no interpretation
+  required.
+- AC4 fixes a reproducible measurement protocol (median of 20 invocations, one
+  darwin-arm64 host, single session, no build running), so the recorded numbers
+  are at least comparable even though no target is set.
+- Context and Technical Notes supply the attribution evidence (107.9 ms
+  fresh-write-and-exec versus 10.6 ms re-exec of an existing probe), which makes
+  the quantity under test explicit rather than assumed.
+- Validation Results pre-declares a slot for each pending verification
+  (before/after medians, host, noexec check mode, shim decision), so an unfilled
+  criterion is visible rather than forgotten.
+
+**Findings**:
+
+- 🟡 **major** / confidence: high — **Latency criterion records a number but
+  defines no pass/fail threshold**
+  *Location*: Acceptance Criteria (warm-path saving measured and recorded)
+  Work item 0186 exists to remove a ~108 ms exec probe from the
+  `bin/accelerator` warm path, but the only criterion covering that objective
+  says the before/after medians of 20 warm invocations are "measured and
+  recorded in Validation Results" — it states no threshold, so any pair of
+  numbers satisfies it, including a zero or negative saving.
+  **Impact**: The item's primary goal is unverifiable — the criterion can always
+  be claimed as passed, and a change that produced no speedup would still be
+  signed off; note the sibling item 0169 does set a bound (`G ≤ 1.1 × B`) for
+  its comparable latency criterion.
+  **Suggestion**: Add an explicit gate to the criterion, e.g. "the after-median
+  is at most 60 ms and the before-minus-after delta is at least 80 ms on
+  darwin-arm64", and name the measurement method (e.g. hyperfine, or a bash loop
+  over 20 runs taking the median) so the two numbers are produced identically.
+
+- 🟡 **major** / confidence: medium — **The warm-to-cold fall-through that
+  justifies the removal is not covered by any criterion**
+  *Location*: Requirements (first bullet) / Acceptance Criteria
+  The safety argument for deleting the warm-path probe is that "a `noexec`
+  directory makes `verify_launcher` fail into the cold branch where the probe
+  belongs", but no acceptance criterion exercises that path: AC2 tests an
+  *empty* (i.e. cold) cache dir made non-executable, not a *populated* cache dir
+  that has become non-executable.
+  **Impact**: The load-bearing claim behind the change goes untested, so the
+  regression it protects against — a warm cache on a noexec mount failing with a
+  confusing error instead of the existing diagnostic — would not be caught by
+  the stated verification.
+  **Suggestion**: Add a criterion of the form "given a warmed cache dir
+  subsequently made non-executable, the invocation exits non-zero with the same
+  noexec diagnostic (asserted as a substring), demonstrating the fall-through
+  into the cold branch", under the same non-root precondition AC1 defines.
+
+- 🟡 **major** / confidence: medium — **No criterion verifies the cold happy
+  path or that `ensure_dir` still creates the cache dir**
+  *Location*: Requirements (second bullet) / Acceptance Criteria
+  The change splits `probe_dir` into `ensure_dir` (the `mkdir -p`, always) and
+  the cold-path-only probe, yet every criterion covers either the warm path
+  (AC1, AC4) or a cold *failure* (AC2) — none asserts that a first-run
+  invocation against a **non-existent** cache dir still creates the directory,
+  probes, fetches and succeeds.
+  **Impact**: The most likely regression from the refactor (the `mkdir -p` being
+  lost or moved behind a branch, breaking first-use bootstrap on a clean
+  machine) has no criterion that would fail; relying on "`mise run` is green"
+  leaves it to whatever coverage happens to exist.
+  **Suggestion**: Add a criterion such as "with `ACCELERATOR_CACHE_DIR` set to a
+  path that does not yet exist, a cold invocation creates the directory and
+  `bin/accelerator version` exits 0 with the expected version output", so the
+  always-run `ensure_dir` half of the split is pinned.
+
+- 🟡 **major** / confidence: medium — **AC1's precondition is under-specified
+  and its pass depends on the warm path being write-free**
+  *Location*: Acceptance Criteria (warm path performs no exec probe)
+  AC1 says to point `ACCELERATOR_CACHE_DIR` at a directory that is "executable
+  but not writable" and assert a warm invocation still succeeds, but warming a
+  cache requires writing into that same directory, and the criterion does not
+  state the setup sequence (populate while writable, then remove the write bit,
+  then invoke). It also implicitly requires the warm path to perform *no* writes
+  at all, whereas the Open Questions section describes warm-path shim staging
+  into `cache_dir` that this item deliberately leaves in place.
+  **Impact**: As written the test is either ambiguous to set up or potentially
+  unsatisfiable for reasons unrelated to the probe, and a failure would not
+  distinguish "probe still present" from "staging still writes" — the criterion
+  loses its discriminating power either way.
+  **Suggestion**: Spell out the sequence (warm the cache with the directory
+  writable, `chmod -w`, then assert the second invocation exits 0 with the
+  expected `version` output) and state explicitly whether the warm path is
+  expected to be write-free after this change, or scope the assertion to
+  probe-specific writes if staging may still write.
+
+- 🔵 **minor** / confidence: medium — **Cold-path diagnostic criterion neither
+  quotes the expected text nor states a privilege precondition**
+  *Location*: Acceptance Criteria (noexec diagnostic on the cold path)
+  AC2 requires a cold invocation against a `chmod -x` cache dir to exit non-zero
+  with "the existing diagnostic text, asserted as a substring", but the expected
+  string is never quoted; separately, removing a directory's execute bit also
+  blocks writing files inside it, so the failure may originate from the write
+  step rather than the exec probe — and unlike AC1, AC2 states no `id -u` guard
+  even though root traverses directories regardless of the execute bit.
+  **Impact**: A substring assertion against an unnamed message cannot
+  distinguish the intended probe diagnostic from an unrelated write/traversal
+  error, and the test's behaviour when run as root or on a restricted CI runner
+  is undefined, so "cannot run unprivileged on CI" becomes a judgement call at
+  verification time.
+  **Suggestion**: Quote the exact diagnostic substring in the criterion, assert
+  the specific non-zero exit code, and apply the same explicit non-root
+  precondition (and hard-fail-if-root rule) that AC1 already defines.
+
+- 🔵 **minor** / confidence: medium — **AC1 is satisfiable by a probe made
+  non-fatal rather than removed**
+  *Location*: Acceptance Criteria (warm path performs no exec probe)
+  AC1 verifies that a warm invocation *succeeds* against a non-writable cache
+  dir, which an implementation that keeps the write-chmod-exec probe on the warm
+  path but tolerates its failure would also satisfy — retaining the full
+  ~108 ms cost the item exists to remove.
+  **Impact**: Combined with the absence of a latency threshold in the
+  measurement criterion, the AC set as a whole can pass while the target cost
+  remains, meaning no criterion actually pins "the probe does not run on the
+  warm path".
+  **Suggestion**: Strengthen AC1 with a direct absence assertion that does not
+  rely on residue — e.g. run the warm invocation under `bash -x`/`PS4` tracing
+  (or with a stub on the interpreter/`chmod` used by the probe) and assert no
+  probe write-chmod-exec sequence appears in the trace — or add the latency
+  threshold so the cost is gated numerically.
+
+- 🔵 **suggestion** / confidence: medium — **The shim double-hash decision is
+  not bound by any acceptance criterion**
+  *Location*: Open Questions / Validation Results
+  The Open Question asks whether the verify shim's second `sha256_file` call
+  should also be removed, states a default ("take the exec-probe win and leave
+  this") and instructs that the decision be recorded — and Validation Results
+  has a `Shim double-hash decision — pending` slot — but no acceptance criterion
+  requires that slot to be filled.
+  **Impact**: The item can be closed with all criteria ticked while the
+  trust-boundary decision remains unrecorded, losing the rationale for a
+  deliberately deferred ~23 ms cost.
+  **Suggestion**: Add a short criterion such as "the shim double-hash decision
+  (remove, or keep with rationale on the planted-stub trust boundary) is
+  recorded in Validation Results", so the recording obligation is part of done.
+
+- 🔵 **suggestion** / confidence: low — **Criteria do not say where the new
+  tests live, so their durability as regression guards is unclear**
+  *Location*: Acceptance Criteria
+  AC1 refers to "the test" and AC2 allows "automated or manual", but neither
+  names the harness or suite the checks join — the repo's shell suites are
+  standalone scripts wired into `mise run` tasks, so whether these become
+  permanent guards or one-off local checks is left open.
+  **Impact**: A verifier cannot tell whether re-running the criteria later is
+  possible, and a passing one-off check would not prevent the probe being
+  reintroduced on the warm path by a future edit to `bin/accelerator`.
+  **Suggestion**: State in AC1/AC2 which suite the cases are added to (and that
+  the suite is reached from `mise run`), or explicitly mark them as manual
+  checks recorded in Validation Results so the choice is deliberate rather than
+  implied.
+
+## Re-Review (Pass 2) — 2026-07-31
+
+**Verdict:** REVISE
+
+All five lenses re-ran against the revised work item. Every pass-1 finding is
+resolved or deliberately closed, and all five lenses opened by saying so. Pass 2
+is not a repeat of pass 1: the new majors are defects **introduced by the pass-1
+edits** (an over-claimed soundness rationale, a condition/body conflation, an
+absolute gate calibrated on the wrong baseline) plus one genuine gap pass 1
+missed entirely — that `chmod -x` cannot distinguish the exec half of the probe
+from the write half. All pass-2 findings have now been addressed; a third pass
+would be needed to confirm.
+
+### Previously Identified Issues
+
+Majors:
+
+- 🟡 **Testability/Completeness**: no latency threshold — **Resolved.** Gate
+  added, then corrected in pass 2 (see below).
+- 🟡 **Dependency/Scope**: residual ~23 ms unowned vs 0169's gate — **Resolved.**
+  Recorded in Dependencies with arithmetic, and pass 2 forced it further: a
+  Requirement now carries a dated hand-off note to 0169, which has been appended
+  to `0169`'s Dependencies.
+- 🟡 **Dependency**: 0182 sequencing only "Related" — **Resolved.** `blocked_by`
+  edge with stated direction, epic annotation corrected, and pass 2 added the
+  reciprocal `blocks: ["work-item:0186"]` on 0182 plus the second shared
+  artefact (the entrypoint suite).
+- 🟡 **Clarity/Testability**: AC1 precondition under-specified — **Resolved**,
+  though the rewrite over-claimed what AC1 proves; corrected in pass 2.
+- 🟡 **Testability**: warm-to-cold fall-through untested — **Resolved.** New
+  criterion.
+- 🟡 **Testability**: cold happy path / `ensure_dir` untested — **Resolved.** New
+  criterion, tightened in pass 2 to assert only what it observes.
+- 🟡 **Dependency**: harness owned by downstream 0169 — **Resolved — finding was
+  incorrect.** The harness exists in
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py`; pass 2's
+  dependency lens independently confirmed this.
+- 🟡 **Clarity**: shim-hash question conflated two changes — **Resolved.** Both
+  options priced separately and the question resolved with test evidence.
+
+Minors and suggestions: all ten minors and three suggestions resolved —
+Drafting Notes added, diagnostic substring quoted, warm/cold defined, pronoun
+chain fixed, citations pinned to functions, test suite named, execution
+environment recorded, 0164/0167 provenance added, Requirements split into
+behaviour and mechanism, References expanded.
+
+### New Issues Introduced
+
+- 🟡 **Clarity/Testability** (2 lenses): **AC1's "even one made non-fatal"
+  clause was wrong.** A non-fatal probe fails its write, swallows the error and
+  still exits 0 — so AC1 never discriminated that variant, contradicting AC2's
+  stated purpose. **Fixed**: AC1 now claims only a *fatal* probe, and AC2 is
+  relabelled load-bearing rather than belt-and-braces.
+- 🟡 **Clarity**: **condition/body conflation in the write-free argument.** The
+  pass-1 text said the staging `if` at `:255-261` "is not entered on a warm
+  call" while elsewhere pricing the hash inside it at ~11.7 ms of retained
+  warm-path cost — mutually exclusive as written. **Fixed**: the invariant now
+  distinguishes the condition (evaluated always, reads only) from the body
+  (skipped when digests match), so both claims hold.
+- 🟡 **Testability**: **`chmod -x` cannot pin the exec half of the probe.**
+  Removing a directory's execute bit also blocks creating files inside it, so a
+  write-only check would satisfy both `noexec` criteria — leaving the one
+  behaviour the item consciously preserves unverified. Pass 1 missed this
+  entirely. **Fixed**: a criterion now requires either a real `noexec`-mount
+  case or an explicit recorded gap; Drafting Notes records the choice.
+- 🟡 **Testability**: **AC2's negative assertion had no positive control** and
+  keyed on an implementation-chosen filename. **Fixed**: the same trace pattern
+  must be asserted *present* on the cold run, and the assertion targets a
+  rename-stable signal.
+- 🟡 **Testability/Clarity/Completeness** (3 lenses): **the 60 ms absolute gate
+  was calibrated on a pre-0182 baseline with an unrecorded host**, and "before"
+  had two candidate meanings. **Fixed**: the before-median is re-measured
+  post-0182 in the same session, and the gate is host-relative
+  (`after ≤ before − 80 ms` and `after ≤ 0.5 × before`) with 60 ms demoted to
+  advisory.
+- 🟡 **Testability**: **green-path feasibility evidenced by a failure-path
+  precedent.** **Fixed** — and the premise was verified in the code:
+  `test_happy_path_forwards_args_and_exit_code` and
+  `test_cache_hit_performs_no_further_fetch` are green-path end-to-end
+  bootstraps, now cited. The one genuinely missing capability (threading
+  `bash -x`/`PS4` through `_run_bootstrap`) is named as in-scope helper work.
+- 🟡 **Dependency**: **the 0169 consequence never reached 0169.** **Fixed**: a
+  Requirement mandates the hand-off note, and the note is appended to 0169.
+- 🔵 **Scope/Completeness/Testability** (3 lenses): the shim-decision criterion
+  was pre-discharged. **Fixed**: ticked with a pointer.
+- 🔵 **Scope**: the write-free Requirement stated an invariant, not work —
+  a scope-elasticity seam. **Fixed**: moved to Assumptions with an explicit
+  "raise it, don't absorb it" boundary.
+- 🔵 **Completeness**: Open Questions held no open question, triplicated across
+  three sections. **Fixed**: condensed to "None outstanding" with one pointer;
+  full reasoning lives once, in Validation Results.
+- 🔵 Also fixed: Summary now names the exec probe and attributes ~97 ms (not
+  ~108 ms) to the first-exec check; the terminology rule is softened to
+  first-use-per-section so the text no longer breaks its own convention; the
+  three conflicting responses to a non-conforming CI lane are replaced by one
+  precedence rule in the preamble; Validation Results gained slots for the two
+  warm-path criteria, lane observations and exclusions; a linux-lane criterion
+  was added; and the release-artefact host is recorded as an external dependency
+  of the measurement only.
+
+### Assessment
+
+The work item is materially stronger than at pass 1 and the verdict stays REVISE
+only on the mechanical threshold (two or more majors in the pass), not on any
+judgement that it is unready. Every pass-2 major is now fixed in the document.
+
+Two substantive things changed in the underlying record beyond 0186 itself:
+0169 carries a dated hand-off note that its `G ≤ 1.1 × B` gate may be
+unreachable and must be relaxed or justified before acceptance, and 0182 now
+declares `blocks: ["work-item:0186"]`. Epic 0136's annotation was corrected in
+pass 1.
+
+Two acknowledged residuals, both deliberate and recorded rather than closed: the
+exec-specific branch of the cold-path probe has no test that distinguishes it
+from a write-only check unless a `noexec` mount is added, and the ~23 ms of shim
+hashing stays on the warm path to preserve a tested trust boundary. Neither
+blocks implementation.
+
+## Re-Review (Pass 3) — 2026-07-31
+
+**Verdict:** APPROVE
+
+> **Verdict set by the author on 2026-08-01**, overriding the mechanical
+> threshold. The lens tally for this pass was two-or-more majors, which the
+> configured `work_item_revise_major_count` maps to REVISE — but every pass-3
+> finding was addressed in the document before the pass closed, and the
+> residual findings were refinements of pass-2 repairs rather than gaps in the
+> work. The work item is approved for implementation.
+
+All five lenses re-ran. Every pass-2 finding is resolved, and the lenses said so
+in their summaries. Pass 3's majors are again mostly **defects in the pass-2
+fixes** — and one of them is serious: the positive control added in pass 2 to
+stop a vacuous assertion was itself vacuous. Two lenses caught it independently
+at high confidence, and it was confirmed against the source. All pass-3 findings
+have been addressed.
+
+### Previously Identified Issues
+
+- 🟡 AC1 over-claimed against a non-fatal probe — **Resolved.**
+- 🟡 Condition/body conflation in the write-free argument — **Resolved.**
+- 🟡 `chmod -x` cannot pin the exec half — **Resolved**, and pass 3 improved the
+  remedy: instead of an either/or that allowed a privileged `noexec` mount, the
+  exec half is now verified by asserting in the cold-run xtrace that the probe
+  file is *executed*. Near-zero cost, and the mount option moved out of scope.
+- 🟡 AC2 lacked a positive control — **Resolved but wrongly**; see below.
+- 🟡 Absolute 60 ms gate on a pre-0182 baseline — **Resolved**, then tightened
+  in pass 3 (the `− 80 ms` clause was still absolute).
+- 🟡 Green-path feasibility from a failure-path precedent — **Resolved.**
+- 🟡 0169 consequence never reached 0169 — **Resolved**; pass 3 added the
+  missing criterion and Validation Results slot for it.
+- 🔵 Pre-discharged shim criterion, invariant-as-Requirement, triplicated Open
+  Questions, Summary attribution, terminology rule, CI-lane precedence,
+  Validation Results slots, linux lane, release-artefact host — **all
+  Resolved.**
+
+### New Issues Introduced
+
+- 🟡 **The positive control was vacuous** (clarity + testability, both high
+  confidence — the most important finding of the review). Pass 2 broadened AC2's
+  trace pattern to "any `chmod` or any write into the resolved cache dir" so it
+  would survive renaming the probe file. But the cold path independently does
+  exactly those operations — `cp` plus `chmod` staging the shim
+  (`bin/accelerator:257-260`, always taken against a fresh cache dir) and the
+  launcher write — so the control matched on the cold run whether or not the
+  probe fired. Verified against the source. **Fixed**: the signal is now the
+  probe *function* name via `PS4='+${FUNCNAME[0]}:'` — rename-stable with
+  respect to the probe file, yet probe-scoped. The control was also promoted to
+  its own criterion and now additionally asserts the probe file is *executed*,
+  which doubles as the exec-half verification.
+- 🟡 **"Any write into the cache dir" is not observable in xtrace**
+  (testability). Bash's xtrace prints expanded command words but not
+  redirections, so a probe creating its file via `>` emits no path at all — half
+  the stated predicate was unimplementable. **Fixed** by the same change.
+- 🟡 **The preamble claimed all six behavioural criteria were automated suite
+  cases** (clarity), while the record-the-gap criterion is discharged by writing
+  a sentence and Validation Results called another "automated or manual".
+  **Fixed**: each criterion is now labelled automated case, recorded check, lint
+  gate, or aggregate build.
+- 🟡 **The 0182 edge did not say what discharges it** (dependency) — and 0182's
+  closure is gated on a manual pre-release check against a signed artifact
+  (confirmed: its criterion at `:601` is unticked). Read literally,
+  `blocked_by: 0182` gated this bash change — and transitively 0169 and its five
+  children — on a release cut. **Fixed**: the edge is explicitly discharged when
+  0182's changes reach `main`, not on its closure.
+- 🟡 **The 0169 hand-off Requirement had no criterion and no Validation Results
+  slot** (completeness, testability, dependency — 3 lenses), and was recorded as
+  outstanding despite already being done. **Fixed**: marked discharged, retained
+  as a re-confirmation criterion with a slot, and bounded to "record only —
+  changing 0169's threshold is 0169's work".
+- 🔵 Also fixed: the `− 80 ms` clause was absolute despite the gate being
+  labelled host-relative, so a fast host could remove the whole probe and still
+  fail — the ratio is now the sole pass condition and the delta is recorded;
+  "~60 ms implied by the Context table" was wrong arithmetic (149.1 − 107.9 ≈ 41)
+  and the derivation is now shown in Context; the residual is distinguished as
+  ~11.7 ms (second hash) vs ~23 ms (skip staging) at first use; "probe" is no
+  longer overloaded for the privilege check; the filesystem privilege check is
+  specified concretely; the warm-to-cold criterion's purpose is softened to what
+  it actually proves; the 0169 edge is qualified as acceptance-time so the two
+  can run in parallel; the launcher-lockstep constraint from 0182 is carried
+  into the measurement; 0165 added to completed dependencies; `resolve_cache_dir`
+  citations labelled definition vs call site; the Summary matches the Context
+  table's vocabulary; and `status: ready` beside a populated `blocked_by` is now
+  explained.
+
+### Assessment
+
+Ready for implementation. The verdict stays REVISE only on the mechanical
+two-major threshold; every pass-3 finding is fixed in the document, and the
+remaining items are refinements of refinements rather than gaps in the work.
+
+The pattern across three passes is worth noting: each pass found fewer *original*
+gaps and more defects in the previous pass's fixes, and pass 3's headline finding
+was that a guard added in pass 2 did not guard anything. That is the point at
+which further passes have diminishing returns — the substantive content has been
+stable since pass 2, and pass 3 changed how three criteria are asserted rather
+than what the item does.
+
+Two deliberate residuals remain, both recorded: the cold-path probe's exec half
+is verified by xtrace rather than a real `noexec` mount (the mount is out of
+scope), and the verify shim's staging cost stays on the warm path to preserve a
+trust boundary three tests assert — with the consequence carried to 0169.

--- a/meta/reviews/work/0187-generalise-sub-binary-registration-surface-review-1.md
+++ b/meta/reviews/work/0187-generalise-sub-binary-registration-surface-review-1.md
@@ -1,0 +1,1824 @@
+---
+type: work-item-review
+id: "0187-generalise-sub-binary-registration-surface-review-1"
+title: "Work Item Review: Generalise the Sub-Binary Registration Surface"
+date: "2026-08-01T13:00:40+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0136"
+target: "work-item:0187"
+work_item_id: "0187"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 5
+tags: [build-system, distribution, rust]
+last_updated: "2026-08-01T17:40:11+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Generalise the Sub-Binary Registration Surface
+
+**Verdict:** REVISE
+
+0187 is a well-formed platform extraction with an unusually strong evidence
+base: nearly every claim carries a `file:line` anchor, the fixture-token
+strategy is a genuine decoupling device that lets the task land ahead of all
+four consumers, and AC1's demand that the guard be demonstrably non-vacuous is
+exactly the right mutation-style framing. All five lenses agreed the item is
+scoped as a single coherent concern in a single component with no double
+ownership against 0169. The revisions needed are concentrated in three places:
+a headline contradiction between the Summary's "one-line allowlist change" and
+the multi-step checklist the Requirements mandate; a registration checklist
+that is narrower than the research §8 enumeration it cites; and three
+mechanisms the item depends on — the fixture token, the skill-exemption
+declaration, and the token→skill discovery rule — that are named but never
+defined.
+
+### Cross-Cutting Themes
+
+- **Summary promises an outcome the body does not deliver** (flagged by:
+  clarity, scope, testability, completeness) — "one-line allowlist change"
+  versus a documented six-point checklist. All four lenses independently
+  reached this, from different angles: ambiguity, scope-sizing, unmeasured
+  success condition, and outcome mismatch. This is the single highest-signal
+  finding in the review.
+- **The checklist is narrower than its own cited source** (flagged by:
+  completeness, dependency, scope, testability) — research §8 enumerates eight
+  registration points; the Requirements cover six, silently dropping
+  cross-compile staging (`tasks/build.py:37`, `:290-331`, incl.
+  `_assert_static_elf`) and `version.workspace = true`. Because the checklist
+  *is* the deliverable, a short checklist reproduces the rediscovery cost the
+  extraction exists to remove.
+- **Three load-bearing mechanisms are named but undefined** (flagged by:
+  clarity, completeness, testability, dependency) — "fixture token",
+  "declared skill-exempt", and the token→skill discovery rule. Each admits two
+  materially different implementations, and each is depended on by an
+  acceptance criterion.
+- **The already-parameterised assumption is never discharged** (flagged by:
+  completeness, dependency, testability, scope) — the Assumptions section says
+  signing/upload/re-verify/SLSA are worth re-confirming and that any
+  visualiser-shaped stage belongs in *this* task, but no criterion covers the
+  re-confirmation and no ceiling bounds the absorption.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Clarity / Scope / Testability / Completeness**: Summary's "one-line
+  allowlist change" contradicts the multi-point registration checklist the
+  Requirements mandate
+  **Location**: Summary (vs. Requirements 2-3, Acceptance Criteria)
+  The Summary states the goal is making registration "a one-line allowlist
+  change", while Requirement 2 mandates documenting at least six distinct
+  registration points and Requirement 3 adds a naming constraint on top. These
+  bound the task very differently — an implementer taking the Summary
+  literally could attempt to derive the other registration points from the
+  allowlist, a build-system refactor several times the described size. The
+  headline outcome also has no acceptance criterion measuring it.
+
+- 🟡 **Completeness / Dependency / Testability / Scope**: The registration
+  checklist enumerates fewer points than the research it cites, and AC4 cannot
+  fail
+  **Location**: Requirements (2nd bullet) / Acceptance Criteria (4th)
+  Research §8 lists eight registration points; the Requirements cover six,
+  omitting cross-compile staging (`tasks/build.py:37`, `:290-331`, with the
+  musl `_assert_static_elf` check) and `version.workspace = true`
+  (enforced by `tasks/build.py:74-101`). Neither is mentioned in the
+  Assumptions' already-parameterised list either, so ownership of point 8 is
+  unassigned between this task and its first consumer. AC4 asks only that the
+  README "carries the registration checklist" with no enumeration, so a
+  three-of-eight checklist would satisfy it.
+
+- 🟡 **Clarity / Completeness / Testability**: "Declared skill-exempt" has no
+  stated declaration mechanism, and nothing verifies the exempt path
+  **Location**: Requirements (1st bullet) / Acceptance Criteria (3rd)
+  Requirement 1 and AC3 both depend on an exemption declaration, but no
+  section says where or how it is made — a sibling constant beside
+  `DISPATCHED_SUBBINARIES`, a richer per-token structure, a config entry. AC3
+  also requires no test of the exempt-and-passing path. The exemption is the
+  escape hatch the whole guard depends on and the surface most likely to be
+  abused later, yet its shape is invented at implementation time and
+  propagates to all four consumers.
+
+- 🟡 **Clarity / Testability**: "Fixture token" carries the whole verification
+  strategy but is never defined, and neither the discovery rule nor the
+  injection seam is stated
+  **Location**: Requirements (4th bullet) / Acceptance Criteria (1st) /
+  Technical Notes
+  Two readings are equally available: a test-only value patched into
+  `DISPATCHED_SUBBINARIES`, or a permanently-registered token with no real
+  binary — and the latter would flow into signing, manifest generation and
+  upload, silently invalidating the Assumptions. Separately, the generalised
+  guard could resolve token→skill by scanning the skills tree or by consulting
+  an explicit map; the two give different answers to "the binding is missing"
+  for the same repo state. `DISPATCHED_SUBBINARIES` is a module constant, so
+  no injection seam means monkeypatching may leave the test off the path the
+  release actually runs.
+
+- 🟡 **Dependency**: The registration checklist omits the skill-binding /
+  exemption step the newly-strict guard will enforce on consumers
+  **Location**: Requirements (2nd bullet) / Acceptance Criteria (4th)
+  Requirement 1 makes `validate_dispatch_coherence` fail for any non-exempt
+  token lacking a skill binding, and it runs on every release
+  (`tasks/manifest.py:138`) — but the checklist enumerates only the six
+  mechanical registration points and never says "add the skill binding, or
+  declare the token exempt". A downstream story can complete every documented
+  step and still fail its release on the one new constraint this task
+  introduces.
+
+- 🟡 **Dependency**: Three of the four declared downstream consumers do not
+  record the reciprocal dependency, and nothing requires them to
+  **Location**: Dependencies (Blocks) / Frontmatter: blocks
+  Only 0169 carries `blocked_by: work-item:0187`. 0170 and 0171 have no
+  `blocked_by` at all; 0173 lists only 0167. All three are `status: draft`.
+  0187 has no requirement or acceptance criterion obliging the hand-off,
+  unlike 0169 which has an explicit "the downstream hand-offs are raised"
+  criterion. The coupling is invisible from the consuming side — reproducing
+  exactly the rediscovery cost this task was extracted to eliminate.
+
+- 🟡 **Testability**: The `allowed-tools`-mismatch failure mode is required
+  but never tested
+  **Location**: Acceptance Criteria (1st-2nd)
+  AC1 requires the guard to fail on two conditions — a missing skill binding
+  *and* an `allowed-tools` rule that does not name the subcommand — but the
+  verification it specifies covers only the first, and AC2 asks for a singular
+  fail path. The second is the half most likely to ship as a no-op (e.g. a
+  substring match that an ancestor glob satisfies), and it is precisely the
+  defect `tasks/lint/skill_permissions.py:41-44` exists to catch.
+
+#### Minor
+
+- 🔵 **Testability**: AC1's blanket "any token" predicate contradicts AC3's
+  exemption
+  **Location**: Acceptance Criteria (1st and 3rd)
+  Read literally, AC1 requires a failure for a token AC3 requires to pass. The
+  criteria do not define a single determinate predicate for exempt tokens.
+
+- 🔵 **Completeness / Dependency / Testability**: The assumption
+  re-confirmation is in scope but has no acceptance criterion
+  **Location**: Assumptions / Acceptance Criteria
+  Assumptions pulls the re-confirmation of signing/upload/re-verify/SLSA into
+  scope with a conditional scope expansion, but no criterion covers it, so the
+  item can close with the check never performed. The fixture-token strategy
+  also cannot exercise the real signing/upload path, and no non-release
+  verification route is named.
+
+- 🔵 **Scope**: The scope-absorption clause in Assumptions is unbounded
+  **Location**: Assumptions
+  "If any turns out visualiser-shaped, it belongs in this task" is the right
+  anti-leakage rule but has no ceiling. A `kind: task` sized at one function
+  plus tests plus a doc section could quietly become release-pipeline work —
+  and because 0187 blocks four stories, the absorption extends the critical
+  path for all of them.
+
+- 🔵 **Testability**: Nothing verifies the generalised guard still runs in its
+  real release invocation path
+  **Location**: Acceptance Criteria (1st-2nd, 5th)
+  All specified verification is unit-level against
+  `tests/unit/tasks/test_build.py`, and `mise run` does not exercise a
+  release. A signature change (likely, given the fixture-token strategy) could
+  leave `tasks/manifest.py:138` passing a stale or empty collection with every
+  unit test green — the guard becoming vacuous in production, the exact
+  failure AC1 works to prevent at unit level.
+
+- 🔵 **Testability**: "Still passes unchanged" does not define what is
+  compared
+  **Location**: Acceptance Criteria (2nd)
+  An implementation that quietly relaxes the visualiser's `allowed-tools`
+  expectation to make the generalised check pass would still be defensible
+  under this wording, hiding a regression in guard strictness.
+
+- 🔵 **Dependency**: 0172 may be a fifth consumer but is absent from Blocks
+  **Location**: Dependencies (Blocks)
+  0172 ("Migration Engine Subdomain") sits under the same epic-0136 "Subdomain
+  migrations (Phases 5-10)" heading as the other four, and ADR-0054's "one
+  binary per independently-shippable subdomain" implies it registers a token
+  too. If so, the dependency graph under-reports this task's reach.
+
+- 🔵 **Dependency**: 0168 is recorded as "code landed" but its work item is
+  still `ready`, with no closure action named
+  **Location**: Dependencies (Related)
+  0168's landed layout is load-bearing — the checklist documents the
+  `cli/<token>/Cargo.toml` default and the `_SUBBINARY_MANIFESTS` override
+  precisely because of the visualiser's nested placement. Sibling 0169 handles
+  the identical situation for 0167 with an explicit "close out 0167's status
+  before this story starts"; 0187 offers no equivalent.
+
+- 🔵 **Clarity**: "SKILL↔producer binding" uses "producer" in a sense that
+  collides with the repo's frontmatter meaning
+  **Location**: Context / Summary
+  Requirement 1 later restates the same concept as a skill↔subcommand binding
+  and calls the skill the *consumer*, leaving "producer" to mean the binary or
+  its build task — while `producer:` in this repo's frontmatter (including
+  this work item's own) means something entirely unrelated.
+
+- 🔵 **Clarity**: "Generalise it" has two candidate referents
+  **Location**: Summary
+  The Summary names two distinct problems then says "Generalise it". "It" can
+  refer to `validate_dispatch_coherence`, to the registration surface, or to
+  "the dispatched-sub-binary machinery" — three readings of differing size for
+  the headline goal.
+
+- 🔵 **Clarity**: "Documented nowhere" conflicts with the References entry
+  that enumerates the registration points
+  **Location**: Summary (vs. References)
+  The intended meaning is presumably that no *durable developer-facing*
+  documentation exists, but as written the Summary contradicts the References
+  section's "Registration points enumerated in: … §8".
+
+- 🔵 **Clarity**: The checklist ordering is called "ordered" but no ordering
+  principle is stated
+  **Location**: Requirements (2nd bullet)
+  It is unclear whether the sequence given in the bullet *is* the required
+  order or whether the implementer must determine one.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "review-2, pass 4" and the personified "scope" are
+  unresolvable provenance references
+  **Location**: Context (final paragraph)
+  The coordinate has no link, and "scope" as a bare noun performing an action
+  reads as an undefined actor unless the reader knows it names a review lens.
+
+- 🔵 **Testability**: Consider a drift guard so the README checklist stays
+  truthful
+  **Location**: Acceptance Criteria (4th)
+  A documentation-only artefact with no executable check will rot, and four
+  consumer stories will trust a stale checklist. A lightweight test asserting
+  the README names each registration identifier would make a rename fail a
+  test rather than age the docs.
+
+### Strengths
+
+- ✅ Almost every technical claim is anchored to an explicit `file:line`
+  reference (`tasks/build.py:35`, `tasks/shared/paths.py:25`,
+  `tasks/manifest.py:51-53`), so work can begin without a discovery pass.
+- ✅ AC1 explicitly demands non-vacuity — "a deliberately missing binding …
+  not merely passing" — closing the most common way a guard test provides
+  false assurance.
+- ✅ The fixture-token requirement is a genuine decoupling *mechanism*, not an
+  assumption: it substantiates the no-blockers position and lets the task land
+  ahead of every consumer.
+- ✅ Correctly extracted as shared platform work rather than riding inside its
+  first consumer, with the anti-pattern named explicitly in Context.
+- ✅ Non-couplings are stated as positively as couplings — signing
+  (`tasks/signing.py:50-73`), upload and re-verification
+  (`tasks/github.py:218-235`, `:270-293`) and the SLSA globs are named as
+  needing no work, so the surface boundary is checkable rather than guessed.
+- ✅ No double ownership with the primary consumer: 0169 states "this story
+  adds the token, it does not generalise the surface", and the parent epic
+  0136 records the same edge — item-level and epic-level views agree.
+- ✅ Blocks entries carry rationale rather than bare ids, and Related entries
+  annotate current state ("0165 — done", "0168 — code landed").
+- ✅ `kind: task` is proportionate: internal build-system enablement with no
+  user-visible increment, sized to one function plus tests plus a doc section.
+- ✅ Requirements are phrased as imperatives with an unambiguous actor, and
+  Requirement 3 gives the *reason* behind the naming constraint so it cannot
+  be misread as arbitrary convention.
+- ✅ SLSA — the one acronym that could trip a reader — is expanded on first
+  use.
+- ✅ AC2 names the exact test module (`tests/unit/tasks/test_build.py`) and
+  AC5 is a project-defined binary gate with no interpretive room.
+
+### Recommended Changes
+
+1. **Restate the Summary to match the delivered outcome** (addresses: the
+   one-line-allowlist contradiction across four lenses)
+   Replace "a one-line allowlist change" with something like "a mechanical,
+   documented checklist rather than a rediscovery exercise". If collapsing
+   registration to a single entry is genuinely wanted, scope it as a separate
+   follow-up and reference it here. Also replace the ambiguous "it" in
+   "Generalise it", and qualify "documented nowhere" as "documented only in
+   research, not in `tasks/README.md`".
+
+2. **Reconcile the checklist against research §8 and make AC4 enumerable**
+   (addresses: checklist narrower than cited source; AC4 cannot fail)
+   Either add cross-compile staging (`tasks/build.py:37`, `:290-331`, incl.
+   `_assert_static_elf`) and `version.workspace = true` to the checklist, or
+   state in Assumptions why they are excluded. Then rewrite AC4 to enumerate
+   the required entries by name, or to require coverage of every §8
+   registration point with an explicit note for any deliberate omission.
+
+3. **Add the skill-binding / exemption step to the checklist** (addresses: the
+   dependency finding on the consumer-facing checklist)
+   Make "add the skill binding, or declare the token exempt" an explicit
+   numbered step naming the file that holds the exemption declaration, and
+   extend AC4 to require it — otherwise a consumer completes every documented
+   step and still fails at release.
+
+4. **Define the exemption mechanism and pin both its directions with a test**
+   (addresses: undefined declaration mechanism; unverified exempt path)
+   Name the declaration site and shape in Requirement 1 (even loosely, e.g.
+   "an explicit exempt-token set in `tasks/shared/paths.py`"), and extend AC3:
+   "a fixture token listed in the exemption declaration and having no skill
+   passes the guard; the same token with the exemption removed fails it."
+
+5. **Define "fixture token", the discovery rule, and the injection seam**
+   (addresses: undefined fixture token; unspecified token→skill binding;
+   under-specified test procedure)
+   State whether the fixture token exists only within the test or is
+   registered in production code; state whether the guard discovers skills by
+   scanning for the subcommand invocation or reads a declared token→skill map
+   (and whether multiple consuming skills are permitted); and name the seam —
+   e.g. `validate_dispatch_coherence` taking the token collection and skills
+   root as parameters, so tests pass fixtures rather than patching module
+   state.
+
+6. **Split AC1 so both guard failure modes are tested, and qualify it against
+   AC3** (addresses: untested `allowed-tools` mismatch; AC1/AC3 contradiction)
+   Split into: (a) fixture token whose skill does not exist → guard fails;
+   (b) fixture token whose skill exists but whose `allowed-tools` carries only
+   an ancestor glob (e.g. `Bash(accelerator:*)`) rather than naming the
+   subcommand → guard fails. Change "any token" to "any **non-exempt** token".
+
+7. **Add an acceptance criterion for the downstream hand-off** (addresses:
+   0170/0171/0173 missing reciprocal edges)
+   Mirror 0169's hand-off criterion: require a dated note plus
+   `blocked_by: work-item:0187` on 0170, 0171 and 0173, each pointing at the
+   `tasks/README.md` checklist. Also confirm whether 0172 registers a dispatch
+   token — if it does, add it to `blocks`; if not, say so in a clause.
+
+8. **Discharge the already-parameterised assumption with a criterion, and cap
+   the absorption clause** (addresses: unverified assumption; unbounded scope)
+   Add a criterion such as "with the fixture token registered, the
+   signing-input list, upload asset list and re-verify globs each include the
+   fixture token" — a non-release verification route. Then bound the clause:
+   absorb visualiser-shaped findings whose fix is local to the token loop;
+   anything requiring signing- or release-flow changes is raised as a sibling
+   task and recorded in Dependencies.
+
+9. **Tighten two wording gaps and add the release-path check** (addresses:
+   "still passes unchanged"; guard vacuous in production)
+   Restate AC2 as two observable facts (no edits to the visualiser skill's
+   frontmatter or `_VISUALISE_SKILL_RELATIVE`'s target; the generalised guard
+   reports the visualiser token as bound), and add a criterion that manifest
+   generation still invokes the guard over the real `DISPATCHED_SUBBINARIES`.
+
+10. **Minor cleanups** (addresses: producer/consumer terminology; 0168
+    closure; provenance reference; checklist ordering)
+    Define or drop "producer" in the Context's "SKILL↔producer binding"; add
+    0169's closure instruction for 0168 or note its residual scope cannot move
+    the visualiser crate; link or drop the "review-2, pass 4" coordinate and
+    name the scope *lens* as the actor; state the ordering principle or drop
+    "ordered".
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is unusually well-anchored — nearly every claim
+carries a `file:line` reference, SLSA is expanded on first use, and the
+Requirements are written as imperatives with an unambiguous actor (the
+implementer). The clarity weaknesses are concentrated in three
+coined-but-undefined terms — "fixture token", "declared skill-exempt", and
+"the SKILL↔producer binding" — each of which admits two materially different
+implementations, and in a headline contradiction between the Summary's
+"one-line allowlist change" and the six-point registration checklist the
+Requirements mandate.
+
+**Strengths**:
+
+- Almost every technical claim is anchored to an explicit `file:line`
+  reference (`tasks/build.py:35`, `tasks/shared/paths.py:25`,
+  `tasks/manifest.py:51-53`), which removes any doubt about which code each
+  statement refers to.
+- The one acronym that could have tripped a reader (SLSA) is expanded on first
+  use in Context.
+- Requirements are phrased as imperatives directed at the implementer
+  ("Generalise…", "Document…", "Make…", "Verify…"), so the performing actor is
+  never in doubt.
+- Acceptance Criterion 1 pre-empts a common ambiguity by stating explicitly
+  that the guard must be demonstrably non-vacuous rather than merely passing.
+- The Dependencies section states not just *that* this blocks
+  0169/0170/0171/0173 but *why* (each adds a token rather than reworking the
+  pipeline), so the blocking relationship has a single interpretation.
+- Requirement 3 gives the reason behind the naming constraint (manifest-path
+  defaulting plus cargo-pup whole-crate-name matching), so the constraint
+  cannot be misread as arbitrary convention.
+
+**Findings**:
+
+- **major** / confidence high — *"One-line allowlist change" contradicts the
+  multi-point registration checklist the Requirements mandate*
+  **Location**: Summary (vs. Requirements 2-3)
+  The Summary states the goal is to "[g]eneralise it so adding the second and
+  subsequent sub-binaries is a one-line allowlist change", but Requirement 2
+  mandates documenting a checklist of at least six distinct registration
+  points (`DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`, `cli/Cargo.toml`
+  members, a mandatory `package.description`, `.gitignore`, and
+  `manifest.example.json`) and Requirement 3 adds a package-naming constraint
+  on top. These describe two different outcomes: collapsing registration to a
+  single edit, versus documenting that registration is irreducibly multi-step.
+  **Impact**: An implementer reading the Summary could reasonably attempt a
+  refactor that derives the other registration points from the allowlist,
+  which is a substantially larger change than the documentation-plus-guard
+  work the Requirements and Acceptance Criteria actually describe.
+  **Suggestion**: Restate the Summary's goal in terms consistent with the
+  Requirements — e.g. that registration becomes a *mechanical, documented*
+  checklist rather than a rediscovery exercise — or, if single-edit
+  registration really is the intent, add it as an explicit requirement and
+  reconcile it with the checklist.
+
+- **major** / confidence high — *"Fixture token" is used three times but never
+  defined*
+  **Location**: Requirements (4th bullet) / Acceptance Criteria (1st) /
+  Technical Notes
+  The term carries the whole verification strategy — Requirement 4, Acceptance
+  Criterion 1, and Technical Notes — but the work item never says what one is.
+  Two readings are equally available: a test-only value patched into
+  `DISPATCHED_SUBBINARIES` at test time, or a permanently-registered token in
+  the production allowlist that has no real binary behind it.
+  **Impact**: The two readings have very different consequences — a
+  permanently-registered token would flow into signing, manifest generation,
+  upload and re-verification, which the Assumptions section explicitly says
+  need no change, so picking the wrong reading silently invalidates that
+  assumption.
+  **Suggestion**: Define "fixture token" on first use in Requirement 4,
+  stating whether it exists only within the test (e.g. injected into the
+  allowlist by the test) or is registered in production code, and where it
+  lives.
+
+- **major** / confidence high — *"Declared skill-exempt" has no stated
+  declaration mechanism, and "undeclared" has two readings*
+  **Location**: Requirements (1st bullet) / Acceptance Criteria (3rd)
+  Requirement 1 says "[a] token with no skill consumer is a stated, explicit
+  exemption rather than an unchecked gap" and Acceptance Criterion 3 says "[a]
+  token may be declared skill-exempt explicitly; an *undeclared* token with no
+  skill consumer fails the guard" — but neither says where or how the
+  declaration is made (a separate exemption set alongside
+  `DISPATCHED_SUBBINARIES`, a richer per-token structure replacing the current
+  tuple, a comment, a config entry). Separately, "undeclared" can be read as
+  "not declared exempt" or as "not present in `DISPATCHED_SUBBINARIES`", which
+  are different conditions.
+  **Impact**: The exemption is the escape hatch the guard depends on, so an
+  unstated mechanism means the implementer invents the registration data shape
+  — and the ambiguous "undeclared" leaves it unclear whether the guard is also
+  expected to catch tokens missing from the allowlist entirely.
+  **Suggestion**: Name the declaration site and shape in Requirement 1 (even
+  loosely, e.g. "an explicit exempt-token set in `tasks/shared/paths.py`"),
+  and replace "undeclared" in Acceptance Criterion 3 with the specific
+  condition intended ("not declared exempt").
+
+- **major** / confidence medium — *"The skill that invokes `accelerator
+  <token>`" implies a one-to-one binding whose direction is unspecified*
+  **Location**: Requirements (1st bullet)
+  The definite article assumes exactly one skill per token, and the work item
+  does not say how the check locates it: by scanning all skills for an
+  `accelerator <token>` invocation (in which case "must exist" means "at least
+  one skill was found"), or by a token→skill-path map generalising today's
+  hardcoded `_VISUALISE_SKILL_RELATIVE` (`tasks/build.py:35`). Nothing states
+  what happens when two or more skills invoke the same token.
+  **Impact**: The scan-based and map-based readings produce different guard
+  semantics and different registration burdens — a map adds a seventh entry to
+  the registration checklist that Requirement 2 does not list, contradicting
+  the claim that the checklist makes registration mechanical.
+  **Suggestion**: State the binding direction explicitly — whether the guard
+  discovers skills by scanning for the subcommand invocation or reads a
+  declared token→skill mapping — and say whether multiple consuming skills are
+  permitted.
+
+- **minor** / confidence medium — *"SKILL↔producer binding" uses "producer" in
+  a sense that collides with the repo's frontmatter meaning*
+  **Location**: Context / Summary
+  Context refers twice to "the SKILL↔producer binding" that
+  `validate_dispatch_coherence` enforces, without saying what the "producer"
+  is. Requirement 1 later restates the same concept concretely as "the skill
+  that invokes `accelerator <token>` must exist and must carry a matching
+  `allowed-tools` rule", i.e. a skill↔subcommand binding — and the same
+  section calls the skill the *consumer*, leaving "producer" to mean the
+  binary or its build task. The term also collides with `producer:` in this
+  repo's document frontmatter (this very work item carries
+  `producer: create-work-item`), where it means something entirely unrelated.
+  **Impact**: A reader encountering "SKILL↔producer" before reaching the
+  Requirements has to guess which of three entities "producer" names, and the
+  frontmatter collision actively steers them wrong.
+  **Suggestion**: On first use in Context, name the two sides concretely (e.g.
+  "the binding between a consuming skill and the sub-binary subcommand it
+  invokes") and drop or define "producer".
+
+- **minor** / confidence medium — *The checklist enumeration diverges from the
+  referenced research §8 table, and its "ordered" ordering is unstated*
+  **Location**: Requirements (2nd bullet)
+  Requirement 2 asks for "an ordered checklist" and enumerates six
+  registration points, while the referenced source —
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §8 — tabulates eight, additionally covering `version.workspace = true`
+  coherence (`tasks/build.py:74-101`) and cross-compile staging plus the musl
+  `_assert_static_elf` check (`tasks/build.py:37`, `:290-331`). It is also
+  unclear whether the sequence given in the bullet *is* the required order or
+  whether the implementer must determine one.
+  **Impact**: An implementer cannot tell whether the README checklist is
+  complete when it reproduces the six listed items, or whether the omitted §8
+  rows were deliberately excluded — undermining the stated goal that following
+  the checklist makes registration mechanical.
+  **Suggestion**: State whether the checklist must reproduce all of research
+  §8's registration points (and say why any are excluded), and either give the
+  intended ordering principle or drop "ordered".
+
+- **minor** / confidence medium — *"Generalise it" has two candidate
+  referents*
+  **Location**: Summary
+  The Summary names two distinct problems in one sentence — that
+  `validate_dispatch_coherence` is hardcoded to the visualiser, and that the
+  registration surface is documented nowhere — then says "Generalise it so
+  adding the second and subsequent sub-binaries is a one-line allowlist
+  change". "It" can plausibly refer to `validate_dispatch_coherence` (the
+  immediately preceding subject), to the registration surface, or to "the
+  dispatched-sub-binary machinery" from the opening clause.
+  **Impact**: The sentence carries the work item's headline goal, so an
+  unresolved referent leaves the top-line scope open to three readings of
+  differing size.
+  **Suggestion**: Replace "it" with the intended noun phrase.
+
+- **minor** / confidence medium — *"Documented nowhere" conflicts with the
+  References entry that enumerates the registration points*
+  **Location**: Summary (vs. References)
+  The Summary asserts that "the registration surface is documented nowhere",
+  while the References section points at
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §8 as the place where "[r]egistration points [are] enumerated". The intended
+  meaning is presumably that no *durable developer-facing* documentation
+  exists (hence Requirement 2's `tasks/README.md` target), but as written the
+  two statements contradict each other.
+  **Impact**: A reader may conclude the research enumeration is unreliable or
+  already superseded, or may under-scope the documentation work by assuming
+  the research doc can simply be linked.
+  **Suggestion**: Qualify the Summary claim (e.g. "documented only in
+  research, not in `tasks/README.md`").
+
+- **suggestion** / confidence high — *"review-2, pass 4" and the personified
+  "scope" are unresolvable provenance references*
+  **Location**: Context (final paragraph)
+  Context closes with "Extracted from 0169 (review-2, pass 4), where scope
+  observed that shared platform work delivered as a side effect of its first
+  consumer both inflates that consumer and silently gates its siblings." The
+  "review-2, pass 4" coordinate has no stated meaning or link, and "scope" as
+  a bare noun performing an action reads as an undefined actor unless the
+  reader already knows it names a review lens.
+  **Impact**: A reader who wants to trace the rationale cannot locate the
+  cited review pass, and momentarily misparses "scope observed" as a sentence
+  fragment.
+  **Suggestion**: Either link the review artefact or drop the coordinate, and
+  name the actor explicitly (e.g. "the scope lens of review 2 observed…").
+
+### Completeness
+
+**Summary**: 0187 is a well-populated task: every template section except Open
+Questions and Drafting Notes is present and substantively filled, and for a
+`kind: task` the definition of the work is clear enough to start — file:line
+anchors, an explicit non-vacuous-guard criterion, and a stated fixture-token
+strategy that justifies landing ahead of its four consumers. Frontmatter is
+complete and internally consistent (recognised `kind`, `status: ready`,
+parent/blocks/relates_to all populated). The gaps are content-density ones
+inside present sections: the documentation deliverable enumerates fewer
+registration points than the research it cites, the skill-exemption mechanism
+it makes testable is never defined, and one stated in-scope activity
+(re-confirming the already-parameterised stages) has no corresponding
+acceptance criterion.
+
+**Strengths**:
+
+- All core template sections are present and substantively populated —
+  Summary, Context, Requirements, Acceptance Criteria, Dependencies,
+  Assumptions, Technical Notes and References; nothing is placeholder-only.
+- Frontmatter is complete and coherent for a ready task: `kind: task`,
+  `status: ready`, `priority: high`, `parent: work-item:0136`, and a `blocks`
+  list naming all four consumer stories, matching the parent epic's own
+  listing of 0187 as unblocked.
+- Context explains the forces behind the work (four sibling stories each
+  rediscovering the same registration points) and records provenance precisely
+  — extracted from 0169 review-2 pass 4 — rather than merely restating the
+  Summary.
+- Acceptance Criteria go beyond "it works": the first criterion explicitly
+  demands the guard be demonstrably non-vacuous, and the second names the
+  exact test module that must cover both pass and fail paths.
+- Technical Notes give the implementer concrete entry points
+  (`tasks/build.py:35`, `:189-208`, the `tasks/manifest.py:138` call site, and
+  the related `tasks/lint/skill_permissions.py` rule), so work can begin
+  without a discovery pass.
+- The Dependencies section annotates each relationship with its current state
+  ("0165 — done", "0168 — code landed") rather than listing bare IDs.
+
+**Findings**:
+
+- **major** / confidence high — *Registration checklist enumerates fewer
+  points than the research it cites*
+  **Location**: Requirements
+  The work item's second requirement specifies the `tasks/README.md`
+  registration checklist as covering six points (`DISPATCHED_SUBBINARIES`,
+  `_SUBBINARY_MANIFESTS`, `cli/Cargo.toml` members, `package.description`,
+  `.gitignore`, `manifest.example.json`), but the research it names as the
+  enumeration source (`meta/research/codebase/2026-07-29-0169-…` §8) lists
+  eight registration points — additionally cross-compile staging
+  (`tasks/build.py:37`, `:290-331`, with `_assert_static_elf` for musl) and
+  the `version.workspace = true` requirement on the new crate (enforced by
+  `tasks/build.py:74-101`). Neither omitted point is mentioned anywhere in the
+  work item, including in the Context paragraph that lists what is already
+  parameterised and needs no work.
+  **Impact**: The checklist is the primary deliverable and the artefact four
+  downstream stories will follow; shipping it two points short reproduces
+  exactly the rediscovery cost this task exists to remove, and the omission is
+  invisible because the acceptance criterion only asks that a checklist
+  exists.
+  **Suggestion**: Either add cross-compile staging and the
+  `version.workspace = true` constraint to the checklist requirement, or state
+  explicitly in Context why they are excluded (e.g. already parameterised),
+  and make the acceptance criterion require the checklist to cover every
+  registration point enumerated in §8 of the referenced research.
+
+- **minor** / confidence high — *Skill-exempt declaration mechanism is
+  required and tested but never defined*
+  **Location**: Requirements
+  The first requirement states that "a token with no skill consumer is a
+  stated, explicit exemption rather than an unchecked gap" and the third
+  acceptance criterion makes that exemption testable ("a token may be declared
+  skill-exempt explicitly"), but no section says how or where an exemption is
+  declared — a companion constant beside `DISPATCHED_SUBBINARIES`, a per-token
+  mapping, or an entry in the allowlist tuple itself. There is no Open
+  Questions section in which this choice is deferred either.
+  **Impact**: An implementer has to invent the exemption surface, and because
+  that surface becomes part of the very registration checklist this task
+  documents, an ad-hoc choice propagates to all four consumer stories.
+  **Suggestion**: Name the intended shape of the exemption declaration in
+  Requirements (even loosely, e.g. "a `SKILL_EXEMPT_SUBBINARIES` sibling
+  constant in `tasks/shared/paths.py`"), or add an Open Questions section
+  recording it as a deliberate implementation-time decision.
+
+- **minor** / confidence medium — *Assumption re-confirmation is pulled in
+  scope but has no acceptance criterion*
+  **Location**: Acceptance Criteria
+  The Assumptions section states that signing, upload, re-verification and
+  SLSA provenance need no change but that this is "worth re-confirming at
+  implementation time; if any turns out visualiser-shaped, it belongs in this
+  task rather than in its first consumer". That is an in-scope activity with a
+  conditional scope expansion, yet none of the five acceptance criteria
+  mentions it, so the work item can be closed with the check never performed.
+  **Impact**: The assumption is the one thing standing between this task and a
+  consumer story rediscovering a visualiser-shaped stage — the outcome the
+  task exists to prevent — and nothing in the definition of done records that
+  it was validated.
+  **Suggestion**: Add an acceptance criterion covering the re-confirmation of
+  the already-parameterised stages (signing, upload, re-verify, SLSA globs)
+  against a non-visualiser token, so the assumption is discharged before the
+  task closes.
+
+- **suggestion** / confidence medium — *Summary's "one-line allowlist change"
+  outcome is not what the body delivers*
+  **Location**: Summary
+  The Summary states the goal as making "adding the second and subsequent
+  sub-binaries a one-line allowlist change", but the Requirements and
+  Acceptance Criteria deliver a multi-step checklist (six-plus registration
+  points, a package-naming constraint, and a `_SUBBINARY_MANIFESTS` exception
+  rule) — the work makes registration *mechanical and documented*, not one
+  line.
+  **Impact**: A reader taking the Summary at face value will expect a level of
+  consolidation the work item does not scope, which can surface as a perceived
+  shortfall at review or as a consumer story planning for a single-line
+  change.
+  **Suggestion**: Restate the Summary's outcome to match the body — e.g. "so
+  adding a sub-binary is a documented, mechanical checklist rather than a
+  rediscovery exercise" — or add a scoping sentence noting that collapsing the
+  checklist to a single registration point is explicitly out of scope.
+
+### Dependency
+
+**Summary**: 0187 is unusually well-decoupled on the upstream side: the
+fixture-token requirement is an explicit, stated mechanism for having no
+blockers, and the components that need no change (signing, upload,
+re-verification, SLSA globs) are enumerated with file:line so the boundary of
+the work is legible. The downstream side is weaker — the work item's entire
+value proposition rests on four named consumers inheriting a shared surface,
+but three of the four (0170, 0171, 0173) do not record the reciprocal edge and
+nothing in this work item requires them to be updated. Two inherited couplings
+are also unassigned: the skill-binding/exemption step that the newly-strict
+guard enforces is missing from the registration checklist consumers will
+follow, and registration point 8 from the cited research (cross-compile
+staging) is neither documented nor declared already-parameterised.
+
+**Strengths**:
+
+- The fixture-token requirement ("Verify the generalisation against a fixture
+  token rather than a real new binary, so this task can land before any of its
+  consumers") is an explicit decoupling mechanism, not an assumption — it
+  substantiates the "no blockers" position rather than leaving it implicit.
+- Blocks entries carry rationale rather than bare ids: each of
+  0169/0170/0171/0173 is named with why it inherits the surface and what
+  landing this first avoids ("adds a token rather than reworking the
+  pipeline").
+- Non-couplings are stated as positively as couplings — signing
+  (`tasks/signing.py:50-73`), release upload and re-verification
+  (`tasks/github.py:218-235`, `:270-293`) and the SLSA provenance globs are
+  named as needing no work, so the surface boundary is checkable rather than
+  guessed.
+- The reciprocal edge with the primary consumer is coherent: 0169 lists 0187
+  in its `blocked_by`, states "Registration follows 0187's checklist — this
+  story adds the token, it does not generalise the surface", and carries an
+  acceptance criterion asserting the generalised `validate_dispatch_coherence`
+  covers the `vcs` token.
+- The parent epic 0136 records the same edge ("0187 — Generalise the
+  Sub-Binary Registration Surface (no blockers; unblocks 0169/0170/0171/0173)"),
+  so the epic-level and item-level dependency views agree.
+
+**Findings**:
+
+- **major** / confidence high — *Three of the four declared downstream
+  consumers do not record the reciprocal dependency, and nothing requires them
+  to*
+  **Location**: Dependencies (Blocks) / Frontmatter: blocks
+  0187 declares `blocks: [0169, 0170, 0171, 0173]` and stakes its whole
+  rationale on those four stories not being "serialised behind whichever gets
+  there first", but only 0169 records the reciprocal edge (`blocked_by: […
+  work-item:0187 …]`). 0170, 0171 and 0173 are all `status: draft` and carry
+  no `blocked_by: work-item:0187` — 0170 and 0171 have no `blocked_by` at all,
+  and 0173 lists only 0167 — and 0187 contains no requirement or acceptance
+  criterion obliging the implementer to append the hand-off, unlike its
+  sibling 0169 which has an explicit "the downstream hand-offs are raised"
+  criterion naming each receiving item.
+  **Impact**: The coupling is invisible from the consuming side, so
+  0170/0171/0173 can be planned or started without discovering that a shared
+  registration surface exists — reproducing exactly the rediscovery-and-refight
+  cost this task was extracted to eliminate.
+  **Suggestion**: Add an acceptance criterion (mirroring 0169's hand-off
+  criterion) requiring a dated note plus `blocked_by: work-item:0187` to be
+  recorded on 0170, 0171 and 0173, pointing each at the `tasks/README.md`
+  checklist.
+
+- **major** / confidence high — *The registration checklist omits the
+  skill-binding/exemption step the newly-strict guard will enforce on
+  consumers*
+  **Location**: Requirements (registration checklist) / Acceptance Criteria
+  Requirement 1 makes `validate_dispatch_coherence` fail for *any*
+  `DISPATCHED_SUBBINARIES` token whose skill binding is missing or whose
+  `allowed-tools` rule does not name the subcommand, unless the token is
+  declared skill-exempt — and that check runs on every release
+  (`tasks/manifest.py:138`). But the ordered checklist in Requirement 2
+  enumerates only `DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`,
+  `cli/Cargo.toml` members, `package.description`, `.gitignore` and
+  `manifest.example.json`, and the corresponding acceptance criterion asks
+  only for "the package-naming constraint and the `_SUBBINARY_MANIFESTS`
+  exception rule". Neither names "add the skill binding, or declare the token
+  exempt" as a checklist step, and no location is given for where an exemption
+  is declared.
+  **Impact**: A downstream story (0169, 0170, 0171, 0173) can complete every
+  documented checklist step and still fail its release at manifest generation
+  on the one new constraint this task introduces — a hidden blocker discovered
+  at the worst possible moment, on the release path.
+  **Suggestion**: Add the skill-binding/exemption declaration as an explicit
+  numbered step in the Requirement 2 checklist, naming the file that holds the
+  exemption list, and extend the `tasks/README.md` acceptance criterion to
+  require it.
+
+- **major** / confidence medium — *Registration point 8 (cross-compile
+  staging) from the cited research is neither documented nor declared
+  already-parameterised*
+  **Location**: Requirements (registration checklist) / Assumptions
+  The referenced research §8 enumerates eight registration points for a new
+  dispatched sub-binary. 0187's checklist covers points 1–6 and generalises
+  point 7 (`validate_dispatch_coherence`), but point 8 — cross-compile staging
+  at `tasks/build.py:37` / `:290-331`, including the musl `_assert_static_elf`
+  check — appears nowhere in the Requirements, the Acceptance Criteria, or the
+  Assumptions' list of already-parameterised machinery (which names only
+  `tasks/signing.py`, `tasks/github.py` and the SLSA globs, matching the
+  research's own "already parameterised, needing no edit" list, which likewise
+  excludes build staging).
+  **Impact**: Ownership of that registration point is unassigned between this
+  task and its first consumer, so if the staging path turns out to be
+  visualiser-shaped it lands inside whichever story ships the second
+  sub-binary — the inflate-the-first-consumer failure mode this extraction
+  exists to prevent. 0169 already carries an acceptance criterion depending on
+  it ("the musl build passes `_assert_static_elf`").
+  **Suggestion**: Either add `tasks/build.py` cross-compile staging to the
+  documented checklist (and to the coherence/parameterisation work if it is
+  hardcoded), or state explicitly in Assumptions that it is already
+  token-parameterised, alongside signing, upload and SLSA.
+
+- **minor** / confidence medium — *The "signing/upload/SLSA need no change"
+  assumption has no named verification route, owner, or acceptance criterion*
+  **Location**: Assumptions
+  The Assumptions section states that signing, upload, re-verification and
+  SLSA provenance "genuinely need no change" and that this is "worth
+  re-confirming at implementation time; if any turns out visualiser-shaped, it
+  belongs in this task rather than in its first consumer" — but no acceptance
+  criterion covers that re-confirmation, and no route is named. The
+  fixture-token strategy that keeps this task consumer-independent cannot
+  exercise the real signing/upload path, and an end-to-end confirmation would
+  need a release run, which per sibling 0169 requires the minisign signing key
+  and a release owner ("Owner: whoever performs epic-0136 releases").
+  **Impact**: The assumption's stated failure mode — work falling back into
+  the first consumer — is precisely the outcome this task exists to prevent,
+  yet nothing in the acceptance set would surface it before the consumer hits
+  it.
+  **Suggestion**: State how the assumption is confirmed without a release
+  (e.g. an inspection or unit-level assertion that each of those three call
+  sites iterates `DISPATCHED_SUBBINARIES`) and add it as an acceptance
+  criterion, or name the release owner and the release run as the confirming
+  event.
+
+- **minor** / confidence medium — *0172 may be a fifth consumer of the
+  registration surface but is absent from Blocks*
+  **Location**: Dependencies (Blocks)
+  The Blocks list names four subdomain stories (0169, 0170, 0171, 0173) but
+  omits 0172 ("Migration Engine Subdomain"), which the parent epic 0136 groups
+  under the same "Subdomain migrations (Phases 5–10)" heading as the other
+  four. ADR-0054 — referenced by this work item — decides "one binary per
+  independently-shippable subdomain", which implies 0172 registers a dispatch
+  token too and therefore inherits this surface.
+  **Impact**: If 0172 does ship a sub-binary, the dependency graph
+  under-reports this task's reach, and 0172 is planned without visibility of
+  the checklist and of the release-gating coherence guard.
+  **Suggestion**: Confirm whether 0172 registers a dispatch token; if it does,
+  add it to `blocks` and to the Dependencies prose, and if it deliberately
+  does not, say so in one clause so the omission reads as a decision rather
+  than an oversight.
+
+- **minor** / confidence high — *0168 is recorded as "code landed" but its
+  work item is still open, and no closure action is named*
+  **Location**: Dependencies (Related)
+  The Dependencies section records 0168 as "folded the visualiser into `cli/`
+  — code landed" under Related, but 0168's work item is still `status: ready`,
+  not `done`. Its landed layout is load-bearing for this task: the checklist
+  documents the `cli/<token>/Cargo.toml` default and the `_SUBBINARY_MANIFESTS`
+  override precisely because of the visualiser's nested
+  `cli/visualiser/server/` placement, and the coherence check's one existing
+  passing binding is the visualiser's. Sibling 0169 handles the identical
+  situation for 0167 explicitly ("its work item is still `ready`, so **close
+  out 0167's status before this story starts** … or the edge stays stale
+  throughout"); 0187 offers no equivalent.
+  **Impact**: If 0168 retains unlanded scope that moves or renames the
+  visualiser crate, the checklist this task writes into `tasks/README.md` and
+  the visualiser binding the generalised guard asserts against both go stale
+  immediately after landing.
+  **Suggestion**: Either note that 0168's residual scope cannot move the
+  visualiser crate path, or add the same closure instruction 0169 uses —
+  confirm and close 0168's status before this task starts.
+
+### Scope
+
+**Summary**: 0187 is a well-formed platform extraction: one coherent concern
+(making the dispatched-sub-binary registration surface token-generic and
+documented) delivered in a single component (the Python `tasks/` build system
+plus `tasks/README.md`), with no cross-boundary work and no double ownership
+against its four consumer stories. The `kind: task` declaration fits the scope
+described — one function generalisation, its unit tests, an exemption
+mechanism, and a README section — and the fixture-token requirement is a
+deliberate, effective move to make the item deliverable standalone ahead of
+every consumer. The main scope concern is internal inconsistency about the size
+of the deliverable: the Summary and Dependencies promise that registering a
+token becomes "a one-line allowlist change", while the Requirements deliver a
+six-step manual checklist, and the checklist itself is narrower than the
+registration-point enumeration in the research it cites.
+
+**Strengths**:
+
+- Single coherent purpose: every requirement (generalise the guard, document
+  the surface, state the naming constraint, verify via fixture) serves one
+  deliverable — making sub-binary registration token-generic rather than
+  visualiser-shaped.
+- Correctly extracted as shared platform work rather than riding inside its
+  first consumer; the Context states the anti-pattern explicitly ("shared
+  platform work delivered as a side effect of its first consumer both inflates
+  that consumer and silently gates its siblings") and Dependencies names all
+  four gated stories.
+- Requirement 4 (verify against a fixture token rather than a real new binary)
+  is a strong scope-independence device — it removes any dependency on
+  0169/0170/0171/0173 and lets the task land first, which is the whole point
+  of the extraction.
+- Clear out-of-scope statement: signing, release upload, re-verification and
+  SLSA provenance are named as already token-parameterised and needing no
+  work, so the reviewer can state what is in and what is out.
+- No double ownership with the consumer story: 0169's Requirements say
+  "Registration follows 0187's checklist — this story adds the token, it does
+  not generalise the surface", and its acceptance criterion references
+  "`validate_dispatch_coherence` (generalised by 0187)". The boundary between
+  enabler and consumer is agreed on both sides.
+- Single-component, single-owner work (the `tasks/` Python toolchain and its
+  docs) with no service-boundary or team-ownership spread.
+- `kind: task` is a proportionate declaration — internal build-system
+  enablement with no user-visible increment, sized to one function plus tests
+  plus a doc section.
+
+**Findings**:
+
+- **major** / confidence medium — *Summary promises a one-line registration
+  surface; Requirements deliver a six-step manual checklist*
+  **Location**: Summary
+  The Summary states the goal as making "adding the second and subsequent
+  sub-binaries … a one-line allowlist change", and Dependencies repeats it
+  ("each of those stories adds a token rather than reworking the pipeline").
+  The Requirements, however, deliver a *documented* six-step manual checklist
+  — `DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`, `cli/Cargo.toml`
+  members, a mandatory `package.description`, `.gitignore`, and
+  `cli/launcher/tests/fixtures/manifest.example.json` — plus one guard
+  generalisation. Documenting a six-point surface and collapsing it to one
+  line are different units of work of very different size.
+  **Impact**: The two readings bound the task differently. An implementer
+  taking the Summary literally could attempt to consolidate the six
+  registration points (deriving manifest paths, auto-generating ignore entries
+  and the fixture manifest) — a build-system refactor several times the size
+  of the described task — while an implementer taking the Requirements
+  literally ships a README section. Neither can tell from the work item which
+  is being asked for.
+  **Suggestion**: Restate the Summary to match the Requirements, e.g. "make
+  the coherence guard token-generic and document the registration surface as a
+  mechanical checklist, so each consumer story adds a token instead of
+  rediscovering the surface". If genuinely collapsing registration to a single
+  allowlist entry is wanted, scope it explicitly as a separate follow-up item
+  and reference it here.
+
+- **minor** / confidence high — *Checklist scope omits a registration point
+  enumerated in the research it cites*
+  **Location**: Requirements
+  0187's Requirements enumerate the registration checklist as six items,
+  matching rows 1–6 of the eight-row registration table in its own cited
+  source (§8). Row 7 is covered by the guard generalisation, but row 8 —
+  cross-compile staging at `tasks/build.py:37` / `:290-331`, including the
+  `_assert_static_elf` musl assertion — appears in neither the Requirements
+  nor the Assumptions (which re-confirm only signing, upload, re-verification
+  and SLSA). The same section's cargo-pup guidance (mirroring rule 6 to stop a
+  new binary crate reaching into `crate::launch`) is cited as rationale for
+  the naming constraint but is not itself a checklist step.
+  **Impact**: The item's stated purpose is that consumers add a token rather
+  than rediscover the surface; a checklist narrower than the enumerated
+  surface leaves exactly the residue the extraction was meant to remove, and
+  pushes it onto whichever of 0169/0170/0171/0173 ships first — 0169 already
+  carries `_assert_static_elf` and cargo-pup in its own acceptance criteria.
+  **Suggestion**: Either add the cross-compile staging point (and a line on
+  whether a new pup rule is expected) to the Requirements' checklist, or state
+  explicitly in the Requirements that those points are consumer-owned and out
+  of scope for this task, so the boundary is declared rather than silently
+  left open.
+
+- **minor** / confidence medium — *Open-ended scope-absorption clause leaves
+  the task's size contingent on implementation-time discovery*
+  **Location**: Assumptions
+  The Assumptions section states that signing, upload, re-verification and
+  SLSA provenance need no change, but adds: "if any turns out
+  visualiser-shaped, it belongs in this task rather than in its first
+  consumer." That is a deliberate and sensible anti-leakage rule, but it is
+  unbounded — the task absorbs whatever the release, signing and provenance
+  pipelines turn out to need, with no stated ceiling.
+  **Impact**: A `kind: task` sized at one function, its tests and a doc
+  section could quietly become release-pipeline work, and because 0187 blocks
+  four stories, an unbounded absorption clause extends the critical path for
+  all of them rather than just this item.
+  **Suggestion**: Cap the clause — e.g. "absorb visualiser-shaped assumptions
+  found in these four areas if the fix is local to the token loop; anything
+  requiring changes to the signing or release-upload flow is raised as a
+  sibling task and recorded in Dependencies" — so the task's boundary stays
+  statable regardless of what implementation finds.
+
+### Testability
+
+**Summary**: Work item 0187 has an unusually strong core criterion — the
+demand that the coherence guard be demonstrably non-vacuous against a
+deliberately broken fixture token is exactly the right mutation-style framing,
+and the fixture-token strategy keeps verification independent of the four
+consumer stories. Below that, verification thins out: the documentation
+criterion has no enumerable content so it cannot be failed, the Summary's
+headline outcome ("a one-line allowlist change") is measured by nothing and is
+arguably contradicted by the six-item checklist the Requirements demand, and
+one of the two failure modes the guard is required to detect (an
+`allowed-tools` rule that does not name the subcommand) has no stated test.
+The fixture-token procedure itself is under-specified — neither the token→skill
+discovery rule nor the injection seam is defined, so two implementers could
+produce tests that pass on materially different behaviour.
+
+**Strengths**:
+
+- AC1 explicitly demands non-vacuity — "a fixture token with a deliberately
+  missing binding and asserts the guard fires … not merely passing" — which
+  closes the most common way a guard test provides false assurance.
+- The fixture-token approach (Requirement 4, Technical Notes) makes the task
+  verifiable in isolation, ahead of all four consumer stories, rather than
+  depending on unlanded work.
+- AC2 names the exact test file (`tests/unit/tasks/test_build.py`) and
+  requires both pass and fail paths, giving the verifier a concrete target
+  rather than a vague "add tests".
+- AC5 (`mise run` green end to end) is a project-defined, binary pass/fail
+  gate with no interpretive room.
+- Technical Notes supply precise `file:line` anchors (`tasks/build.py:35`,
+  `:189-208`, `tasks/lint/skill_permissions.py:41-44`) so a verifier can
+  locate every surface the criteria talk about.
+
+**Findings**:
+
+- **major** / confidence high — *"Carries the registration checklist" is not
+  enumerable, so the doc criterion cannot fail*
+  **Location**: Acceptance Criteria (4th)
+  AC4 requires that `tasks/README.md` "carries the registration checklist,
+  including the package-naming constraint and the `_SUBBINARY_MANIFESTS`
+  exception rule", but never enumerates what the checklist must contain. The
+  Requirements list six registration points, while the referenced research §8
+  enumerates eight — including two the work item never mentions:
+  `version.workspace = true` in the new crate's `Cargo.toml` (point 3) and
+  cross-compile staging plus the musl `_assert_static_elf` check
+  (`tasks/build.py:37`, `:290-331`, point 8).
+  **Impact**: A README section containing three of eight registration points
+  would satisfy the criterion as written, yet leave the surface the task
+  exists to document partly undocumented — and the next sub-binary author
+  (0169/0170/0171/0173) would rediscover the gaps, which is precisely the
+  failure this task was extracted to prevent.
+  **Suggestion**: Rewrite AC4 to enumerate the required entries by name, e.g.
+  "the checklist covers all eight registration points from research §8
+  (`DISPATCHED_SUBBINARIES`, `_SUBBINARY_MANIFESTS`, crate `Cargo.toml` with
+  mandatory `package.description` and `version.workspace = true`,
+  `cli/Cargo.toml` members, `.gitignore` `bin/<token>-*`,
+  `manifest.example.json`, the coherence guard, cross-compile staging), or
+  explicitly records why an omitted point needs no author action."
+
+- **major** / confidence high — *The Summary's headline outcome ("one-line
+  allowlist change") has no acceptance criterion*
+  **Location**: Summary / Acceptance Criteria
+  The Summary states the goal as "adding the second and subsequent
+  sub-binaries is a one-line allowlist change", but no acceptance criterion
+  measures that outcome — the five criteria cover the coherence guard, its
+  tests, the exemption rule, the README, and `mise run`. The Requirements
+  themselves describe a six-item checklist, so the stated success condition is
+  both unmeasured and in tension with the specified work.
+  **Impact**: The task can be signed off with the guard generalised and a
+  README written while the pipeline is still visualiser-shaped somewhere
+  untested — the very risk the Assumptions section flags — leaving the four
+  blocked stories to discover it, so the criteria do not collectively cover
+  the Summary's intent.
+  **Suggestion**: Either restate the Summary's promise to match reality
+  ("adding a token is a mechanical, documented N-step change"), or add a
+  criterion that exercises it: with a fixture token added to
+  `DISPATCHED_SUBBINARIES` and only the checklist steps followed, manifest
+  generation, signing-input enumeration and re-verify glob construction each
+  yield an entry for the fixture token.
+
+- **major** / confidence medium — *The `allowed-tools`-mismatch failure mode
+  is required but never tested*
+  **Location**: Acceptance Criteria (1st-2nd)
+  AC1 requires the guard to fail on two distinct conditions — a missing skill
+  binding **and** an `allowed-tools` rule that "does not name the subcommand"
+  — but the verification it specifies covers only the first ("a fixture token
+  with a deliberately missing binding"), and AC2 asks for "both the pass and
+  fail paths" (singular fail path). The second condition is the subtler of the
+  two: per Technical Notes it must align with
+  `tasks/lint/skill_permissions.py:41-44`, `:183-188`, where a `Bash(...)`
+  permission relying on an ancestor glob rather than naming the subcommand is
+  the exact defect being guarded against.
+  **Impact**: The half of the guard most likely to be implemented as a no-op
+  (e.g. a substring match that an ancestor glob satisfies) would ship with no
+  non-vacuous test, so the criterion's "demonstrably non-vacuous" demand is
+  only half honoured.
+  **Suggestion**: Split AC1 into two criteria, each with its own fixture case:
+  (a) fixture token whose skill does not exist → guard fails; (b) fixture
+  token whose skill exists but whose `allowed-tools` carries only an ancestor
+  glob such as `Bash(accelerator:*)` rather than `Bash(accelerator <token>:*)`
+  → guard fails.
+
+- **major** / confidence medium — *The fixture-token verification procedure is
+  under-specified in two ways*
+  **Location**: Requirements / Acceptance Criteria (1st)
+  0187 rests its whole verification strategy on "a unit test that adds a
+  fixture token", but two preconditions that determine whether such a test is
+  even writable are left open. First, the token→skill mapping rule: the guard
+  currently reads a hardcoded `_VISUALISE_SKILL_RELATIVE`
+  (`tasks/build.py:35`), and the generalised version could either scan the
+  skills tree for whichever SKILL.md invokes `accelerator <token>` or consult
+  an explicit token→path map — the two give different answers to "the skill
+  binding is missing" for the same repository state. Second, no injection seam
+  is named: `DISPATCHED_SUBBINARIES` is a module constant
+  (`tasks/shared/paths.py:25`) and the skill paths are real repo paths, so
+  adding a fixture token requires either a parameterised function signature or
+  monkeypatching plus a fixture skills tree.
+  **Impact**: Two implementers could satisfy AC1 with tests that exercise
+  materially different behaviour, and the test may end up monkeypatching so
+  much that it no longer covers the code path the release actually runs.
+  **Suggestion**: State the discovery rule explicitly (e.g. "the guard
+  resolves a token to its skill via an explicit token→skill-path map, absence
+  from which is the exemption mechanism") and state the seam (e.g.
+  "`validate_dispatch_coherence` takes the token collection and the skills
+  root as parameters, defaulting to `DISPATCHED_SUBBINARIES` and the repo
+  root, so tests pass fixtures rather than patching module state").
+
+- **minor** / confidence medium — *The skill-exemption criterion names no
+  verification and no declaration mechanism*
+  **Location**: Acceptance Criteria (3rd)
+  AC3 states "A token may be declared skill-exempt explicitly; an *undeclared*
+  token with no skill consumer fails the guard", but neither says how an
+  exemption is declared (a constant, a map sentinel, a per-token flag) nor
+  requires a test for the exempt-and-passing path — AC2's "both the pass and
+  fail paths" refers to the visualiser binding and the missing-binding
+  failure.
+  **Impact**: The exemption escape hatch is the mechanism most likely to be
+  abused later (any awkward token gets exempted), yet nothing verifies it
+  behaves as specified, so a verifier cannot conclusively confirm the
+  criterion.
+  **Suggestion**: Extend AC3 with an explicit verification: "a fixture token
+  listed in the exemption declaration and having no skill passes the guard;
+  the same token with the exemption removed fails it" — a paired test that
+  pins both directions, and name where the exemption is declared.
+
+- **minor** / confidence medium — *AC1's blanket "any token" predicate
+  contradicts AC3's exemption*
+  **Location**: Acceptance Criteria (1st and 3rd)
+  AC1 requires the guard to fail "when any token's skill binding is missing",
+  while AC3 requires that an explicitly declared skill-exempt token with no
+  skill consumer passes. Read literally, the two criteria specify opposite
+  outcomes for the same input.
+  **Impact**: A test written against AC1's wording would assert a failure that
+  AC3 requires to be a pass, so the criteria do not define a single
+  determinate pass/fail predicate for exempt tokens.
+  **Suggestion**: Qualify AC1 to "fails when any **non-exempt** token's skill
+  binding is missing…", making AC3 the sole statement of the exemption
+  carve-out.
+
+- **minor** / confidence medium — *Nothing verifies the generalised guard
+  still runs in its real release invocation path*
+  **Location**: Acceptance Criteria (1st-2nd, 5th)
+  Technical Notes record that `validate_dispatch_coherence` is "invoked from
+  `tasks/manifest.py:138` so it runs on every release", but all specified
+  verification is unit-level against `tests/unit/tasks/test_build.py`, and
+  AC5's `mise run` gate does not exercise a release. A generalisation that
+  changes the function's signature (e.g. to accept an injected token
+  collection, as the fixture-token strategy likely requires) could leave the
+  call site passing a stale or empty collection with every unit test still
+  green.
+  **Impact**: The guard could become vacuous in production — the exact failure
+  AC1 works hard to prevent at unit level — with no criterion catching it.
+  **Suggestion**: Add a criterion that the manifest-generation entry point
+  still invokes the generalised guard over the real `DISPATCHED_SUBBINARIES`,
+  verified by a test at the `tasks/manifest.py` call site (e.g. manifest
+  generation fails when a fixture token is registered without its binding).
+
+- **minor** / confidence medium — *"Still passes unchanged" does not define
+  what is compared*
+  **Location**: Acceptance Criteria (2nd)
+  AC2 requires that "the existing visualiser binding still passes unchanged",
+  without stating what "unchanged" is measured against — the binding
+  declaration itself (no edits to the visualiser SKILL.md or its
+  `allowed-tools`), the guard's verdict, or the existing test's assertions.
+  **Impact**: An implementation that quietly relaxes the visualiser's
+  `allowed-tools` expectation to make the generalised check pass would still
+  be defensible under this wording, hiding a regression in guard strictness
+  behind a green criterion.
+  **Suggestion**: Restate as two observable facts: "no edits are made to the
+  visualiser skill's frontmatter or to `_VISUALISE_SKILL_RELATIVE`'s target
+  file, and the generalised guard reports the visualiser token as bound."
+
+- **suggestion** / confidence medium — *The signing/upload/SLSA
+  re-confirmation is assigned no verification step*
+  **Location**: Assumptions
+  The Assumptions section says signing, upload, re-verification and SLSA
+  provenance "genuinely need no change… Worth re-confirming at implementation
+  time; if any turns out visualiser-shaped, it belongs in this task", but no
+  acceptance criterion covers that re-confirmation, so the conditional scope
+  has no trigger a verifier can evaluate.
+  **Impact**: The re-confirmation is easy to skip silently, and a
+  visualiser-shaped assumption in `tasks/signing.py` or `tasks/github.py`
+  would then surface inside the first consumer story — reinstating exactly the
+  serialisation this extraction was meant to remove.
+  **Suggestion**: Add a criterion such as "with the fixture token in
+  `DISPATCHED_SUBBINARIES`, the signing-input list, the upload asset list and
+  the re-verify globs each include the fixture token, asserted by test or by a
+  recorded manual check in the work item's completion notes."
+
+- **suggestion** / confidence low — *Consider a drift guard so the README
+  checklist stays truthful*
+  **Location**: Acceptance Criteria (4th)
+  0187 makes `tasks/README.md` the canonical registration checklist for four
+  downstream stories, but the only verification is that the section exists —
+  nothing detects the checklist drifting from the code it describes as
+  `tasks/shared/paths.py`, `tasks/manifest.py` and `tasks/build.py` evolve.
+  **Impact**: A documentation-only artefact with no executable check will
+  silently rot, and the consumer stories will trust a stale checklist rather
+  than rediscovering the surface.
+  **Suggestion**: Optionally add a lightweight test asserting the README
+  checklist names each registration identifier (`DISPATCHED_SUBBINARIES`,
+  `_SUBBINARY_MANIFESTS`, `package.description`, the `bin/<token>-*` gitignore
+  pattern, `manifest.example.json`), so renaming a registration point fails a
+  test rather than aging the docs.
+
+## Re-Review (Pass 2) — 2026-08-01
+
+**Verdict:** REVISE
+
+All five lenses re-ran against the revised work item. Every one of pass 1's
+seven majors had its root cause addressed, and eight of the eleven minors are
+fully closed. But specifying the previously-vague mechanisms exposed the next
+layer of detail beneath them: choosing scan-based discovery raised "what counts
+as an invocation", and the new criterion discharging the signing/upload/SLSA
+assumption (AC6) is unsatisfiable under the work item's own definition of a
+fixture token — a defect the revision introduced rather than inherited.
+
+### Previously Identified Issues
+
+**Majors**
+
+- 🟡 **Clarity / Scope / Testability / Completeness**: "One-line allowlist
+  change" contradicts the checklist — **Resolved**. No lens raised it; scope
+  now lists the explicit out-of-scope paragraph as a strength ("a reviewer can
+  state what is in and out without inference").
+- 🟡 **Completeness / Dependency / Testability / Scope**: Checklist narrower
+  than research §8; AC4 cannot fail — **Partially resolved**. The eight points
+  are now enumerated inline with file:line anchors (completeness: "the work
+  item is self-contained and does not require reading the research"). But AC4
+  still has no pass procedure (testability, major), and dependency found two
+  further §8 details outside the eight-row table that the checklist drops.
+- 🟡 **Clarity / Completeness / Testability**: Exemption mechanism undefined —
+  **Resolved**. `SKILL_EXEMPT_SUBBINARIES` is named and sited, and AC3 pins
+  both directions. Residual: no stated bar for when an exemption is justified
+  (completeness, suggestion).
+- 🟡 **Clarity / Testability**: "Fixture token" undefined; discovery rule and
+  seam unspecified — **Partially resolved**. The token is now defined
+  (test-only, injected, never registered) and the guard's seam is specified.
+  But the discovery rule's *matching form* is still open, and the fixture
+  token has no route to the signing/upload stages AC6 requires it to reach.
+- 🟡 **Dependency**: Checklist omits the skill-binding/exemption step —
+  **Resolved**. It is checklist point 7, and AC7 requires the README to carry
+  it.
+- 🟡 **Dependency**: 0170/0171/0173 lack reciprocal edges — **Resolved** via
+  AC8, which dependency calls out as converting the gap into a checkable
+  condition. Residual: the parent epic's own annotation still reads
+  "unblocks 0169/0170/0171/0173" (dependency, minor).
+- 🟡 **Testability**: `allowed-tools` mismatch untested — **Resolved**. AC2
+  requires its own fixture case "rather than folded into the missing-binding
+  test". Residual: the multi-skill quantifier is now ambiguous (clarity,
+  major) and untested (testability, minor).
+
+**Minors**
+
+- 🔵 AC1 "any token" vs AC3 exemption — **Resolved** (non-exempt qualifier).
+- 🔵 Assumption re-confirmation has no criterion — **Resolved in intent** via
+  AC6, but AC6 as written is unsatisfiable (see New Issues) and omits SLSA
+  provenance, one of the four stages the assumption claims to discharge.
+- 🔵 Unbounded absorption clause — **Resolved**. Residual: "local to the token
+  loop" is itself undefined (clarity, minor).
+- 🔵 Guard's real release-path invocation unverified — **Resolved in intent**
+  via AC5; the criterion exists but names no artefact (see New Issues).
+- 🔵 "Still passes unchanged" undefined — **Resolved** (two observable facts).
+  Residual: it anchors on `_VISUALISE_SKILL_RELATIVE`, which the change likely
+  deletes (testability, minor).
+- 🔵 0172 absent from blocks — **Addressed**, but scope notes epic 0136 and
+  0169 both record 0172 outside the sub-binary set, so the records now
+  disagree.
+- 🔵 0168 "code landed" but still `ready` — **Partially resolved**. The
+  closure instruction is now prose under *Related*; dependency argues it is a
+  start-gate and belongs on `blocked_by` (major, see below).
+- 🔵 "SKILL↔producer" terminology — **Resolved**.
+- 🔵 "Generalise it" ambiguous referent — **Resolved**.
+- 🔵 "Documented nowhere" vs References — **Resolved**.
+- 🔵 "Ordered" with no ordering principle — **Resolved** ("in the order an
+  author would work through them").
+
+**Suggestions**
+
+- 🔵 "review-2, pass 4" provenance — **Resolved** (artefact linked, scope lens
+  named as actor).
+- 🔵 README drift guard — **Addressed** as an optional Technical Note;
+  testability now argues it should be promoted into AC4 (see below).
+
+### New Issues Introduced
+
+- 🟡 **Clarity / Completeness / Scope / Testability**: AC6 is unsatisfiable
+  under the work item's own definitions. A fixture token is defined as
+  reaching code only through the guard's injected parameters and never being
+  registered in `DISPATCHED_SUBBINARIES` — but the signing, upload and
+  re-verify stages have no such parameter and, per Assumptions, read
+  `DISPATCHED_SUBBINARIES` directly. Four lenses reached this independently.
+  The fix is either a Requirements bullet extending the injectable-collection
+  treatment to those three builders, or restating AC6 in terms of a seam that
+  already exists.
+- 🟡 **Clarity / Completeness / Testability**: "Scanning the skills tree for
+  the invocation" never says what constitutes an invocation — a SKILL.md body
+  line, a `!`-preprocessor line, an `allowed-tools` entry, or a skill-local
+  script. Real skills use the plugin-root form
+  (`${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs status`), not the bare
+  `accelerator <token>` the criteria write. Worse, if `allowed-tools` is also
+  the discovery signal, AC1 and AC2 become indistinguishable — a glob-only
+  skill would simply never be discovered as a consumer.
+- 🟡 **Testability**: Nothing distinguishes a guard that checks every token
+  from one that checks only the first. Every fixture case uses a single token
+  and the real collection has one entry, so an implementation inspecting only
+  `[0]`, or passing vacuously on an empty collection, satisfies all nine
+  criteria — the exact hazard AC5 names.
+- 🟡 **Testability**: AC4's "carries the registration checklist covering all
+  eight points" still has no pass procedure; eight headings with no usable
+  content would satisfy it. The only mechanical check is filed as *Optional*
+  in Technical Notes.
+- 🟡 **Testability**: AC5's "verified at the `tasks/manifest.py:138` call
+  site" reads as code inspection, which cannot regress-protect against the
+  signature change the criterion exists to guard against.
+- 🟡 **Clarity**: The multi-skill quantifier is ambiguous. Requirement 1 is
+  singular ("**that** skill's `allowed-tools`"), the next requirement permits
+  multiple consumers, and AC2 reads as a rule over every consumer — so it is
+  undefined whether one correctly-scoped consumer suffices when a sibling
+  skill is glob-only.
+- 🟡 **Dependency**: The 0168 start-gate is prose under *Related* with no
+  `blocked_by` edge. Sibling 0169 puts the identical 0167 gate on
+  `blocked_by`, so the epic's convention is clear, and schedulers read the
+  frontmatter rather than the prose.
+- 🟡 **Dependency**: The checklist claims to cover "every registration point
+  enumerated in research §8" but drops a §8 constraint stated outside the
+  eight-row table: the token derives `ACCELERATOR_<TOKEN>_BIN`, so a token
+  containing `_` is rejected by the launcher. 0170 ("Work-Item Subdomain") is
+  the consumer most likely to reach for `work_item` and rediscover this.
+- 🔵 **Dependency**: Checklist point 6 names
+  `cli/launcher/tests/fixtures/manifest.example.json` but not its co-reader
+  `tests/unit/tasks/test_manifest.py:38`, which §8 records as a coupled pair.
+- 🔵 **Completeness**: AC6 omits SLSA provenance, one of the four stages the
+  Assumptions section claims it discharges.
+- 🔵 **Clarity**: The "skills root" parameter is said to default to "the repo
+  root" — name and default disagree.
+- 🔵 **Clarity**: "The coherence check at `tasks/build.py:74-101`" (checklist
+  point 3) is the *version*-coherence check, not the guard this task
+  generalises; only the line numbers distinguish them.
+- 🔵 **Clarity / Completeness**: The fate of the two visualiser hardcodings
+  named in Context is unstated — the Requirements address
+  `_VISUALISE_SKILL_RELATIVE` but not the `"visualiser" in
+  DISPATCHED_SUBBINARIES` assertion, and AC4 still refers to the constant in
+  the present tense.
+- 🔵 **Clarity**: "Local to the token loop" is the scope boundary but is never
+  defined.
+- 🔵 **Scope**: The consumer set now disagrees with its own references — epic
+  0136 annotates 0187 as unblocking four stories, and 0169 groups 0172 outside
+  the sub-binary set (its coupling to 0169 is the `hooks.json` rewrite).
+- 🔵 **Testability**: The permitted multi-skill case has no criterion.
+- 🔵 **Testability**: AC4's regression anchor (`_VISUALISE_SKILL_RELATIVE`)
+  may not exist after the change.
+- 🔵 **Completeness**: No Open Questions section, though the 0168 residual
+  scope question is genuinely open and parked in Dependencies as an
+  instruction.
+
+### Assessment
+
+The revision worked on the substance: the headline contradiction is gone, the
+checklist is self-contained and covers the §8 table, the exemption mechanism
+is named and pinned in both directions, and the four missing reciprocal edges
+now have a criterion. Scope's verdict shifted markedly — it raised no majors
+at all this pass, against one in pass 1.
+
+But the work item is not yet ready. One new defect is disqualifying on its
+own: AC6 cannot be satisfied by any mechanism the Requirements authorise, so
+an implementer would either expand scope unplanned or fall back to the
+module-patching the item elsewhere rules out. Two more are structural rather
+than cosmetic — the invocation-matching rule is the single most load-bearing
+undefined term in the item (a too-narrow matcher makes the guard vacuous for
+every future token, the exact failure the task exists to prevent), and no
+criterion distinguishes iterating the collection from inspecting its first
+entry. The remaining majors are cheap: promote the 0168 gate to `blocked_by`,
+add the no-underscore token constraint, state the multi-skill quantifier once,
+and give AC4 and AC5 executable pass procedures.
+
+A third pass focused on those five points should reach APPROVE. None require
+rethinking the approach — the decisions taken between passes (scan-based
+discovery, test-only fixture token, parameter injection) all held up under
+re-review; what they need is one more level of specification.
+
+## Re-Review (Pass 3) — 2026-08-01
+
+**Verdict:** REVISE
+
+Two lenses now raise no majors at all (completeness 1→2→0, scope 1→0→0), and
+every pass-2 major is closed. The pass-3 majors are narrower and mostly
+mechanical, but two are substantive: the permission-half requirement inverts
+how `covered_by` is actually used, which would produce a guard that accepts the
+ancestor-glob rule AC3 requires it to reject; and nothing asserts the
+visualiser hardcoding is actually *removed*, so the task's central outcome has
+no pass/fail procedure.
+
+### Previously Identified Issues
+
+- 🟡 AC6 unsatisfiable — **Resolved**. The three release-stage builders now get
+  the same parameter-with-default shape, and AC10 states the observable per
+  stage plus "no signing key and no network access are required".
+- 🟡 "What counts as an invocation" undefined — **Resolved**. Defined against
+  `preprocessor_commands` / `is_plugin_invocation`, with a dedicated criterion
+  pinning that prose and backticked references do not bind. Clarity now lists
+  the two-properties-must-survive callout as a strength.
+- 🟡 Iteration not distinguished from checking `[0]` — **Resolved** by AC2,
+  which testability singles out for asserting error *content* ("the error names
+  the second token").
+- 🟡 AC4 had no pass procedure — **Resolved**. Promoted from an optional note
+  into AC12 with an enumerated literal-string list; residual gaps in *which*
+  strings (below).
+- 🟡 AC5 "verified at the call site" — **Resolved**. Now a spy test; testability
+  calls it out as pinning the classic signature-change failure.
+- 🟡 Multi-skill quantifier ambiguous — **Resolved**. Stated once in
+  Requirements, confirmed by AC5 rather than contradicted.
+- 🟡 0168 gate not on `blocked_by` — **Resolved** in this item's frontmatter,
+  but the edge is unreciprocated (below).
+- 🟡 Token no-underscore constraint missing — **Resolved** in the Requirements;
+  not yet anchored in AC12's string list (below).
+- 🔵 `manifest.example.json` co-reader — **Resolved**, and corrected: the real
+  co-readers are `tests/unit/tasks/test_manifest_contract.py:16` and the
+  `include_str!` at `cli/launcher/src/launch/outbound/resolve/manifest.rs:135`.
+  Research §8's `test_manifest.py:38` is stale. Dependency flagged the
+  divergence — the work item should say it is a correction, not a discrepancy.
+- 🔵 SLSA omitted from the discharge — **Resolved**, and sharpened: the
+  `subject-path` is only partly token-generic, now recorded as a documented
+  condition.
+- 🔵 "Skills root" vs repo root, "coherence check" collision, "local to the
+  token loop", exemption bar, visualiser anchor by path, Open Questions
+  section, epic annotation — **all resolved**.
+
+### New Issues Introduced
+
+- 🟡 **Clarity**: The permission half inverts `covered_by`. The requirement
+  says the rule must "name the subcommand, checked with `covered_by` against a
+  `${CLAUDE_PLUGIN_ROOT}/bin/accelerator <token>` probe" — but an ancestor glob
+  *does* cover that probe, so a `covered_by`-only check passes exactly the rule
+  AC3 requires to fail. In `skill_permissions.py` the helper is used the other
+  way round: `covered_by(_BARE_LAUNCHER, rule)` detects a rule that is *too
+  broad*. The two conditions need stating separately and in order.
+- 🟡 **Testability**: No criterion verifies the hardcoding is removed. Every
+  criterion would pass if a generalised guard were added *alongside* the
+  retained `_VISUALISE_SKILL_RELATIVE` check. The task's headline outcome has
+  no pass/fail procedure.
+- 🟡 **Testability**: The "no behavioural change" claim for the three builders
+  is discharged only for *injected* values. A mis-wired default (empty tuple,
+  wrong constant) satisfies every criterion while silently emptying the real
+  release's asset set.
+- 🟡 **Testability**: AC12's literal-string list omits several
+  Requirements-mandated contents — the two `manifest.example.json` co-readers,
+  `ACCELERATOR_<TOKEN>_BIN`, `cli/Cargo.toml`, and the points-1-and-7
+  same-change rule. The highest-consequence entries are the unpinned ones.
+- 🟡 **Dependency**: The hand-off edges are written into 0170–0173 at *this
+  task's acceptance* — i.e. when they stop constraining anything. While 0187 is
+  in flight those four still look unblocked, which is the serialisation the
+  Summary says the task exists to prevent. The `blocked_by` half should be a
+  now action.
+- 🟡 **Dependency**: The 0168 edge is unreciprocated and contradicts the epic.
+  0136 still annotates 0187 as "*(no blockers; …)*" and places it under
+  Foundations while 0168 sits under Subdomain migrations. AC13 corrects only
+  the "unblocks" list; 0168 gains no reciprocal `blocks` edge.
+- 🟡 **Dependency**: The launcher's built-in subcommand list (`version`,
+  `config`) is now duplicated into Python with no lockstep obligation recorded
+  — a future built-in would leave the guard's set stale, surfacing as a red
+  release path attributed to an unrelated change.
+- 🟡 **Clarity**: "Fixture manifest" has two referents — the shipped golden
+  `manifest.example.json` in the Summary/checklist, and a test-constructed
+  manifest in AC10.
+- 🔵 **Dependency**: The visualiser skill's *permission* shape is asserted as
+  an outcome, not recorded as a precondition, and both fallbacks are closed
+  (no SKILL.md edits; exemption set must be empty). *(Verified during editing:
+  `skills/visualisation/visualise/SKILL.md:8` carries
+  `Bash(${CLAUDE_PLUGIN_ROOT}/bin/accelerator visualiser *)`, a
+  subcommand-naming rule — the precondition holds and should simply be
+  recorded.)*
+- 🔵 **Dependency**: The new coupling on `skill_permissions.py` internals —
+  including the private `_BARE_LAUNCHER` — is not recorded as a dependency.
+- 🔵 **Clarity / Completeness / Scope**: The hand-off work and the
+  release-stage signature changes appear in Requirements/AC but not in the
+  Summary's two-deliverable framing; the hand-off has no Requirements bullet
+  at all.
+- 🔵 **Clarity**: AC9's "called exactly once with `DISPATCHED_SUBBINARIES` and
+  `SKILL_EXEMPT_SUBBINARIES`" is ambiguous when the parameters default — passed
+  explicitly, or resolved to those values?
+- 🔵 **Clarity**: AC4's "different token" case does not say whether that token
+  is registered; if not, the reverse-direction rule also fires and the test
+  proves the wrong thing.
+- 🔵 **Testability**: No criterion pins the *passing* half of the built-in
+  allowance (a skill invoking `accelerator config` must pass).
+- 🔵 **Testability**: AC13's "dated note" has no defined location, content or
+  check across five files.
+- 🔵 **Completeness**: No Validation Results section for the two
+  manually-discharged items (SLSA inspection, visualiser manifest path).
+- 🔵 **Scope**: The epic-annotation correction is partial — it fixes the
+  "unblocks" list but leaves the now-false "no blockers" clause.
+
+### Assessment
+
+The trajectory is clearly convergent: seven majors in pass 1, eight in pass 2
+(mostly consequences of newly-specified mechanisms), nine in pass 3 — but the
+*character* has changed completely. Pass-1 majors were missing mechanisms;
+pass-3 majors are one inverted helper call, three missing assertions, and three
+bookkeeping edges. Two lenses now raise none at all.
+
+Two must be fixed before implementation. The `covered_by` inversion is a
+semantic defect in the specification — implemented literally it produces a
+guard that accepts the exact rule shape the task exists to reject. And with no
+criterion asserting the hardcoding is gone, the work could be accepted with
+`_VISUALISE_SKILL_RELATIVE` intact, leaving the next five stories the surface
+this task was extracted to remove.
+
+The rest are cheap and mechanical: extend AC12's string list, add a default-path
+assertion, record the visualiser permission precondition (already verified to
+hold), reciprocate the 0168 edge and finish the epic annotation, move the
+`blocked_by` writes to now, add a built-in-list lockstep note, and disambiguate
+"fixture manifest". A fourth pass carrying those should reach APPROVE — and at
+that point further passes would be polishing prose rather than reducing
+implementation risk.
+
+## Re-Review (Pass 4) — 2026-08-01
+
+**Verdict:** REVISE
+
+Between passes 3 and 4 the work item took the pass-3 fixes and the reciprocal
+dependency edges were written into the five sibling documents. Pass 4 confirms
+the substance landed: the `covered_by` inversion is corrected, the
+"hardcoding is gone" criterion exists, the defaults are separately asserted,
+and dependency verified the sibling edges directly ("all four carry
+`blocked_by: work-item:0187` plus dated Dependencies bullets, and 0168 carries
+`blocks: work-item:0187`"). Its major count fell 4→1; scope held at zero for a
+second pass.
+
+The pass-4 majors are almost entirely a new class: **internal consistency
+debt created by the edits themselves**. Sections that were updated now
+contradict sections that were not.
+
+### Previously Identified Issues
+
+- 🟡 `covered_by` inversion — **Resolved**. The permission half is now two
+  conditions over a single rule, with the omission failure called out.
+  Clarity lists the operational definitions as a strength.
+- 🟡 No criterion asserting the hardcoding is removed — **Resolved**. Now the
+  first criterion, a source-scan test. Residual: "its helpers" is an
+  undefined scan scope (testability, minor).
+- 🟡 Defaults not asserted for the three builders — **Resolved** by the
+  "…and for the defaults" criterion, which testability singles out as
+  targeting exactly the bug class a parameter-with-default refactor
+  introduces. Residual: "today's visualiser asset set" is not enumerated.
+- 🟡 AC12's string list incomplete — **Resolved** (fifteen literals).
+  Residual: nothing from checklist point 10 is pinned.
+- 🟡 Hand-off edges written at acceptance — **Resolved**. Recorded up front and
+  independently verified by the dependency lens this pass.
+- 🟡 0168 edge unreciprocated, epic annotation stale — **Resolved**. 0168
+  carries `blocks`, the epic names the prerequisite and lists five consumers.
+- 🟡 Built-in list lockstep unrecorded — **Resolved** as checklist point 10.
+  Dependency now lists it as a strength ("captures a lockstep coupling that
+  would otherwise be invisible").
+- 🟡 "Fixture manifest" ambiguous — **Resolved** (golden fixture vs in-test
+  manifest).
+- 🔵 Visualiser permission precondition — **Resolved** as a dated assumption
+  quoting the rule. But its fallback now collides with a criterion (below).
+
+### New Issues Introduced
+
+**Consistency debt from the pass-4 edits** — flagged by four lenses:
+
+- 🟡 **Clarity / Dependency**: The Dependencies "Blocks" bullet still reads
+  "Only 0169 currently records the reciprocal edge … closes that gap at
+  pickup", contradicting the Hand-offs subsection headed **Done 2026-08-01**
+  and the ticked criterion. Hand-offs also says "Nothing further is owed to the
+  siblings at acceptance" while the criterion requires a grep re-verification.
+- 🟡 **Clarity / Dependency**: The 0168 discharge condition is stated three
+  ways — "cannot move the visualiser crate path" (Dependencies, Hand-offs),
+  "documentation-only" (Open Questions), and a proceed-anyway default that
+  neither 0168's reciprocal bullet nor the epic records. Residual scope that is
+  code-bearing but path-safe satisfies one test and fails another.
+- 🟡 **Completeness / Dependency / Scope / Testability**: The helper-promotion
+  deliverable exists only as one sentence in Dependencies — no Requirements
+  bullet, no criterion. Every behavioural criterion passes if the guard simply
+  imports `_BARE_LAUNCHER` privately, which is the coupling the sentence exists
+  to remove. Four lenses raised this independently.
+- 🟡 **Clarity / Completeness / Scope / Testability**: The signing-extraction
+  fallback silently voids two unconditional criteria and contradicts the
+  Assumptions' claim that those criteria discharge the parameterisation by
+  test. No alternative discharge route and no Validation Results placeholder.
+- 🔵 **Clarity / Testability**: The "No edits are made to
+  `skills/visualisation/visualise/SKILL.md`" criterion forbids exactly the
+  scoped `allowed-tools` edit the first Assumption prescribes as its fallback.
+
+**A logical defect in one criterion:**
+
+- 🟡 **Testability**: The spy criterion cannot observe what it asserts. If the
+  call site passes no override, the spy receives no collection argument and the
+  real function's default resolution never runs — any spy reporting those
+  values was handed them, making the assertion tautological. Needs splitting
+  into a spy assertion (no argument passed) plus a signature-identity assertion
+  on the defaults.
+
+**Smaller gaps:**
+
+- 🔵 The Summary says edges land on "the five consuming items"; Hand-offs
+  records four consumers plus the 0168 blocker.
+- 🔵 The guard Requirements are written against the module constants where the
+  criteria require the injected parameters.
+- 🔵 `token→consumer` is introduced in Context as a drift-preventing label and
+  then never used again; `invocation→registration` is used throughout.
+- 🔵 "Applied in order" describes a conjunction as if ordered; the failure mode
+  glossed as "backwards" is an omission.
+- 🔵 Checklist point 10 names no artefact — the one entry an author is least
+  likely to know is the only one with no target and no doc-ageing literal.
+- 🔵 `SKILL_EXEMPT_SUBBINARIES` "empty when this task lands" has no criterion,
+  though seeding it is the named vacuity failure mode.
+- 🔵 The "prose does not bind" fixture does not say whether the skill carries a
+  correct permission rule; without one it fails on the permission half and
+  never exercises the matcher.
+- 🔵 The golden-fixture no-modification boundary is stated but unasserted,
+  unlike the parallel SKILL.md boundary.
+- 🔵 0170–0173 remain sequenced behind 0169 for an unrelated reason (its
+  hook-envelope module decision), so the de-serialisation is partial.
+- 🔵 0182 is filed as merely Related despite a stated vacuous-guard failure
+  mode, with no status, owner or discharge route.
+- 🔵 0172's hand-off bullet lacks the exemption-route warning its hook-only
+  consumer will need — the consumer most likely to hit the exemption path is
+  the one least warned.
+- 🔵 SLSA is used without expansion; the hand-off re-grep has no Validation
+  Results line.
+
+### Assessment
+
+Majors by pass: 7 → 8 → 9 → 10. The count is flat-to-rising, but it is
+measuring something different each time. Pass-1 majors were missing mechanisms;
+pass-3 majors were missing assertions; pass-4 majors are five contradictions
+between sections and one criterion that cannot be implemented as written. Only
+the spy defect and the helper-promotion gap are substantive — the other four
+majors are the same edit-induced staleness in different places, fixable by
+reconciling three sections against each other.
+
+This is the signature 0169's own review recorded: "three editing passes had not
+reduced its major-finding count … with most later findings being defects
+introduced by the previous pass's fixes". 0187 has now reached the same regime
+at a much finer grain. The work item is well past the specification bar for
+implementation — fifteen criteria with named fixtures and observables, a
+defined verification strategy, complete and reciprocated dependency edges. What
+remains is editorial reconciliation, and each further round of it carries its
+own chance of introducing the next contradiction.
+
+Recommended stopping point: fix the spy criterion (it is wrong, not merely
+imprecise), promote the helper-promotion deliverable into Requirements with a
+criterion, and reconcile the three stale cross-references — Dependencies vs
+Hand-offs, the 0168 discharge wording, and the two fallback-vs-criterion
+collisions. Then implement. Further lens passes should be spent on the
+implementation, not the document.
+
+## Re-Review (Pass 5) — 2026-08-01, final
+
+**Verdict:** REVISE
+
+All three pass-4 recommendations were carried out: the spy criterion split into
+a spy assertion plus an `inspect.signature` identity assertion, the
+helper-promotion deliverable moved into Requirements with its own criterion, and
+the stale cross-references reconciled across four documents.
+
+**The major count fell for the first time — 7 → 8 → 9 → 10 → 6.** Completeness
+and scope both returned zero majors, and testability now opens with "an
+unusually testable work item", singling out the spy/signature pairing as "test
+design reasoning at the specification level".
+
+Of the six remaining majors, two are genuinely new defects, two are pass-4
+minors that were left unfixed and have been re-raised at higher severity, and
+two are boundary questions the edits surfaced rather than created.
+
+### Previously Identified Issues
+
+- 🟡 Spy criterion could not observe what it asserted — **Resolved**. Now two
+  criteria; testability lists the pairing as a strength and quotes the
+  work item's own explanation of why neither alone suffices.
+- 🟡 Helper promotion untracked — **Resolved**. In Requirements as a
+  one-symbol rename with a source-scan criterion. Scope calls the ride-along
+  "bounded to a single symbol plus its one existing caller … justified by a
+  stated coupling argument rather than convenience". Residual: the criterion
+  asserts the new name exists but not that the old one is gone (testability,
+  minor).
+- 🟡 Dependencies vs Hand-offs staleness — **Resolved**. No lens re-raised it.
+- 🟡 0168 discharge wording stated three ways — **Resolved** as a single
+  mirrored formulation; dependency lists the mirroring as a strength. But see
+  the new finding on its *scope*.
+- 🟡 Signing fallback voiding two criteria — **Resolved** via the carve-out;
+  testability now lists the conditional-path handling as a strength ("a
+  deviation is recorded rather than argued").
+- 🟡 Visualiser SKILL.md no-edits vs its fallback — **Resolved** (conditional
+  criterion, Validation Results slot).
+- 🔵 "Applied in order" ordering language — **Resolved**.
+- 🔵 Summary deliverable count — **Resolved**.
+- 🔵 Default-case cardinalities — **Resolved** (4 / 8 / 4), listed as a
+  strength.
+
+### Remaining Majors
+
+**Genuinely new:**
+
+- 🟡 **Clarity**: "Iterating the collection subsumes the membership assertion"
+  is false. If the collection were emptied or the token dropped, the loop
+  checks nothing and passes, whereas the `"visualiser" in
+  DISPATCHED_SUBBINARIES` assertion would fail. The justification contradicts
+  the item's own non-vacuity demand and its refusal to seed the exemption set
+  on vacuity grounds. As written it licenses removing the one assertion that
+  stops the release guard passing on an empty allowlist.
+- 🟡 **Testability**: No criterion would fail if the guard **duplicated** the
+  parser instead of reusing it. The behavioural criteria all pass against an
+  inline re-implementation, and the shared-contract criterion only forbids
+  underscore-prefixed imports — importing nothing at all satisfies it. The
+  reuse requirement is the entire justification for the `BARE_LAUNCHER` rename
+  and the Shared-artefact entry, and it is unverified. Needs a positive
+  assertion that the guard imports the six names and defines no local
+  equivalent.
+
+**Pass-4 minors re-raised as majors** (left unfixed by choice):
+
+- 🟡 **Testability**: "An imperative action line" cannot be mechanically
+  decided, in a criterion titled "mechanically checkable".
+- 🟡 **Testability**: The source-scan region "its helpers" is undefined, and
+  `tasks/build.py` legitimately holds visualiser-specific material elsewhere
+  (cross-compile staging, the version-coherence check).
+
+**Boundary questions the edits surfaced:**
+
+- 🟡 **Clarity**: `blocked_by: ["work-item:0168"]` versus a discharge condition
+  that ends "proceed anyway". No stated circumstance prevents pickup, so the
+  machine-readable edge and the prose disagree — and 0187 blocks five stories,
+  so a task the prose says is never blocked can present as serialising them.
+- 🟡 **Dependency**: The 0168 discharge condition is scoped to the *crate
+  path*, but 0168 also moves the visualiser's `skills/.../bin` staging and
+  retires its `bin/checksums.json` — surfaces checklist points 5 and 9
+  document. The acceptance-time re-verification is scoped too narrowly to
+  catch that.
+
+### Notable Minors
+
+`token→consumer` is still the only unused half of the drift-prevention labelling
+Context promises; the guard Requirements still speak of the module constants
+where the criteria require the injected collection; `SKILL_EXEMPT_SUBBINARIES`
+being empty at landing is prose-only with no assertion; the built-in criterion
+exercises `config` but never `version`; checklist point 10's content is the only
+one unpinned by a literal string; the SLSA inspection has no stated pass
+condition; 0172's `blocked_by` still omits 0169 (a gap 0169's own review noted);
+no Drafting Notes section; and 0182 carries no reciprocal edge despite being the
+one in-flight related item with a silent failure mode.
+
+### Assessment — closing
+
+Five passes, four editing rounds. The curve finally turned: majors fell from ten
+to six, and the two lenses that assess whether the item is *the right size and
+fully populated* have been silent for two passes running. What remains splits
+cleanly in three.
+
+**Worth fixing before implementation** — one item. The "subsumes" claim is
+wrong, and it is wrong in the direction that matters: an implementer following
+it removes an anti-vacuity assertion while believing the work item authorised
+the removal as behaviour-preserving. That is a one-sentence fix.
+
+**Worth fixing if the guard is to hold its shape over time** — the
+parser-duplication gap. Everything about the shared-contract dependency and the
+rename rests on reuse that nothing verifies.
+
+**Everything else is documentation quality**, not implementation risk. The two
+re-raised testability majors describe tests that would be weaker than claimed,
+not code that would be wrong. The `blocked_by` tension is a metadata convention
+question. The remaining minors are labelling, cross-references and assertions
+that would each tighten the document without changing what gets built.
+
+This review is closed at pass 5. The work item is specified well past the bar
+for implementation: seventeen criteria with named fixtures, injected inputs and
+quantitative expectations; a verification strategy independent of any consumer,
+signing key or network; complete reciprocated dependency edges across six
+documents; and pre-declared fallbacks with recording slots for every conditional
+path. Further passes would continue to find things — that is what lenses do —
+but the yield is now prose quality, and each editing round has demonstrably
+carried its own risk of introducing the next inconsistency.
+
+---
+
+## Verdict: APPROVE — 2026-08-01
+
+Set by the reviewer after pass 5, superseding the pass-5 lens verdict of
+REVISE. Recorded here so the frontmatter and the pass sections do not read as
+contradicting each other: **this is an author decision, not a sixth lens run.**
+
+**Fixed after pass 5, before approval** — both substantive findings:
+
+- The "iterating the collection subsumes the membership assertion" claim was
+  false — an emptied allowlist makes the loop check nothing and pass. The
+  Requirements now say so explicitly and require the guard to fail on an empty
+  resolved collection, with a dedicated criterion. This was the one finding
+  that could have caused wrong code.
+- The parser-duplication gap is closed: the shared-contract criterion now
+  asserts the imports **positively** (all six names imported, none shadowed, no
+  local regex against `Bash(` or the `!`-preprocessor form) rather than only
+  forbidding private imports. The alias hole in the same criterion was closed
+  at the same time — `_BARE_LAUNCHER` must be absent under `tasks/`, so a
+  retained alias cannot satisfy the rename.
+
+**Accepted as-is** — the four remaining pass-5 majors, all documentation
+quality rather than implementation risk:
+
+- "An imperative action line" is not mechanically decidable, in a criterion
+  titled "mechanically checkable" — the test will be weaker than the criterion
+  claims, but the checklist content is still pinned by fifteen literal strings.
+- The source-scan region "its helpers" is undefined; the implementer will scope
+  it, and `tasks/build.py` holds legitimate visualiser-specific material
+  (cross-compile staging, the version-coherence check) that the scan must
+  exclude.
+- `blocked_by: ["work-item:0168"]` versus a discharge condition ending "proceed
+  anyway" — a metadata convention question. The prose is the operative
+  statement: this is a confirmation gate, not a wait.
+- The 0168 discharge condition covers the crate path but not the visualiser's
+  `skills/.../bin` staging or its retired `checksums.json` — checklist points 5
+  and 9 could go stale if 0168's residual scope touches them. The
+  acceptance-time re-verification should be read as covering those points too.
+
+The minors and suggestions across all five passes are left unactioned by
+decision. They are recorded in the pass sections above and remain available if
+the item is revisited.
+
+**Final state**: 18 acceptance criteria; reciprocal dependency edges recorded
+across six documents; five Validation Results slots for the conditional and
+inspection-only paths. Work item status stays `ready` — review does not
+transition status, and the 0168 confirmation gate is discharged at pickup.

--- a/meta/reviews/work/0188-library-backed-vcs-adapter-review-1.md
+++ b/meta/reviews/work/0188-library-backed-vcs-adapter-review-1.md
@@ -1,0 +1,1942 @@
+---
+type: work-item-review
+id: "0188-library-backed-vcs-adapter-review-1"
+title: "Work Item Review: Library-Backed VCS Adapter over gix and jj-lib"
+date: "2026-08-01T21:16:19+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0136"
+target: "work-item:0188"
+work_item_id: "0188"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 4
+tags: [rust, vcs, dependencies]
+last_updated: "2026-08-02T14:52:24+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Library-Backed VCS Adapter over gix and jj-lib
+
+**Verdict:** APPROVE (author decision, 2026-08-02 — see Approval below;
+the four lens passes below recorded REVISE and are left unaltered)
+
+0188 is a strong, evidence-backed work item: every section is present and
+substantively filled, the split rationale is a genuine orthogonality argument
+rather than an arbitrary size cut, feasibility is measured (dated, versioned)
+rather than assumed, and the non-goals — `CommandProbe` retained, no consumer
+converged, 0125 not closed — are each pinned by an acceptance criterion. Its
+weakness is concentrated in the surface it owes downstream: the taxonomy query
+set is described by intent rather than as an enumerated contract with a defined
+home and an oracle, and three of the story's substantive criteria (the
+`detection.rs` pass, the boundary-containment fixture, the zero-spawn
+assertion) can each be reported as passing without exercising what they claim
+to verify. No critical findings; ten major findings across four lenses take
+this past the two-major REVISE threshold.
+
+### Cross-Cutting Themes
+
+- **The taxonomy query surface is a contract with no shape** (flagged by:
+  clarity, completeness, dependency, scope, testability) — all five lenses
+  landed on the same seam. Requirements say "extend the adapters with the
+  queries the `classify_checkout` taxonomy needs, so 0169 can build
+  classification on them", but the work item never says *where* those queries
+  live (port methods, which would contradict "the domain crate is untouched",
+  vs inherent adapter methods, which 0169's domain-side classifier could not
+  call through a port), *what* the full set is (0169 separately requires
+  `GIT_DIR` handling that 0188's list omits), or *what answers are correct*
+  (AC2 demands "available and unit-tested" with no expected values). This is
+  the single highest-value revision: fixing it closes four of the ten majors.
+
+- **Criteria that can pass without exercising what they verify** (flagged by:
+  testability, clarity) — three of the eight ACs have a vacuous-pass route.
+  AC1 leans on "the existing `detection.rs` suite", whose entry point the
+  referenced research records as hard-wired to `CommandProbe`. AC4's boundary
+  fixture is undermined by the Technical Notes' own suggestion to set
+  `GIT_CEILING_DIRECTORIES` in fixtures — the environment would stop discovery,
+  not the adapter. AC3's "any path that cannot be shadowed is recorded" has no
+  floor, and on a SIP-protected macOS the normal case is that none of the
+  absolute paths can be shadowed.
+
+- **Requirements stated without a matching definition of done** (flagged by:
+  completeness, testability, clarity, scope) — the bolded "avoid
+  `Workspace::load`" requirement has no criterion at all, though its sibling
+  bolded requirement does. The `cli/pup.ron` rule is conditional on an
+  undefined "warrants", and its criterion is satisfied by adding no rule. The
+  `deny.toml` inline-comment obligation and the `GIT_CEILING_DIRECTORIES`
+  fixture practice sit in advisory prose ("should", "consider") outside both
+  Requirements and ACs.
+
+- **Version pinning is asymmetric** (flagged by: clarity, completeness,
+  testability) — `gix` gets an explicit pin, a rationale and a direct lockfile
+  assertion; `jj-lib`, on whose 0.43 loader internals the entire design rests,
+  is never named in Requirements or ACs at all. The `gix` pin is defined
+  *relative* to jj-lib ("the version `jj-lib` depends on (currently 0.85)"), so
+  an unpinned jj-lib silently decays the gix pin too.
+
+- **Downstream consequences observed but unowned** (flagged by: dependency,
+  scope) — 0188 is the change that dissolves 0125's lexical-fallback rationale,
+  but 0169 carries the acceptance criterion to append the hand-off note.
+  Similarly, 0188 builds the zero-spawn harness that 0185 plans to extend,
+  while 0185's text still attributes it to 0169.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Clarity**: "The domain crate is untouched" conflicts with adding the
+  taxonomy queries 0169 must build on
+  **Location**: Requirements
+  The ports live in `cli/vcs`, so new query methods on them would touch the
+  domain crate; inherent adapter methods would not be callable through a port
+  by 0169's classifier. AC2's "available" never says available through what, so
+  the two stories can be built to incompatible designs.
+
+- 🟡 **Testability**: Taxonomy-query criterion states no expected values,
+  fixtures or exposed surface
+  **Location**: Acceptance Criteria (second bullet)
+  Five queries are named with no oracle for any of them and no defined fixture
+  set. Any test that calls each query and asserts anything satisfies the
+  criterion — providing no evidence the queries answer *correctly*, which is
+  the entire basis on which 0169 builds `classify_checkout`.
+
+- 🟡 **Dependency / Scope**: `GIT_DIR`/common-dir override handling is required
+  by 0169 but absent from the delivered query surface
+  **Location**: Requirements (taxonomy queries)
+  0169's Requirements name "the submodule, bare and `GIT_DIR` handling that
+  feeds them"; 0188's enumerated list omits it. `GIT_DIR`/`GIT_COMMON_DIR` are
+  environment overrides sitting inside 0188's discovery-bounding requirement,
+  not in 0169's domain logic. Two sequential stories claim an overlapping query
+  surface defined by intent, so a query can fall between them or be built twice
+  with divergent semantics.
+
+- 🟡 **Testability**: "Passes the existing detection.rs suite" does not specify
+  how the new adapter is exercised
+  **Location**: Acceptance Criteria (first bullet)
+  The referenced research records `vcs_adapters::facts(start)` as hard-wiring
+  `MarkerWalkRoot` + `CommandProbe::new()` "with no injection variant". Running
+  the suite unchanged verifies the retained subprocess adapter; the criterion
+  could be truthfully reported as passing with none of the new code exercised.
+
+- 🟡 **Clarity / Testability**: Bounded `gix` discovery is neither defined as a
+  rule nor verifiable as written
+  **Location**: Requirements (bound gix discovery) / Acceptance Criteria
+  (fourth bullet)
+  "The intended boundary" is never defined — nearest marker, jj workspace root,
+  or caller-supplied ceiling are all readings. AC4 then asserts "`gix::discover`
+  cannot escape a workspace boundary", which contradicts the requirement's own
+  verified finding that it *does*; the intended subject is the adapter's bounded
+  use. Worse, if the boundary fixture inherits the `GIT_CEILING_DIRECTORIES`
+  that Technical Notes recommends, discovery is stopped by the environment and
+  the criterion passes against an adapter that does no bounding at all.
+
+- 🟡 **Completeness / Testability**: The "avoid `Workspace::load`" requirement
+  has no acceptance criterion
+  **Location**: Requirements (fourth bullet) / Acceptance Criteria
+  Its sibling bolded requirement gets a criterion, so the omission looks
+  unintentional. The zero-spawn criterion's empty `JJ_CONFIG`/`HOME` is partial
+  coverage at best, and only if that run traverses the path in question. A
+  regression to `Workspace::load` — the trap the research spent a probe
+  identifying — would surface as a runtime panic on a user's machine.
+
+- 🟡 **Dependency / Testability**: The in-process performance and binary-size
+  cost is never measured, yet 0169's gate depends on it
+  **Location**: Summary / Context / Acceptance Criteria
+  0169 carries a hard gate (`G ≤ 1.1 × B`, ≈38.6 ms) that its own Dependencies
+  already flags as at risk from a ~41 ms warm bootstrap. Whether it passes is
+  largely set by this story's in-process discovery cost and by the sub-binary
+  size the two new trees produce. If loading `gix`/`jj-lib` state costs more
+  than the spawns it replaces, that is discovered in 0169 *after* the trees,
+  the licence exception and the API bet have landed — the opposite of the
+  "rolled back on its own terms" property the split was made for.
+
+- 🟡 **Testability**: Unbounded escape hatch in the zero-spawn criterion
+  **Location**: Acceptance Criteria (third bullet)
+  "Any path that cannot be shadowed in the test environment is recorded in
+  Validation Results" has no floor. On macOS with SIP a read-only `/usr/bin` is
+  the normal case, so in the limit every absolute path goes unshadowed, leaving
+  only the PATH stub — reducing the story's central safety claim to the weak
+  assertion it was written to strengthen, while still reporting as passed.
+
+- 🟡 **Dependency**: Toolchain preconditions — the real `jj`/`git` binaries and
+  the rustc floor — are uncaptured upstream dependencies
+  **Location**: Assumptions / Dependencies (External systems)
+  Every criterion is validated against repositories written by the *installed*
+  `jj` CLI, whose on-disk format must be readable by the pinned `jj-lib 0.43` —
+  a version-coherence coupling between a toolchain pin and a crate pin that is
+  never stated. Separately, two large pre-1.0 trees impose an MSRV the repo's
+  pinned Rust toolchain must satisfy; the Assumptions record `cargo deny` and
+  musl-static results but say nothing about the compiler floor.
+
+#### Minor
+
+- 🔵 **Clarity**: "Its parity suite" has three candidate referents
+  **Location**: Acceptance Criteria (seventh bullet)
+  The possessive could refer to `CommandProbe`, `cli/corpus-adapters`, or the
+  story. 0169 warns that two distinct things in this codebase are called
+  "parity" surfaces (the hooks parity gate and the `corpus-adapters` metadata
+  parity suite), so the ambiguity is not academic.
+
+- 🔵 **Clarity**: The single-`gix`-version criterion names neither the checking
+  mechanism nor the scope of "one version"
+  **Location**: Acceptance Criteria (fifth bullet)
+  Who asserts it (Rust test, `tasks/` lint, CI step, human observation) and
+  whether "one `gix` version" covers the facade crate only or every `gix-*`
+  crate are both open. A check against the facade alone would pass while
+  duplicate `gix-hash`/`gix-object` trees persist.
+
+- 🔵 **Clarity / Completeness / Testability**: No requirement states which
+  `jj-lib` version is adopted, yet "the pinned version" is referenced
+  **Location**: Requirements (dependency policy) / Assumptions
+  The gix pin is defined relative to an unstated jj-lib version, so "currently
+  0.85" decays the moment jj-lib moves. A caret range resolving forward at any
+  `cargo update` silently invalidates the loader-internals evidence with no
+  failing check.
+
+- 🔵 **Clarity**: "The adapters" (plural) and "the library-backed adapter"
+  (singular) refer to an unstated set
+  **Location**: Requirements / Acceptance Criteria
+  Unclear whether one adapter type spans both libraries or a pair does, and
+  whether "the adapters" includes the retained `CommandProbe` — which would
+  have to grow the same queries if they become port methods, conflicting with
+  "changes no existing consumer".
+
+- 🔵 **Clarity**: Shell-side terms `classify_checkout`, `BOUNDARY` and
+  `JJ_PARENT` are used without definition or a path reference
+  **Location**: Requirements / Technical Notes
+  0169 carries a Terminology section covering this vocabulary; 0188 does not,
+  and References does not point at `scripts/vcs-common.sh`. A reviewer cannot
+  check the loader-parity claim without independently locating an unreferenced
+  bash function.
+
+- 🔵 **Clarity / Testability / Scope / Completeness**: "If its import surface
+  warrants one" gives no criterion for whether the cargo-pup rule is required
+  **Location**: Requirements (final bullet)
+  No statement of what warrants it or who decides, and the matching criterion
+  ("any new rule is demonstrably non-vacuous") passes vacuously if no rule is
+  added. A required architectural guard could be silently dropped with no
+  grounds to object.
+
+- 🔵 **Clarity**: "Run each query against fixture repos" does not identify the
+  set of queries
+  **Location**: Acceptance Criteria (third bullet)
+  Could mean the two port traits' methods, the five taxonomy extensions, or
+  both. The story's strongest guarantee is asserted over an unbounded set.
+
+- 🔵 **Testability**: Zero-spawn test asserts success, not correct answers
+  **Location**: Acceptance Criteria (third bullet)
+  "Every query still succeeds" — an adapter that silently degrades under the
+  stubbed environment (returning `None`/empty facts) writes no marker and
+  "succeeds". The run most likely to expose hidden external-state dependence
+  has the weakest oracle.
+
+- 🔵 **Completeness**: Two obligations sit only in advisory prose
+  **Location**: Dependencies / Technical Notes
+  The `deny.toml` inline comment citing this story ("should") is the only
+  durable in-repo record of why a workspace-wide licence exception exists;
+  `GIT_CEILING_DIRECTORIES` in fixtures is a "consider". Neither is in
+  Requirements or ACs.
+
+- 🔵 **Completeness**: Frontmatter does not record the research document or the
+  extraction from 0169
+  **Location**: Frontmatter: relates_to
+  References cites the 2026-07-29 research §9 as the source of every empirical
+  claim, and names 0169 as the origin; `relates_to` lists only 0125.
+  Relationship-graph traversal will not connect this story to its evidence base.
+
+- 🔵 **Dependency**: Shared repo-wide Rust artefacts are contended with in-flight
+  sibling stories, with no ordering captured
+  **Location**: Requirements (dependency policy / pup.ron) / Dependencies
+  `cli/deny.toml`, `cli/pup.ron` and `cli/Cargo.lock` are also touched by 0168
+  (folds the visualiser into the workspace) and 0187. The "exactly one `gix`
+  version" invariant can be silently broken by whichever branch lands second.
+
+- 🔵 **Dependency**: 0185 depends on the zero-spawn harness this story builds,
+  but the record still attributes it to 0169
+  **Location**: Dependencies (Blocks: 0185)
+  0185's criteria say "the zero-spawn black-box assertion introduced by 0169" —
+  stale after the split. If 0188 builds the stubs as a private test helper,
+  0185 rebuilds them and the shadow list drifts between suites.
+
+- 🔵 **Dependency / Scope**: The 0125 hand-off is identified but has no owner
+  **Location**: Dependencies (Related: 0125)
+  0169 carries the AC requiring a dated note appended to 0125, but 0188 is now
+  the item that dissolves the rationale and lands first. Between 0188 landing
+  and 0169 completing, 0125 carries a rationale the codebase no longer supports.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "Passes the existing detection.rs suite" is ambiguous about
+  whether the suite may change
+  **Location**: Acceptance Criteria (first bullet)
+  "Existing" reads as "unchanged", but exercising a second adapter necessarily
+  requires parameterising the hard-wired entry point.
+
+- 🔵 **Clarity**: "Scope's argument for the split" names an actor the reader
+  cannot identify
+  **Location**: Context
+  Capitalised and possessive, it reads as a person; it means the scope review
+  lens of 0169 review-2, which is not in References.
+
+- 🔵 **Clarity**: "The swap" in Context sits uneasily with "adds an adapter; it
+  does not remove one"
+  **Location**: Summary / Context
+  A reader skimming for scope could conclude the subprocess adapter is being
+  replaced here rather than in 0185.
+
+- 🔵 **Clarity**: "Repo-wide" describes a workspace-scoped file
+  **Location**: Summary / Dependencies
+  `cli/deny.toml` governs the `cli/` Rust workspace, not the repository; the
+  blast radius is overstated to a reviewer assessing the policy change.
+
+- 🔵 **Completeness**: No requirement states how a caller selects the new
+  implementation
+  **Location**: Requirements
+  AC7 pins existing consumers to `CommandProbe`, but nothing states the
+  composition surface 0169 builds on — risking unplanned wiring work moving
+  into 0169 at pickup.
+
+- 🔵 **Dependency**: Ongoing advisory and version-drift surface of the new trees
+  has no named owner
+  **Location**: Dependencies (External systems)
+  A future RustSec advisory anywhere in the `gix`/`jj-lib` closure fails the
+  repo-wide check for every unrelated change, and the pin rule makes any
+  `jj-lib` bump a coordinated two-crate bump.
+
+### Strengths
+
+- ✅ Every section a story needs is present and substantively populated — the
+  only "pending" markers are deliberate evidence slots in Validation Results
+  tied to specific criteria, so those outputs cannot be quietly omitted.
+- ✅ The scope boundary is expressed as a single memorable invariant — "the
+  existing `CommandProbe` is **retained**, not replaced" / "this story adds an
+  adapter; it does not remove one" — restated consistently across Summary, ACs
+  and Dependencies, and pinned as an observable by AC7.
+- ✅ The split rationale is a genuine orthogonality argument, not a size cut:
+  dependency adoption fails at build level, hook-envelope changes fail
+  user-visibly, and bundled neither could be accepted or rolled back alone.
+- ✅ Feasibility is measured, dated and versioned (2026-07-29, `gix 0.85` +
+  `jj-lib 0.43`), with `cargo deny` verdicts, the musl static-ELF result and the
+  loader-parity probe recorded — and Assumptions cleanly separate measured fact
+  from the residual bet on jj-lib's self-declared unstable API.
+- ✅ AC3 is an exemplary anti-evasion criterion: it names the stub mechanism,
+  neutralises the config environment, and explicitly closes the absolute-path
+  escape a PATH-only assertion would miss.
+- ✅ AC5 states not just the assertion but *why* a direct one is needed (the
+  duplicate-version policy is warn-level), making it resistant to being
+  "satisfied" by an existing check that cannot fail.
+- ✅ AC6 demands the pup rule be demonstrably non-vacuous — a mutation-style
+  check most work items omit.
+- ✅ Both library traps are stated as named, bolded requirements with the
+  observed behaviour, the verification date and the concrete failing case, so
+  the reader understands why each constraint exists rather than trusting it.
+- ✅ Dependencies are fully populated across every axis, each with a stated
+  reason rather than a bare identifier, and the edges are bidirectionally
+  consistent with 0169 and 0185 — the split left no dangling reference.
+- ✅ The coupling *between* the two external dependencies is captured as an
+  explicit requirement (pin `gix` to jj-lib's version) and backed by a direct
+  lockfile criterion.
+
+### Recommended Changes
+
+1. **Fix the taxonomy query surface — enumerate it, home it, and give it an
+   oracle** (addresses: "domain crate untouched" conflict; taxonomy criterion
+   states no expected values; `GIT_DIR` absent from the surface; "the adapters"
+   plural/singular; "each query" unidentified)
+   This is the highest-leverage revision — it closes four majors and three
+   minors. In Requirements, replace "the queries the `classify_checkout`
+   taxonomy needs" with a numbered list that *is* the delivery contract, adding
+   `GIT_DIR`/`GIT_COMMON_DIR` and the ceiling-vs-environment precedence (or
+   stating explicitly that env-override handling is 0169's). State where they
+   live — new methods on `RepoRoot`/`VcsProbe`, a new port trait, or inherent
+   adapter methods — and reconcile that with "the domain crate is untouched".
+   Then give AC2 an oracle: Technical Notes already maps every query to a shell
+   reference, so "for each query, against the colocated / secondary / worktree /
+   submodule / bare fixtures, the adapter's answer equals the named
+   `vcs-common.sh` function's answer" is available almost for free. Reuse that
+   named set in AC3's "each query". Consider a matching reword in 0169 so it
+   composes the taxonomy from this fixed list rather than "extending the
+   crates".
+
+2. **Close the three vacuous-pass routes in the acceptance criteria**
+   (addresses: `detection.rs` suite doesn't exercise the new adapter; boundary
+   test passes on fixture hygiene; zero-spawn escape hatch has no floor)
+   For AC1, state the injection seam: "each of the eight enumerated cases runs
+   against *both* `CommandProbe` and the library-backed adapter and produces
+   identical `RepoFacts`" — which also buys a differential parity check. For
+   AC4, name the environment ("with `GIT_CEILING_DIRECTORIES` unset or set above
+   the parent repository…") and fix the subject so it describes the adapter's
+   bounded discovery, not `gix::discover` itself; a paired negative case showing
+   unbounded `gix::discover` *does* escape the same fixture would make it
+   airtight. For AC3, add an unwaivable floor: the PATH stub is always in force
+   *and* at least one non-PATH mechanism (all listed absolute paths shadowed, or
+   a process-level spawn counter) proves absence — so an unshadowable path
+   degrades the evidence without removing it.
+
+3. **Define "the intended boundary" as a rule** (addresses: bounded discovery
+   neither defined nor verifiable)
+   State it normatively — e.g. "discovery stops at the first ancestor containing
+   a `.jj` or `.git` marker; ceilings are set from that path" — since the
+   boundary rule determines behaviour in exactly the topologies this story
+   exists to serve, and the single AC4 fixture pins only one of them.
+
+4. **Give the `Workspace::load` requirement a criterion** (addresses: bolded
+   requirement with no definition of done)
+   A source-level guard plus environment coverage is cheap: "no
+`cli/vcs-adapters`
+   source path references `jj_lib::workspace::Workspace::load`, and every jj
+   query succeeds with `HOME`, `JJ_CONFIG` and `XDG_CONFIG_HOME` at empty temp
+   dirs" — the second half reusing AC3's environment.
+
+5. **Record the cost this story hands to 0169** (addresses: performance
+   rationale never measured; 0169 latency and binary-size budget uncaptured)
+   Add a *recording* criterion, not a threshold — "median of 20 invocations of
+   each library-backed query against a fixture repo on one host, alongside the
+   same query via `CommandProbe`, plus the sub-binary size delta, recorded in
+   Validation Results with host and OS" — and name 0169's `G ≤ 1.1 × B` gate in
+   the Blocks entry. This preserves the story's independent-rollback property
+   without importing 0169's gate.
+
+6. **Make the version pinning symmetric** (addresses: jj-lib version never
+   named; single-gix criterion's mechanism and scope; toolchain preconditions)
+   State the jj-lib version and pin strictness in the dependency-policy
+   requirement, and extend AC5 to assert both: "`cli/Cargo.lock` resolves no
+   `gix` *or* `gix-*` package at more than one version, and `jj-lib` at 0.43",
+   naming the mechanism (committed test/lint, not a manual observation). Add an
+   upstream-dependency bullet for the installed `jj` CLI ↔ `jj-lib` on-disk
+   format coherence and the MSRV of both crates against the pinned toolchain.
+
+7. **Resolve the conditional pup rule and promote the advisory obligations**
+   (addresses: "if its import surface warrants one"; obligations in advisory
+   prose)
+   Decide now — state the rule and its import constraint, or state that no rule
+   is needed and why (the existing `^vcs($|::)` pattern not reaching
+   `vcs_adapters` is the argument). Promote the `deny.toml` inline comment to a
+   "must" in Requirements or AC6, and resolve `GIT_CEILING_DIRECTORIES` from
+   "consider" to a yes/no — noting its interaction with Change 2's AC4 fix.
+
+8. **Assign the downstream hand-offs** (addresses: 0125 hand-off unowned; 0185
+   harness attribution stale)
+   Either add an AC here requiring the dated note appended to 0125's
+   Dependencies when the adapter lands, or state in the Related entry that 0169
+   retains that obligation. Extend the 0185 Blocks entry to name the zero-spawn
+   harness as a consumed deliverable and say whether it is a shared fixture;
+   append a dated correction to 0185 repointing the attribution from 0169.
+
+9. **Tidy the referents and the frontmatter** (addresses: "Its parity suite";
+   `classify_checkout`/`BOUNDARY`/`JJ_PARENT` undefined; "Scope's argument";
+   "the swap"; "repo-wide"; relates_to)
+   Name the parity suite by path; gloss the shell vocabulary on first use or add
+   `scripts/vcs-common.sh` to References; name the review document behind
+   "Scope's argument" and add it to References; avoid "swap" in this item; say
+   "the `cli/` workspace's dependency policy"; and add the research document to
+   `relates_to` with a `derived_from` for 0169.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: 0188 is a dense, well-referenced work item whose central scope
+boundary — "this story adds an adapter; it does not remove one" — is stated
+crisply and repeated consistently across Summary, Acceptance Criteria and
+Dependencies. Clarity weakens around the new surface the story delivers: it is
+unclear whether the taxonomy queries are new ports (contradicting "the domain
+crate is untouched"), whether "the adapters" includes the retained
+`CommandProbe`, and what "the intended boundary" for bounded `gix` discovery
+actually is. A handful of ambiguous referents ("Its parity suite", "each
+query", "the pinned version", "Scope's argument") and shell-side terms used
+without definition (`classify_checkout`, `BOUNDARY`, `JJ_PARENT`) would each
+make a reader stop and ask the author.
+
+**Strengths**:
+
+- The story's scope boundary is expressed as a single memorable invariant — "The
+  existing `CommandProbe` is **retained**, not replaced" / "this story adds an
+  adapter; it does not remove one" — and is restated consistently in Summary,
+  Acceptance Criteria and Dependencies, so the reader cannot mistake the intent.
+- The two library traps are stated as named, bolded requirements with the
+  observed behaviour, the verification date and the concrete failing case
+  (`gix::discover` returning the parent repo's `.git` from inside
+  `workspaces/build-system`), so the reader understands why each constraint
+  exists rather than having to trust it.
+- The zero-spawn acceptance criterion names the exact evasion it defends against
+  (an absolute-path spawn bypassing a `PATH`-only stub) and enumerates the
+  specific paths to shadow, leaving no room for a weaker interpretation of "zero
+  spawns".
+- Every dependency edge is stated with its relationship in words rather than as
+  a bare number — 0179 "delivered the ports this story implements", 0185
+  "converges `corpus-adapters` onto them and deletes `CommandProbe`" — so the
+  reader never has to open another work item to know why an edge exists.
+- The Assumptions section explicitly separates what was measured (with a date
+  and the exact crate versions probed) from what remains a genuine bet (jj-lib's
+  unstable API), which is unusually honest labelling.
+
+**Findings**:
+
+**🟡 major (high confidence) — Requirements — "The domain crate is untouched"
+conflicts with adding the taxonomy queries 0169 must build on**
+
+The first requirement states "Implement the `vcs` crate's `RepoRoot` and
+`VcsProbe` ports … The domain crate is untouched", while the second requires
+"Extend the adapters with the queries the `classify_checkout` taxonomy needs, so
+0169 can build classification on them". Since the ports live in the domain crate
+(`cli/vcs/src/lib.rs`), a reader cannot tell whether these new queries are
+additional port methods (which would touch the domain crate), inherent methods
+on the concrete adapter types (which 0169's domain-side classifier could not
+call through a port), or something else — and Acceptance Criterion 2's "The
+taxonomy queries 0169 needs are **available**" does not say available through
+what.
+
+*Impact*: The implementer must guess the shape of the interface this story
+delivers, and 0169 — which is blocked on it — cannot know whether it inherits
+ports or must define them itself, so the two stories can be built to
+incompatible designs.
+
+*Suggestion*: State explicitly where the new queries live (new methods on the
+existing `RepoRoot`/`VcsProbe` traits, a new port trait in `cli/vcs`, or
+inherent
+adapter methods) and reconcile that with the "domain crate is untouched" claim —
+noting, if inherent methods are intended, that 0169 owns the port definitions
+that expose them.
+
+**🟡 major (high confidence) — Requirements / Acceptance Criteria — "The
+intended boundary" for bounded gix discovery is never defined, and AC4 restates
+it as a property of `gix::discover` itself**
+
+The requirement "Bound `gix`'s discovery explicitly" concludes "Discovery must
+stop at the intended boundary rather than trusting the library's default walk",
+but "the intended boundary" is never defined — candidate readings include the
+nearest `.jj` or `.git` marker, the jj workspace root specifically, or a
+caller-supplied ceiling. The corresponding acceptance criterion then asserts
+"`gix::discover` cannot escape a workspace boundary", which literally
+contradicts the requirement's own verified finding that `gix::discover` *does*
+walk up past a jj workspace boundary; the intended subject is presumably the
+adapter's bounded use of it, not the library function.
+
+*Impact*: The boundary rule determines behaviour in exactly the topologies this
+story exists to serve — nested git-in-jj, jj-in-git, worktrees and submodules —
+so two implementers could produce different, both-defensible results, and the
+single acceptance fixture (a jj secondary workspace inside a git repository)
+pins only one of them.
+
+*Suggestion*: State the bounding rule as a rule (e.g. "discovery stops at the
+first ancestor containing a `.jj` or `.git` marker; `GIT_CEILING_DIRECTORIES`-
+equivalent ceilings are set from that path") and rephrase the criterion so its
+subject is the adapter's discovery rather than `gix::discover`.
+
+**🔵 minor (high confidence) — Acceptance Criteria — "Its parity suite" has
+three candidate referents**
+
+The criterion reads "`CommandProbe` still exists and `cli/corpus-adapters` still
+resolves through it — this story adds an adapter and changes no existing
+consumer. Its parity suite passes unchanged." The possessive "Its" could refer
+to `CommandProbe`, to `cli/corpus-adapters`, or to the story; the immediately
+preceding pronoun "it" refers to `CommandProbe`, which is the one candidate that
+has no parity suite of its own. The blocking story 0169 additionally warns that
+two distinct things in this codebase are called "parity" surfaces (the hooks
+parity gate and the `corpus-adapters` metadata parity suite), so the ambiguity
+is not academic.
+
+*Impact*: An implementer could assert the wrong suite — or the unrelated hooks
+parity gate — and believe the criterion is satisfied.
+
+*Suggestion*: Name the suite by path (e.g.
+"`cli/corpus-adapters/tests/parity.rs`
+passes unchanged") instead of using a possessive pronoun.
+
+**🔵 minor (high confidence) — Acceptance Criteria — The single-`gix`-version
+criterion names neither the checking mechanism nor the scope of "one version"**
+
+The criterion "Exactly **one** `gix` version resolves in `cli/Cargo.lock`
+(asserted directly — the repo's duplicate-version policy is warn-level, so a
+drifted pin would otherwise pass silently)" leaves two things open: who or what
+performs the assertion (a Rust test, a Python lint task under `tasks/`, a CI
+step, or a human recording the result), and whether "one `gix` version" means
+one version of the `gix` facade crate only or a single version of every `gix-*`
+crate in the resolved graph. The Requirements phrase the goal as "one `gix`
+graph, not two", which suggests the whole family, while Validation Results
+carries "**`gix` version resolved in `Cargo.lock`** — _pending_", which suggests
+a one-off manual observation.
+
+*Impact*: A check written against the `gix` facade alone would pass while
+duplicate `gix-hash`/`gix-object` trees persist, defeating the stated purpose of
+the pin; and a manually recorded observation would not prevent later drift.
+
+*Suggestion*: State the mechanism ("a committed test/lint asserts…") and the
+scope ("…that no `gix` or `gix-*` package appears at more than one version in
+`cli/Cargo.lock`").
+
+**🔵 minor (medium confidence) — Requirements / Acceptance Criteria — "The
+adapters" (plural) and "the library-backed adapter" (singular) refer to an
+unstated set**
+
+The Requirements say "Extend **the adapters** with the queries the
+`classify_checkout` taxonomy needs", while the Acceptance Criteria consistently
+say "**The** library-backed **adapter**" (singular) implements the ports and is
+the subject of the zero-spawn assertion. It is therefore unclear whether this
+story delivers one adapter type spanning both `gix` and `jj-lib` or a pair of
+them, and — more consequentially — whether "the adapters" includes the retained
+`CommandProbe`, which would have to grow the same queries if they become port
+methods.
+
+*Impact*: If `CommandProbe` is in scope for the extension, that conflicts with
+the story's repeated "changes no existing consumer / parity suite passes
+unchanged" posture; if it is out of scope, the port surface cannot be widened,
+which constrains the design decision in the first finding.
+
+*Suggestion*: Fix the count and the membership in one place — e.g. name the new
+type(s) and add "`CommandProbe` gains no new methods" (or the converse) to the
+Requirements.
+
+**🔵 minor (high confidence) — Requirements / Assumptions — No requirement
+states which `jj-lib` version is adopted, yet "the pinned version" is
+referenced**
+
+The dependency-policy requirement pins only `gix`, and does so *relative* to
+jj-lib: "pin `gix` to the version `jj-lib` depends on (currently 0.85)". No
+requirement states which `jj-lib` version is adopted or whether it is pinned at
+all, yet the Assumptions say "`jj-lib`'s loader API remains stable across **the
+pinned version**. Verified against 0.43" — a phrase with no antecedent, which
+could equally be read as referring to the `gix` pin.
+
+*Impact*: The gix pin is defined in terms of an unstated jj-lib version, so
+"currently 0.85" silently decays the moment jj-lib moves; and since the story
+rests on jj-lib's explicitly unstable loader internals, the reader cannot tell
+whether an exact pin is a requirement or a caretaker's discretion.
+
+*Suggestion*: State the jj-lib version and its pin strictness as a requirement
+(e.g. "depend on `jj-lib` 0.43 with an exact pin"), and make the Assumptions
+sentence name which crate's pin it means.
+
+**🔵 minor (high confidence) — Requirements / Technical Notes — Shell-side terms
+`classify_checkout`, `BOUNDARY` and `JJ_PARENT` are used without definition or a
+path reference**
+
+The Requirements hinge on "the queries the `classify_checkout` taxonomy needs"
+and the Technical Notes assert that jj-lib's loader answers "match
+`classify_checkout` exactly: `workspace_root()` equals the shell's `BOUNDARY`,
+and `repo_path()` minus `/.jj/repo` equals `JJ_PARENT`". None of the three terms
+is defined or given a file reference in this work item: `classify_checkout` is a
+bash function in `scripts/vcs-common.sh`, and `BOUNDARY`/`JJ_PARENT` are keys of
+the `KEY=VALUE` record it emits. The blocking story 0169 carries a Terminology
+section that covers this vocabulary; 0188 does not, and its References list does
+not point at the shell source.
+
+*Impact*: A reviewer assessing whether the adapter's semantics are correct — the
+whole point of this story — cannot check the claim without independently
+locating an unreferenced shell function and inferring the meaning of two
+undefined record keys.
+
+*Suggestion*: Add a one-line gloss with a path on first use (e.g.
+"`classify_checkout` (`scripts/vcs-common.sh:177-280`), whose record fields
+`BOUNDARY` (the checkout root) and `JJ_PARENT` (the main repo directory) …"), or
+add `scripts/vcs-common.sh` to References.
+
+**🔵 minor (high confidence) — Requirements — "If its import surface warrants
+one" gives no criterion for whether the cargo-pup rule is required**
+
+The final requirement reads "Add a `cli/pup.ron` rule for the new adapter module
+**if its import surface warrants one**", with no statement of what would warrant
+it or who decides. The matching acceptance criterion is likewise conditional
+("**any** new rule is demonstrably non-vacuous"), so the work item can be
+satisfied with or without the rule and never says which outcome is correct.
+
+*Impact*: A required architectural guard could be silently dropped as "not
+warranted", and no reviewer would have grounds to object.
+
+*Suggestion*: Replace the vague conditional with a decision rule and its owner —
+e.g. "add a rule denying the adapter module any import outside `std`, `gix`,
+`jj_lib`, `kernel::Error` and `crate::`" — or state plainly that no rule is
+required and why.
+
+**🔵 minor (medium confidence) — Acceptance Criteria — "Run each query against
+fixture repos" does not identify the set of queries**
+
+The zero-spawn criterion instructs "run **each query** against fixture repos …
+Assert no marker is written and **every query** still succeeds", but the work
+item never defines the set of "queries". It could mean the two port traits'
+methods (`RepoRoot::discover`/`repository_root`, `VcsProbe::kind`/`revision`),
+the five taxonomy extensions listed in the preceding criterion, or both — and
+the word "query" is used loosely for both surfaces elsewhere in the Requirements
+and Technical Notes.
+
+*Impact*: The strongest guarantee in the story — zero subprocess spawns — is
+asserted over an unbounded set, so a partial implementation could satisfy the
+letter of the criterion while a spawning code path goes untested.
+
+*Suggestion*: Enumerate the queries once (or point at the enumeration in the
+taxonomy criterion plus the port methods) and use that named set in both
+criteria.
+
+**🔵 suggestion (medium confidence) — Acceptance Criteria — "Passes the existing
+detection.rs suite" is ambiguous about whether the suite may change**
+
+The first criterion requires the new adapter to pass "**the existing**
+`cli/vcs-adapters/tests/detection.rs` suite". "Existing" reads as "unchanged",
+but the referenced research records that the current entry point hard-wires
+`MarkerWalkRoot` + `CommandProbe::new()` with no injection variant — so
+exercising a second adapter through that suite necessarily requires
+parameterising it.
+
+*Impact*: An implementer may either believe the suite is off-limits and write a
+parallel duplicate, or modify it and be unsure whether that breaches the
+criterion.
+
+*Suggestion*: Say what may change — e.g. "the cases in `detection.rs` are
+parameterised over both adapters and all listed cases pass for the
+library-backed one".
+
+**🔵 suggestion (medium confidence) — Context — "Scope's argument for the split"
+names an actor the reader cannot identify**
+
+Context states "**Scope's** argument for the split is that the two changes carry
+very different risk profiles". Capitalised and possessive, "Scope" reads as a
+person or a named section, but it appears to mean the scope review lens from the
+review that drove the split (0169's Drafting Notes attribute the split to
+"review-2 pass 4"). That review document is not in this work item's References.
+The same sentence's "the two changes" also has no antecedent until the following
+clause supplies them.
+
+*Impact*: A reader outside the review workflow cannot tell whose judgement is
+being cited or verify it, which weakens the stated justification for the split.
+
+*Suggestion*: Name the source explicitly ("the scope lens of
+`meta/reviews/work/0169-…-review-2.md`") and add it to References, and name the
+two changes before referring to them collectively.
+
+**🔵 suggestion (medium confidence) — Summary / Context — "The swap" in Context
+sits uneasily with "adds an adapter; it does not remove one"**
+
+The Summary is emphatic that nothing is replaced — "The existing `CommandProbe`
+is **retained**, not replaced … This story adds an adapter; it does not remove
+one" — but Context then says "the **swap** is an adapter change by
+construction", using a term the sibling story 0169 also uses for this work ("the
+`gix`/`jj-lib` adapter swap"). The intended meaning is presumably that swapping
+*implementations* would not touch the domain, but as written the two sections
+appear to describe different operations.
+
+*Impact*: A reader skimming for scope could conclude the subprocess adapter is
+being replaced here rather than in 0185.
+
+*Suggestion*: Rephrase the Context sentence in terms of the property being
+claimed (e.g. "a library-backed implementation is an adapter-level change by
+construction") and avoid "swap" in this work item.
+
+**🔵 suggestion (medium confidence) — Summary / Dependencies — "Repo-wide"
+describes a workspace-scoped file, and the inline-comment obligation is only a
+"should"**
+
+The Summary calls the licence exception "a repo-wide `cli/deny.toml` licence
+exception" and Dependencies repeats "a repo-wide policy change", although the
+file is scoped to the `cli/` Rust workspace rather than the repository.
+Dependencies then adds that the exception "**should** carry an inline comment
+citing this story so a future dependency audit can find the justification" — an
+obligation stated in a non-normative modal, placed outside Requirements, and not
+covered by any acceptance criterion.
+
+*Impact*: The blast radius of the policy change is overstated to a reviewer
+assessing it, and the audit-trail comment reads as optional advice, so it may
+plausibly be omitted.
+
+*Suggestion*: Say "the `cli/` workspace's dependency policy" (or state that
+`cli/deny.toml` governs all Rust in the repo, if that is the case), and promote
+the inline comment to a Requirement with "must" if it is intended to be
+delivered.
+
+### Completeness
+
+**Summary**: Work item 0188 is a densely populated story: every section a story
+needs is present and substantively filled — Summary, Context, Requirements,
+eight specific Acceptance Criteria, Dependencies, Assumptions, Technical Notes,
+Validation Results and References — with frontmatter complete and valid (`kind:
+story`, `status: ready`, `priority: high`, parent/blocked_by/blocks all set).
+Its strongest completeness feature is that Requirements, Acceptance Criteria and
+Validation Results are wired to each other: the two criteria demanding recorded
+evidence have pre-declared slots in Validation Results. The residual gaps are
+coverage rather than presence — one explicit Requirement has no matching
+criterion, one Requirement is left conditional with no Open Questions section to
+hold the undecided call, the `jj-lib` version the whole feasibility case rests
+on is never named in Requirements or AC, and two obligations sit only in
+advisory prose.
+
+**Strengths**:
+
+- Every section a story requires is present and substantively populated — no
+  empty or placeholder sections; the only 'pending' markers are in Validation
+  Results, where they are deliberate evidence slots tied to specific acceptance
+  criteria.
+- The Summary states both what is added and, unusually, what is explicitly not
+  changed ('The existing CommandProbe is retained, not replaced'), pre-empting
+  the most likely misreading of an adapter-swap story.
+- Context explains three distinct forces behind the work — the current
+  subprocess implementation, the differing risk profiles that justified
+  extracting this from 0169, and the dissolution of 0125's lexical-fallback
+  rationale — rather than restating the Summary.
+- Assumptions cleanly separate measured fact from residual risk, dating the
+  feasibility measurement (2026-07-29) and naming the exact remaining bet
+  (jj-lib's self-declared unstable API).
+- Acceptance criteria are unusually concrete for an infrastructure story — AC3
+  enumerates the specific evasion its zero-spawn assertion must resist
+  (absolute-path spawns at three named locations) and requires unshadowable
+  paths to be recorded rather than silently skipped.
+- The Dependencies section is fully populated across every axis — blocked_by,
+  blocks, external systems, related and parent — each with a stated reason
+  rather than a bare identifier.
+
+**Findings**:
+
+**🟡 major (medium confidence) — Acceptance Criteria**
+
+Work item 0188 (library-backed VCS adapter over `gix` and `jj-lib`) carries an
+explicit Requirement to avoid `jj_lib::workspace::Workspace::load` on detection
+paths and use `DefaultWorkspaceLoaderFactory` instead, but none of the eight
+acceptance criteria references it. Every other Requirement bullet has a matching
+criterion — ports → AC1, taxonomy queries → AC2, bounded `gix` discovery → AC4,
+dependency policy → AC5/AC6 — so this is the one stated obligation with no
+definition of done.
+
+*Impact*: One of the two hard-won traps the story exists to encode is absent
+from the acceptance set, so an implementation could satisfy every criterion
+while taking the fragile settings-dependent path.
+
+*Suggestion*: Add a criterion asserting the detection path constructs no
+`UserSettings` and calls no `Workspace::load`. AC3 already runs queries with
+`JJ_CONFIG` and `HOME` pointed at empty temp dirs, which would likely surface
+the failure, so making that coverage explicit should be cheap.
+
+**🔵 minor (high confidence) — Requirements**
+
+In work item 0188 the dependency-policy Requirement pins `gix` explicitly ("to
+the version `jj-lib` depends on (currently 0.85)") and AC5 asserts exactly one
+`gix` version resolves in `cli/Cargo.lock`, but neither Requirements nor
+Acceptance Criteria ever names the `jj-lib` version to adopt. Version 0.43
+appears only in Assumptions (as what feasibility was measured against) and in
+Technical Notes source citations.
+
+*Impact*: The story's entire evidence base — the `cargo deny` verdicts, the musl
+static-link result, and the loader-API-matches-`classify_checkout` probe — is
+measured against jj-lib 0.43, yet nothing in the requirements or the definition
+of done ties the implementation to it.
+
+*Suggestion*: State the `jj-lib` version in the dependency-policy Requirement
+alongside the `gix` pin, and extend AC5 to assert the resolved `jj-lib` version
+as well as the single-`gix` graph.
+
+**🔵 minor (medium confidence) — Requirements**
+
+The final Requirement in work item 0188 says to add a `cli/pup.ron` rule for the
+new adapter module "if its import surface warrants one", with no stated
+criterion for what warrants one and no decision recorded anywhere in the
+document. The work item has no Open Questions section where such an undecided
+item would normally live (the sibling story 0169 it was extracted from does have
+one).
+
+*Impact*: The implementer inherits an unstated architectural-policy call with
+nowhere in the document recording the default, and AC6's "any new rule is
+demonstrably non-vacuous" is trivially satisfied by adding no rule at all.
+
+*Suggestion*: Either resolve it in Requirements ("add a rule denying X", or "no
+new rule is needed because the existing `^vcs($|::)` pattern does not reach
+`vcs_adapters`"), or add an Open Questions section that records the question
+with a stated default if unresolved.
+
+**🔵 minor (medium confidence) — Dependencies**
+
+Work item 0188 places two obligations in commentary sections rather than in
+Requirements or Acceptance Criteria: the Dependencies section says the
+`cli/deny.toml` licence exception "should carry an inline comment citing this
+story so a future dependency audit can find the justification", and Technical
+Notes says to "Consider `GIT_CEILING_DIRECTORIES` in fixtures".
+
+*Impact*: Obligations stated only in advisory prose are easy to drop during
+implementation and nothing in the definition of done catches their omission —
+the audit comment in particular is the only durable in-repo record of why a
+repo-wide licence-policy exception exists.
+
+*Suggestion*: Promote the inline-comment obligation into the dependency-policy
+Requirement bullet or into AC6, and resolve the `GIT_CEILING_DIRECTORIES`
+"consider" into a yes/no statement in Requirements.
+
+**🔵 minor (medium confidence) — Frontmatter: relates_to**
+
+Work item 0188's References section cites
+`meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md` §9
+as the source of every empirical claim in the story (the `cargo deny` verdicts,
+the musl static-link result, the jj-lib loader probe, the `uluru` finding) and
+names 0169 as the item it was extracted from — but the frontmatter records
+neither. `relates_to` lists only `work-item:0125`, and there is no
+`derived_from` or `source` field. The sibling story 0169 does carry that
+research document in its `relates_to`.
+
+*Impact*: Relationship-graph traversal of the corpus will not connect this story
+to its evidence base, so a future reader auditing the licence exception or a
+`jj-lib` version bump has to rediscover the research through prose.
+
+*Suggestion*: Add
+`codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration` to
+`relates_to`, and record the extraction from 0169 in a `derived_from` (or
+`source`) field.
+
+**🔵 suggestion (medium confidence) — Requirements**
+
+Work item 0188 requires implementing the `RepoRoot` and `VcsProbe` ports
+"alongside the existing `CommandProbe`", and AC7 pins that existing consumers
+keep resolving through `CommandProbe` — but no Requirement or criterion states
+how a caller selects the new library-backed implementation, which is precisely
+what the blocked story 0169 has to build on.
+
+*Impact*: The downstream consumer may discover at pickup that the enabling story
+delivered types with no composition surface, moving unplanned wiring work into
+0169.
+
+*Suggestion*: Add a sentence to Requirements naming the selection surface this
+story delivers — e.g. a composition helper taking the library-backed adapters,
+or an explicit "public constructors only; consumer wiring belongs to 0169".
+
+### Dependency
+
+**Summary**: 0188 captures its principal couplings well: the upstream 0179 edge
+is named and marked done, both downstream consumers (0169, 0185) are listed as
+Blocks with a one-line reason each, and the External systems entry names gix and
+jj-lib, their crates.io origin, the pre-1.0 unstable-API risk, and the repo-wide
+`cli/deny.toml` licence-policy change including the requirement to leave a
+citation comment for future audits. The gaps are at the edges of the contract it
+owes downstream and at the environment it depends on: the story's runtime and
+binary-size cost is on the critical path of 0169's numeric latency gate but is
+nowhere captured; the enumerated query surface omits
+`GIT_DIR`/`--git-common-dir` override handling that 0169's taxonomy explicitly
+declares it needs; and the toolchain preconditions (the real `jj`/`git` binaries
+that build the fixtures, and the rustc floor the two new trees impose) are
+absent. Secondary gaps are shared-artefact contention with in-flight sibling
+stories on `cli/Cargo.lock`/`deny.toml`/`pup.ron`, and an ownerless hand-off
+note to 0125.
+
+**Strengths**:
+
+- The Blocks/Blocked-by edges are bidirectionally consistent with the referenced
+  items: 0169's frontmatter lists 0188 in `blocked_by`, and 0185's Dependencies
+  explicitly records that its edge was repointed from 0169 to 0188 when the
+  split happened — the split did not leave a dangling reference.
+- The External systems entry is unusually complete for a library-adoption story:
+  it names both crates, their registry, the pre-1.0 API-break risk with the
+  specific reason (the design leans on loader internals), and the repo-wide
+  `cli/deny.toml` licence exception as a policy change, plus a requirement that
+  the exception carry an inline comment citing this story so a future dependency
+  audit can find the justification.
+- The coupling *between* the two external dependencies is captured as an
+  explicit requirement — pin `gix` to the version `jj-lib` depends on so one
+  graph resolves — and is backed by a direct acceptance criterion asserting
+  exactly one `gix` version in `cli/Cargo.lock`, with the reason the repo's own
+  duplicate-version policy cannot be relied on (warn-level).
+- The Summary and Requirements state explicitly that `CommandProbe` is retained
+  and no existing consumer changes, which protects the downstream
+  `corpus-adapters` consumer and makes the boundary with 0185 unambiguous rather
+  than implicit.
+- Feasibility is recorded as measured with a date (2026-07-29) against named
+  versions, so the dependency bet is evidence-backed rather than assumed, and
+  the one licence rejection is carried into the Requirements as concrete work.
+
+**Findings**:
+
+**🟡 major (medium confidence) — Dependencies (Blocks: 0169) / Acceptance
+Criteria — Downstream 0169 latency and binary-size budget depends on this story
+but is not captured**
+
+This story (0188, the library-backed `gix`/`jj-lib` VCS adapter) records its
+downstream edge to 0169 as only "builds the subdomain's classification on these
+adapters", but 0169 carries a hard numeric acceptance gate — warm-call latency
+`G ≤ 1.1 × B` — and a hand-off note from 0186 already warns the budget is at
+risk (~41 ms warm bootstrap against a ≈38.6 ms gate, before a sub-binary exec
+and verify). Whether 0169 can pass that gate is largely determined by this
+story's in-process discovery cost and by the sub-binary size the two new
+dependency trees produce (which also feeds the fetch/verify path), yet 0188 has
+no performance or size criterion and its Dependencies section does not name the
+constraint it must satisfy.
+
+*Impact*: 0188 can be accepted as "green" and then cause 0169 to fail acceptance
+on a criterion 0188 has no visibility of, forcing a reopen of the dependency
+work after it has been reviewed and merged as a self-contained change.
+
+*Suggestion*: Name 0169's latency gate and the sub-binary size implication in
+the Blocks entry, and add an acceptance criterion here that records the measured
+per-query cost of the library-backed adapter (and the resulting binary-size
+delta) in Validation Results, so 0169's budget can be checked before this story
+closes.
+
+**🟡 major (medium confidence) — Requirements (taxonomy queries / bound gix
+discovery) — `GIT_DIR`/common-dir override handling is required by 0169 but
+absent from the delivered query surface**
+
+0188 commits to "extend the adapters with the queries the `classify_checkout`
+taxonomy needs, so 0169 can build classification on them" and enumerates them:
+bare check, worktree detection, superproject/submodule resolution, jj workspace
+root, main-vs-secondary. 0169's own Requirements state the taxonomy needs "the
+submodule, bare and **`GIT_DIR`** handling that feeds them", and
+`GIT_DIR`/`GIT_COMMON_DIR` are environment overrides that sit inside this
+story's discovery-bounding requirement (gix honours discovery-affecting
+environment by default), not inside 0169's domain logic.
+
+*Impact*: 0169 starts on the assumption that the adapter answers correctly under
+a `GIT_DIR` override, discovers it does not, and either reopens 0188 or grows an
+unplanned adapter change inside the hooks-migration story — exactly the coupling
+the split was meant to eliminate.
+
+*Suggestion*: Add `GIT_DIR`/`GIT_COMMON_DIR` (and the ceiling-versus-environment
+precedence) to the enumerated query surface in Requirements and to the
+taxonomy-query acceptance criterion, or state explicitly in the Blocks entry
+that env-override handling is 0169's responsibility so the boundary is agreed in
+advance.
+
+**🟡 major (medium confidence) — Assumptions / Dependencies (External systems) —
+Toolchain preconditions — the real `jj`/`git` binaries and the rustc floor — are
+uncaptured upstream dependencies**
+
+Two environment dependencies this story rests on are never named in
+Dependencies. First, the Technical Notes state the `bash-parity` gate means
+"needs real `jj`/`git` binaries to build fixtures", so every acceptance
+criterion here is validated against repositories written by the *installed* `jj`
+CLI, whose on-disk format must be readable by the pinned `jj-lib 0.43` — a
+version-coherence coupling between a toolchain pin and a crate pin that is not
+stated. Second, adopting two large pre-1.0 dependency trees imposes an MSRV that
+the repo's pinned Rust toolchain must satisfy; the Assumptions record `cargo
+deny` and musl-static results but say nothing about the compiler floor.
+
+*Impact*: If the installed `jj` writes a repo format `jj-lib 0.43` will not
+load, or if either crate's MSRV exceeds the pinned toolchain, the story is
+blocked at first build or its fixtures fail in a way that looks like an adapter
+defect rather than a version-pin mismatch — and the fix (bumping a shared
+toolchain pin) is a repo-wide change with its own blast radius.
+
+*Suggestion*: Add an upstream-dependency bullet naming the installed `jj` CLI
+version and the pinned Rust toolchain as preconditions, stating the `jj` CLI ↔
+`jj-lib` version-coherence rule and recording the observed MSRV of `gix 0.85` /
+`jj-lib 0.43` against the pinned toolchain in Validation Results.
+
+**🔵 minor (medium confidence) — Requirements (dependency policy / pup.ron) /
+Dependencies — Shared repo-wide Rust artefacts are contended with in-flight
+sibling stories, with no ordering captured**
+
+This story edits three repo-wide artefacts — `cli/deny.toml` (licence
+exception), `cli/pup.ron` (a possible new rule) and `cli/Cargo.lock` (which must
+be committed in the same change because clippy runs `--locked`) — but
+Dependencies records no coupling to the sibling epic-0136 stories that touch the
+same workspace concurrently, notably 0168 (folds the visualiser into the `cli/`
+workspace, restructuring membership and the lock) and 0187 (generalises the
+sub-binary registration surface). The epic's decomposition implies 0168 precedes
+0188 by list order only; no explicit ordering constraint exists on either item.
+
+*Impact*: Two in-flight branches adding large dependency trees and restructuring
+the same workspace produce non-trivial `Cargo.lock` conflicts and a lock that
+must be regenerated rather than merged, and the "exactly one `gix` version"
+invariant can be silently broken by whichever branch lands second.
+
+*Suggestion*: Add a sequencing note in Dependencies stating this story's
+relationship to 0168/0187 on the shared `cli/` workspace files (or explicitly
+that no ordering is required and lock conflicts are regenerated), so whoever
+schedules the two knows the contention exists.
+
+**🔵 minor (high confidence) — Dependencies (Blocks: 0185) / Acceptance Criteria
+(zero-spawn assertion) — 0185 depends on the zero-spawn test harness this story
+builds, but the record still attributes it to 0169**
+
+0188's third acceptance criterion introduces the zero-spawn black-box harness
+(marker-writing `git`/`jj` stubs on `PATH` plus shadowed absolute paths, with
+`HOME`/`GIT_CONFIG_*`/`JJ_CONFIG` redirected). 0185's acceptance criteria
+require
+extending "the zero-spawn black-box assertion **introduced by 0169**" to a
+`corpus-adapters` metadata read — an attribution left stale by the split. 0188's
+own Blocks entry describes the 0185 coupling only as "converges
+`corpus-adapters` onto them and deletes `CommandProbe`" and does not mention
+that it also hands 0185 a reusable test harness.
+
+*Impact*: 0185 is planned against a harness it believes 0169 owns; if 0188
+builds the stub set as a private test helper rather than a reusable fixture,
+0185 rebuilds it, and the absolute-path shadow list can drift between the two
+suites.
+
+*Suggestion*: Extend the Blocks entry for 0185 to name the zero-spawn harness as
+a deliverable 0185 consumes, and state whether it is exposed as a shared test
+fixture; append a dated correction to 0185 repointing the harness attribution
+from 0169 to 0188.
+
+**🔵 minor (medium confidence) — Dependencies (Related: 0125) — The 0125
+hand-off is identified but has no owner or action after the split**
+
+Both the Context and the Dependencies section state that this story dissolves
+0125's stated rationale for the shell lexical fallback "without closing it".
+0169 carries an acceptance criterion requiring a dated hand-off note to be
+appended to 0125's Dependencies on exactly this ground ("the in-process adapter
+dissolves its lexical-fallback rationale") — but the in-process adapter is now
+0188's deliverable, not 0169's, and 0188 has no requirement or criterion for
+recording the hand-off.
+
+*Impact*: Neither item unambiguously owns the note, so the consequence for 0125
+can be observed by both stories and recorded by neither, leaving a downstream
+item whose stated justification is silently obsolete.
+
+*Suggestion*: Either add an acceptance criterion here requiring a dated note
+appended to 0125's Dependencies when the adapter lands, or state explicitly in
+the Related entry that 0169 retains that hand-off obligation.
+
+**🔵 suggestion (medium confidence) — Dependencies (External systems) — Ongoing
+advisory and version-drift surface of the new trees has no named owner**
+
+The External systems entry captures the one-off adoption risks (pre-1.0 API
+break, the `uluru` licence exception) but not the ongoing coupling the adoption
+creates: two large transitive trees enter `cargo deny`'s `advisories` scope, so
+a future RustSec advisory against any crate in the `gix`/`jj-lib` closure fails
+the repo-wide check for every unrelated change, and the "pin `gix` to `jj-lib`'s
+version" rule means any future `jj-lib` bump is a coordinated two-crate bump
+that the single-version criterion will otherwise fail.
+
+*Impact*: A dependency-driven CI break lands on whoever is next to push rather
+than on an owner who understands the pin rule, and the coupling between the two
+pins is discoverable only from this work item.
+
+*Suggestion*: Add a line to the External systems entry noting the expanded
+advisory surface and the coordinated-bump rule, and require the `gix` pin
+declaration to carry an inline comment stating it must track `jj-lib`'s `gix`
+version — the same treatment already given to the `deny.toml` exception.
+
+### Scope
+
+**Summary**: 0188 is a coherent, well-bounded unit of work: it adopts two
+dependency trees, implements the existing `vcs` ports over them, and carries the
+one repo-wide policy change (the `uluru` MPL exception) that adoption forces —
+all of which stand or fall together and share one risk profile (build-level, not
+user-visible). The declared `story` kind fits the scope, and the item states its
+non-goals explicitly (`CommandProbe` retained, no consumer converged, 0125 not
+closed), each backed by an acceptance criterion. The one scope weakness is the
+seam with its downstream consumer 0169: the taxonomy-query surface is the only
+part of 0188 with no in-story consumer, and its boundary is described by intent
+("the queries the `classify_checkout` taxonomy needs") rather than as an
+enumerated contract, while 0169 separately requires extending the same crates
+with the taxonomy.
+
+**Strengths**:
+
+- The Summary, Requirements and Acceptance Criteria describe the same scope —
+  every requirement (port implementation, taxonomy queries, bounded discovery,
+  gix pin + uluru exception, optional pup rule) has a corresponding acceptance
+  criterion, with no AC introducing work the Requirements do not state.
+- The split rationale is recorded explicitly and is a genuine orthogonality
+  argument rather than an arbitrary size cut: dependency adoption fails at build
+  level, hook-envelope changes fail user-visibly, and the two cannot be accepted
+  or rolled back independently if bundled.
+- Non-goals are stated positively and gated: `CommandProbe` is retained,
+  `cli/corpus-adapters` is untouched, and AC7 asserts 'this story adds an
+  adapter and changes no existing consumer' — so the delivery boundary against
+  0185 is unambiguous.
+- The repo-wide `cli/deny.toml` licence exception is kept inside this item
+  rather than orphaned into a separate policy change, which is correct — it has
+  no meaning without the dependency it unblocks.
+- The relationship to 0125 is scoped explicitly ('dissolves its stated rationale
+  for the shell lexical fallback without closing it'), preventing a downstream
+  item from being silently absorbed.
+- Feasibility is measured rather than assumed (deny checks, musl static ELF,
+  jj-lib loader probe against real fixtures), which materially reduces the risk
+  that the item's scope turns out to be the wrong shape mid-delivery.
+
+**Findings**:
+
+**🔵 minor (medium confidence) — Requirements (second bullet: taxonomy queries)**
+
+Work item 0188 ("Library-Backed VCS Adapter over gix and jj-lib") requires
+extending the adapters with "the queries the `classify_checkout` taxonomy
+needs, so 0169 can build classification on them", listing bare check, worktree
+detection, superproject/submodule resolution, jj workspace-root and
+main-vs-secondary. This is the only part of 0188 with no in-story consumer, and
+its boundary against downstream story 0169 is defined by intent rather than as
+an enumerated contract — meanwhile 0169's own Requirements say "Extend the
+crates with the `classify_checkout` taxonomy … with the submodule, bare and
+**GIT_DIR handling** that feeds them", naming a query (GIT_DIR) that 0188's list
+omits.
+
+*Impact*: Two sequential stories both claim to extend the same crate pair with
+an overlapping query surface, so a query such as GIT_DIR handling can fall
+between them, or be implemented twice with divergent semantics — a seam gap that
+only surfaces mid-0169.
+
+*Suggestion*: Replace the intent-based phrasing with an enumerated query list
+that is the delivery contract for 0188 (adding GIT_DIR handling if it belongs on
+the adapter side), and reword 0169's corresponding requirement to compose the
+taxonomy from that fixed list rather than to "extend the crates".
+
+**🔵 suggestion (high confidence) — Requirements (final bullet: cli/pup.ron
+rule)**
+
+The final requirement of work item 0188 reads "Add a `cli/pup.ron` rule for the
+new adapter module **if its import surface warrants one**", leaving whether this
+work is in or out of scope to an implementation-time judgement call.
+
+*Impact*: A conditional requirement means the item's boundary cannot be stated
+before work starts, and the corresponding acceptance criterion ('any new rule is
+demonstrably non-vacuous') passes vacuously if the implementer decides no rule
+is warranted.
+
+*Suggestion*: Either decide now (state that a rule is added, with its intended
+import constraint) or move it out of Requirements into Technical Notes as a
+discretionary implementation consideration, so the Requirements list contains
+only committed scope.
+
+**🔵 suggestion (medium confidence) — Dependencies (Related: 0125)**
+
+Work item 0188 states that going in-process "dissolves 0125's stated rationale
+for the shell lexical fallback" but assigns no action for it, while sibling
+story 0169 carries the acceptance criterion that appends the dated hand-off note
+to 0125. Since 0188 lands first and is the change that actually dissolves the
+rationale, the causing item and the item that records the consequence are
+different.
+
+*Impact*: Between 0188 landing and 0169 completing, 0125 carries a rationale the
+codebase no longer supports, with no work item accountable for saying so — and
+if 0169 is deferred or re-scoped, the hand-off is lost entirely.
+
+*Suggestion*: Move the 0125 hand-off note into 0188's acceptance criteria (it is
+a one-line note append), or state explicitly in 0188's Dependencies that the
+note is deliberately deferred to 0169 and why.
+
+### Testability
+
+**Summary**: 0188 is one of the more verifiable work items of its type: the
+zero-spawn criterion (AC3), the single-`gix`-version assertion (AC5) and the
+non-vacuity demand on any new cargo-pup rule (AC6) each name a concrete
+procedure and explicitly close an evasion route, and the Assumptions record
+measured rather than presumed feasibility. The weaknesses are concentrated in
+the two criteria that carry the story's substance: AC1 leans on "passes the
+existing `detection.rs` suite" without stating how that suite comes to exercise
+the *new* adapter (the referenced research records the existing wiring as
+hard-coded to `CommandProbe`), and AC2 asks for taxonomy queries to be
+"available and unit-tested" with no expected values, no named fixtures and no
+stated surface — so any test at all would satisfy it. Secondary gaps: the bolded
+`Workspace::load` requirement has no criterion, AC4's boundary test can pass
+vacuously if the fixture sets `GIT_CEILING_DIRECTORIES` as Technical Notes
+suggests, and the Summary's in-process performance rationale is nowhere measured
+despite 0169 inheriting a tight latency gate.
+
+**Strengths**:
+
+- AC3 is an exemplary anti-evasion criterion: it names the mechanism (stub
+  binaries that write a marker and exit non-zero), neutralises the config
+  environment (`HOME`, `GIT_CONFIG_*`, `JJ_CONFIG` at empty temp dirs), and
+  explicitly closes the absolute-path escape (`/usr/bin/git`,
+  `/usr/local/bin/git`, `/opt/homebrew/bin/git` and jj equivalents) that a
+  PATH-only assertion would miss.
+- AC5 states not just the assertion (exactly one `gix` version in
+  `cli/Cargo.lock`) but why a direct assertion is required — the repo's
+  duplicate-version policy is warn-level, so a drifted pin would pass silently.
+  That reasoning makes the criterion resistant to being 'satisfied' by an
+  existing check that cannot fail.
+- AC6 demands the new cargo-pup rule be demonstrably non-vacuous (a deliberately
+  forbidden import must fail it) — a mutation-style check that most work items
+  omit, and which prevents a rule that matches nothing from being counted as
+  passing.
+- AC7 pins the story's 'adds an adapter, removes none' invariant as an
+  observable (`CommandProbe` still exists, `corpus-adapters` still resolves
+  through it), turning an easily-drifted scope boundary into something a
+  verifier can check.
+- Assumptions distinguish measured facts (dated 2026-07-29 `cargo deny` results,
+  the musl `_assert_static_elf` outcome, the single `uluru` rejection) from the
+  standing risk (`jj-lib`'s self-declared unstable API), so a verifier knows
+  exactly which claims were empirically established and which were not.
+- The Validation Results section pre-declares the two facts the criteria require
+  to be recorded (shadowed/unshadowable absolute paths, resolved `gix` version),
+  so those outputs cannot be quietly omitted at acceptance.
+
+**Findings**:
+
+**🟡 major (medium confidence) — Acceptance Criteria (first bullet) — "Passes
+the existing detection.rs suite" does not specify how the new adapter is
+exercised**
+
+Work item 0188 (library-backed VCS adapter over `gix`/`jj-lib`) states as its
+first acceptance criterion that the library-backed adapter "implements
+`RepoRoot` and `VcsProbe` and passes the existing
+`cli/vcs-adapters/tests/detection.rs` suite", but does not say how that suite
+comes to run against the new adapter. The referenced research
+(`meta/research/codebase/2026-07-29-0169-...` §1) records that
+`vcs_adapters::facts(start)` hard-wires `MarkerWalkRoot` + `CommandProbe::new()`
+"with no injection variant", so running the suite unchanged would verify the
+retained subprocess adapter, not the new one.
+
+*Impact*: The criterion can be truthfully reported as passing while none of the
+new `gix`/`jj-lib` code is exercised by any of the eight enumerated cases — the
+story's primary correctness evidence would be vacuous.
+
+*Suggestion*: Restate as a parameterised requirement — e.g. "each of the eight
+enumerated cases in `detection.rs` runs against *both* `CommandProbe` and the
+library-backed adapter and produces identical `RepoFacts`, with the adapter
+supplied by an injection seam" — so the pass depends on the new implementation
+and doubles as a differential parity check.
+
+**🟡 major (high confidence) — Acceptance Criteria (second bullet) —
+Taxonomy-query criterion states no expected values, fixtures or exposed
+surface**
+
+In work item 0188, the criterion "The taxonomy queries 0169 needs are available
+and unit-tested against real fixtures: bare check, worktree detection,
+submodule/superproject resolution, jj workspace root, jj main-vs-secondary"
+names five queries but gives no expected output for any of them, does not define
+the fixture set, and does not state on what surface the queries must be
+"available" (domain port methods versus inherent adapter methods).
+
+*Impact*: Any test that calls each query and asserts anything at all satisfies
+the criterion, so it provides no verification that the queries answer
+*correctly* — which is the entire basis on which 0169 will build
+`classify_checkout`.
+
+*Suggestion*: Give each query an oracle and a fixture. The Technical Notes
+already map every query to a shell reference (`vcs-common.sh:207` bare,
+`:217-219` worktree, `:140-146` superproject, `:74-81` jj secondary) — make
+those
+the expected values, e.g. "for each of the five queries, against the colocated /
+secondary-workspace / worktree / submodule / bare fixtures, the adapter's answer
+equals the named `vcs-common.sh` function's answer", and state whether the
+queries are added to the `vcs` ports or exposed only on the adapter.
+
+**🟡 major (medium confidence) — Acceptance Criteria (third bullet — zero spawns)
+— Unbounded escape hatch in the zero-spawn criterion**
+
+Work item 0188's zero-spawn criterion closes the absolute-path evasion by
+requiring `/usr/bin/git`, `/usr/local/bin/git`, `/opt/homebrew/bin/git` and the
+`jj` equivalents to be stubbed, but then adds "Any path that cannot be shadowed
+in the test environment is recorded in Validation Results, not silently skipped"
+with no floor on how many may go unshadowed.
+
+*Impact*: In the limit every absolute path could be unshadowable (a read-only
+`/usr/bin` is the normal case on macOS with SIP), leaving only the PATH-based
+stub in force and reducing the story's central safety claim to the weak
+assertion it was written to strengthen — while the criterion still reports as
+passed.
+
+*Suggestion*: Add a floor that cannot be waived — e.g. "the PATH stub is always
+in force, and at least one non-PATH mechanism proves absence of spawns: either
+every listed absolute path is shadowed, or a process-level seam (spawn counter /
+`PanicExec`-style null, per the research's
+`cli/launcher/tests/crypto_provider.rs` template) asserts zero invocations" — so
+recording an unshadowable path degrades the evidence but never removes it.
+
+**🔵 minor (medium confidence) — Acceptance Criteria (third bullet — zero spawns)
+— Zero-spawn test asserts success, not correct answers**
+
+Work item 0188's zero-spawn criterion ends "Assert no marker is written and
+every query still succeeds" — success, not correctness. An adapter that silently
+degrades under the stubbed environment (returning `None`/empty facts rather than
+the real answer) writes no marker and "succeeds".
+
+*Impact*: The one test run in the hostile environment — no usable `git`/`jj`,
+empty `HOME`/`GIT_CONFIG_*`/`JJ_CONFIG` — is exactly the run most likely to
+expose a hidden dependency on external state, yet it is the run with the weakest
+oracle.
+
+*Suggestion*: Require value equality, not just success: "every query returns the
+same value under the stubbed environment as it does in the unrestricted
+`detection.rs` run" — reusing the expected values from the first two criteria
+rather than introducing a separate, weaker assertion.
+
+**🟡 major (medium confidence) — Acceptance Criteria (fourth bullet) / Technical
+Notes — Boundary-containment criterion can pass on fixture hygiene rather than
+adapter behaviour**
+
+Work item 0188 requires "`gix::discover` cannot escape a workspace boundary — a
+fixture placing a jj secondary workspace inside a git repository resolves to the
+workspace, not the parent's `.git`", while its Technical Notes separately
+recommend setting `GIT_CEILING_DIRECTORIES` in fixtures "so a stray `.git` above
+the temp dir cannot leak into a probe". If the boundary fixture inherits that
+ceiling, discovery is stopped by the environment, not by the adapter's own
+bounding.
+
+*Impact*: The criterion that verifies the story's first bolded requirement
+("Bound `gix`'s discovery explicitly") could pass against an adapter that does
+no bounding at all, and the defect would surface only in real repositories where
+no ceiling is set.
+
+*Suggestion*: State the environment explicitly in the criterion — e.g. "with
+`GIT_CEILING_DIRECTORIES` unset (or set above the parent repository), discovery
+from inside the nested jj workspace resolves to the workspace root, not the
+parent's `.git`" — and, if useful, add the paired negative case showing that an
+unbounded `gix::discover` call on the same fixture does escape.
+
+**🟡 major (medium confidence) — Requirements (fourth bullet) / Acceptance
+Criteria — The "avoid Workspace::load" requirement has no acceptance criterion**
+
+Work item 0188 states as a bolded requirement "Avoid
+`jj_lib::workspace::Workspace::load` on detection paths" — because it needs a
+fully-populated `UserSettings` whose defaults are private and are "discovered
+one panic at a time" — but no acceptance criterion verifies it. Its sibling
+bolded requirement (bound `gix` discovery) does get a criterion, so the omission
+looks unintentional. The zero-spawn criterion's empty `JJ_CONFIG`/`HOME`
+environment is partial coverage at best, and only if that run happens to
+traverse the code path in question.
+
+*Impact*: A regression to `Workspace::load` — the trap the research spent a
+probe identifying — would be caught only by a runtime panic on some user's
+machine with unusual jj config, not by anything in this story's acceptance set.
+
+*Suggestion*: Add a criterion with a definite procedure, e.g. "no
+`cli/vcs-adapters` source path references `jj_lib::workspace::Workspace::load`
+(asserted by a source-level guard), and every jj query succeeds with `HOME`,
+`JJ_CONFIG` and `XDG_CONFIG_HOME` pointed at empty temp dirs" — the second half
+being cheap to state as a reuse of the zero-spawn environment.
+
+**🟡 major (medium confidence) — Summary / Context / Acceptance Criteria — The
+in-process performance rationale is never measured**
+
+Work item 0188's Summary and Context justify the change partly on cost — reading
+git and jj "in-process instead of spawning `jj`/`git` subprocesses", and
+dissolving 0125's rationale that "probing costs 1-3 subprocesses per call" — but
+no acceptance criterion measures the library-backed adapter's per-query cost,
+and the Validation Results section records only shadowed paths and the `gix`
+version. The consuming story 0169 carries a hard gate (`G ≤ 1.1 × B`, ≈ 38.6 ms)
+that its own Dependencies section already flags as at risk from a ~41 ms warm
+bootstrap.
+
+*Impact*: If loading `gix`/`jj-lib` state costs more than the subprocess spawns
+it replaces, that is discovered in 0169 at its latency gate — after the
+dependency trees, the licence exception and the API bet have all landed and are
+expensive to reverse, which is the opposite of the "reviewed and rolled back on
+its own terms" property the split was made for.
+
+*Suggestion*: Add a measurement criterion with a recorded output rather than a
+threshold, e.g. "median of 20 invocations of each library-backed query against a
+fixture repo on one host, alongside the same query via `CommandProbe`, recorded
+in Validation Results with host and OS" — enough for 0169 to budget against,
+without importing 0169's gate into this story.
+
+**🔵 minor (high confidence) — Requirements (final bullet) — "Add a pup rule if
+its import surface warrants one" has no decision criterion**
+
+Work item 0188's final requirement — "Add a `cli/pup.ron` rule for the new
+adapter module if its import surface warrants one" — leaves "warrants"
+undefined, and the matching acceptance clause is conditional ("any new rule is
+demonstrably non-vacuous"). If no rule is added, both requirement and clause are
+satisfied trivially.
+
+*Impact*: A verifier cannot determine whether the requirement was met or quietly
+skipped, so the architectural-boundary question the requirement raises is
+resolved by implementer discretion with no record.
+
+*Suggestion*: Either state the rule concretely (e.g. "a rule scoped to
+`vcs_adapters` permitting `gix`, `jj_lib`, `std`, `kernel::Error` and `crate::`,
+mirroring `vcs_domain_imports_only_permitted`'s shape"), or make the decision
+itself the deliverable: "the decision on whether a `vcs_adapters` pup rule is
+needed is recorded in Validation Results with its rationale".
+
+**🔵 minor (medium confidence) — Assumptions / Acceptance Criteria (fifth
+bullet) — No criterion pins the jj-lib version the feasibility evidence rests
+on**
+
+Work item 0188 asserts "exactly **one** `gix` version resolves in
+`cli/Cargo.lock`" as a directly-asserted criterion, but nothing equivalent
+covers `jj-lib`, whose Assumptions entry reads "`jj-lib`'s loader API remains
+stable across the pinned version. Verified against 0.43; unstable by the crate's
+own declaration." No criterion states what "the pinned version" is or that the
+lock resolves to it.
+
+*Impact*: The story's entire loader-internals design
+(`DefaultWorkspaceLoaderFactory`, `WorkspaceLoader::{workspace_root,
+repo_path}`) was validated against 0.43 specifically; a caret range resolving
+forward at any later `cargo update` silently invalidates that evidence with no
+failing check.
+
+*Suggestion*: Extend the lock-file criterion — "`cli/Cargo.lock` resolves
+exactly one `gix` version and `jj-lib` at the version the feasibility probe
+validated (0.43), both recorded in Validation Results" — and state whether the
+manifest requirement is exact (`=0.43`) or ranged.
+
+## Re-Review (Pass 2) — 2026-08-01
+
+**Verdict:** REVISE
+
+All five lenses re-run against the revised work item. **Every one of the ten
+pass-1 majors is resolved or substantially resolved at the structural level** —
+the query surface is enumerated and homed, the vacuous-pass routes are closed,
+the missing criteria exist, the pins are symmetric, and the hand-offs are
+assigned. The verdict stays REVISE because the revision introduced a new layer
+of *specification-detail* defects, several of them squarely attributable to the
+pass-1 fixes themselves. This is a materially better work item that is not yet
+done.
+
+The re-review had one advantage pass 1 lacked: adding `scripts/vcs-common.sh`
+to References (a pass-1 recommendation) meant the lenses could read the shell
+oracle. Two of the strongest new findings come directly from that.
+
+### Previously Identified Issues
+
+- 🟡 **Clarity**: "domain crate untouched" vs taxonomy queries — **Resolved**.
+  Queries are inherent methods; `CommandProbe`/`MarkerWalkRoot` explicitly gain
+  none. Residual: no criterion asserts `cli/vcs/src/**` is unmodified, so an
+  *added* trait would still pass (new minor).
+- 🟡 **Testability**: AC2 states no expected values/fixtures/surface —
+  **Partially resolved**. Oracle, fixture matrix and surface are now stated, but
+  two of the four cited shell references are not callable functions (new major).
+- 🟡 **Dependency/Scope**: `GIT_DIR` absent from the surface — **Resolved as
+  scope, incomplete as specification**. Query 6 exists, but whether the override
+  is honoured or scrubbed is left to the implementation (new major).
+- 🟡 **Testability**: AC1 doesn't exercise the new adapter — **Resolved**.
+  Injection seam plus identical-`RepoFacts` differential check. Residual: four
+  of the eight cases are oracled only differentially (new minor).
+- 🟡 **Clarity/Testability**: bounded discovery undefined and unverifiable —
+  **Resolved, with two new defects in the fix**. The rule is now normative and
+  AC4 has its paired negative assertion, but the rule says "first ancestor of
+  the start path", which literally excludes the start path itself, and queries
+  2-3 must legitimately resolve outside the boundary (both new).
+- 🟡 **Completeness/Testability**: `Workspace::load` has no AC — **Resolved**.
+  Residual: "detection path" is undefined and the crate-wide guard is broader
+  than the path-scoped rule (new major).
+- 🟡 **Dependency/Testability**: in-process cost never measured — **Resolved as
+  an obligation, unsatisfiable as written**. The criterion exists, but the
+  sub-binary it sizes does not exist in this story (new major, four lenses).
+- 🟡 **Testability**: zero-spawn escape hatch — **Partially resolved**. The
+  floor is added, but neither alternative reliably observes the target violation
+  class (new major).
+- 🟡 **Dependency**: toolchain preconditions uncaptured — **Resolved for jj,
+  partially for the rest**. MSRV is named but has no owner or fallback, and the
+  symmetric `git` CLI ↔ `gix` coupling is missing (new).
+- 🟡 **Dependency/Scope**: 0125 hand-off unowned — **Resolved**. Now an AC here.
+  Residual: the note's claim is contingent on shell-caller migration that has
+  not happened, and 0169's duplicate criterion drop has no owner (new minor).
+
+### New Issues Introduced
+
+Ordered by how many lenses independently flagged them.
+
+- 🟡 **Clarity + Completeness + Scope + Testability**: **"The sub-binary size
+  delta" has no artefact.** The story delivers "public constructors and nothing
+  more" and adds no selection mechanism, so nothing links the new trees. The
+  same root defeats the musl `_assert_static_elf` criterion — with no caller,
+  dead-code elimination may mean neither check exercises `gix`/`jj-lib` at all.
+  Both criteria can pass while proving nothing. *Introduced by the pass-1
+  measurement fix.*
+- 🟡 **Completeness + Dependency + Scope + Testability**: **The 0185
+  obligations are prose-only.** Exposing the zero-spawn harness as a shared
+  fixture, and the dated correction repointing 0185's attribution, are both
+  declared "part of closing this story" in Dependencies with no Requirement and
+  no criterion — the precise failure mode pass 1 flagged for the `deny.toml`
+  comment. Dependency also notes the correction is understated: 0185 attributes
+  the adapter to 0169 in its Summary, Context, Assumptions and Technical Notes,
+  not only its criteria. *Introduced by the pass-1 hand-off fix.*
+- 🟡 **Testability**: **Two of the four cited shell oracles are not callable.**
+  `vcs-common.sh:207` and `:217-219` are inline expressions inside
+  `classify_checkout` setting locals (`is_bare`, `git_worktree`,
+  `git_common_dir`) that never appear in the `KEY=VALUE` record it emits; and no
+  shell function returns the common git directory —
+  `find_git_main_worktree_root` returns its parent via `dirname` (`:154`). For
+  queries 1 and 2 the stated oracle cannot be executed. *Introduced by the
+  pass-1 oracle fix, which promoted a Technical Notes mapping to a normative
+  oracle without checking the targets were functions.*
+- 🟡 **Clarity + Testability**: **`GIT_DIR` semantics unspecified, and the shell
+  oracle contradicts itself on this exact point.** `find_git_main_worktree_root`
+  deliberately scrubs a caller-set `GIT_DIR` and re-enters (`:130-135`), so
+  query 3 ignores the override, while the inline bare/worktree checks inherit it
+  through `git rev-parse` and honour it. The criterion requires testing the
+  override-vs-ceiling disagreement with no stated expected value. "The discovery
+  ceiling" also has two candidate referents (the marker-derived ceiling vs
+  `GIT_CEILING_DIRECTORIES`).
+- 🟡 **Clarity**: **The pup rule permits `std` and denies `std::process`.**
+  `std::process` is not "everything else" — it is inside the permitted `std`, so
+  under a prefix-matching allow-list the two clauses cannot both hold. This rule
+  is the stated reason zero-spawn is "structural rather than only
+  test-asserted". *Introduced by the pass-1 pup fix.*
+- 🟡 **Clarity**: **"Detection path" is undefined and the guard is wider than
+  the rule.** It is unstated whether the `VcsProbe::revision` read is a
+  detection path, while the verifying guard is crate-wide over
+  `cli/vcs-adapters` and cannot distinguish one path from another.
+- 🟡 **Testability**: **Neither zero-spawn floor alternative observes the target
+  violation.** A process-level seam inside the crate cannot intercept a spawn
+  originating inside `gix` or `jj-lib` (and the library-backed module has no
+  exec port by design); shadowing `/usr/bin/git` is impossible on SIP-protected
+  macOS, the primary dev platform. The floor can be satisfied by a mechanism
+  that cannot fail.
+- 🟡 **Dependency**: **The six-query contract may under-serve 0169.** 0169's arm
+  list includes `nested-jj-in-git` and `nested-git-in-jj`, which need to know
+  whether a marker exists *above* the boundary — a capability the bounding rule
+  explicitly forbids and no query provides. 0169 also owns `vcs status`/`vcs
+  log` while stating it "adds no dependencies", so those in-process reads must
+  come from these trees but are in neither the six queries nor the ports. The
+  change-control clause converts either gap into a reopening of a closed story.
+- 🟡 **Completeness + Dependency**: **MSRV is an unresolved precondition with no
+  owner, no fallback and no Open Questions section.** If `jj-lib` 0.43's MSRV
+  exceeds the pinned toolchain, the exact `=0.43` pin that the whole dependency
+  policy rests on is not viable, and the item states no position on what
+  happens. `mise.toml`'s Rust pin is also absent from the shared-artefact list.
+- 🟡 **Testability**: **The cost measurement is not comparable to 0169's gate.**
+  No fixture named, no statement of whether an "invocation" is an in-process
+  call or a process launch, warm or cold. An in-process microbenchmark yields
+  microsecond numbers against 0169's millisecond process-level baseline.
+
+Minor and suggestion-level items also surfaced: three internal contradictions
+of the form "X and nothing more" beside a bullet requiring more ("public
+constructors and nothing more" vs the six methods; "0125 is not otherwise
+modified" vs appending a note; the `std`/`std::process` pair above); the
+bounding rule's "first ancestor" excluding the start path; no stated comparison
+rule between shell strings and typed values (canonicalisation, exit-1-as-`None`
+— a real macOS `/var` vs `/private/var` trap); the reciprocal nested-git-in-jj
+boundary fixture untested; the zero-spawn fixture set not tied to the two
+preceding matrices; the shell oracle declared authoritative with no disposition
+for where it is known to be wrong; "probe" carrying three senses; and 0187
+likely miscited in the shared-artefact contention list (its Requirements are
+entirely `tasks/`-side and name none of the three `cli/` artefacts).
+
+### Assessment
+
+The work item is **not yet ready for implementation**, but the remaining
+distance is much shorter than pass 1's. The structural questions — what is
+delivered, where it lives, what "done" means, who owns each hand-off — are all
+answered now. What remains is a specification-detail pass concentrated in four
+places:
+
+1. **Name the reference artefact** for the musl and size criteria (a test-only
+   binary calling the six queries, mirroring the 2026-07-29 probe), and pin the
+   cost measurement's fixture, unit and warm/cold state to what 0169 measures.
+   Closes two majors and makes the hand-off numbers usable.
+2. **Fix the oracle** — substitute callable commands (`git rev-parse
+   --is-bare-repository`, `--git-dir` vs `--git-common-dir`) for the two
+   non-function references, state the comparison rule (canonicalised paths,
+   exit-1 = `None`), and decide `GIT_DIR` precedence normatively rather than
+   deferring it to adapter documentation.
+3. **Promote the 0185 obligations to criteria**, matching the treatment 0125
+   already gets, and widen the correction to 0185's Summary/Context/Assumptions.
+4. **Repair the internal contradictions** — the pup allow/deny overlap, "first
+   ancestor", the two "and nothing more" clauses — and define "detection path".
+
+Two items need a decision rather than an edit: the `GIT_DIR` honour-vs-scrub
+semantics, and whether the six-query contract is reconciled against 0169's
+nested arms and its `status`/`log` surface before pickup. The second is the more
+consequential — it is the one finding that could change what this story
+delivers rather than how it is described.
+
+## Re-Review (Pass 3) — 2026-08-02
+
+**Verdict:** REVISE
+
+Most pass-2 findings are resolved. But this pass changes the recommendation
+rather than extending it: **the iteration method itself is now the main source
+of new defects, and the document has acquired the growth signature that forced
+its parent 0169 to be split.** Three passes of closing findings by adding text
+have taken it from 181 to 516 lines, and its Requirements section now describes
+roughly half of what its thirteen acceptance criteria deliver.
+
+### Previously Identified Issues
+
+- 🟡 **Sub-binary size delta had no artefact** — **Resolved**; a reference
+  artefact is named. Residual: nothing asserts it actually *links*
+  `gix`/`jj-lib`, so LTO can still eliminate the calls and both the musl and
+  size criteria pass vacuously — the same vacuity, moved one level down.
+- 🟡 **0185 obligations prose-only** — **Resolved**; both are criteria now.
+  Two new consequences: repointing 0185's attribution leaves it holding
+  composition-root work it believes someone else does, and nothing in this
+  story compiles the "shared fixture" across a crate boundary.
+- 🟡 **Two shell oracles not callable** — **Half resolved, half regressed.**
+  Queries 1-2 are correctly repointed to `git rev-parse
+  --is-bare-repository` / `--git-dir` vs `--git-common-dir`. But the fix
+  introduced **two new non-executable oracles** (below).
+- 🟡 **`GIT_DIR` semantics** — **Resolved.** Scrub-everywhere, with the shell's
+  internal asymmetry recorded as a deliberate non-reproduction.
+- 🟡 **pup allow/deny overlap** — **Resolved** via the two-clause form.
+- 🟡 **"Detection path" undefined** — **Resolved** by enumeration. Residual: the
+  paragraph concludes "the verifying guard is *correspondingly* crate-wide"
+  immediately before a requirement insisting the *other* guard is module-scoped
+  — adjacent opposite scopings joined by a connective implying they agree.
+- 🟡 **Zero-spawn floor** — **Partially resolved.** Platform-scoped now, but
+  "on at least one platform where it is achievable" is self-judged: if the
+  Linux runner's `/usr/bin` is read-only, every platform legitimately degrades
+  and the strong form runs nowhere while the criterion still reads as met.
+- 🟡 **Six-query contract under-serving 0169** — **Resolved.** Query 6 added,
+  `status`/`log` recorded as 0169-authored.
+- 🟡 **MSRV ownerless** — **Resolved** via Open Questions with escalation
+  defaults. New: Open Questions and Dependencies now give *opposite* answers on
+  whether `mise.toml` may be edited in this story.
+- 🟡 **Cost measurement not comparable** — **Partially resolved.** Shape pinned
+  (median of 20, three figures), but the fixture anchor is circular (below).
+
+### New Issues Introduced
+
+**Two more non-executable oracles — verified directly against
+`scripts/vcs-common.sh`, not inferred:**
+
+- 🟡 **`BOUNDARY` is the wrong oracle for queries 4 and 6.** The record contract
+  documents it as "realpath of the active workspace; **empty for main and
+  none**" (`:165`), and the `nested-git-in-jj` arm sets it to
+  `$git_worktree_root` — the *git* root (`:259`). Both the `colocated` and
+  `nested-jj-in-git` arms gate on `jj_secondary=1` (`:242`, `:248`), so a main
+  workspace falls through to `KIND=main` with `BOUNDARY=""` even where query 4
+  has a real answer. On at least three of the eight required fixtures the
+  stated oracle returns empty or the wrong root — precisely the fixtures query
+  6 exists to distinguish. The correct oracle is `jj workspace root`, which
+  `classify_checkout` itself probes with at `:184`.
+- 🟡 **`find_git_main_worktree_root` cannot express query 3's "not a
+  submodule".** It returns the superproject only when
+  `--show-superproject-working-tree` is non-empty (`:142-146`); otherwise it
+  falls through to `dirname(--git-common-dir)` and exits 0 with an ordinary
+  root. So on seven of eight fixtures it returns a value the adapter must *not*
+  return, and the empty-equals-`None` clause does not rescue it. The correct
+  oracle is `git rev-parse --show-superproject-working-tree` directly.
+- 🔵 **A citation points at the wrong function.** "queries 4-5 →
+  `classify_checkout`'s `BOUNDARY` and `JJ_PARENT` record fields (`:74-81`)" —
+  `:74-81` is `_jj_workspace_is_secondary`. The record contract is `:164-171`,
+  emission `:274-279`.
+
+**Structural contradictions from layering:**
+
+- 🟡 **"The query set" is defined twice with different extents** — Requirements
+  says "exactly" the seven numbered items; the AC preamble says the seven
+  "**plus** the port methods". Three criteria iterate this set.
+- 🟡 **Item 7 is not a query.** "`GIT_DIR`/`GIT_COMMON_DIR` are scrubbed" is an
+  invariant over items 1-6, yet the set must be delivered as "inherent
+  methods", the reference artefact must "call every query in the set", and cost
+  figures are required "for the seven queries".
+- 🟡 **Open Questions vs Dependencies on `mise.toml`** — escalate the toolchain
+  bump out of scope, or edit it here; the document says both.
+- 🟡 **One adapter or a pair, still stated both ways** — "one implementation of
+  each port" and "adapter **types**" against "**The** library-backed adapter
+  implements `RepoRoot` and `VcsProbe`" and "both adapter **pairs**". With two
+  types it is unstated which carries queries 1-3, which 4-5, and where the
+  dual-root query 6 lives.
+- 🔵 The cost criterion's figure matrix does not match the Validation Results
+  slots, and figure (a) "library initialisation cost" is meaningless for the
+  subprocess pair it is required for.
+
+**Circular and unscoped dependencies:**
+
+- 🟡 **The cost fixture anchor is circular** (4 lenses). "The same pure-jj
+  fixture 0169 measures against" — 0169 names no fixture; it lists the fixture
+  as something to *record* at acceptance, and 0188 lands first. Neither
+  document contains enough to build it twice identically, so the comparability
+  that is "the point" is not guaranteed.
+- 🟡 **The strong-form zero-spawn run depends on unscoped CI infrastructure**
+  (3 lenses). A Linux container with a writable `/usr/bin` and bind-mount
+  privileges is an infrastructure precondition with no named job, no owner and
+  no fallback — and nothing else in this story touches CI.
+- 🟡 **Obligations handed forward to 0169 live only here.** 0169 must widen the
+  pup rule, define its own port over inherent methods, and honour a closed
+  seven-query contract — but the correction criterion appends only the 0125
+  strike-out, so 0169's implementer will not learn any of it from 0169.
+- 🟡 **`tasks/` is an uncaptured shared artefact.** `_assert_static_elf` and
+  cross-compile staging live in `tasks/build.py`, which 0187 also rewrites — so
+  the parenthetical de-listing 0187 tests only the three `cli/` files and
+  misses the plausible overlap.
+- 🟡 **"No selection mechanism" has no verifying criterion** — a new
+  `[features]` entry or composition helper inside `cli/vcs-adapters` would
+  satisfy every existing criterion.
+- 🔵 **"No TLS stack enters the graph"** is claimed in prose and never checked;
+  it could ride the existing lockfile guard.
+
+**Scope:**
+
+- 🟡 **Seven of thirteen criteria deliver work Requirements never states** — the
+  injection seam, the zero-spawn harness, the lockfile check, the reference
+  binary, the shared fixture, the cost measurement, the sibling hand-offs.
+  Zero-spawn, the story's central safety claim, appears in Requirements only as
+  a subordinate clause explaining why the pup rule has two parts.
+- 🔵 **The growth is absorbed deliverables, not clarification** — five of them,
+  only one of which is the adapter the story is named for. This is the pattern
+  that split 0169 after four passes.
+
+### Assessment
+
+**Stop patching; consolidate.** Two things make another incremental pass the
+wrong move.
+
+First, **I have now written non-executable oracle mappings twice**, in the same
+section, by reasoning from line numbers instead of running the commands. Pass 2
+fixed two; pass 3 found two more that pass 2 introduced. The oracle table cannot
+be written correctly from inference — it needs to be built by executing each
+candidate command against each fixture and recording what comes back. That is a
+different activity from editing prose, and it should happen before the criterion
+is written again.
+
+Second, the document has outgrown its Requirements section. Sizing or planning
+from Requirements now under-reads the story by half its acceptance surface, and
+the fix is restructuring — moving delivered artefacts into Requirements,
+collapsing the duplicate definitions, resolving the three contradictions — not
+adding more text.
+
+Recommended next step is a **consolidation pass that adds no new obligations**:
+
+1. Build the oracle table empirically against real fixtures; write the criterion
+   from the results.
+2. Promote the seven undeclared deliverables into Requirements so Summary,
+   Requirements and Criteria describe one unit.
+3. Resolve the three contradictions (`mise.toml`, query-set extent, one adapter
+   vs a pair) by deleting one side of each.
+4. Break the circular fixture anchor by defining the pure-jj fixture here.
+5. Decide the two genuinely open scope questions rather than absorbing them:
+   whether the shared fixture and the CI container belong in this story at all.
+
+If the item is still this large after consolidation, the scope lens's split
+suggestion deserves a hearing — dependency adoption plus ports (the
+risk-isolation core, which is what the split was *for*) separated from the
+taxonomy query surface and its oracle apparatus.
+
+## Re-Review (Pass 4) — 2026-08-02
+
+**Verdict:** REVISE
+
+The consolidation worked. Two things pass 3 could not resolve are now settled,
+and the character of what remains has changed: pass 3's findings were structural
+and methodological, pass 4's are mostly small, concrete and mechanical — plus a
+cluster of stale text the consolidation itself left behind.
+
+### Previously Identified Issues
+
+- 🟡 **Should it be split?** — **Resolved: no.** The scope lens is unambiguous
+  this pass: "a coherent, well-bounded single unit of work … it should **not**
+  be split", because each candidate seam "produces a fragment with no
+  independently verifiable value". It notes the item sits at the upper end of
+  story sizing but that the weight is verification of one indivisible bet.
+- 🟡 **Oracle mapping written from inference** — **Resolved.** Testability calls
+  the deferral "well framed and actionable", crediting it for naming the oracle
+  set, widening it from the shell wrappers to the underlying `git`/`jj`
+  invocations (which is what makes the inline-local queries tractable), and
+  citing the two wrong inferences. Residual: the mapping's own delivery has no
+  checkbox and "with evidence" is undefined.
+- 🟡 **Requirements described half the criteria** — **Resolved** for the seven
+  promoted deliverables. Two more surfaced that are still AC-only: the
+  cost-measurement work and the sibling hand-off notes.
+- 🟡 **Query set defined twice / item 7 not a query** — **Resolved.** Six
+  queries, scrub restated as an invariant over them.
+- 🟡 **One adapter or a pair** — **Resolved in Requirements, regressed in AC.**
+  The first criterion still says "both adapter pairs" (below).
+- 🟡 **`mise.toml` contradiction** — **Resolved for the Rust pin** (MSRV fits),
+  **reintroduced for the `jj` pin** (below).
+- 🟡 **Circular pure-jj fixture anchor** — **Resolved** in the criterion (it is
+  defined here, 0169 reuses it), **but Validation Results still attributes it to
+  0169**.
+- 🟡 **CI infrastructure for strong-form zero-spawn** — **Still open, third
+  consecutive pass.** Now flagged by dependency *and* scope as a hard gate with
+  no owner and no confirmed runner capability.
+
+### New Issues Introduced
+
+**Stale text the consolidation left behind — all mine, all one-line fixes:**
+
+- 🟡 **Validation Results contradicts the body** (3 lenses). It still records
+  "`mise.toml` pins 0.36.0, installed 0.36.0 … coherence unverified (see Open
+  Questions)" — pointing at an Open Question the document declares retired, and
+  contradicting Dependencies, Requirements and the actual file. It also heads a
+  slot "Cost, against **0169's** pure-jj fixture" when the criterion defines the
+  fixture here.
+- 🟡 **The `jj` pin state is stated four ways** — a standing obligation in
+  Requirements, already-done in Dependencies and Open Questions, an edited file
+  in Shared-artefact contention, and not-done in Validation Results.
+- 🟡 **"Both adapter pairs"** in the first criterion contradicts the single
+  library-backed type Requirements spent a sentence justifying.
+
+**Genuinely new, and good — mostly one-line criterion tightenings:**
+
+- 🟡 **The fixture matrix never fixes the start directory.** All six queries are
+  start-path-relative and the oracle is directory-parameterised. Queried from a
+  superproject root the submodule query answers "not a submodule"; from inside
+  the submodule it answers with the superproject. Same for linked-worktree
+  (worktree vs main) and both nesting directions. An implementer could run all
+  six from each fixture's root, produce 54 green cells, and never exercise the
+  distinctions the queries exist to make.
+- 🟡 **The scrub invariant can pass vacuously.** It requires equal answers "with
+  and without `GIT_DIR`/`GIT_COMMON_DIR` set" but never says what they are set
+  *to*. Pointed at a non-existent path both are ignored and the test proves
+  nothing; the invariant only bites when they point at a real git directory that
+  would produce a different answer. This is the one criterion in the item with
+  no non-vacuity control, in a document that applies them carefully elsewhere.
+- 🟡 **"Assert the delta is non-trivial" is an unthresholded gate** inside a
+  criterion that opens "measured and recorded, **not gated**" — and the two
+  builds being differenced are not defined. It is the clause guarding the
+  story's headline false-pass (dead-code elimination) and currently the least
+  decidable in the item.
+- 🟡 **The composition root is handed to two dependants with no ordering.**
+  Requirements says wiring "belongs to 0169 and 0185"; the hand-off
+  criterion
+  tells 0185 it is "0185's own work". 0185's `blocked_by` is 0188 only, so both
+  are simultaneously unblocked to change `vcs_adapters::facts` on contradictory
+  assumptions — 0185's Technical Notes still assume 0169 goes first.
+- 🟡 **0185's deletion invalidates the dual-adapter suite this story builds.**
+  The first criterion runs `detection.rs` against both pairs; 0185 deletes
+  `CommandProbe` and believes those pins hold "unchanged". Collapsing the
+  comparison to a single adapter is unowned work in 0185's "wiring plus
+  deletion" sizing.
+- 🟡 **The nine-shape fixture matrix is not a listed deliverable**, though four
+  criteria range over it and Test-support deliverables is explicitly the list
+  that is "sized as such". Bare, submodule, linked-worktree and both nesting
+  shapes are substantial to build, and the item never says which exist today.
+- 🟡 **"One consumer inside this story" names no crate**, and the only suite the
+  story touches is inside the crate that owns the fixture — so it cannot
+  demonstrate a crate boundary. "Consumer" is also overloaded against its
+  production sense used throughout.
+
+Minor and suggestion level: an ambiguous "its" in the 0185 note with a section
+list that disagrees with Dependencies; `G`/`B` never expanded; the lockfile
+check omits the `gix` 0.85 pin itself (single-version can hold vacuously if
+`jj-lib`'s `gix` feature is off) and the `mise.toml` lockstep; the Rust pin is
+the only leg of the three-pin coupling with no inline comment; the
+`UserSettings` guard has no non-vacuity demonstration while the pup rule does;
+no out-of-repository fixture; 0168's restructuring has in fact already landed so
+the contention is overstated; MSRV and SIP unexpanded.
+
+### Assessment
+
+**Converging, but not by finding count.** Pass 3 raised roughly thirteen majors
+and pass 4 raises about twelve — yet they are not comparable. Pass 3's were
+"the method is wrong" and "Requirements describes half the story". Pass 4's
+split cleanly into three groups: **stale text from the consolidation** (three
+findings, all one-line, all mine), **criterion tightenings** (start directories,
+poisoning value, size threshold — each a sentence), and **two genuine open
+decisions** that have now survived multiple passes without being resolved:
+
+1. **Who owns the CI job** for the strong-form zero-spawn run, and does the
+   runner actually permit replacing or bind-mounting `/usr/bin/git`? Flagged in
+   passes 2, 3 and 4. It is a hard gate on a capability nobody has confirmed.
+2. **Who changes `vcs_adapters::facts`** — 0169 or 0185 — and in what order.
+
+Everything else is editing. The recommendation is to fix the stale text and the
+criterion tightenings directly, put those two decisions to the author, and then
+stop reviewing: the remaining findings are the kind a plan resolves by being
+written, and a fifth pass would be measuring diminishing returns. "Ready" at
+this point is a judgement call about the two decisions above, not a lens
+verdict.
+
+## Approval — 2026-08-02
+
+**Verdict changed to APPROVE by author decision**, overriding the pass-4 lens
+verdict of REVISE. The four pass sections above are left exactly as written;
+this section records the decision, not a fifth pass.
+
+The basis is the pass-4 assessment's own conclusion: after the consolidation,
+what remained divided into stale text (since swept), one-line criterion
+tightenings (since applied), and two decisions that no further review pass could
+resolve. With the first two groups closed, readiness turned on those two
+decisions — and that is an author call, not a lens verdict.
+
+**Approved with two Open Questions outstanding.** Both are recorded in the work
+item with stated defaults, and both gate planning rather than approval:
+
+1. **Who owns the CI job for the strong-form zero-spawn run, and does the runner
+   permit replacing or bind-mounting `/usr/bin/git`?** Raised in passes 2, 3 and
+   4. It is the one acceptance gate resting on an unconfirmed infrastructure
+   capability. Default if it cannot be arranged: carve provisioning into its own
+   item that 0188 declares `blocked_by`, rather than weakening the criterion to
+   `PATH`-only everywhere — which would leave the property unproven on any
+   platform.
+2. **Who changes `vcs_adapters::facts`, 0169 or 0185, and in what order?** Both
+   are currently unblocked by 0188 alone, on contradictory assumptions.
+
+**One implementation-time obligation also carries forward**: the `mise.toml`
+`jj` pin was bumped 0.36.0 → 0.43.0 during this review, but `mise install` and a
+re-run of the jj-fixture shell suites are still outstanding — recorded as
+_pending_ in the work item's Validation Results.
+
+**Approval does not signal that the oracle mapping is settled.** It is
+deliberately deferred to planning, to be built by executing candidates against
+fixtures; two attempts to write it from line references during this review were
+both wrong, and the criteria now require command-and-verbatim-output evidence
+per cell.

--- a/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
+++ b/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
@@ -11,7 +11,7 @@ priority: medium
 source: "note:2026-06-22-ideas-backlog"
 relates_to: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture", "codebase-research:2026-06-23-0136-shell-scripts-rust-cli-migration-surface"]
 tags: [rust, cli, migration, epic]
-last_updated: "2026-06-28T17:01:56+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: PP-157
@@ -50,14 +50,24 @@ skills and is constrained by a bash 3.2 floor.
 
 ## Decomposition
 
-This epic is decomposed into the following child work items (status: draft),
-ordered along the dependency spine; each keeps the plugin functional at its step:
+This epic is decomposed into the following child work items, ordered along the
+dependency spine; each keeps the plugin functional at its step. Four were added
+on 2026-07-31 when 0169 was split (see Drafting Notes); statuses vary and are
+tracked on the items themselves.
 
 **Foundations (Phases 0–2):**
 - 0162 — Rust Toolchain Guard Rails in mise + CI
 - 0163 — Scaffold the cli/ Hexagonal Workspace with a version Subcommand
 - 0164 — Launcher and Git-Style Dispatch
 - 0165 — Multi-Binary Static Distribution and Release Pipeline with minisign
+- 0186 — Remove the Exec Probe from the Bootstrap Warm Path *(blocked by 0182 —
+  same file; unblocks 0169)*
+- 0187 — Generalise the Sub-Binary Registration Surface *(blocked by 0168 —
+  discharged when 0168 is closed or its residual scope is confirmed unable to
+  move the visualiser crate path; if neither holds at pickup, 0187 proceeds and
+  re-verifies at acceptance, so this is a gate on confirmation and stays a
+  Foundations item rather than waiting on Phase 5; unblocks
+  0169/0170/0171/0172/0173)*
 
 **Shared core + the contract cutover (Phases 3–4):**
 - 0166 — Shared config, corpus, and store Crates
@@ -65,6 +75,7 @@ ordered along the dependency spine; each keeps the plugin functional at its step
 
 **Subdomain migrations (Phases 5–10):**
 - 0168 — Fold the Visualiser into the cli/ Workspace
+- 0188 — Library-Backed VCS Adapter over gix and jj-lib *(precedes 0169)*
 - 0169 — VCS Subdomain and Hooks Migration
 - 0170 — Work-Item Subdomain and Sync Engine
 - 0171 — Jira and Linear Integrations
@@ -72,28 +83,31 @@ ordered along the dependency spine; each keeps the plugin functional at its step
 - 0173 — Remaining Subdomains: corpus, design, collaboration
 
 **Cleanup (Phase 11):**
+- 0185 — Converge corpus-adapters on the Library-Backed VCS Adapter
 - 0174 — Retire Shell Tooling and CI Guards
 
-The target architecture (git-style `accelerator` launcher dispatching to on-demand
-`accelerator-<sub>` static binaries, each a hexagonal crate; the visualiser folded
-in as the first sub-binary) is fixed by ADR-0045/0046/0047/0051/0052/0053/0054.
+The target architecture (git-style `accelerator` launcher dispatching to
+on-demand `accelerator-<sub>` static binaries, each a hexagonal crate; the
+visualiser folded in as the first sub-binary) is fixed by
+ADR-0045/0046/0047/0051/0052/0053/0054.
 
 ## Acceptance Criteria
 
 - [ ] Shell-script responsibilities are migrated into a Rust CLI without
       regressing skill behaviour, with the migration sequenced so the plugin
       stays functional at each step.
-- [ ] All child work items 0162–0174 are completed.
+- [ ] All child work items are completed: 0162–0174, plus 0185–0188 added by the
+      2026-07-31 split of 0169.
 
 ## Open Questions
 
 *(All resolved — see the architecture research's decision log. The two original
 questions are answered:)*
 
-- Which scripts migrate first, and which remain as shell? — Leaf/shared crates and
-  the launcher first, the migration engine last; a thin residual shell surface
-  (launcher bootstrap, hook wrapper, Playwright executor) remains under the bash
-  3.2 floor (ADR-0048/0049).
+- Which scripts migrate first, and which remain as shell? — Leaf/shared crates
+  and the launcher first, the migration engine last; a thin residual shell
+  surface (launcher bootstrap, hook wrapper, Playwright executor) remains under
+  the bash 3.2 floor (ADR-0048/0049).
 - How is the CLI distributed? — Zero-setup, fully static musl/darwin binaries
   fetched, sha256+minisign-verified, and exec'd on demand, reusing the existing
   visualiser release pipeline (ADR-0046).
@@ -102,32 +116,51 @@ questions are answered:)*
 
 - Blocked by: None.
 - Blocks: None directly (the children carry the internal dependency spine).
-- Children: 0162–0174 (parented to this epic).
+- Children: 0162–0174 and 0185–0188 (parented to this epic). Note 0178, 0179 and
+  0180 are parented to 0166 rather than directly to this epic, so they are
+  grandchildren and are covered transitively by 0166's completion.
 
 ## Assumptions
 
 - The Rust CLI is distributed similarly to the existing visualiser binary
-  (release artefact + checksum verification), confirmed and extended with minisign
-  by ADR-0046.
+  (release artefact + checksum verification), confirmed and extended with
+  minisign by ADR-0046.
 
 ## Technical Notes
 
-- Removes the bash 3.2 floor constraint for migrated functionality; a thin residual
-  shell surface remains and stays under the floor (ADR-0048/0049).
-- Must preserve bare-path invocation semantics expected by skill `allowed-tools`;
-  the cache lives under `${CLAUDE_PLUGIN_ROOT}` to keep permission matches working
-  (the contract cutover is 0167).
+- Removes the bash 3.2 floor constraint for migrated functionality; a thin
+  residual shell surface remains and stays under the floor (ADR-0048/0049).
+- Must preserve bare-path invocation semantics expected by skill
+  `allowed-tools`; the cache lives under `${CLAUDE_PLUGIN_ROOT}` to keep
+  permission matches working (the contract cutover is 0167).
 
 ## Drafting Notes
 
 - Treated as an epic per the user's instruction. Decomposed 2026-06-28 from the
   scope/architecture research into children 0162–0174, with all open questions
   resolved interactively; promoted from `draft` to `ready`.
+- **Extended 2026-07-31 with 0185–0188**, when 0169 was split. A four-pass
+  review measured that three editing passes had not reduced its major-finding
+  count (19 → 15 → 14 → 14), with most later findings being defects introduced
+  by the previous pass's fixes — the signature of one work item carrying more
+  than a single document can hold consistently. The extracted concerns are each
+  independently deliverable: 0186 (bootstrap exec-probe fix, ~108 ms per hook
+  invocation, benefits every SessionStart hook today), 0187 (sub-binary
+  registration surface, unblocks four sibling subdomain stories), 0188 (the
+  `gix`/`jj-lib` dependency adoption and its licence-policy change), and 0185
+  (converging the remaining `CommandProbe` consumer). 0169 retains the
+  subdomain, the hooks migration and the skill repoint — the parts that cannot
+  be separated, since the shell hooks cannot be deleted before their
+  replacements exist.
 
 ## References
 
 - Source: `meta/notes/2026-06-22-ideas-backlog.md`
-- Research: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
-- Research: `meta/research/codebase/2026-06-23-0136-shell-scripts-rust-cli-migration-surface.md`
-- Spike: `meta/work/0158-modular-rust-cli-architecture-and-hexagonal-workspace-layout.md`
-- ADRs: ADR-0045, ADR-0046, ADR-0047, ADR-0048, ADR-0049, ADR-0051, ADR-0052, ADR-0053, ADR-0054
+- Research:
+  `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+- Research:
+  `meta/research/codebase/2026-06-23-0136-shell-scripts-rust-cli-migration-surface.md`
+- Spike:
+  `meta/work/0158-modular-rust-cli-architecture-and-hexagonal-workspace-layout.md`
+- ADRs: ADR-0045, ADR-0046, ADR-0047, ADR-0048, ADR-0049, ADR-0051, ADR-0052,
+  ADR-0053, ADR-0054

--- a/meta/work/0168-fold-visualiser-into-cli-workspace.md
+++ b/meta/work/0168-fold-visualiser-into-cli-workspace.md
@@ -10,9 +10,10 @@ kind: story
 priority: medium
 parent: "work-item:0136"
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
+blocks: ["work-item:0187"]
 relates_to: ["work-item:0165", "work-item:0166"]
 tags: [rust, visualiser, frontend, workspace]
-last_updated: "2026-07-19T23:12:20+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-189"
@@ -177,6 +178,19 @@ dispatch path end to end.
 - Not blocked by: 0180 (atomic-store primitives) — the fold-in reuses
   `corpus-adapters`' existing `FileCorpusStore` write path from 0179; 0180's extra
   JSONL/lock primitives are not on this story's path.
+- Blocks: 0187 (generalise the sub-binary registration surface). 0187 documents
+  the `cli/<token>/Cargo.toml` manifest-path default and the
+  `_SUBBINARY_MANIFESTS` override using this story's landed nested placement
+  (`cli/visualiser/server/`) as the worked example, and the visualiser is the
+  one existing binding its generalised coherence guard is verified against.
+  0187's discharge condition: this story is closed, or its residual scope is
+  confirmed unable to move the visualiser crate path. If neither holds when 0187
+  is picked up, 0187 proceeds anyway and re-verifies the path at acceptance — so
+  this is a gate on confirmation, not a wait on this story's phase. If the
+  residual scope *does* move `cli/visualiser/server/` after 0187 has landed,
+  update the `_SUBBINARY_MANIFESTS` entry and the
+  `tasks/README.md#registering-a-dispatched-sub-binary` checklist in the same
+  change. (2026-08-01)
 - Relates to: 0165 (the visualiser joins the multi-binary release), 0166 (this
   refactor validates the shared-crate approach 0166 described; 0166 itself built
   nothing — see Drafting Notes).

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -9,12 +9,12 @@ status: ready
 kind: story
 priority: high
 parent: "work-item:0136"
-blocked_by: ["work-item:0164", "work-item:0166", "work-item:0167", "work-item:0179"]
-blocks: ["work-item:0172", "work-item:0174"]
-relates_to: ["work-item:0172", "work-item:0174"]
+blocked_by: ["work-item:0164", "work-item:0166", "work-item:0167", "work-item:0179", "work-item:0186", "work-item:0187", "work-item:0188"]
+blocks: ["work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173", "work-item:0174"]
+relates_to: ["work-item:0125", "work-item:0165", "work-item:0182", "work-item:0183", "work-item:0185", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, vcs, hooks, migration]
-last_updated: "2026-07-20T09:34:16+00:00"
+last_updated: "2026-07-31T11:10:05+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-190"
@@ -29,235 +29,508 @@ external_id: "PP-190"
 
 ## Summary
 
-Build the `accelerator-vcs` subdomain (detection/status/log/guard) and migrate the
-SessionStart and PreToolUse hook logic into the CLI (ADR-0048), registering the
-bootstrap path (`${CLAUDE_PLUGIN_ROOT}/bin/accelerator`) in `hooks.json` to invoke
-domain subcommands with a `--format=hook` envelope rather than a hook-specific
-subcommand. The SessionStart migration covers VCS detection and config detection
-only; the config side is **already shipped by 0167** as
-`accelerator config summary --format=hook --fail-safe` (there is no
-`config detect` subcommand — 0167 reuses `config summary`), so this story owns
-the VCS half. The migration-discoverability reminder is deferred to 0172.
+Build the VCS subdomain — `vcs detect`, `vcs status`, `vcs log`, `vcs guard` —
+over the library-backed adapters 0188 delivers, migrate the SessionStart
+VCS-detection and PreToolUse guard logic into the CLI (ADR-0048), and repoint
+`skills/vcs/commit` at the new subcommands so the two shell helpers it solely
+consumes retire alongside the hooks.
+
+**Scope of the hook surface**: this story owns the two VCS hooks
+(`vcs-detect.sh`, `vcs-guard.sh`) and the `config-detect.sh` wrapper's
+registration — three of the five `hooks.json` entries.
+`migrate-discoverability.sh` belongs to 0172; `launcher-link-refresh.sh` is
+untouched. The SessionStart config *behaviour* shipped with 0167 as `accelerator
+config summary --format=hook --fail-safe`; there is no `config detect`
+subcommand and none is added, but this story folds that registration into
+`hooks.json` and deletes the wrapper.
+
+Three concerns that once lived here are now siblings: the bootstrap exec-probe
+fix (0186), the sub-binary registration surface (0187), and the `gix`/`jj-lib`
+adapter swap (0188). This story consumes all three.
+
+## Terminology
+
+- **bootstrap** — `bin/accelerator`, the bash script registered in `hooks.json`.
+- **launcher binary** — the cached Rust binary the bootstrap execs, package
+  `accelerator`.
+- **verify shim** — `bin/accelerator-verify-<platform>`, the minisign verifier
+  the bootstrap stages and runs.
+- **VCS subdomain** — the conceptual grouping of `vcs detect|status|log|guard`.
+- **`vcs` / `vcs-adapters`** — the domain and adapter crates from 0179, extended
+  with library-backed implementations by 0188.
+- **`accelerator-vcs`** — the Cargo **package** producing the dispatched
+  sub-binary, in a directory other than `cli/vcs/`. Never used for the crates or
+  the subdomain.
+- **dispatch token** — `vcs`, the argv token users type.
+- **probe layer** — the *shell* detection functions in `scripts/vcs-common.sh`
+  (`classify_checkout` and friends). Never abbreviated to "probe".
+- **the wrapper** — `hooks/config-detect.sh` specifically.
+- **the parity gate** — `hooks/test-vcs-detect.sh`, the 42-case suite. Distinct
+  from `cli/corpus-adapters`' metadata parity suite.
+- **plugin-root variables** — Claude-Code-substituted surfaces (`hooks.json`,
+  `SKILL.md`) use `${CLAUDE_PLUGIN_ROOT}`; Rust under `cli/**` must use
+  `ACCELERATOR_PLUGIN_ROOT` and is forbidden from naming any `CLAUDE_*` variable
+  by `tasks/lint/claude_coupling.py`.
 
 ## Context
 
-`scripts/vcs-common.sh` (the `.jj`-wins dispatch, the load-bearing
-`classify_checkout` arm ordering) backs both the VCS skills and the hooks. ADR-0048
-says hook logic moves into the CLI; consolidating it there removes the parallel bash
-implementation the hooks and skills currently share and unblocks the remaining
-epic-0136 shell retirement (0172, 0174) — the goal this story ultimately serves. The
-hooks are currently four bare `.sh` paths in `hooks.json` honouring the Claude Code
-hook I/O protocol. The invocation mechanism
-(resolved during refinement of the parent epic 0136) is fixed: register the
-universal wrapper invoking domain subcommands, with the hook I/O envelope produced
-by a CLI `--format=hook` switch. The SessionStart hook
-currently fans out to VCS detection, config detection, and a migration-discoverability
-reminder; this story ports the first two and leaves the migration reminder to land
-with the migration subdomain (0172).
+`scripts/vcs-common.sh` backs both the VCS skills and the hooks. ADR-0048 says
+hook logic moves into the CLI. Two user-visible symptoms motivate it beyond the
+refactor: `skills/planning/validate-plan` is **blocked in pure-jj repos today**
+because `log` and `diff` sit in the guard's blocked set, and the colocated
+"prefer jj" warning has never reached a user because the shell nests it where
+the hook schema has no field.
+
+Only the second is fixed here. **Unblocking `log`/`diff` is deliberately out of
+scope**: the blocked set is reproduced verbatim under the parity requirement, so
+`validate-plan` stays blocked in pure-jj repos after this story. Changing that
+set is a user-facing policy decision that should not ride inside a migration
+whose whole safety argument is decision-parity; it is raised as a follow-up by
+the hand-off criterion. What the migration does deliver is making it a one-line
+change afterwards, which is the sense in which the symptom motivates this work.
+
+This story removes the **hooks'** copy of the detection logic and retires the
+two status/log helpers. The lexical shell layer (`find_repo_root`, `vcs_mode`)
+survives for its 20+ non-VCS callers, so duplication is reduced, not eliminated
+— see the 0125 note in Dependencies.
+
+`hooks.json` registers **five** hooks across **two owning stories plus one
+unowned**: four SessionStart (`vcs-detect.sh` → this story; `config-detect.sh` →
+this story, registration only; `migrate-discoverability.sh` → 0172;
+`launcher-link-refresh.sh` → **no epic-0136 story**) and one PreToolUse
+(`vcs-guard.sh` → this story).
+
+## The guard's inputs
+
+Stated authoritatively here so the decision table's row count is derivable
+without consulting the capture. Blocked git subcommands, from
+`hooks/vcs-guard.sh:53` (13):
+
+```
+status  diff  add  commit  log  branch  checkout  switch
+merge   rebase  reset  stash  show
+```
+
+`log` and `diff` are **blocked**, not allowed. Everything outside the set
+passes; the 7 named allowed subcommands are `push`, `pull`, `fetch`, `remote`,
+`clone`, `config`, `tag`. `gh` and `rtk` are allowed unconditionally. **Compound
+rule**: the command splits on `&&`, `||`, `;` and `|`, and is blocked if *any*
+segment matches; the first matching segment names the reported subcommand.
 
 ## Requirements
 
-- Implement `accelerator-vcs` as a hexagon: `vcs detect`, `vcs status`, `vcs log`,
-  `vcs guard`, over the `vcs`/`vcs-adapters` crates delivered by 0179 — porting
-  `vcs-common.sh` semantics (jj-outranks-git dispatch, the 6-line `classify_checkout`
-  record with its first-match-wins arm order, worktree/submodule/bare/`GIT_DIR`
-  handling) and extending those crates with the full `classify_checkout` taxonomy.
-  "Full taxonomy" here means reproducing the shell's existing classification set
-  (worktree, submodule, bare, `GIT_DIR`, plain) as typed variants — not adding
-  classifications beyond what the shell produces. External VCS state (`jj`,
-  `git`) is read through in-process Rust libraries — `gix` (gitoxide) for git
-  and `jj-lib` for jujutsu — bound behind the outbound port, not by spawning
-  `jj`/`git` subprocesses; a per-query shell fallback behind the same port is
-  permitted only where no library equivalent exists.
-- Migrate the VCS hook logic into the CLI: `hooks.json` registers the bootstrap
-  path (which fetches `accelerator` on first use, then execs it) invoking domain
-  subcommands — SessionStart → `accelerator vcs detect` (the config side,
-  `accelerator config summary --format=hook --fail-safe`, is already registered by
-  0167); PreToolUse(`Bash`) → `accelerator vcs guard`. No hook-specific subcommand.
-  The SessionStart migration-discoverability reminder is out of scope here and
-  remains its existing bash hook until 0172.
-- Add a `--format=hook` switch producing the Claude Code hook I/O envelope, so one
-  domain operation serves both its skill-injection caller (plain) and its hook
-  caller (envelope).
-- Serve the hot PreToolUse guard as the `accelerator-vcs` sub-binary invoked through
-  the wrapper, relying on the 0164 fetch-verify-cache model so the sub-binary fetch
-  is a first-use-only cost amortised by the warmed cache — no per-Bash-call fetch
-  after warm-up. Keep the wrapper bash-3.2-safe.
+- Implement the VCS subdomain as a hexagon over the `vcs`/`vcs-adapters` crates,
+  using the library-backed adapters 0188 delivers. This story adds no
+  dependencies and changes no dependency policy.
+- Extend the crates with the `classify_checkout` taxonomy. The **authoritative
+  arm list**, stated once and referenced by the fixture criterion, is: `main`,
+  `jj-secondary`, `git-worktree`, `colocated`, `nested-jj-in-git`,
+  `nested-git-in-jj`, `none` — with the submodule, bare and `GIT_DIR` handling
+  that feeds them. First-match-wins ordering is load-bearing and `colocated`
+  must precede the `nested-*` arms. No classifications beyond what the shell
+  produces.
+- **Normative parity reference, per subcommand** — mode detection is duplicated
+  four ways today and the hooks do not call `vcs_mode()`, so "reproduce the
+  shell" needs a named target each:
+  - `vcs detect` → `hooks/vcs-detect.sh` (three-valued:
+    `git`/`jj`/`jj-colocated`)
+  - `vcs guard` → `hooks/vcs-guard.sh`
+  - `vcs status` / `vcs log` → `scripts/vcs-status.sh` / `scripts/vcs-log.sh`
+  - `classify_checkout` semantics → `scripts/vcs-common.sh`
+- **Declared behavioural changes** — exactly two departures, each tested as the
+  *new* behaviour:
+  1. the PreToolUse envelope moves to the `permissionDecision` shape;
+  2. the `.git`-as-*file* colocated misclassification is **corrected**, for `vcs
+     detect` and `vcs guard` only. Those two test `-d "$REPO_ROOT/.git"`
+     (`vcs-detect.sh:29`, `vcs-guard.sh:77`), so a colocated checkout whose
+     `.git` is a *file* (worktree, submodule) is misread as pure-jj.
+     `vcs-status.sh:9` and `vcs-log.sh:9` branch on `-d "$REPO_ROOT/.jj"` alone
+     and never inspect `.git`, so they are **unaffected** and stay strict
+     parity. The concrete change, stated as values because the shell cannot be
+     the oracle for a deliberate departure:
+
+     | Subcommand | Today (`.git` is a file) | After |
+     | --- | --- | --- |
+     | `classify_checkout` | `main` (git side unseen) | `colocated` |
+     | `vcs detect` mode | `jj` | `jj-colocated` |
+     | `vcs guard` | **blocks** (pure-jj) | **warns** (colocated) |
+
+     Everything else is parity.
+- Migrate the hook logic into the CLI. **The three registered command strings,
+  verbatim** (the parity gate asserts the exact literal):
+  - SessionStart: `${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs detect
+    --format=hook --fail-safe`
+  - SessionStart: `${CLAUDE_PLUGIN_ROOT}/bin/accelerator config summary
+    --format=hook --fail-safe`
+  - PreToolUse(`Bash`): `${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs guard
+    --format=hook --fail-safe`
+
+  `hooks/config-detect.sh` is deleted once its registration is inlined. No
+  hook-specific subcommand. The migration-discoverability reminder stays until
+  0172.
+- **Fail-open on both hook event types.** `--fail-safe` is on all three
+  registrations because a PreToolUse hook exiting non-zero is a *blocking
+  error*: any failure — a failed first-use fetch, an unreachable release host,
+  an unreadable repository — must let the Bash call through. The bootstrap
+  honours `--fail-safe` as a global token (`bin/accelerator:28-39`), so
+  bootstrap and trust-chain aborts inherit it.
+- **Output contract, stated once.** `--format=hook` renders a per-hook-type
+  envelope. The two non-normal outcomes are **disjoint by definition** — one is
+  a success, the other an error, and no run is both:
+  - **Success with nothing to report** (the adapter answered; there is simply no
+    context — e.g. a main checkout with no boundary, or no repository at all):
+    **zero bytes**, exit 0.
+  - **Adapter failure** (the adapter could not answer — unreadable or corrupt
+    repository): **exactly one JSON object containing `systemMessage`**, exit 0
+    under `--fail-safe`. On stdout, not stderr, because 0183 establishes stderr
+    at exit 0 is discarded.
+
+  At most one object reaches stdout, so `systemMessage` merges into the same
+  object as any `hookSpecificOutput`. `--fail-safe` governs the exit code only.
+  Without `--format=hook`, `vcs detect` emits the same context text unwrapped
+  and `vcs guard` emits a human-readable allow/deny line; both plain forms are
+  pinned by goldens so they cannot drift from the enveloped ones.
+- Serve the guard as a dispatched sub-binary invoked through the bootstrap. The
+  **package** is `accelerator-vcs` in a directory other than `cli/vcs/`, with
+  the dispatch token `vcs` mapped via `_SUBBINARY_MANIFESTS`. Registration
+  follows 0187's checklist — this story adds the token, it does not generalise
+  the surface.
+- Repoint `skills/vcs/commit` at the new subcommands and delete the two shell
+  scripts it solely consumes. `SKILL.md:13-14` are their only references in the
+  repo, and `tasks/lint/call_site_migration.py` guards only `scripts/config-`
+  call sites, so nothing would catch the omission. This also lets the skill's
+  broad `Bash(${CLAUDE_PLUGIN_ROOT}/scripts/*)` permission be dropped for a
+  subcommand-scoped `Bash(${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs *)`.
+
+## Sequencing Constraints
+
+1. **Confirm the hook schema at the floor before designing the envelope.** If
+   `permissionDecision` is not honoured at Claude Code v2.1.144, that decision
+   must be revisited. Minutes-long empirical check; gates planning.
+2. **Capture the shell's behaviour as fixtures before deleting any of it**, in a
+   commit that precedes the deletion commit so the ordering is checkable from
+   history. `hooks/vcs-guard.sh` has zero coverage today and the status/log
+   comparators are removed by this story.
+3. **Land the `test:integration:hooks` launcher edge before repointing the
+   parity gate** — it cannot run against a binary until the task gains
+   `build:cli:dev` and `accelerator_env()`.
+4. **Do not ship the `hooks.json` rewrite ahead of a release whose manifest
+   lists `accelerator-vcs`.** The launcher's exact-version-equality
+   anti-rollback rule makes a missing entry a hard failure. The dev path
+   (`build:cli:dev` plus `ACCELERATOR_VCS_BIN`) is unaffected; the
+   installed-plugin path is not.
 
 ## Acceptance Criteria
 
-- [ ] `accelerator vcs detect` reproduces the shell detection behaviour, verified
-      against the repointed `hooks/test-vcs-detect.sh` parity gate.
-- [ ] `accelerator vcs status` and `accelerator vcs log` reproduce the shell
-      behaviours, each verified against a golden-output test asserting the same
-      output as the corresponding `vcs-common.sh` path across a fixture-repo set
-      covering, at minimum: clean git, dirty git, git ahead/behind, detached-HEAD
-      git, clean jj, and dirty jj.
-- [ ] `accelerator vcs guard` reproduces the shell guard behaviour, verified
-      against an allow/deny fixture set that covers each Bash-call class the shell
-      guard distinguishes — the blocked git/jj mutation patterns and the
-      allowed read-only/non-VCS patterns — not merely one allow and one deny.
-- [ ] `classify_checkout` is verified by a fixture covering each arm (worktree,
-      submodule, bare, `GIT_DIR`, plain) and asserting first-match-wins precedence
-      for at least one ambiguous checkout, so the load-bearing arm order cannot
-      regress silently.
-- [ ] The `accelerator-vcs` adapters read VCS state through the `gix` and
-      `jj-lib` libraries rather than by spawning `jj`/`git` subprocesses —
-      verified by asserting zero `jj`/`git` process spawns across the
-      detect/status/log/guard paths under an instrumented process launcher; any
-      shell fallback is explicit, per-query, and covered by its own test.
-- [x] The SessionStart config-detection behaviour is reproduced — **delivered by
-      0167** as `accelerator config summary --format=hook --fail-safe`, registered
-      via `hooks/config-detect.sh` (a thin exec-wrapper of the bootstrap path).
-- [ ] `hooks.json` registers the bootstrap path invoking the VCS subcommands;
-      SessionStart injects the VCS context and PreToolUse guards Bash calls, each
-      emitting its hook I/O envelope via `--format=hook`, verified against a golden
-      envelope fixture per hook type (SessionStart, PreToolUse). **The two envelopes
-      are different shapes** — SessionStart is
-      `{hookSpecificOutput:{hookEventName,additionalContext}}`; the PreToolUse guard
-      is `{decision, reason}` / `{decision, hookSpecificOutput}` — so the fixture is
-      per hook type, not one shared envelope.
-- [ ] After first use, the PreToolUse guard resolves `accelerator vcs guard` from the
-      warmed cache — verified by asserting zero sub-binary fetch invocations against
-      a stubbed/instrumented fetcher across repeated guard calls after the cache is
-      warm.
-- [ ] The wrapper passes the bash-3.2 gate — `scripts/lint-bashisms.sh` (and the
-      standard shfmt/ShellCheck checks) report no findings against it.
-- [ ] The `vcs-detect.sh` and `vcs-guard.sh` hook scripts are removed and the hooks
-      suite floor adjusted in the same change; `migrate-discoverability.sh` is left
-      in place for 0172. `config-detect.sh` was re-homed by 0167 to a thin
-      exec-wrapper of the bootstrap path — this story may fold it directly into
-      `hooks.json` and delete it **only once the argument-splitting probe below is
-      resolved** (whether `hooks.json`'s `command` field expands
-      `${CLAUDE_PLUGIN_ROOT}` and splits argument tokens); until then the wrapper
-      stays.
+- [ ] **The envelope is honoured at the declared floor**: on Claude Code
+      v2.1.144, a real Bash call to a blocked git subcommand in a pure-jj repo
+      is denied, and the colocated warning appears in the session transcript.
+      Recorded in Validation Results with the observed client version. If the
+      shapes are unsupported, the fallback taken here is **exit-2 with stderr
+      feedback**; raising the plugin's minimum version is escalated to epic
+      0136, not taken here, and the plan states which goldens survive under
+      exit-2.
+- [ ] **Shell behaviour captured as committed fixtures before any deletion**, in
+      a commit preceding the deletion commit: the `vcs status`/`vcs log` goldens
+      and the `vcs guard` decision table. The volatile-field mask set is derived
+      from the capture, enumerated per subcommand in the plan, committed as a
+      file alongside the goldens, and closed thereafter — no mask may be added
+      to make a failing golden pass. It covers at least: hex object ids of 7-40
+      characters, jj change ids (32-character non-hex), ISO-8601 *and* jj's
+      space-separated timestamps, relative age strings, the fixture tempdir
+      path, and author identity.
+- [ ] `accelerator vcs detect` reproduces `hooks/vcs-detect.sh`, verified
+      against the repointed parity gate. The two goldens
+      (`hooks/test-fixtures/vcs-detect/*.json`) are compared after `jq -S .`
+      canonicalisation on both sides and must equal the current shell-produced
+      content; a value difference fails. Separately, a **third** detect fixture
+      covers the corrected case: a colocated checkout whose `.git` is a file
+      must report mode `jj-colocated` (today: `jj`). Its golden is **authored as
+      the new expectation and marked in the fixture as a deliberate
+      divergence**, not derived from the capture — the shell is not the oracle
+      for a declared behavioural change.
+- [ ] **The 42 parity-gate cases partition into four disjoint buckets**, each
+      case in exactly one, stated in the plan as a line-range partition summing
+      to 42: (a) 27 in-process `vcs-common.sh` cases → moved to
+      `scripts/test-vcs-common.sh`; (b) the subprocess cases that repoint by
+      changing the `HOOK` constant; (c) the missing-`jj`/`git`-binary cases →
+      deleted, since no external binary is consulted; (d) two singletons — the
+      comment-block grep case → deleted, and the `hooks.json` literal assertion
+      → updated to the new registration and made order-independent rather than
+      pinned to `SessionStart[0]`.
+- [ ] `accelerator vcs status` and `accelerator vcs log` match the captured
+      goldens across: clean git, dirty git, git ahead/behind, detached-HEAD git,
+      clean jj, dirty jj, colocated, jj secondary workspace, and no repository
+      at all. (No `.git`-as-file case: `vcs-status.sh:9`/`vcs-log.sh:9` branch
+      on `.jj` alone, so the correction does not reach them and strict parity
+      holds.) Definitions, so two people build them identically — "dirty" is one
+      untracked plus one modified tracked file (plus one staged change for git);
+      "ahead/behind" is a local clone two commits ahead and one behind upstream;
+      the no-repository expectation is the shell's own behaviour, captured with
+      the rest.
+- [ ] `accelerator vcs guard` reproduces the captured decision table. The row
+      count is **34 command cases × 4 repo modes = 136**, plus the
+      `.git`-as-file colocated case: 13 blocked subcommands + 7 allowed + `gh` +
+      `rtk` + 12 compound cases (4 separators × match-first / match-later /
+      no-match) = 34; repo modes are pure-jj, colocated, git, non-repo. The
+      multiplier applies uniformly, so the total is checkable against the
+      capture.
+- [ ] The `classify_checkout` port is verified by a fixture covering every arm
+      in the authoritative list, asserting first-match-wins for the named
+      ambiguous case: **a colocated checkout nested inside another repository
+      classifies as `colocated`, not `nested-*`**. The set is asserted
+      **closed** — exactly the seven named variants — so a superset taxonomy is
+      detectable.
+- [ ] `hooks.json` registers the three command strings verbatim. A golden exists
+      **per emitted output shape**; the plan enumerates the final list, which
+      includes at least: SessionStart with `systemMessage`, SessionStart
+      without, plain `vcs detect`, plain `vcs guard`, PreToolUse deny, and
+      PreToolUse warn-only.
+- [ ] The PreToolUse guard emits
+      `{hookSpecificOutput:{hookEventName:"PreToolUse",
+      permissionDecision:"deny", permissionDecisionReason:…}}` for a pure-jj
+      block. The colocated "warn but permit" case emits a bare top-level
+      `{systemMessage:…}` with **no** `permissionDecision` — `"allow"` skips the
+      interactive permission prompt and would widen privilege under cover of a
+      format change; `"ask"` would force a prompt where none is forced today.
+      *Applies unless the floor check selects the exit-2 fallback, in which case
+      the fallback's stderr text is pinned instead.*
+- [ ] **The guard fails open, three ways.** (a) Release host unreachable with an
+      empty cache — `ACCELERATOR_RELEASE_BASE_URL` at a dead address — the hook
+      exits 0 and emits no blocking envelope. (b) Host reachable but serving a
+      manifest with no `accelerator-vcs` entry — same outcome. (c) A corrupt
+      repository fixture (`.git/HEAD` truncated to non-ref bytes) — exits 0 and
+      emits no `permissionDecision`. Fault injection is by a test-only failing
+      adapter or a named env override, never by file permissions, so none of
+      these can pass vacuously under root.
+- [ ] **The two non-normal outputs are pinned separately**, matching the
+      disjoint contract: (a) *success with nothing to report* — in a main
+      checkout with no boundary, `vcs detect --format=hook --fail-safe` exits 0
+      and writes exactly zero bytes to stdout; (b) *adapter failure* — with a
+      test-only failing adapter, the same command exits 0 and writes exactly one
+      JSON object containing `systemMessage`. The guard's failure output is
+      pinned by the same rule: its corrupt-repository case emits that one object
+      and no `permissionDecision`.
+- [ ] `accelerator-vcs` is registered per 0187's checklist and ships end to end:
+      it appears in the generated manifest with a description and signature;
+      `validate_dispatch_coherence` (generalised by 0187) covers the `vcs`
+      token; `cargo deny`, `cargo-pup` and `--locked` clippy pass; the musl
+      build passes `_assert_static_elf`.
+- [ ] **The release precedes the rewrite.** A published manifest listing
+      `accelerator-vcs` exists before the `hooks.json` rewrite reaches an
+      installed-plugin path, verified against the *published* manifest rather
+      than the locally generated one. (The reachable-host-but-missing-entry case
+      is covered by the fail-open criterion; this one covers the ordering.)
+- [ ] After first use, the guard resolves from the warmed cache — zero
+      sub-binary fetch invocations against a stubbed fetcher across repeated
+      calls.
+- [ ] **Warm-call latency**, host-relative: in one session on one darwin-arm64
+      host with no build running, capture the median of 20 `hooks/vcs-guard.sh`
+      invocations (**B**) and 20 warm `accelerator vcs guard` invocations
+      (**G**), using the same stdin payload (a blocked `git status` call)
+      against the same pure-jj fixture. Acceptance requires **G ≤ 1.1 × B**.
+      Record B, G, the ratio, the payload, the fixture and the host in
+      Validation Results. Not a CI job — which means "not automated", not "not
+      required".
+- [ ] `skills/vcs/commit/SKILL.md:13-14` invoke
+      `${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs status` and `… vcs log`, and
+      its `allowed-tools` drops `Bash(${CLAUDE_PLUGIN_ROOT}/scripts/*)` for
+      `Bash(${CLAUDE_PLUGIN_ROOT}/bin/accelerator vcs *)`. Verified by (a) the
+      permission lint and the count of SKILL.md files using `!` injection
+      staying at 42 (`tasks/lint/skill_permissions.py:39`,
+      `EXPECTED_INJECTION_SKILLS` — this replaces two sites *within one
+      already-counted skill*, so the file count is unaffected), and (b) a
+      runtime check that both commands exit 0 and emit non-empty output in a
+      fixture repo.
+- [ ] `hooks/vcs-detect.sh`, `hooks/vcs-guard.sh`, `hooks/config-detect.sh`,
+      `scripts/vcs-status.sh` and `scripts/vcs-log.sh` are removed, and prose
+      documentation naming any of them (`README.md`, `docs/internals.md`,
+      `tasks/README.md`) is updated to the new subcommands — no listed guard
+      would catch a stale reference. The hooks suite floor
+      (`tasks/test/integration.py:47`) **remains 2, unchanged** — the two
+      surviving suites are `hooks/test-migrate-discoverability.sh` and the
+      repointed parity gate — and is re-verified green after the deletions. All
+      five removed files are entrypoints, so `SHELL_LIBRARIES` needs no edit.
+- [ ] **The downstream hand-offs are raised** as a dated note appended to each
+      receiving work item's Dependencies section — 0172 (proposed `blocked_by:
+      work-item:0169` plus `hooks/migrate-discoverability.sh` in its source
+      list), 0183 (`accelerator vcs detect` is a new SessionStart site for its
+      audit), and 0125 (the in-process adapter dissolves its lexical-fallback
+      rationale) — plus **the implementer creates** two follow-up work items:
+      one owning the `scripts/vcs-common.sh` residue and
+      `hooks/launcher-link-refresh.sh`, and one owning the decision on whether
+      `log`/`diff` leave the guard's blocked set (which would unblock
+      `skills/planning/validate-plan` in pure-jj repos). Appending the notes and
+      creating the two items are in scope; re-scoping existing items is not.
+- [ ] `mise run` is green end to end.
 
 ## Open Questions
 
-- None outstanding — the config-detect / migrate-discoverability scope boundary was
-  resolved during refinement (config detect in scope here; migrate discoverability
-  deferred to 0172).
+- **Are `permissionDecision` and top-level `systemMessage` honoured at Claude
+  Code v2.1.144?** The documentation dates neither field, and the guard
+  migration rests on them. **Default if unresolved: do not implement the guard
+  envelope** — resolve first (Sequencing Constraint 1). The in-story fallback is
+  exit-2 with stderr feedback; raising the plugin floor is escalated to epic
+  0136.
+- Where does the shared hook-envelope module live? 0167's renderer has no
+  `systemMessage` slot, and cargo-pup forbids `config_command` importing
+  `crate::launch`. **Default if unresolved: a new module in the launcher**
+  (`crate::hooks::envelope`), imported by both renderers; `kernel` is the
+  alternative. 0170/0171/0173 inherit whichever is chosen.
+- Is `hooks.json`'s `args` exec form available at the floor? **Default: register
+  the shell form**, which works either way.
 
 ## Dependencies
 
-- Blocked by: 0164 (the fetch-verify-cache model the warmed-cache guard relies on —
-  AC "guard resolves from the warmed cache with no per-Bash-call fetch" is not
-  validatable until 0164 lands), 0166 (shared crates — complete), 0167 (the wrapper
-  + invocation contract, and the built-in `config` command this story extends with
-  `config detect` — in progress, expected complete before this is picked up),
-  0179 (the `vcs`/`vcs-adapters` crates this subdomain consumes and extends —
-  complete on the feature branch).
-- Blocks: 0172 (its final migrate-discoverability hook migration builds on this
-  story's `hooks.json` rewrite), 0174 (retires the wrapper/shell tail left precisely
-  because this story removes only three of the four hook scripts).
-- Related: 0172, 0174 (see Blocks — both consume this story's `hooks.json` output).
-- Parent: epic 0136.
+- **Blocked by**: 0164 (fetch-verify-cache — **done**), 0166 (shared crates —
+  **done**), 0179 (the `vcs`/`vcs-adapters` crates — **done**), 0167 (bootstrap
+  invocation contract and the `config` command — **code landed on `main`**; its
+  work item is still `ready`, so **close out 0167's status before this story
+  starts** rather than at its acceptance, or the edge stays stale throughout),
+  0186 (exec-probe fix — the latency criterion measures against a fixed
+  bootstrap), 0187 (registration surface — this story adds a token to it), and
+  0188 (library-backed adapters — the subdomain is built on them).
+- **Completed dependencies not in `blocked_by`**: 0165 (distribution pipeline —
+  **done**).
+- **Hand-off note from 0186 (2026-07-31): 0186 is necessary but may not be
+  sufficient for this story's warm-call latency criterion.** 0186 removes the
+  ~108 ms exec probe but deliberately retains the verify shim's second
+  `sha256_file` (~11.7 ms of a ~23 ms staging cost), because three existing
+  tests
+  in `tests/integration/entrypoint/test_accelerator_entrypoint.py` assert the
+  planted-stub defence it provides — removing it would weaken a tested trust
+  boundary, so no work item owns that residual. Expect a warm bootstrap around
+  41 ms, against this story's `G ≤ 1.1 × B` gate of ≈ 38.6 ms, with a sub-binary
+  exec and verify on top. **Resolve this before acceptance**: either relax the
+  threshold, or accept the overrun with a stated rationale. See 0186's
+  Dependencies and Validation Results.
+- **In-flight dependency**: 0182 (plugin-root self-location — **`in-progress`**,
+  code landed). It delivers the `ACCELERATOR_PLUGIN_ROOT` regime the new
+  `cli/**` code must use, and `hooks/launcher-link-refresh.sh`, which must
+  survive untouched. It also edits `bin/accelerator`, as does 0186 — those two
+  must be sequenced against each other.
+- **External systems**: the **Claude Code hook I/O schema** at floor v2.1.144
+  (see the first Open Question); the **release-artefact host**, on which both
+  the guard hook *and* the repointed `skills/vcs/commit` depend for their first
+  invocation — the fail-open posture covers the hook paths, and the skill
+  degrades its injected context rather than failing when the sub-binary cannot
+  be fetched.
+- **Process prerequisite — the release cut.** Sequencing Constraint 4 forbids
+  shipping the `hooks.json` rewrite ahead of a release whose manifest lists
+  `accelerator-vcs`, because the launcher's exact-version-equality anti-rollback
+  rule turns a missing entry into a hard failure for every installed plugin.
+  That release is **not** produced by this story's code changes — it requires a
+  release run and the minisign signing key. Owner: whoever performs epic-0136
+  releases. It must be scheduled as part of accepting this story, and is gated
+  by an acceptance criterion rather than left to the sequencing constraint
+  alone.
+- **Blocks**: 0172 (its migrate-discoverability migration builds on this
+  `hooks.json` rewrite; 0172 currently records **no `blocked_by` at all**);
+  0170, 0171, 0173 (each ships its own sub-binary and inherits the hook-envelope
+  module home decided here); 0174 (retires the surviving shell tooling).
+- **Related**: 0125 — not closed here; this story leaves the shell probe and
+  lexical layers alive alongside the Rust classifier. 0183 — owns the
+  SessionStart audit this story adds a site to. 0185 — converges
+  `corpus-adapters` and deletes `CommandProbe`, blocked by 0188 rather than by
+  this story.
+- **Unowned debt this story creates**: `classify_checkout` and the probe-layer
+  helpers in `scripts/vcs-common.sh` lose every production caller while
+  `find_repo_root` (20+ callers) and `vcs_mode` (1) survive. **0174's recorded
+  scope is tooling and CI guards and never names `vcs-common.sh` or any hook
+  script**, so despite the `blocks: 0174` edge it does not claim this.
+  Separately, `hooks/launcher-link-refresh.sh` is claimed by no epic-0136 story.
+  An acceptance criterion requires a follow-up item owning both.
+- **Parent**: epic 0136.
 
 ## Assumptions
 
-- The four target platforms (the epic 0136 target triples per
-  `tasks/shared/targets.py`: `aarch64`/`x86_64-apple-darwin` and
-  `aarch64`/`x86_64-unknown-linux-musl`) are all Unix.
-- After the first-use fetch, the guard's warmed-cache per-Bash-call cost is
-  comparable to today's `vcs-guard.sh` spawn. Only the absence of a per-call fetch
-  is gated by an acceptance criterion; per-call latency parity is an assumption, not
-  a verified bound.
+- The four target platforms (`tasks/shared/targets.py`) are all Unix.
+- The darwin-arm64 latency reference (B ≈ 35 ms) is representative of the host
+  the parity measurement runs on. The measurement is host-relative precisely so
+  this assumption need not hold exactly.
 
 ## Technical Notes
 
-- Source bash: `scripts/vcs-common.sh`, `hooks/vcs-detect.sh`, `hooks/vcs-guard.sh`,
+- Source bash: `scripts/vcs-common.sh`, `scripts/vcs-status.sh`,
+  `scripts/vcs-log.sh`, `hooks/vcs-detect.sh`, `hooks/vcs-guard.sh`,
   `hooks/config-detect.sh`, `hooks/hooks.json`, and the
-  `hooks/test-fixtures/vcs-detect/` fixtures. (`hooks/migrate-discoverability.sh` is
-  deliberately out of scope — it ports with the migration subdomain in 0172.)
-- The `vcs`/`vcs-adapters` crates land in 0179; this story extends them with the full
-  `classify_checkout` taxonomy rather than defining them from scratch.
-- `classify_checkout` arm ordering is load-bearing — preserve first-match-wins
-  semantics exactly.
-- **Implementation approach — bind VCS libraries, don't shell out.** The adapters
-  should drive git and jujutsu through in-process Rust libraries — `gix`
-  (gitoxide) for git and `jj-lib` for jujutsu — bound behind the outbound VCS
-  ports, rather than spawning `jj`/`git` child processes. This departs from the
-  current `CommandProbe` adapter (`cli/vcs-adapters/src/lib.rs:48-196`), which
-  runs `jj log`/`git rev-parse` as subprocesses; the port abstraction
-  (`cli/vcs/src/lib.rs:48-55`) already allows swapping in a library-backed
-  adapter without touching the domain.
-  - Git queries `classify_checkout` needs map to `gix`: bare check
-    (`git rev-parse --is-bare-repository`, `vcs-common.sh:207`), worktree
-    detection (`--git-dir` vs `--git-common-dir`, `vcs-common.sh:217-219`), and
-    superproject/submodule resolution (`--show-superproject-working-tree`,
-    `vcs-common.sh:140-146`).
-  - jj queries map to `jj-lib`: workspace-root resolution and the
-    main-vs-secondary distinction (`.jj/repo` dir vs file,
-    `vcs-common.sh:74-81`), plus revision reads.
-  - Risk to validate early: `jj-lib`'s public API is explicitly unstable and
-    pins to the jj release; confirm its workspace/repo-loading surface covers
-    the secondary-workspace and colocated cases before committing. `gix` is the
-    more mature of the two. Where a query has no library equivalent, a per-query
-    shell fallback *behind the same port* is acceptable, but library-first is
-    the default.
-- Behavioural reference (`path:line`):
-  - jj-outranks-git dispatch — a command-set selector, not a topology (git's
-    index lags jj's working copy in colocated): `scripts/vcs-common.sh:27-36`.
-  - `classify_checkout` contract + six-line `KEY=VALUE` record:
-    `scripts/vcs-common.sh:157-176`; body `:177-280`.
-  - Load-bearing arm cascade (first-match-wins) — `colocated` must precede the
-    `nested-*` arms: `scripts/vcs-common.sh:240-272`.
-  - Hook I/O envelopes to reproduce under `--format=hook`: SessionStart
-    `{hookSpecificOutput:{hookEventName,additionalContext}}` + optional
-    `systemMessage` (`hooks/vcs-detect.sh:177-181`); PreToolUse guard
-    `{decision:block,reason}` (pure-jj) vs
-    `{decision:allow,hookSpecificOutput}}` (colocated)
-    (`hooks/vcs-guard.sh:97-108`).
-  - Guard command-parsing (a separate behaviour from detection): compound-command
-    split on `&& || ; |` then git-subcommand pattern match
-    (`hooks/vcs-guard.sh:44-108`); `gh`/`rtk` unconditionally allowed.
-  - Rust starting point: `vcs`/`vcs-adapters` today model corpus `RepoFacts`
-    (root/name/kind/revision), *not* the hook taxonomy —
-    `cli/vcs/src/lib.rs:32-78`; parity tests assert facts only
-    (`cli/vcs-adapters/tests/detection.rs`). The launcher dispatches any new
-    `accelerator-vcs` external subcommand with no launcher changes
-    (`cli/launcher/src/launch/inbound/cli.rs:15-22`).
+  `hooks/test-fixtures/vcs-detect/` fixtures.
+- **Mode detection is duplicated four ways** and the hooks do not use
+  `vcs_mode()`: `vcs-common.sh:27-36` tests `-e`, while `vcs-detect.sh:28-36`,
+  `vcs-guard.sh:22,77`, `vcs-status.sh:9` and `vcs-log.sh:9` each inline `-d`.
+  Hence the per-subcommand normative reference, and hence the `.git`-as-file
+  correction applying to all four.
+- Behavioural reference (`path:line`): jj-outranks-git dispatch
+  (`vcs-common.sh:27-36`); `classify_checkout` contract and six-line record
+  (`:157-176`, body `:177-280`); load-bearing arm cascade (`:240-272`);
+  SessionStart envelope (`vcs-detect.sh:177-181`); the deprecated PreToolUse
+  shapes deliberately not reproduced (`vcs-guard.sh:97-108`); guard
+  command-parsing (`vcs-guard.sh:44-108`).
+- At most one JSON object may reach stdout — see
+  `hooks/launcher-link-refresh.sh:16-27` for the accumulate-then-emit-once
+  pattern. The parity gate extracts via `jq -r
+  '.hookSpecificOutput.additionalContext'`, so compact-versus-pretty rendering
+  is transparent to it.
+- New code under `cli/**` must not name any `CLAUDE_*` variable
+  (`tasks/lint/claude_coupling.py`). The parity gate's `CLAUDE_PLUGIN_ROOT=`
+  overlay changes accordingly, and **`test:integration:hooks` gaining a
+  `build:cli:dev` dependency plus `accelerator_env()` is in scope for this
+  story**, including the `tests/unit/tasks/test_mise.py` pin update that
+  currently asserts their absence.
+- The launcher dispatches any new external subcommand with no launcher changes
+  (`cli/launcher/src/launch/inbound/cli.rs:15-22`).
 
 ## Notes from 0167 (2026-07-22)
 
-- **The SessionStart envelope contract is settled by 0167** and this story
-  inherits it: `accelerator config summary --format=hook` emits
+- **The SessionStart envelope contract is settled by 0167** and inherited here:
+  `accelerator config summary --format=hook` emits
   `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"…"}}`
-  (compact `serde_json`, not `jq`'s pretty-print), emits **nothing** when the
-  summary is empty, and — with `--fail-safe` — exits 0 with a stderr diagnostic on
-  a read/IO failure. `accelerator vcs detect`'s SessionStart output must slot into
-  the same `additionalContext` shape.
-- **The registration names the bootstrap path**, `${CLAUDE_PLUGIN_ROOT}/bin/accelerator`,
-  not a "universal wrapper" — 0164/0165's fetch-verify-cache launcher. The word
-  "wrapper" in this story's earlier prose refers to that bootstrap script.
-- **PreToolUse's envelope is this story's own to define.** `vcs-guard.sh` emits
-  `{decision, reason}` and `{decision, hookSpecificOutput}`, an unrelated shape to
-  SessionStart's — there is no single envelope spanning all hooks, so the
-  `--format=hook` switch renders a per-hook-type envelope, not one uniform one.
-- **The hooks.json argument-splitting question is unresolved and shared.** 0167
-  could not confirm headlessly whether `hooks.json`'s `command` field expands
-  `${CLAUDE_PLUGIN_ROOT}` *and* splits argument tokens, so it left
-  `config-detect.sh` as a thin exec-wrapper rather than inlining
-  `bin/accelerator config summary --format=hook --fail-safe` into `hooks.json`.
-  This story resolves the probe (it must, to register argument-bearing VCS
-  subcommands) and can then fold the config registration in and delete the wrapper.
+  (compact `serde_json`), emits **nothing** when the summary is empty, and with
+  `--fail-safe` exits 0 on a read/IO failure. `vcs detect` slots into the same
+  `additionalContext` shape but must **extend** it with the optional
+  `systemMessage` sibling that 0167's renderer
+  (`cli/launcher/src/config_command/render/summary.rs:66-74`) has no slot for.
+- **The registration names the bootstrap**, not a "universal wrapper".
+- **The `hooks.json` argument-splitting question is RESOLVED.** The `command`
+  field is handed to `sh -c` in shell form, so `${CLAUDE_PLUGIN_ROOT}` *is*
+  expanded and argument tokens *are* split; an alternative exec form takes a
+  sibling `args` array passed verbatim with no shell. Either way no wrapper is
+  needed, so `hooks/config-detect.sh` is inlined and deleted here.
+
+## Validation Results
+
+- **Claude Code floor check**: observed client version — _pending_; are
+  `permissionDecision` and top-level `systemMessage` honoured — _pending_;
+  fallback taken, if any — _pending_.
+- **Warm-call latency**: B — _pending_; G — _pending_; ratio — _pending_;
+  payload and fixture — _pending_; host and OS version — _pending_.
 
 ## Drafting Notes
 
-- Treated as the Phase 6 story; bundles the VCS subdomain with the hooks migration
-  because the hooks are the VCS subdomain's primary consumer.
-- Scope boundary confirmed with the author: `config detect` is migrated here; the
-  SessionStart migrate-discoverability reminder is deferred to 0172, so this story
-  removes three hook scripts, not four.
-- The built-in-vs-sub-binary question was closed: the guard is served as the
-  `accelerator-vcs` sub-binary, and the fetch cost is a first-use-only hit amortised
-  by the 0164 warmed cache — so it is not carried as an open question.
-- Priority raised medium → high: this is a critical-path Phase 6 story that gates the
-  hooks migration for epic 0136.
+- **Split 2026-07-31**, after review-2 pass 4 measured that three editing passes
+  had not reduced the major-finding count (19 → 15 → 14 → 14), with eleven of
+  the fourteen pass-4 majors being defects introduced by the previous pass's
+  fixes. Four concerns were extracted: 0186 (exec-probe fix), 0187 (registration
+  surface), 0188 (library-backed adapters), and 0185 (corpus-adapters
+  convergence, created earlier). This story keeps the subdomain, the hooks
+  migration and the skill repoint — the three pieces that cannot be delivered
+  separately, since the shell hooks cannot be deleted before their Rust
+  replacements exist, and `vcs status`/`vcs log` would otherwise ship with no
+  consumer.
+- The PreToolUse envelope moved to the `permissionDecision` shape (2026-07-30),
+  making the guard a deliberate behavioural change rather than a byte-for-byte
+  port.
+- Priority high: critical-path Phase 6 story gating the hooks migration.
 
 ## References
 
-- Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+- Source:
+  `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+- Implementation surface:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+- Review driving the split:
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`
 - Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
-- Related: 0166, 0167, 0172, 0174, 0179
-- ADRs: ADR-0048, ADR-0053
+- Siblings from the split: 0185, 0186, 0187, 0188
+- ADRs: ADR-0048 (hook logic lives in the CLI), ADR-0053 (thin CLI over a
+  hexagonal ports-and-adapters core)

--- a/meta/work/0170-work-item-subdomain-and-sync-engine.md
+++ b/meta/work/0170-work-item-subdomain-and-sync-engine.md
@@ -9,10 +9,11 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
+blocked_by: ["work-item:0187"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 relates_to: ["work-item:0171"]
 tags: [rust, work-items, sync, tracker]
-last_updated: "2026-06-28T17:01:56+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-191"
@@ -77,6 +78,13 @@ dedicated test suite — a coverage gap to close.
 ## Dependencies
 
 - Blocked by: 0166 (shared crates).
+- Blocked by: 0187 (generalises the sub-binary registration surface). This story
+  adds a dispatch token; it does not generalise the surface. Registration
+  follows the checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary`. Note the token
+  constraint that bites here specifically: the dispatch token may not contain
+  `_`, because it derives `ACCELERATOR_<TOKEN>_BIN` — so `work-item`, not
+  `work_item`. (2026-08-01)
 - Relates to: 0171 (provides the `jira-client`/`linear-client` adapters the sync
   engine wires in).
 - Parent: epic 0136.

--- a/meta/work/0171-jira-and-linear-integrations.md
+++ b/meta/work/0171-jira-and-linear-integrations.md
@@ -9,10 +9,11 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
+blocked_by: ["work-item:0187"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 relates_to: ["work-item:0170"]
 tags: [rust, jira, linear, integrations, reqwest]
-last_updated: "2026-06-28T17:01:56+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-192"
@@ -74,6 +75,10 @@ into separate Jira and Linear stories if finer granularity is wanted.
 ## Dependencies
 
 - Blocked by: 0166 (shared crates), and the `tracker` port from 0170.
+- Blocked by: 0187 (generalises the sub-binary registration surface). This story
+  adds a dispatch token; it does not generalise the surface. Registration
+  follows the checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary`. (2026-08-01)
 - Relates to: 0170 (the sync engine consumes these clients).
 - Parent: epic 0136.
 

--- a/meta/work/0172-migration-engine-subdomain.md
+++ b/meta/work/0172-migration-engine-subdomain.md
@@ -9,12 +9,12 @@ status: ready
 kind: story
 priority: high
 parent: "work-item:0136"
-blocked_by: ["work-item:0166", "work-item:0167", "work-item:0169"]
+blocked_by: ["work-item:0166", "work-item:0167", "work-item:0169", "work-item:0187"]
 blocks: ["work-item:0174"]
 relates_to: ["work-item:0173", "work-item:0180", "work-item:0182", "work-item:0183"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, migration-engine, concurrency, interactive]
-last_updated: "2026-08-01T11:59:07+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-193"
@@ -649,6 +649,10 @@ script *and* registration — here.
   `vcs-detect`/`vcs-guard` registrations and leaves `migrate-discoverability` —
   script and registration — here.
 - Blocked by **0166** (done): retained because 0166 declares `blocks: 0172`.
+- Blocked by **0187** (generalises the sub-binary registration surface). This
+  story adds a dispatch token; it does not generalise the surface. Registration
+  follows the checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary`. (2026-08-01)
 - Blocks: 0174.
 - Parent: epic 0136.
 - Crate foundation (done): 0178 (`config`, `config-adapters`), 0179 (`corpus`,

--- a/meta/work/0173-remaining-subdomains-corpus-design-collaboration.md
+++ b/meta/work/0173-remaining-subdomains-corpus-design-collaboration.md
@@ -9,10 +9,10 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0167"]
+blocked_by: ["work-item:0167", "work-item:0187"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, corpus, design, collaboration, subdomains]
-last_updated: "2026-07-19T18:00:00+00:00"
+last_updated: "2026-08-01T16:57:37+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-194"
@@ -83,6 +83,11 @@ granularity is wanted.
 
 - Blocked by: 0166 (shared crates), 0167 (the invocation-contract pattern these
   subdomains' call sites follow).
+- Blocked by: 0187 (generalises the sub-binary registration surface). This story
+  adds a dispatch token per subdomain; it does not generalise the surface.
+  Registration follows the checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary` — three times over, once
+  for each of corpus, design and collaboration. (2026-08-01)
 - Parent: epic 0136.
 
 ## Assumptions

--- a/meta/work/0182-cli-derives-plugin-root-from-own-location.md
+++ b/meta/work/0182-cli-derives-plugin-root-from-own-location.md
@@ -5,10 +5,11 @@ title: "bin/accelerator requires CLAUDE_PLUGIN_ROOT in the environment (never ex
 date: "2026-07-26T21:28:26+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: in-progress
+status: ready
 kind: bug
 priority: high
-relates_to: ["work-item:0164", "work-item:0167", "work-item:0136", "work-item:0183", "work-item:0184", "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface"]
+blocks: ["work-item:0186"]
+relates_to: ["work-item:0164", "work-item:0167", "work-item:0136", "work-item:0183", "work-item:0184", "work-item:0186", "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface"]
 source: "issue-research:2026-07-26-cli-requires-claude-plugin-root-env-var"
 tags: [bug, cli, launcher, bootstrap, plugin-root, skills]
 last_updated: "2026-07-29T00:00:00+00:00"

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -1,0 +1,157 @@
+---
+type: work-item
+id: "0185"
+title: "Converge corpus-adapters on the Library-Backed VCS Adapter"
+date: "2026-07-31T08:36:03+00:00"
+author: Toby Clemson
+producer: create-work-item
+status: draft
+kind: task
+priority: medium
+parent: "work-item:0136"
+blocked_by: ["work-item:0188"]
+relates_to: ["work-item:0125", "work-item:0179"]
+tags: [rust, vcs, cleanup, tech-debt]
+last_updated: "2026-07-31T08:36:03+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0185: Converge corpus-adapters on the Library-Backed VCS Adapter
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Migrate `cli/corpus-adapters` off the subprocess-based `CommandProbe` onto the
+library-backed (`gix` / `jj-lib`) VCS adapter that 0169 introduces, then delete
+`CommandProbe`. This closes the two-implementations state 0169 deliberately
+leaves behind, and extends the zero-`jj`/`git`-spawn guarantee from the four
+hook paths to every consumer of `vcs-adapters`.
+
+## Context
+
+0169 replaces `vcs-adapters`' subprocess probe with in-process `gix`/`jj-lib`
+bindings, but **bounds that swap to the `vcs detect|status|log|guard` paths**.
+The one production consumer outside those paths —
+`cli/corpus-adapters/src/metadata.rs:201`, which calls `vcs_adapters::facts` and
+reads `RepoFacts.name` and `.revision` to stamp artefact frontmatter — keeps
+using `CommandProbe`.
+
+That boundary was drawn deliberately, on review-2's recommendation (2026-07-31,
+unanimous across the scope, completeness and testability lenses): converging the
+metadata path inside 0169 would have coupled a pre-1.0 `jj-lib` bet to an
+already-shipped consumer with its own parity suite, and nothing in the hooks
+migration required it. The cost is that `vcs-adapters` ships **two** probe
+implementations, and the zero-spawn property holds only for the hook paths.
+
+This task pays that back once the library-backed adapter has proven itself on
+the four paths.
+
+## Requirements
+
+- Route `cli/corpus-adapters`' `RepoFacts` resolution through the library-backed
+  adapter instead of `CommandProbe`. The call site is
+  `cli/corpus-adapters/src/metadata.rs:201`; only `.name` and `.revision` are
+  read (`:185-186`), so the required surface is narrow.
+- Delete `CommandProbe` (`cli/vcs-adapters/src/lib.rs:73`) and its supporting
+  subprocess machinery once it has no callers — including the capped-stdout
+  helper and environment scrubbing that exist solely to serve it, if nothing
+  else uses them.
+- Preserve `vcs_adapters::facts`'s existing signature and semantics
+  (`cli/vcs-adapters/src/lib.rs:225`) so the change is invisible to callers: a
+  repository with no commits still yields `revision: None`, a bare repository
+  still yields `None` facts, and a jj secondary workspace still reports the
+  repository's name rather than the workspace directory's.
+- Extend the zero-spawn assertion to cover the corpus metadata read, so the
+  guarantee is crate-wide rather than path-scoped.
+
+## Acceptance Criteria
+
+- [ ] `CommandProbe` no longer exists in `cli/vcs-adapters`, and no
+      `Command::new` for `jj` or `git` remains in the crate's non-test code.
+- [ ] `cli/corpus-adapters` obtains `RepoFacts` through the library-backed
+      adapter, and its existing suites pass unchanged —
+      `cli/corpus-adapters/tests/parity.rs`,
+      `cli/corpus-adapters/tests/metadata.rs`, and
+      `cli/corpus-adapters/tests/work_item_pattern_parity.rs`.
+- [ ] The zero-spawn black-box assertion introduced by 0169 (fixture repos run
+      with `PATH` containing only marker-writing `git`/`jj` stubs) is extended
+      to a `corpus-adapters` metadata read: no marker is written and the read
+      still succeeds.
+- [ ] Behaviour is unchanged at the boundaries that
+      `cli/vcs-adapters/tests/detection.rs` already pins: no-commits →
+      `revision: None`; bare repository → no facts; colocated → `VcsKind::Jj`;
+      jj secondary workspace → the repository's name, not the workspace
+      directory's.
+- [ ] `mise run` is green end to end.
+
+## Dependencies
+
+- **Blocked by**: 0188 — the library-backed adapter does not exist until it
+  lands. (Originally recorded against 0169; repointed when 0169 was split and
+  the adapter work moved to 0188.)
+- **Related**: 0179 (delivered the `vcs`/`vcs-adapters` crate pair this
+  modifies); 0125 (converge lexical VCS detection on the probe layer — a
+  separate, shell-side convergence, but the same underlying "several detection
+  implementations coexist" problem, and worth sequencing consciously against).
+- **Parent**: epic 0136.
+
+## Assumptions
+
+- 0169 lands the library-backed adapter behind the existing `RepoRoot` /
+  `VcsProbe` ports, so this task is a wiring change plus a deletion rather than
+  new adapter work. If 0169 instead builds a `vcs`-local adapter that does not
+  generalise, this task grows and should be re-estimated.
+- The corpus metadata path needs no VCS query beyond `name` and `revision`.
+  Worth re-checking at implementation time — if `RepoFacts` has gained fields or
+  consumers by then, the surface to preserve is wider.
+
+## Technical Notes
+
+- Consumer: `cli/corpus-adapters/src/metadata.rs:201` (`vcs_adapters::facts`),
+  reading `.name` / `.revision` at `:185-186`; `use vcs::RepoFacts` at `:14`.
+- Composition root to change: `vcs_adapters::facts`
+  (`cli/vcs-adapters/src/lib.rs:225-227`) currently hard-wires `MarkerWalkRoot`
+  + `CommandProbe::new()` with no injection variant. 0169 will need to alter
+  this anyway; this task finishes the job by removing the old probe rather than
+  leaving both wired.
+- `CommandProbe`'s subprocess surface is small — two commands (`jj log -r @ -T
+  commit_id` at `:110-120`, `git rev-parse HEAD` at `:124-125`) funnelling
+  through a single `spawn()` at `:168` — so the deletion is well-bounded.
+- Watch the crate's own unit tests: several drive the private `capped_stdout`
+  and `scrub_environment` helpers directly
+  (`cli/vcs-adapters/src/lib.rs:229-322`) using generic shell binaries rather
+  than `jj`/`git`. They test machinery that exists only for `CommandProbe` and
+  should go with it, not be retargeted.
+- The `bash-parity` feature gate on `cli/vcs-adapters/tests/detection.rs` means
+  "needs real `jj`/`git` binaries to build fixtures", not "shells out in
+  production" — it stays relevant after this change, since fixtures are still
+  built with the real binaries.
+
+## Drafting Notes
+
+- Raised by 0169's downstream-hand-off acceptance criterion, which requires a
+  follow-up item owning this convergence rather than leaving it as unowned debt.
+- Sized as a `task` rather than a story: it is a wiring change plus a deletion
+  behind an adapter another item delivers, with no new behaviour and no user-
+  visible change.
+- Priority `medium`: nothing is broken while both implementations coexist — the
+  cost is a second code path and a narrower zero-spawn guarantee, not a defect.
+  It should not block epic 0136's shell-retirement work.
+
+## References
+
+- Boundary and rationale: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+  (Requirements → "Adapter-swap boundary"; Dependencies → "Unowned debt this
+  story creates or inherits", item 1)
+- Review that recommended the boundary:
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md` (Pass
+  3, 2026-07-31)
+- Crate state and call sites:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §1
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`

--- a/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -1,0 +1,437 @@
+---
+type: work-item
+id: "0186"
+title: "Remove the Exec Probe from the Bootstrap Warm Path"
+date: "2026-07-31T10:41:51+00:00"
+author: Toby Clemson
+producer: create-work-item
+status: ready
+kind: task
+priority: high
+parent: "work-item:0136"
+blocked_by: ["work-item:0182"]
+blocks: ["work-item:0169"]
+relates_to: ["work-item:0164", "work-item:0165", "work-item:0167"]
+tags: [shell, performance, bootstrap]
+last_updated: "2026-07-31T12:34:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0186: Remove the Exec Probe from the Bootstrap Warm Path
+
+**Kind**: Task
+**Status**: Ready
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+`bin/accelerator` runs an **exec probe** on every invocation — it writes a fresh
+executable into the cache dir, `chmod +x`es it, runs it and removes it — to
+detect a `noexec` mount. That probe costs **~108 ms of the ~149 ms** a warm
+`bin/accelerator` invocation takes (bootstrap plus launcher), almost all of it
+macOS's first-exec check on the newly written file. Remove the exec probe from
+the warm path, keeping it on the cold path where it belongs.
+
+## Context
+
+Throughout this work item, **cold path** means an invocation that must fetch
+and verify a launcher binary because no verified one is cached for the running
+platform, and **warm path** means an invocation that finds one already cached
+and execs it. "Cold branch" and "warm branch" refer to the code implementing
+each. `bin/accelerator` probes on both today, because the `resolve_cache_dir`
+call site runs unconditionally at `bin/accelerator:195` — before the branch.
+
+Measured on darwin-arm64, warm cache, 20 iterations each (2026-07-30):
+
+| Path | ms/call |
+| --- | --- |
+| `hooks/vcs-guard.sh` (today's shell guard) | 35.1 |
+| `bin/accelerator version` (bootstrap + launcher) | 149.1 |
+| launcher binary invoked directly | 3.0 |
+| minisign verify of the 8 MB launcher | 2.3 |
+| `probe_dir` write + chmod + exec + rm | **107.9** |
+| re-exec of a *pre-existing* probe file | 10.6 |
+
+The last two rows isolate the cause: executing a *freshly written* binary costs
+~97 ms more than re-executing an existing one, so ~97 ms of the probe's 107.9 ms
+is macOS's first-exec check and the rest is filesystem work. Everything the
+fetch-verify-cache design is usually blamed for — minisign, dispatch, the
+launcher itself — totals under 6 ms. Removing the probe alone should therefore
+land the warm bootstrap near **149.1 − 107.9 ≈ 41 ms**; that is the figure the
+latency gate is calibrated against.
+
+Every SessionStart hook pays this cost today via `hooks/config-detect.sh`, and
+every future CLI-backed hook will. This work item was extracted from 0169
+(review-2, pass 4) as an independently deliverable change with its own risk
+profile: the change touches the bash bootstrap under the 3.2 floor, not the
+Rust CLI.
+
+## Requirements
+
+- The warm path performs no write-chmod-exec probe. The exec probe is redundant
+  once a verified launcher binary is cached: the warm path already execs both
+  the verify shim and the launcher binary from the cache dir, which are stronger
+  exec tests than a synthetic probe, and a `noexec` directory makes
+  `verify_launcher` fail into the cold branch where the probe belongs.
+- Mechanism: split `probe_dir` (definition, `bin/accelerator:166-180`) into
+  `ensure_dir` (the `mkdir -p`, which still runs on every invocation) and the
+  write-chmod-exec probe, calling the latter only on the cold path before
+  fetching. The probe's result never *chooses* a directory —
+  `resolve_cache_dir` (definition, `bin/accelerator:184-193`) has no fallback —
+  so moving it changes only where the `no writable, exec-capable cache
+  directory` diagnostic fires. That diagnostic is emitted by the caller, at the
+  `resolve_cache_dir` call site and the `fail` that follows
+  (`bin/accelerator:195-197`).
+- Extend `tests/integration/entrypoint/test_accelerator_entrypoint.py` (reached
+  from `mise run test:integration:entrypoint`) with the cases the Acceptance
+  Criteria name. The suite already provides the harness — a fake release
+  server, an injected downloader, and the `_run_bootstrap` helper — and already
+  runs green-path bootstraps end to end
+  (`test_happy_path_forwards_args_and_exit_code`, which asserts a forwarded exit
+  code through a real launcher exec, and
+  `test_cache_hit_performs_no_further_fetch`, which warms then re-invokes), as
+  well as the cold-path permission counterpart
+  `test_readonly_root_without_override_is_a_named_error`. One capability is
+  *not* already present: threading `bash -x` and a custom `PS4` through
+  `_run_bootstrap` and capturing the trace, which the direct probe-absence
+  criterion needs — a small helper extension inside the existing suite, in
+  scope here.
+- Keep `bin/accelerator` bash-3.2-safe.
+
+**Already discharged during review (2026-07-31)**: a dated hand-off note was
+appended to 0169's Dependencies recording the residual warm-path cost this item
+does not remove and its consequence for 0169's latency criterion. It survives as
+a **verification** step, not new work — see the corresponding criterion. The
+deliverable is the note only; **changing 0169's threshold or its rationale is
+0169's own work**, not this item's.
+
+## Acceptance Criteria
+
+Criteria 1-4 and 6 are **automated cases** in
+`tests/integration/entrypoint/test_accelerator_entrypoint.py`, reached from
+`mise run test:integration:entrypoint`, so they act as permanent regression
+guards. Criteria 5, 9, 10 and 11 are **recorded checks** discharged by an entry
+in Validation Results. Criterion 7 is a lint gate and criterion 12 is the
+aggregate build.
+
+Three automated criteria are permission-dependent (the `chmod 0o555` warm case,
+the `chmod -x` cold case, and the `chmod -x` warm-to-cold case). One rule
+governs all three and supersedes any per-criterion wording: each asserts
+`id -u` ≠ 0 and **hard-fails rather than skips** when run as root, since root
+bypasses both directory write permissions and the execute bit and would satisfy
+the assertions regardless of the implementation. A lane structurally unable to
+comply is **excluded explicitly by the implementer**, never skipped silently,
+and the exclusion is justified by a recorded **privilege check** — `id -u`
+returning 0, or, for a filesystem that ignores the permission bits, a temp-dir
+check (`chmod 0o555` then assert file creation inside fails; `chmod -x` then
+assert traversal fails). The check's command and output are pasted into
+Validation Results for any exclusion claimed.
+
+- [ ] **Warm path performs no fatal exec probe** — verified **behaviourally**,
+      not by looking for the probe's residue (it is created and removed within
+      one invocation, so a post-hoc check passes either way). Sequence: run a
+      full bootstrap against the harness to populate the cache dir,
+      `chmod 0o555` that directory (executable, not writable), then assert a
+      second invocation exits 0 with the expected `version` output — the
+      version the harness fixture builds, asserted exactly. This works because
+      the warm path performs no writes (see Assumptions), so a *fatal*
+      surviving probe fails its write and the invocation exits non-zero. It
+      does **not** catch a probe kept and made non-fatal, which still exits 0;
+      that variant is ruled out only by the next criterion.
+- [ ] **Probe absent from the warm path, asserted directly** — the criterion
+      that actually pins probe absence, and therefore load-bearing rather than
+      supplementary. Run the bootstrap under `bash -x` with
+      `PS4='+${FUNCNAME[0]}:'` and assert the **probe function's name** (as
+      named after the split) is **absent** from the warm-run trace. The signal
+      must be the function name, not the `.accelerator-probe-` filename and not
+      a generic write or `chmod`: it stays stable across renaming the probe
+      *file*, and — unlike a generic pattern — it does not also match the cold
+      path's own shim staging (`cp` plus `chmod` at `bin/accelerator:257-260`)
+      and launcher write, which occur into the same directory regardless of the
+      probe. A generic pattern would make the positive control below vacuous.
+      Note bash's xtrace prints expanded command words but **not** redirections,
+      so a probe that creates its file via `>` emits no cache-dir path at all —
+      another reason the function name is the only reliable observable.
+- [ ] **Positive control for the trace assertion** — the same probe function
+      name must be asserted **present** in the trace of the cold happy-path run
+      (criterion 6), and the trace must additionally show the probe file being
+      **executed**, not merely written and `chmod`ed. Without this the negative
+      assertion above passes whenever the trace stops matching for unrelated
+      reasons. The exec half also gives the retained cold-path probe its only
+      real verification — see criterion 5 for why the `chmod -x` cases cannot
+      supply it.
+- [ ] **The `noexec` diagnostic survives on the cold path**: with an empty
+      cache dir made non-executable (`chmod -x`), a cold invocation exits
+      non-zero and its combined output contains the substring
+      `no writable, exec-capable cache directory` (`bin/accelerator:196`).
+- [ ] **The exec-vs-write coverage limitation is recorded.** Both `chmod -x`
+      criteria create their failure by removing a directory's execute bit,
+      which also blocks creating files inside it — so an implementation
+      retaining only the *write* half of the probe would produce the same exit
+      and the same diagnostic, and neither criterion distinguishes the two.
+      Record this in Validation Results, noting that the exec half is instead
+      covered by the positive control's execution assertion (criterion 3).
+      Mounting a genuinely `noexec` filesystem (a `mount -o noexec` tmpfs, or
+      an attached disk image on darwin) would close it completely and is
+      **explicitly out of scope here** — raise it as a follow-up if the
+      cold-path probe ever regresses.
+- [ ] **Cold happy path after the split** — pins the always-run `ensure_dir`
+      half: with `ACCELERATOR_CACHE_DIR` set to a path that does not yet exist,
+      a cold invocation creates the directory and `bin/accelerator version`
+      exits 0 with the expected output. This is the run that carries the
+      positive control (criterion 3).
+- [ ] **Diagnostic preserved when a warmed cache dir becomes non-executable**:
+      given a *warmed* cache dir subsequently made non-executable, the
+      invocation exits non-zero with the same `no writable, exec-capable cache
+      directory` substring. Note this is an end-state guard, not proof of
+      routing — today's bootstrap produces the same result by probing before
+      the branch, so the criterion cannot by itself demonstrate the
+      warm-to-cold fall-through. The routing claim is carried by criterion 3.
+- [ ] `bin/accelerator` passes the bash-3.2 gate — `scripts/lint-bashisms.sh`
+      plus the standard shfmt/ShellCheck checks report no findings.
+- [ ] **The warm-path saving clears its gate.** Take the median of 20 warm
+      `bin/accelerator version` invocations, on one darwin-arm64 host in a
+      single session with no build running, using the same method for both
+      figures (a bash loop over 20 runs taking the median, matching how the
+      Context table was produced). The **before-median is re-measured on the
+      post-0182 baseline immediately before the change, in the same session** —
+      the Context table's 149.1 ms is a pre-0182 reference figure, not this
+      gate's input. **The pass condition is `after ≤ 0.5 × before`**, which is
+      host-relative and so survives a faster or slower machine; the expected
+      landing point is ~41 ms against a ~149 ms baseline. The absolute delta
+      (`before − after`) is **recorded but not gating**, because the ~108 ms
+      probe cost is itself host-specific and a fast host could remove the whole
+      probe yet miss a fixed 80 ms bar. Both medians, the delta, and the host
+      and OS version go in Validation Results.
+- [ ] `test:integration:entrypoint` is observed green on **both shipped lanes**
+      (darwin and linux) for the new cases, not only locally — these are the
+      most environment-sensitive criteria in the suite. Which lanes were
+      observed is recorded in Validation Results.
+- [ ] **The 0169 hand-off note is present and still accurate.** Confirm the
+      dated note in 0169's Dependencies still holds after the rebase and after
+      the measurement lands — in particular that the quoted residual and its
+      consequence for 0169's `≤ 1.1 × B` gate match the measured after-median.
+      Update the figure if it moved; do not change 0169's threshold.
+- [x] The shim double-hash decision is recorded with its rationale — discharged
+      during review-1; see the Validation Results entry and Open Questions.
+- [ ] `mise run` is green end to end.
+
+## Open Questions
+
+None outstanding. The one question this item carried — whether to also drop the
+verify shim's second `sha256_file` call — was **resolved on 2026-07-31 during
+review-1: keep both hashes and the staging block unchanged**, and the shim
+staging is explicitly out of scope here. The reasoning and evidence are recorded
+once, in Validation Results.
+
+## Dependencies
+
+- **Blocked by**: 0182 (in-progress) also edits `bin/accelerator`, for
+  plugin-root self-location. **0182's changes land first and this work item
+  rebases onto them.** The edge is **discharged when 0182's `bin/accelerator`
+  and entrypoint-suite changes are on `main`, not when 0182 reaches
+  `complete`** — 0182's closure is gated on a manual pre-release check against a
+  clean install of a signed release artifact, and blocking a bash micro-change
+  (and transitively 0169 and its five children) on a release cut would be
+  wrong. The two items share **two** artefacts:
+  `bin/accelerator` itself, and
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py`, which 0182 also
+  reworks. So every `bin/accelerator` line number *and* every test name or line
+  range quoted here was read pre-0182 and must be re-resolved by name on
+  pick-up. The rebase check must additionally confirm two premises this item
+  rests on: that the self-located plugin root still yields a single `cache_dir`
+  with no fallback, and that the entrypoint suite still supplies a launcher
+  **without** introducing a `build:cli:dev` edge (0182 changes how the launcher
+  reaches the suite). If either has changed, re-scope before starting.
+- **Blocks**: 0169 — but the constraint binds at 0169's **acceptance, not its
+  start**. Only 0169's warm-call latency criterion depends on a fixed
+  bootstrap; its implementation work can proceed in parallel. **This work item
+  is necessary but may not be sufficient for that criterion.** Removing the
+  exec probe alone leaves the warm bootstrap at roughly 41 ms, while 0169
+  requires a warm `accelerator vcs guard` at ≤ 1.1 × the 35.1 ms shell guard
+  (≈ 38.6 ms) and pays a sub-binary exec and verify on top. The residual is the
+  verify shim's staging block — **~11.7 ms for the second `sha256_file` alone,
+  or ~23 ms if staging were skipped entirely**; neither is addressable without
+  weakening a tested trust boundary (see Validation Results). So 0169 must
+  either relax its threshold or accept the cost with a stated rationale. A
+  dated hand-off note in 0169's Dependencies carries this, so the obligation
+  does not die with this task.
+- **Completed dependencies (not blocking)**: 0164 (fetch-verify-cache — created
+  `probe_dir`, `resolve_cache_dir`, the staged verify shim and
+  `verify_launcher`), 0165 (multi-binary distribution and release pipeline —
+  produces the signed assets the measurement's first-choice launcher comes
+  from) and 0167 (bootstrap invocation contract). All have landed on `main`;
+  0167's work item is still `ready` despite its code shipping, so read the code
+  as authoritative over its status.
+- **External**: the **release-artefact host**. The behavioural criteria need
+  none of it — the suite fetches from a fake release server via an injected
+  downloader — but the latency gate measures a real `bin/accelerator version`,
+  which needs a genuine cached launcher for the measuring host. If no matching
+  release asset is published (routine mid-epic), the measurement uses a locally
+  staged launcher or an already-cached binary; state which in Validation
+  Results. **Both medians must use the same launcher binary, and it must be
+  post-0182**: 0182 makes the bootstrap export only `ACCELERATOR_PLUGIN_ROOT`,
+  so a pre-rename launcher finds no root and silently degrades — measuring
+  either side against one would invalidate the comparison.
+- **Execution environment**: the permission-dependent criteria require a
+  **non-root** runner on a filesystem that honours the write bit and the
+  directory execute bit. `test:integration:entrypoint` runs unprivileged on the
+  current darwin and linux lanes. The exclusion rule and its privilege check
+  are stated once in the Acceptance Criteria preamble.
+- **Parent**: epic 0136.
+
+Note on `status: ready` alongside a populated `blocked_by`: this is deliberate.
+0182's code has landed and only its release-gated closing steps remain, and the
+edge above is discharged on merge rather than on 0182's closure — so the item is
+genuinely startable once the rebase baseline exists.
+
+## Assumptions
+
+- The ~108 ms figure is a macOS first-exec penalty with no Linux equivalent, so
+  Linux savings will be materially smaller. Darwin is the worst case and the one
+  worth measuring.
+- **The warm path performs no writes**, which is what makes the removal
+  observable as a behaviour change and the `chmod 0o555` criterion sound. It
+  holds today: the shim-staging *body* (the `cp` and `chmod` at
+  `bin/accelerator:257-260`) is skipped when the staged bytes already match the
+  source digest, and the lock directory is acquired only on the cold path. Note
+  the staging `if`'s **condition** (`:255-256`) is still evaluated on every
+  invocation and contains the second `sha256_file` — that reads, it does not
+  write, so the invariant stands while the ~11.7 ms cost remains. If the warm
+  path proves not to be write-free on some configuration, that is a finding to
+  raise, **not work to absorb here** — the staging block is out of scope.
+- The latency gate assumes 0182's `bin/accelerator` changes leave warm-path
+  latency broadly unchanged. Expressing the gate as a ratio against a freshly
+  measured before-median means a materially different post-0182 baseline shifts
+  both sides together rather than failing a correct implementation.
+
+## Technical Notes
+
+Line numbers below are indicative at time of writing and predate 0182; each is
+paired with its enclosing function or distinguishing code, and labelled
+definition or call site, so it can be re-resolved after the rebase.
+
+- This item says "exec probe" on first use in each section and may shorten it
+  thereafter. The qualifier matters across the epic because 0169 reserves
+  "probe layer" for the shell VCS detection functions in
+  `scripts/vcs-common.sh`. The environment check in the Acceptance Criteria
+  preamble is deliberately called a **privilege check**, not a probe.
+- `probe_dir` exists to catch a `noexec` mount that a write-only check would
+  miss — a real hazard, which is why the cold-path exec probe is retained rather
+  than deleted outright. That same property is what the `chmod -x` criteria
+  cannot verify, which is why the positive control asserts the probe file is
+  executed.
+- `verify_launcher` (`bin/accelerator:310-312`) execs the staged shim from
+  `cache_dir`, and the final `exec "${launcher}"` (`bin/accelerator:352`) execs
+  the launcher binary from the same directory. Either failing is a stronger
+  signal than the synthetic exec probe.
+- The shim staging block spans `bin/accelerator:255-261`: its condition (`:255`
+  and `:256`) hashes both the source and the staged shim on every invocation,
+  and its body (`:257-260`) does the copy and `chmod` only when they differ. The
+  second `sha256_file` at `:256` is what Validation Results resolves to keep.
+- Attribution evidence: re-executing a *pre-existing* probe file costs 10.6 ms
+  against 107.9 ms for writing a new one each time — the delta is the
+  first-exec check, not filesystem work.
+
+## Drafting Notes
+
+Interpretations made while extracting this item from 0169 (review-2, pass 4)
+and during its reviews (review-1, passes 1-3) — each is an author call open to
+challenge:
+
+- **The warm-path exec probe is redundant, not merely expensive.** The argument
+  rests on `verify_launcher` and the final `exec` being strictly stronger exec
+  tests of the same directory. If either could ever run from somewhere other
+  than `cache_dir`, the argument weakens and the probe would need a narrower
+  replacement rather than relocation.
+- **The cold-path probe is retained rather than deleted.** A `noexec` mount is
+  a real hazard and the diagnostic is worth keeping; the cheaper alternative
+  (delete the probe outright and let the fetch fail with a less specific error)
+  was rejected as a worse diagnostic for a rare but confusing failure.
+- **The shim double-hash stays.** Resolved during review-1 on the strength of
+  three existing tests asserting the planted-stub defence. This is the judgement
+  most likely to be revisited if warm-path latency becomes binding again.
+- **The exec branch is verified by trace, not by a `noexec` mount.** Asserting
+  the probe file is executed in the cold-run xtrace costs nothing and
+  distinguishes the exec half from the write half; a real `noexec` mount would
+  be stronger but needs privileged, per-platform CI setup that would dwarf the
+  production change. The residual difference is recorded, not hidden.
+- **The latency gate is a ratio, not a fixed delta.** An absolute ≥ 80 ms
+  saving would fail a correct implementation on a host whose first-exec penalty
+  is smaller than darwin's ~97 ms. The delta is still recorded for comparison
+  against the 2026-07-30 table.
+- **0182 sequences ahead of this item** on the grounds that it is nearly
+  complete, not on any technical ordering requirement, and the edge is
+  discharged on merge rather than on 0182's release-gated closure. Reversing the
+  order is viable if 0182 stalls; the cost is re-resolving this item's line and
+  test references against a different baseline.
+- **No successor item is raised for the residual staging cost.** Recording the
+  shortfall against 0169's threshold, and carrying it to 0169 as a dated note,
+  was preferred over creating a work item for a change that is a security
+  trade-off rather than an optimisation.
+- **The verification burden is accepted deliberately.** The criteria outweigh
+  the production change several times over. That is proportionate for a file
+  every SessionStart hook executes, but it means the measurement session and
+  the cross-lane observation are genuine closure conditions, not formalities.
+
+## Validation Results
+
+- **Warm-path exec-probe-free check** (non-writable populated cache dir) —
+  _pending_.
+- **Direct probe-absence check** (`bash -x`, `PS4='+${FUNCNAME[0]}:'`, probe
+  function name absent from the warm trace) — _pending_.
+- **Positive control** (probe function name present in the cold trace, and the
+  probe file observed being executed) — _pending_.
+- **`noexec` cold-path check** — _pending_.
+- **Exec-vs-write coverage limitation recorded** — _pending_.
+- **Cold happy-path (`ensure_dir`) check** — _pending_.
+- **Diagnostic preserved on a warmed-then-non-executable cache** — _pending_.
+- **Lanes observed green** (darwin, linux) — _pending_.
+- **Lane exclusions**, each with the privilege-check command and output that
+  justified it — _pending_ (none expected).
+- **Warm-path median, before** (re-measured post-0182) — _pending_; **after** —
+  _pending_; gate `after ≤ 0.5 × before` — _pending_; delta (recorded, not
+  gating) — _pending_; host and OS version — _pending_; launcher provenance
+  (release asset, locally staged, or pre-cached) and confirmation both medians
+  used the same post-0182 binary — _pending_.
+- **0169 hand-off note** — appended 2026-07-31; **re-confirmation after rebase
+  and measurement** — _pending_.
+- **Shim double-hash decision** — **resolved 2026-07-31: keep both hashes and
+  the staging block unchanged.** The source research (§12) framed this as an
+  open trade-off worth ~23 ms via two distinct changes: dropping the second
+  hash at `bin/accelerator:256` (~11.7 ms, one hash of the 475 K shim), or
+  skipping staging entirely when `shim_source`'s directory and `cache_dir`
+  resolve to the same path (~23 ms, the default configuration where both are
+  `${plugin_root}/bin`). Neither is as cheap as it looked: the planted-stub
+  defence the second hash provides is **asserted by three existing tests** —
+  `test_planted_staged_shim_rehashed_then_succeeds`,
+  `test_planted_staged_shim_is_not_trusted` and
+  `test_planted_staged_shim_via_cache_dir_is_not_trusted`
+  (`tests/integration/entrypoint/test_accelerator_entrypoint.py:584-644`) — so
+  removing it deliberately weakens a tested trust boundary rather than clearing
+  a redundancy, and skipping staging would drop the same check by running the
+  shim from `shim_source`. That is a security decision with its own risk
+  profile and belongs in its own work item if it is ever wanted. The cost stays
+  on the warm path; the consequence for 0169's latency threshold is recorded in
+  Dependencies.
+
+## References
+
+- Measurements and attribution:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §12
+- Extracted from: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`, whose
+  review-2 (pass 4) produced this split:
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`
+- Review of this work item, in `meta/reviews/work/`:
+  `0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md`
+- The fetch-verify-cache design this item edits:
+  `meta/work/0164-launcher-and-git-style-dispatch.md`
+- Test surface: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+  (`mise run test:integration:entrypoint`)
+- Sequenced against:
+  `meta/work/0182-cli-derives-plugin-root-from-own-location.md`
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- ADRs: ADR-0049 (bash 3.2 compatibility floor)

--- a/meta/work/0187-generalise-sub-binary-registration-surface.md
+++ b/meta/work/0187-generalise-sub-binary-registration-surface.md
@@ -1,0 +1,498 @@
+---
+type: work-item
+id: "0187"
+title: "Generalise the Sub-Binary Registration Surface"
+date: "2026-07-31T10:41:51+00:00"
+author: Toby Clemson
+producer: create-work-item
+status: ready
+kind: task
+priority: high
+parent: "work-item:0136"
+blocked_by: ["work-item:0168"]
+blocks: ["work-item:0169", "work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173"]
+relates_to: ["work-item:0165", "work-item:0182"]
+tags: [build-system, distribution, rust]
+last_updated: "2026-08-01T17:29:06+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0187: Generalise the Sub-Binary Registration Surface
+
+**Kind**: Task
+**Status**: Ready
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+The dispatched-sub-binary machinery 0165 delivered is parameterised over
+`DISPATCHED_SUBBINARIES` almost everywhere — but `validate_dispatch_coherence`
+is hardcoded to the visualiser, and the registration surface is documented only
+in research, not in `tasks/README.md`. Make the coherence guard generic over the
+**dispatch token** (the subcommand name in `accelerator <token>`, and the
+corresponding entry in `DISPATCHED_SUBBINARIES`) and document the registration
+surface as a mechanical checklist, so the five stories that each ship a
+sub-binary add a token rather than rediscovering the surface and re-fighting the
+same visualiser-shaped assumptions — and are not serialised behind whichever
+gets there first.
+
+Two smaller deliverables support those: a parameter-with-default signature
+change across three release-stage builders, so the "already token-parameterised"
+assumption is discharged by test rather than by inspection; and the reciprocal
+dependency edges on the four consuming stories that lacked them, on the 0168
+blocker, and in the parent epic's annotation, so the coupling is visible from
+the consuming side while this task is still in flight. A one-symbol rename in
+`tasks/lint/skill_permissions.py` rides along, so the guard depends on a public
+parsing contract rather than a private one.
+
+Collapsing registration to a single allowlist entry — deriving manifest paths,
+ignore entries and the fixture manifest from the token — is explicitly **out of
+scope**. Registration stays multi-step; this task makes the steps documented and
+enforced rather than rediscovered.
+
+## Context
+
+`accelerator-visualiser` is currently the only dispatched sub-binary. Five
+epic-0136 stories each ship one — 0169 (`vcs`), 0170, 0171, 0172, 0173 — and
+each would otherwise rediscover the same registration points and re-fight the
+same visualiser-shaped assumptions.
+
+Signing (`tasks/signing.py:50-73`) and release upload and re-verification
+(`tasks/github.py:218-235`, `:270-293`) already iterate `DISPATCHED_SUBBINARIES`
+and need no behavioural change. `validate_dispatch_coherence`
+(`tasks/build.py:35`, `:189-208`) does: it reads a hardcoded
+`_VISUALISE_SKILL_RELATIVE` and compares `"accelerator visualiser" in skill`
+against `"visualiser" in DISPATCHED_SUBBINARIES`, so the binding it enforces —
+between a consuming skill and the sub-binary subcommand that skill invokes — is
+unenforced for every other token.
+
+Two properties of today's guard are easy to lose in a naive generalisation and
+must survive. Both directions are named descriptively below and in the
+Requirements, rather than as "first"/"reverse", so the two sections cannot drift
+apart:
+
+- **token→consumer**: every shipped token must have a consuming skill. This is
+  the direction a loop over `DISPATCHED_SUBBINARIES` gives for free.
+- **invocation→registration**: every skill invocation of a non-built-in
+  subcommand must correspond to a shipped token. Today's `invokes != dispatched`
+  comparison catches this; a loop over the allowlist alone would silently drop
+  it.
+
+A third property is a *defect* to fix rather than preserve: the current match is
+a bare substring, which the visualiser SKILL.md satisfies in prose
+(`skills/visualisation/visualise/SKILL.md:46`, `:160`) as well as in its real
+invocations (`:8`, `:30`). A generalised matcher must not inherit that
+looseness, or it will report tokens as bound on the strength of a documentation
+sentence.
+
+Extracted from 0169 (review 2, re-review pass 4 — see
+`meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`), where
+the scope lens observed that shared platform work delivered as a side effect of
+its first consumer both inflates that consumer and silently gates its siblings.
+
+## Requirements
+
+### The generalised guard
+
+- Generalise `validate_dispatch_coherence` so it checks the skill↔subcommand
+  binding for **every non-exempt** entry in `DISPATCHED_SUBBINARIES`, not only
+  the visualiser. Remove `_VISUALISE_SKILL_RELATIVE` and the `"visualiser" in
+  DISPATCHED_SUBBINARIES` membership assertion. No literal `visualiser` may
+  remain in the guard or its helpers.
+- Iterating the collection does **not** subsume the membership assertion being
+  removed: an emptied or truncated allowlist makes the loop check nothing and
+  pass, which is exactly what that assertion caught. Replace its anti-vacuity
+  role explicitly — the guard fails when the resolved token collection is
+  empty. On the release path an empty allowlist means the constant was lost,
+  not that the project ships no sub-binaries.
+- Define an **invocation** precisely, reusing the parsing
+  `tasks/lint/skill_permissions.py` already exposes rather than duplicating it:
+  a `!`-preprocessor command (`preprocessor_commands`) that `is_plugin_invocation`
+  recognises and whose first argument after `bin/accelerator` is the token.
+  Prose mentions, backticked references and plain body text do **not** count.
+- Define the **permission half** as two conditions that must both hold of a
+  *single* one of the invoking skill's `Bash(...)` rules
+  (`frontmatter_bash_rules`). At least one rule must:
+  1. authorise the token's subcommand — `covered_by` is true for the probe
+     `${CLAUDE_PLUGIN_ROOT}/bin/accelerator <token>`; **and**
+  2. *not* also authorise the bare launcher — `covered_by` is false for the
+     `BARE_LAUNCHER` probe.
+
+  Condition 2 is what rejects an ancestor glob, which satisfies condition 1.
+  `skill_permissions.py:183-188` applies condition 2 alone to flag over-broad
+  rules; this guard needs both. Omitting condition 2 produces a guard that
+  accepts exactly the ancestor-glob shape the task exists to reject.
+- Make the shared parsing contract public. Of the six names the guard reuses
+  from `tasks/lint/skill_permissions.py`, five are already public
+  (`preprocessor_commands`, `frontmatter_bash_rules`, `is_plugin_invocation`,
+  `covered_by`, `PLUGIN_PREFIX`); one is not. Rename `_BARE_LAUNCHER`
+  (`:42-44`) to `BARE_LAUNCHER` and update its existing caller at `:183-188`.
+  A release-gating guard depending on a lint module's *private* surface is the
+  coupling to avoid, and one rename removes it — the alternative is that a
+  future change to a private symbol silently alters what the release considers
+  a bound token. Reuse is the point: a guard that re-implemented this parsing
+  inline would satisfy every behavioural criterion while drifting away from the
+  lint rule it is meant to agree with, so the acceptance criterion asserts the
+  imports positively rather than only forbidding private ones.
+- State the quantifier once: a token is **bound** if at least one skill both
+  invokes it and carries a rule satisfying both permission conditions. Other
+  skills invoking the same token are not checked — multiple consumers are
+  permitted.
+- Preserve the **invocation→registration** direction: a plugin invocation of
+  `accelerator <X>` in any skill, where `X` is neither a launcher built-in nor
+  an entry in `DISPATCHED_SUBBINARIES`, fails the guard. The built-in set is
+  `version` and `config` (`cli/launcher/src/launch/inbound/cli.rs:16-29`).
+- Declare legitimately consumer-less tokens in an explicit exemption set —
+  `SKILL_EXEMPT_SUBBINARIES`, a sibling constant to `DISPATCHED_SUBBINARIES` in
+  `tasks/shared/paths.py`, empty when this task lands. The bar for an exemption:
+  the sub-binary is invoked only by hooks or by another binary, never from a
+  SKILL.md. A token that is neither bound nor declared exempt fails the guard.
+
+### Test seams
+
+- Make the guard's inputs injectable: `validate_dispatch_coherence` already
+  takes `repo_root` (the repository root, from which it derives `skills/`); add
+  the token collection and the exemption set as parameters defaulting to
+  `DISPATCHED_SUBBINARIES` and `SKILL_EXEMPT_SUBBINARIES` — so tests pass
+  fixture values rather than patching module state, and the test exercises the
+  same code path the release runs.
+- Give the three release-stage builders the same parameter-with-default shape,
+  so the "already parameterised" assumption can be discharged by test rather
+  than by inspection: the expected-set construction in `sign_staged_binaries`
+  (`tasks/signing.py:50-73`, extracted to a pure helper), `_release_uploads` and
+  `_subbinary_reverifies` (`tasks/github.py:218-235`, `:270-293`). This is a
+  signature change only — no behavioural change, and each default keeps today's
+  behaviour. *Fallback*: if the `sign_staged_binaries` extraction proves
+  non-local (touching the signing flow rather than just the expected-set
+  construction), drop this bullet to a sibling task and discharge the assumption
+  by inspection, rather than growing this task's blast radius into the signing
+  path.
+
+### The registration checklist
+
+- Document the registration surface in `tasks/README.md`, under a heading
+  `## Registering a dispatched sub-binary`, as a checklist covering every
+  registration point below. **This list is the normative enumeration**; research
+  §8 is its provenance, and where the two differ (point 6's co-readers) this
+  list is a correction of stale references rather than a divergence.
+  1. `DISPATCHED_SUBBINARIES` (`tasks/shared/paths.py:25`)
+  2. `_SUBBINARY_MANIFESTS` (`tasks/manifest.py:51-53`) when the crate is not at
+     `cli/<token>/`
+  3. the new crate's `Cargo.toml` — a mandatory `package.description`
+     (`tasks/manifest.py:60-66`) and `version.workspace = true` (else the
+     *version*-coherence check at `tasks/build.py:74-101` fires; this is a
+     different check from the dispatch guard this task generalises)
+  4. `cli/Cargo.toml` members
+  5. `.gitignore` (`bin/<token>-*`)
+  6. `cli/launcher/tests/fixtures/manifest.example.json`, together with **both**
+     its co-readers, which must be updated in the same change:
+     `tests/unit/tasks/test_manifest_contract.py:16` and the `include_str!` at
+     `cli/launcher/src/launch/outbound/resolve/manifest.rs:135`. (Research §8
+     names `tests/unit/tasks/test_manifest.py:38`; that reference is stale.)
+  7. the skill binding — a skill invoking `accelerator <token>` with a
+     `Bash(...)` rule satisfying both permission conditions — or an entry in
+     `SKILL_EXEMPT_SUBBINARIES`
+  8. cross-compile staging (`tasks/build.py:37`, `:290-331`; musl builds must
+     pass `_assert_static_elf`, `:132-159`)
+  9. SLSA provenance (`.github/workflows/main.yml:423-425`) — `subject-path` is
+     token-generic only for binaries staged in `dist/release/`
+     (`dist/release/accelerator-*`). Its other line,
+     `skills/visualisation/visualise/bin/accelerator-visualiser-*`, is
+     visualiser-shaped: a sub-binary staged under a skill's `bin/` tree needs a
+     sibling line. **No action when** the binary is staged only in
+     `dist/release/`.
+
+  Every point states either an author action or an explicit "No action when …"
+  clause; a point that needs no action for a given shape of crate says so
+  rather than being omitted.
+- Add a tenth entry covering the guard's own lockstep obligation: **adding a
+  launcher built-in subcommand** (beyond `version` and `config`) requires
+  updating the guard's built-in set, because the invocation→registration
+  direction would otherwise fail the release on an unrelated change.
+- State in the checklist that points 1 and 7 must land in the **same change**.
+  The guard runs from `tasks/manifest.py:138` on every release, so a token
+  registered before its binding (or its exemption) exists leaves the release
+  path red in the interim.
+- Make the naming constraints explicit in that checklist:
+  - the Cargo **package** is `accelerator-<token>`, and where a domain crate
+    already owns `cli/<token>/` the binary crate must live elsewhere with a
+    `_SUBBINARY_MANIFESTS` entry — because `tasks/manifest.py` defaults the
+    manifest path to `cli/<token>/Cargo.toml` and cargo-pup rules match on whole
+    crate names;
+  - the **token itself** may not contain `_`, because it derives
+    `ACCELERATOR_<TOKEN>_BIN` (`cli/launcher/src/launch/core.rs:215-240`), which
+    rejects underscores. 0170 is the consumer most likely to reach for
+    `work_item`.
+
+### Hand-offs
+
+- **Done 2026-08-01** — the reciprocal dependency edges were recorded up front
+  rather than at acceptance, because they only do their job while this task is
+  in flight and 0170–0173 otherwise look unblocked:
+  - `blocked_by: work-item:0187` plus a dated `- Blocked by: 0187 (…)`
+    Dependencies bullet on 0170, 0171, 0172 and 0173, each pointing at
+    `tasks/README.md#registering-a-dispatched-sub-binary`. 0170's bullet also
+    carries the no-underscore token constraint, since `work_item` is the name
+    that story would otherwise reach for;
+  - `blocks: work-item:0187` on 0168, with a bullet stating that closing it —
+    or confirming its residual scope cannot move the visualiser crate path —
+    discharges this task's blocker;
+  - epic 0136's decomposition annotation for 0187 corrected in full: the
+    `unblocks` list gains 0172, the now-false "no blockers" clause is replaced
+    by the 0168 prerequisite and its two discharge routes, and the annotation
+    states why 0187 stays a Foundations item rather than moving to Phase 5
+    behind its blocker. The Drafting Notes count was corrected from three
+    sibling stories to four.
+- The bullets already point at the `tasks/README.md` anchor; that link goes live
+  when this task lands the section. The only obligation remaining to the siblings
+  is the acceptance-time grep re-verification named in the criterion — no
+  further edits are owed to them.
+
+### Verification strategy
+
+- Verify the generalisation against a **fixture token** — a test-only value
+  passed into the guard (and into the three release-stage builders) through
+  their injected parameters, never registered in `DISPATCHED_SUBBINARIES` — so
+  this task can land before any of its consumers and so the real signing,
+  manifest generation and upload paths are untouched by the verification itself.
+- Where a test needs manifest data, it constructs an **in-test manifest**. The
+  golden manifest fixture (`manifest.example.json`) is a shipped artefact and is
+  not modified by this task.
+
+## Acceptance Criteria
+
+- [ ] **The hardcoding is gone.** `_VISUALISE_SKILL_RELATIVE` no longer appears
+      anywhere under `tasks/`, and neither `validate_dispatch_coherence` nor its
+      helpers contain a literal `visualiser` — asserted by a source-scan test in
+      `tests/unit/tasks/`, so reintroduction fails rather than merely being
+      noticed at review.
+- [ ] **Missing binding fails.** `validate_dispatch_coherence` iterates the
+      injected token collection and fails when any non-exempt token has no
+      skill invoking `accelerator <token>`. Verified by a unit test passing a
+      fixture token with a deliberately missing binding — the guard must be
+      demonstrably **non-vacuous**, not merely passing.
+- [ ] **Every token is checked, not just the first.** A two-token fixture
+      collection whose *second* token is unbound and whose first is bound fails
+      the guard, and the error names the second token.
+- [ ] **An empty collection fails.** The guard fails when the resolved token
+      collection is empty, rather than passing vacuously — verified with an
+      injected empty collection. This is what replaces the removed
+      `"visualiser" in DISPATCHED_SUBBINARIES` assertion, and it holds on the
+      release path, where the test-time criteria below cannot reach.
+- [ ] **Ancestor-glob permission fails.** A fixture token whose consuming skill
+      exists but carries only `Bash(${CLAUDE_PLUGIN_ROOT}/bin/accelerator *)`
+      fails the guard — i.e. permission condition 2 is applied, not just
+      condition 1. Covered by its own fixture case rather than folded into the
+      missing-binding test.
+- [ ] **Prose does not bind.** Two fixture cases, each leaving the target token
+      unbound and the guard firing: a skill that mentions the token only in
+      prose or a backticked reference, and a skill that invokes a *different*
+      token which is itself registered in the fixture collection and separately
+      bound — so the guard fires because the target token is unbound, not
+      because the invocation→registration rule caught an unregistered token.
+- [ ] **Multiple consumers are tolerated.** A fixture token invoked by two
+      skills passes when at least one carries a rule satisfying both permission
+      conditions, even if the other carries only an ancestor glob.
+- [ ] **invocation→registration fires, and built-ins are allowed.** A fixture
+      skill invoking `accelerator <X>` where `X` is neither a launcher built-in
+      nor in the token collection fails the guard; a fixture skill invoking
+      `accelerator config` — a built-in with no entry in the collection —
+      passes.
+- [ ] **Exemption works in both directions.** A fixture token in the injected
+      exemption set with no skill consumer passes; the same token with the
+      exemption removed fails.
+- [ ] **The visualiser binding still passes.** The generalised guard reports
+      `visualiser` as bound, and `skills/visualisation/visualise/SKILL.md` is
+      unedited — *unless* the drafting-time permission assumption has failed by
+      pickup, in which case the scoped `allowed-tools` edit that Assumptions
+      prescribes is permitted and its diff is recorded in Validation Results.
+      Seeding `SKILL_EXEMPT_SUBBINARIES` with `visualiser` is not an acceptable
+      route: it would make the guard vacuous for its only real binding.
+      `tests/unit/tasks/test_build.py` covers this pass path and every fail path
+      above.
+- [ ] **The release path still calls the guard, and passes no override.** A
+      unit test replaces `validate_dispatch_coherence` with a spy, runs manifest
+      generation, and asserts it was called exactly once with **no** collection
+      or exemption argument — so the call site cannot start passing a stale or
+      narrowed collection unnoticed.
+- [ ] **…and the defaults it falls back to are the real constants.** A separate
+      assertion on `inspect.signature(validate_dispatch_coherence)` pins the two
+      parameter defaults by **identity** (`is DISPATCHED_SUBBINARIES`,
+      `is SKILL_EXEMPT_SUBBINARIES`), not equality. The spy above cannot observe
+      this — passing no argument means the spy never sees the defaults, and the
+      real function's resolution never runs — so the two assertions together are
+      what stop a signature change leaving `tasks/manifest.py:138` operating on
+      an empty or wrong collection with every other test green.
+- [ ] **The already-parameterised stages hold for injected values.** With a
+      two-token fixture collection injected: the signing expected-set helper
+      yields one unsigned binary path per token per target across the four
+      `TARGETS`; `_release_uploads` yields an asset *and* its `.minisig` per
+      token per target; and `_subbinary_reverifies`, given an in-test manifest
+      carrying both tokens, yields one item per token per target. No signing key
+      and no network access are required — these are pure list-derivation
+      assertions. *If the signing-extraction fallback in Test seams was taken*,
+      this criterion applies to `_release_uploads` and `_subbinary_reverifies`
+      only; the sibling task id is recorded in Dependencies and the signing
+      inspection outcome in Validation Results.
+- [ ] **…and for the defaults.** Called with no collection argument, each of the
+      three builders yields precisely today's visualiser asset set — 4 unsigned
+      binary paths from the signing helper, 8 upload entries (asset plus
+      `.minisig` per target), and 4 re-verify items, every one naming
+      `visualiser` — so a mis-wired default (empty tuple, wrong constant,
+      mutable-default aliasing) fails rather than silently emptying the real
+      release. The same fallback carve-out as the criterion above applies.
+- [ ] **The shared parsing contract is public, and reused rather than copied.**
+      `tasks/lint/skill_permissions.py` exposes `BARE_LAUNCHER` with no
+      underscore prefix, its caller at `:183-188` is updated, and the literal
+      `_BARE_LAUNCHER` no longer appears anywhere under `tasks/` — so a retained
+      alias cannot satisfy the rename. A source-scan test additionally asserts
+      that the dispatch guard **imports** `preprocessor_commands`,
+      `frontmatter_bash_rules`, `is_plugin_invocation`, `covered_by`,
+      `PLUGIN_PREFIX` and `BARE_LAUNCHER` from `tasks.lint.skill_permissions`,
+      shadows none of those names locally, imports no underscore-prefixed name
+      from that module, and compiles no regex of its own against `Bash(` or the
+      `!`-preprocessor form. Every behavioural criterion above passes equally
+      against an inline re-implementation of the parsing, so without the
+      positive import assertion the reuse requirement — the whole justification
+      for the rename and for the shared-artefact coupling — would go
+      unverified.
+- [ ] **The checklist is mechanically checkable.** The
+      `## Registering a dispatched sub-binary` section of `tasks/README.md`
+      contains exactly ten numbered items, each item body carrying either an
+      imperative action line or the literal phrase `No action when`, and a test
+      in `tests/unit/tasks/` asserts the section contains the literal strings
+      `DISPATCHED_SUBBINARIES`, `SKILL_EXEMPT_SUBBINARIES`,
+      `_SUBBINARY_MANIFESTS`, `package.description`, `version.workspace`,
+      `cli/Cargo.toml`, `bin/<token>-*`, `manifest.example.json`,
+      `test_manifest_contract.py`, `resolve/manifest.rs`, `_assert_static_elf`,
+      `dist/release/accelerator-*`, `accelerator-<token>`,
+      `ACCELERATOR_<TOKEN>_BIN` and `same change` — so renaming a registration
+      point fails a test rather than silently ageing the docs.
+- [x] **The hand-offs are recorded** *(done 2026-08-01, ahead of pickup)*. 0170,
+      0171, 0172 and 0173 each carry `blocked_by: work-item:0187` plus a dated
+      Dependencies bullet naming the `tasks/README.md` anchor; 0168 carries
+      `blocks: work-item:0187`; epic 0136's 0187 annotation names the 0168
+      prerequisite and reads "unblocks 0169/0170/0171/0172/0173". Re-verify by
+      grep at acceptance in case a sibling was rewritten in the interim.
+- [ ] `mise run` is green end to end.
+
+## Dependencies
+
+- **Blocked by**: 0168 (folded the visualiser into `cli/` — code landed, but its
+  work item is still `ready`). Its landed layout is load-bearing: the checklist
+  documents the `cli/<token>/Cargo.toml` default and the `_SUBBINARY_MANIFESTS`
+  override precisely because of the visualiser's nested `cli/visualiser/server/`
+  placement, and the visualiser is the guard's one existing passing binding.
+  **Discharge condition** (this exact wording is mirrored in 0168's reciprocal
+  bullet, epic 0136's annotation and Open Questions — keep the four in step):
+  0168 is closed, *or* its residual scope is confirmed unable to move the
+  visualiser crate path. If neither holds at pickup, proceed anyway and
+  re-verify the path at acceptance — so this is a gate on confirmation, not a
+  wait on 0168's phase.
+- **Blocks**: 0169, 0170, 0171, 0172, 0173 — each registers a dispatched
+  sub-binary and inherits this surface. Landing this first means each of those
+  stories adds a token rather than reworking the pipeline. All five reciprocal
+  edges are recorded as of 2026-08-01 — 0169's pre-dated this task, and the
+  Hand-offs requirement added 0170–0173. The only remaining obligation is the
+  acceptance-time grep re-verification, in case a sibling is rewritten in the
+  interim.
+- **Shared artefact**: `tasks/lint/skill_permissions.py`. This task makes a
+  release-gating guard a second consumer of that module's parsing surface
+  (`preprocessor_commands`, `frontmatter_bash_rules`, `is_plugin_invocation`,
+  `covered_by`, `PLUGIN_PREFIX`, and the `_BARE_LAUNCHER` probe). A future
+  change to that parser now changes what the release guard considers a bound
+  token — a coupling that previously existed only within the lint task. The
+  Requirements carry the mitigation (rename the one private symbol so the
+  contract is explicit) and an acceptance criterion pins it.
+- **Related**: 0165 (delivered the distribution pipeline — **done**); 0182
+  (plugin-root self-location) — SKILL.md retains `${CLAUDE_PLUGIN_ROOT}` under
+  that work, which is the invocation form the new scanner must match. If 0182
+  changes the SKILL.md-facing prefix while this task is in flight, the scanner's
+  matching must move with it or the guard passes vacuously.
+- **Parent**: epic 0136.
+
+## Assumptions
+
+- The visualiser skill already satisfies the stricter permission definition:
+  `skills/visualisation/visualise/SKILL.md:8` carries
+  `Bash(${CLAUDE_PLUGIN_ROOT}/bin/accelerator visualiser *)`, which authorises
+  the token probe without authorising the bare launcher. Confirmed at drafting
+  time. *If this changes before pickup*, the fallback is a scoped `allowed-tools`
+  edit to that skill — not seeding `SKILL_EXEMPT_SUBBINARIES`, which would make
+  the guard vacuous for its only real binding.
+- Signing, upload and re-verification genuinely need no behavioural change —
+  they iterate `DISPATCHED_SUBBINARIES` already, and the two criteria above
+  discharge that by test (for injected values and for the defaults) rather than
+  by inspection. The signature change adding an injectable collection is not a
+  behavioural change.
+- SLSA provenance is the one stage confirmed **partially** visualiser-shaped:
+  `dist/release/accelerator-*` is generic, its sibling line is not. Handled by
+  documenting the condition as checklist point 9 rather than by changing the
+  workflow, because no consumer needs the skill-`bin/` staging path today.
+- If any other stage turns out visualiser-shaped, absorb the fix here **when it
+  is local to the token loop** — meaning confined to the per-token iteration in
+  `tasks/signing.py:50-73` / `tasks/github.py:218-235`, `:270-293`, requiring no
+  change to the surrounding release orchestration and no new external
+  dependency. Anything larger is raised as a sibling task and recorded in
+  Dependencies, so this task's boundary stays statable regardless of what
+  implementation finds.
+
+## Open Questions
+
+- **Can 0168's residual scope move the visualiser crate path?** If it can, the
+  checklist's `cli/<token>/Cargo.toml` default and the guard's one existing
+  passing binding both go stale immediately after this lands. Resolve by closing
+  0168, *or* confirming its residual scope cannot move the visualiser crate path
+  — the same discharge condition stated in Dependencies. *Default if neither
+  holds at pickup*: proceed, and re-verify the visualiser's manifest path and
+  its `_SUBBINARY_MANIFESTS` entry against the tree at acceptance, recording the
+  outcome in Validation Results.
+
+## Validation Results
+
+*Filled at acceptance.*
+
+- **SLSA glob inspection** (checklist point 9 is discharged by inspection, not
+  test, because the globs live in workflow YAML): _pending_
+- **Visualiser manifest path re-verification** (required only if 0168's
+  discharge condition was unmet at pickup — see Open Questions): _pending_
+- **Visualiser `allowed-tools` edit** (required only if the drafting-time
+  permission assumption failed; record the diff): _not required as drafted_
+- **Signing-extraction fallback** (required only if the Test-seams fallback was
+  taken; record the inspection outcome and the sibling task id): _not required
+  as drafted_
+- **Hand-off edge re-verification** (grep `blocked_by: work-item:0187` on
+  0170–0173, `blocks: work-item:0187` on 0168, and the 0136 annotation):
+  _pending_
+
+## Technical Notes
+
+- `tasks/build.py:35` — `_VISUALISE_SKILL_RELATIVE`, the hardcoded skill path,
+  removed by this task.
+- `tasks/build.py:189-208` — `validate_dispatch_coherence`, invoked from
+  `tasks/manifest.py:138` so it runs on every release. It already takes an
+  optional `repo_root`; the token collection and exemption set join it.
+- `tasks/lint/skill_permissions.py` — `preprocessor_commands`,
+  `frontmatter_bash_rules`, `is_plugin_invocation`, `covered_by` and
+  `PLUGIN_PREFIX` are the parsing this task reuses, all already public.
+  `_BARE_LAUNCHER` (`:42-44`) is the second permission probe, applied on its
+  own at `:183-188` to flag over-broad rules; this task renames it
+  `BARE_LAUNCHER`, which is the name the Requirements and criteria use.
+  Note `covered_by(command, pattern)` takes the probe as the command and the
+  skill's rule as the pattern.
+- A fixture token is test-only — passed through injected parameters, never added
+  to `DISPATCHED_SUBBINARIES` — which is what keeps this task independent of any
+  real sub-binary and leaves the release path untouched.
+
+## References
+
+- Extracted from: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+- Registration points originally enumerated in:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §8 — superseded as the normative list by the Requirements above
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- ADRs: ADR-0054 (git-style modular CLI of on-demand static binaries)
+- Review: `0187-generalise-sub-binary-registration-surface-review-1.md` in
+  `meta/reviews/work/`

--- a/meta/work/0188-library-backed-vcs-adapter.md
+++ b/meta/work/0188-library-backed-vcs-adapter.md
@@ -1,0 +1,608 @@
+---
+type: work-item
+id: "0188"
+title: "Library-Backed VCS Adapter over gix and jj-lib"
+date: "2026-07-31T10:41:51+00:00"
+author: Toby Clemson
+producer: create-work-item
+status: ready
+kind: story
+priority: high
+parent: "work-item:0136"
+blocked_by: ["work-item:0179"]
+blocks: ["work-item:0169", "work-item:0185"]
+relates_to: ["work-item:0125", "work-item:0168", "work-item:0187",
+  "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
+derived_from: ["work-item:0169"]
+tags: [rust, vcs, dependencies]
+last_updated: "2026-08-02T14:39:47+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0188: Library-Backed VCS Adapter over gix and jj-lib
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+Add a library-backed implementation of the `vcs` crate's outbound ports —
+together with six inherent taxonomy queries that 0169's checkout-classification
+port will be built over, and the test apparatus that proves the whole thing
+reads git and jj **in-process** — using `gix` (gitoxide) and `jj-lib` instead
+of spawning `jj`/`git` subprocesses. This is the dependency-adoption half of
+the VCS migration: two new dependency trees, a `cli/` workspace-wide
+`deny.toml` licence exception, and a pre-1.0 API bet — separated from the
+subdomain and hooks work so it can be reviewed and rolled back on its own terms.
+
+The existing `CommandProbe` is **retained**, not replaced: it continues to serve
+`cli/corpus-adapters` until 0185 converges that consumer. This story adds an
+adapter; it does not remove one.
+
+The adapter ships **unwired** — no caller reaches it until 0169 and 0185 do the
+consumer work. That is deliberate: the value delivered here is risk isolation,
+landing the dependency trees, the licence exception and the API bet where they
+can be reviewed and reverted alone.
+
+## Context
+
+`cli/vcs-adapters` currently drives `jj log -r @ -T commit_id` and `git
+rev-parse HEAD` as subprocesses (`cli/vcs-adapters/src/lib.rs:110-125`, spawning
+at `:168`). The port abstraction (`cli/vcs/src/lib.rs:48-55`) already permits a
+library-backed implementation without touching the domain — a second
+implementation of the same ports is an adapter-level change by construction.
+
+Extracted from 0169, on the argument of the scope lens in
+`meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md` (pass 4):
+dependency adoption and the hooks migration carry very different risk profiles.
+A hook-envelope regression is user-visible and reversible in `hooks.json`,
+whereas a `jj-lib` API break or a dependency-policy objection is a build-level
+failure. Bundled, neither could be accepted or rolled back without the other.
+
+Going in-process also dissolves 0125's stated rationale for keeping the shell
+lexical fallback — that detection must work with no `git`/`jj` on `PATH`, and
+that probing costs 1-3 subprocesses per call — but only *for consumers that
+reach the Rust adapter*. The ~26 shell call sites keep running in bash until
+later epic-0136 phases migrate them.
+
+## Requirements
+
+### Delivered surface
+
+- **One library-backed type** in `cli/vcs-adapters` implementing *both* the
+  `vcs` crate's `RepoRoot` and `VcsProbe` ports over `gix` and `jj-lib`,
+  alongside the retained `MarkerWalkRoot`/`CommandProbe` pair. A single type
+  avoids having to say which of a pair carries the dual-root query, which needs
+  both libraries. **The domain crate `cli/vcs` is untouched: no port is added,
+  widened or changed.**
+- **Six taxonomy queries** as *inherent methods* on that type — not port
+  methods. `CommandProbe` and `MarkerWalkRoot` gain none of them. 0169 defines
+  whatever domain port its classifier needs and implements it over these; that
+  port is explicitly out of scope here. The set is a fixed delivery contract:
+
+  1. **Bare-repository check.**
+  2. **Worktree detection** — is this a linked worktree, and what is the common
+     (main) git directory? (`--git-dir` vs `--git-common-dir`)
+  3. **Superproject/submodule resolution** — is this a submodule, and what is
+     the superproject's working directory?
+  4. **jj workspace-root resolution.**
+  5. **jj main-vs-secondary distinction**, and where the main repository is.
+  6. **Independent dual-root resolution** — the git repository root and the jj
+     workspace root, each resolved by its own library's walk without being
+     truncated by the other's marker, so a consumer can compare them. This is
+     what separates `colocated` (roots equal) from `nested-jj-in-git` and
+     `nested-git-in-jj`; 0169 cannot build those arms without it.
+
+  **Invariant over all six**: `GIT_DIR`/`GIT_COMMON_DIR` are scrubbed for the
+  duration of any detection call, so every query answers identically whether or
+  not they are set. This matches the one place the shell made the decision
+  deliberately (`vcs-common.sh:130-135`, "cannot be poisoned by ambient env")
+  and diverges from `classify_checkout`'s inline reads, which honour them. The
+  shell is internally inconsistent here — `:206-215` unscrubbed against
+  `:130-135` scrubbed — and it is that asymmetry the adapter declines to carry
+  forward.
+
+  Anything 0169 needs beyond this list is a change to *this* work item, not
+  silent growth in 0169. Two capabilities are explicitly **not** delivered and
+  are 0169's own work over the trees this story lands: the `classify_checkout`
+  arm cascade, and the `vcs status`/`vcs log` reads. 0169 will need to widen the
+  cargo-pup rule below to cover wherever it puts that code.
+- **No selection mechanism.** No feature flag, config switch or composition
+  helper routes callers to the new type; `vcs_adapters::facts` stays hard-wired
+  to `MarkerWalkRoot`/`CommandProbe`. Consumer wiring belongs to 0169 and 0185.
+  This story ships an unwired adapter on purpose — its value is risk isolation.
+
+### Test-support deliverables
+
+These are shipped artefacts, not incidental test code, and are sized as such.
+
+- **An injection seam** in `cli/vcs-adapters/tests/detection.rs`, which today
+  hard-wires `MarkerWalkRoot` + `CommandProbe::new()` and would otherwise keep
+  verifying the subprocess adapter.
+- **A reference artefact** — a test-only binary calling every query and
+  *printing each result*, so the calls are not eliminable. Without a caller,
+  dead-code elimination would let the musl and size checks pass while linking
+  none of `gix`/`jj-lib`.
+- **A zero-spawn harness** — marker-writing `git`/`jj` stubs, the absolute-path
+  shadow list, and the empty-config environment — published as a **shared test
+  fixture consumable from another crate**, since 0185 extends it and one shadow
+  list must serve both suites.
+- **A committed lockfile check** (test or `tasks/` lint) for the version
+  invariants below.
+- **The checkout fixture matrix** — ten shapes × their start directories (see
+  the criterion). Bare, submodule, linked-worktree and both nesting shapes are
+  substantial to build; planning should record which already exist in
+  `detection.rs` and which are new.
+- **A pure-jj benchmark fixture**, committed as a named reusable builder,
+  plus the cost measurements taken against it. Handed to 0169 ungated.
+- **Dated hand-off notes** on 0125, 0185 and 0169, including a `relates_to`
+  edge on 0125.
+- **Documentation** of any new `tasks/` leaf task or CI job in
+  `tasks/README.md`, alongside the existing cargo-deny/cargo-pup enforcement
+  description — undocumented lint gates are the ones later contributors trip
+  over or delete.
+- **Whatever CI wiring the strong-form zero-spawn run needs** (below), *subject
+  to the Open Question on runner capability*. If no existing Linux job can
+  shadow absolute system paths, provisioning one is in scope — cross-surface
+  work, called out so it is visible at sizing.
+
+### Library traps
+
+- **Bound `gix`'s discovery — for boundary resolution.** `gix::discover` walks
+  up *past* a jj workspace boundary (verified 2026-07-29: it returned the parent
+  repository's `.git` from inside `workspaces/build-system`). The rule:
+
+  > The checkout boundary is the start path itself, or its nearest ancestor,
+  > containing a `.jj` or `.git` marker. `RepoRoot` reports that path and never
+  > an ancestor above it, whether or not the environment supplies a ceiling.
+
+  Derive the ceiling from the marker walk rather than trusting the library's
+  default; an inherited `GIT_CEILING_DIRECTORIES` may narrow the walk further
+  but must never be what makes the rule hold. **The rule scopes to boundary
+  resolution only** — queries 2, 3 and 6 legitimately resolve outside the
+  boundary by following a recorded link (gitdir, superproject) or by letting
+  each library complete its own walk. An earlier draft forbade looking above the
+  boundary at all, which would have made 0169's `nested-*` arms unimplementable.
+- **Avoid `jj_lib::workspace::Workspace::load`.** It needs a fully-populated
+  `UserSettings` whose defaults are private to jj-lib, discovered one panic at a
+  time. `DefaultWorkspaceLoaderFactory` is public and
+  `WorkspaceLoader::{workspace_root, repo_path}` need no settings. **No code in
+  `cli/vcs-adapters` may construct a `UserSettings` at all** — stated
+  crate-wide, deliberately wider than the detection paths strictly require, so
+  the guard is a simple one.
+
+### Dependency policy
+
+- **`jj-lib` pinned exactly at `=0.43`.** The loader-internals design and every
+  feasibility measurement were validated against it, and the crate declares its
+  API unstable. `mise.toml`'s `jj` CLI pin is held in lockstep at 0.43.0 so the
+  CLI that writes fixtures and the library that reads them cannot skew. **The
+  bump landed 2026-08-02**; what remains for this story is `mise install` in CI
+  and a re-run of the jj-fixture shell suites.
+- **`gix` pinned to the version `jj-lib` 0.43 depends on when its `gix`
+  feature is enabled** — 0.85 (verified 2026-08-02: `jj-lib` 0.43.0 declares
+  `gix ^0.85.0`, optional). See the Assumption on feature-gating.
+  Load-bearing: `gix`
+  0.86.0 exists, and a caret range on a `0.x` crate will not cross it, so
+  pinning 0.86 here would produce exactly the two graphs this forbids. The pin
+  **must** carry an inline comment saying it tracks `jj-lib`'s `gix` version.
+- **A `[[licenses.exceptions]]` entry for `uluru`** (MPL-2.0) in
+  `cli/deny.toml` — `gix-pack`'s LRU cache, not feature-gatable. It **must**
+  carry an inline comment citing this work item.
+- **`gix` with default features** — network transports are excluded by default,
+  so no TLS stack enters the graph.
+- **A `cli/pup.ron` rule scoped to the library-backed module only** — not to
+  `vcs_adapters` as a whole, since the retained `CommandProbe` legitimately
+  spawns. Two clauses, because a permit-list alone cannot express this
+  (`std::process` sits *inside* the permitted `std`): permit `std`, `gix`,
+  `jj_lib`, `kernel`, `vcs`, `crate::`; then explicitly deny `std::process`.
+  The deny clause is what makes zero-spawn structural rather than only
+  test-asserted. This requires the library-backed code to live in its own module
+  with a stable path.
+
+## Acceptance Criteria
+
+**On oracles.** The behavioural oracle is `scripts/vcs-common.sh` and the
+`git`/`jj` commands it invokes. The exact per-query oracle mapping is
+**established empirically during planning** — by running each candidate against
+each fixture and recording what it returns — and is **not** to be asserted from
+line references. Two attempts to write that mapping by inference were both
+wrong: `classify_checkout`'s `BOUNDARY` is documented empty for the `main` and
+`none` arms and is set to the *git* root in `nested-git-in-jj`, and
+`find_git_main_worktree_root` returns an ordinary root (exit 0) for every
+non-submodule checkout. The mapping belongs in the plan, with evidence.
+
+**On path comparison.** Wherever a criterion asserts path equality — adapter to
+adapter, or adapter to oracle — compare `realpath`-canonicalised absolute paths.
+On macOS a fixture under `$TMPDIR` resolves `/var` → `/private/var`, so an
+uncanonicalised comparison fails spuriously. Absence maps to `None`; the exact
+absence signal per oracle (non-zero exit, empty stdout, or an empty record
+field) is part of the mapping established in planning.
+
+- [ ] `detection.rs` runs every existing case through the injection seam against
+      **the retained `MarkerWalkRoot`/`CommandProbe` pair and the single
+      library-backed type**, producing identical `RepoFacts`, with the suite's
+      existing **fixed expected values** retained — agreement between two
+      implementations is not on its own an oracle. The `.git`-as-file worktree
+      case keeps **today's** value (`classify_checkout` reports `main`, the git
+      side unseen); 0169 owns correcting that to `colocated`, so a
+      library-backed answer of `colocated` here is the deferred correction
+      arriving early, not a defect to chase. This dual comparison is
+      **transitional**: 0185 deletes `CommandProbe`, and collapsing the suite to
+      the library-backed type alone is part of that deletion.
+- [ ] All six queries are unit-tested against every **(fixture, start
+      directory)** pair in the matrix — start directory included because every
+      query is start-path-relative and the oracle is directory-parameterised, so
+      running all six from each fixture's root would produce a full green matrix
+      while never exercising the distinctions the queries exist to make. Each
+      pair carries a recorded expected value drawn from the empirically
+      established mapping, including explicit not-applicable expectations.
+      Matrix, minimum:
+
+      | Fixture | Start directories |
+      | --- | --- |
+      | colocated | root |
+      | jj secondary workspace | workspace root, and a subdirectory |
+      | plain git | root, and a subdirectory |
+      | nested-jj-in-git | inner jj workspace, and the outer git root |
+      | nested-git-in-jj | inner git repo, and the outer jj root |
+      | linked git worktree | the linked worktree, and the main worktree |
+      | git submodule | the submodule, and the superproject root |
+      | bare repository | the bare dir |
+      | no repository at all | a dir with no marker at or above it |
+      | pure-jj measurement fixture | root |
+
+- [ ] The scrub invariant holds across that whole matrix: every query returns
+      the same value with and without `GIT_DIR`/`GIT_COMMON_DIR` set — where
+      "set" means **pointed at a real git directory that would produce a
+      different answer** (another fixture's `.git`, or the enclosing
+      repository's
+      for the nested shapes), not an empty or non-existent path, which both git
+      and the libraries ignore. An unscrubbed control must diverge under the
+      same
+      poisoning, or the test proves nothing. The invariant covers the six
+      queries
+      and `RepoRoot`; `VcsProbe` parity against `CommandProbe` is explicitly
+      **out of scope for this criterion**, since `CommandProbe` shells out and
+      therefore does honour an ambient `GIT_DIR`.
+- [ ] **Zero `jj`/`git` process spawns.** Black-box, over the full query ×
+      fixture table, with `HOME`, `GIT_CONFIG_*`, `JJ_CONFIG` and
+      `XDG_CONFIG_HOME` at empty temp dirs. The **strong form** — `PATH` stubs
+      *plus* `/usr/bin/git`, `/usr/local/bin/git`, `/opt/homebrew/bin/git` and
+      the `jj` equivalents replaced or bind-mounted — must actually run in a
+      named Linux CI job; failing to achieve it there is a blocking finding, not
+      a permitted degradation. Other platforms (SIP-protected macOS) degrade to
+      `PATH`-only with unshadowable paths recorded. An in-crate spawn seam is
+      **not** an acceptable substitute: the module has no exec port by design,
+      so a seam cannot observe a spawn originating inside `gix` or `jj-lib`.
+      Assert no marker is written **and** that every value matches the
+      unrestricted run — an adapter degrading to `None` also writes no marker.
+- [ ] `RepoRoot` cannot report a root above the marker boundary, with
+      `GIT_CEILING_DIRECTORIES` unset or set above the parent repository so the
+      environment cannot be what stops the walk. Both nesting directions are
+      fixtured. A paired negative assertion shows an unbounded `gix::discover`
+      on the same fixture *does* escape.
+- [ ] No code in `cli/vcs-adapters` references `Workspace::load` or constructs a
+      `UserSettings` — enforced by a **committed** check (a `tasks/` lint or an
+      additional cargo-pup deny clause, not a one-off inspection), shown
+      non-vacuous by a deliberately added construction failing it, plus every jj
+      query succeeding under the empty-config environment above. A text guard
+      over a crate that never contained those symbols otherwise passes trivially
+      and gives no evidence it would catch a reintroduction.
+- [ ] The plan records the empirical oracle mapping as a **query × (fixture,
+      start directory) table in which every cell carries the exact command
+      invoked and its verbatim output**, every expected value in the test suite
+      is traceable to a cell, and any adapter/oracle disagreement beyond the
+      pre-authorised `GIT_DIR` scrub is listed in Validation Results with a
+      justification. Without this, a verifier can confirm each cell has a value
+      but not that the value came from observation rather than a third round of
+      inference — the failure the deferral exists to prevent.
+- [ ] The committed lockfile check asserts: `gix` resolves to **0.85.x** (not
+      merely to a single version — because `gix` is optional in `jj-lib`, a
+      single-version assertion holds vacuously if that feature is off); no `gix`
+      or `gix-*` package at more than one version; `jj-lib` at 0.43;
+      `mise.toml`'s
+      `jj` pin at the same minor version as the `jj-lib` pin, with its lockstep
+      comment present; and no TLS stack (`openssl-sys`, `native-tls`, `rustls`,
+      `curl-sys`). Asserted directly because the repo's duplicate-version policy
+      is warn-level.
+- [ ] `cargo deny` passes with the `uluru` exception, and both it and the `gix`
+      pin carry their inline comments; `cargo-pup` passes and the new module
+      rule is demonstrably non-vacuous (a deliberately added `std::process`
+      import fails it); clippy passes `--locked`; the reference artefact
+      cross-compiles to musl and passes `_assert_static_elf`.
+- [ ] Nothing existing changed: `CommandProbe`/`MarkerWalkRoot` still exist with
+      no new methods, `cli/corpus-adapters` still resolves through them and its
+      metadata parity suite passes unchanged, `cli/vcs/src/**` is unmodified,
+      and `cli/vcs-adapters` gains no `[features]` entry beyond `bash-parity`
+      and no runtime port selection.
+- [ ] The shared zero-spawn fixture is proven across a crate boundary **inside
+      this story** by a test in `cli/corpus-adapters` — the crate 0185 will
+      extend — that runs a full strong-form assertion end to end (stubs *and*
+      shadow list *and* empty-config environment) through the fixture's public
+      API with no fixture-private helpers. A test consumer that imports only one
+      of the three parts would satisfy looser wording while leaving exactly the
+      restructuring risk this exists to retire.
+- [ ] Cost is **measured and recorded, not gated** — 0169 owns the warm-call
+      latency gate (`G ≤ 1.1 × B`, where **B** is the baseline shell
+      `hooks/vcs-guard.sh` invocation and **G** the migrated `accelerator vcs
+      guard` one, B ≈ 35 ms) and needs comparable numbers. Against a **pure-jj
+      fixture defined here** — one main jj workspace, no `.git`, a single
+      commit, workspace root three directories below the temp root, committed as
+      a **named reusable builder** so 0169 can reconstruct it identically —
+      median of 20, reporting library initialisation cost, warm per-call
+      in-process cost, and cold per-process cost via the reference artefact.
+      The last is required because an in-process microbenchmark yields
+      microsecond figures that cannot be compared with 0169's millisecond
+      process-level baseline; it is the figure that corresponds to **G**, so the
+      reference artefact needs a single-query mode for it — timing a binary that
+      runs all six queries plus both port methods would inflate it by an unknown
+      factor. The `MarkerWalkRoot`/`CommandProbe` baseline is taken for the port
+      methods only (it has no queries and no library to initialise). Host and OS
+      recorded.
+- [ ] The reference artefact demonstrably links the dependency trees: its size
+      **built with the query calls live** is at least **2 MB larger** than the
+      same binary built with those calls replaced by stubs, both sizes recorded.
+      Without a floor this check cannot fail, and it is the one guarding the
+      story's headline false-pass — dead-code elimination letting the musl and
+      size checks succeed while linking almost none of `gix`/`jj-lib`.
+- [ ] Dated notes are appended to three siblings, **raising** information
+      without re-scoping them:
+      - **0125** — the adapter dissolves its lexical-fallback rationale *for
+        consumers that reach it*, with the ~26 shell call sites still bound
+        until later epic-0136 phases migrate them, plus a `relates_to` edge so
+        the coupling is visible from both ends.
+      - **0185** — the adapter and the zero-spawn harness are 0188's, not
+        0169's; **0185's own** Summary, Context, Assumptions, Technical Notes
+        and acceptance criteria all currently attribute them to 0169.
+        `vcs_adapters::facts` stays hard-wired here by design, so the
+        composition-root change falls to a dependant (see Open Questions), and
+        the transitional dual-adapter `detection.rs` comparison must be
+        collapsed when `CommandProbe` is deleted. Both affect its "wiring plus
+        deletion" sizing.
+      - **0169** — it inherits the closed six-query contract, must define its
+        own port over inherent methods, must widen the pup rule for
+        `status`/`log`, must reuse the pure-jj fixture builder, and its 0125
+        hand-off sub-clause is now redundant.
+- [ ] `mise run` is green end to end, including the shell suites that build jj
+      fixtures, which were last green against the pre-bump `jj` 0.36 pin.
+
+## Dependencies
+
+- **Blocked by**: 0179 — delivered the `vcs`/`vcs-adapters` crate pair and the
+  ports this story implements (**done**).
+- **Blocks**:
+  - **0169** — builds the subdomain's classification on these adapters, by
+    defining its own domain port over the inherent queries delivered here. 0169
+    carries a hard numeric gate (warm-call latency `G ≤ 1.1 × B`, ≈38.6 ms),
+    which its own Dependencies already flag as at risk from a ~41 ms warm
+    bootstrap. Whether it passes is largely set by this story's in-process
+    discovery cost and by the sub-binary size the two new dependency trees
+    produce (which also feeds the fetch/verify path) — hence the measurement
+    criterion above. This story imposes no threshold on itself; it hands 0169
+    the numbers.
+  - **0185** — converges `corpus-adapters` onto these adapters and deletes
+    `CommandProbe`. It also **consumes the zero-spawn harness built here** (the
+    marker-writing stubs, the absolute-path shadow list and the empty-config
+    environment), so that harness is exposed as a shared test fixture rather
+    than a private helper, keeping one shadow list across both suites. 0185's
+    own criteria currently attribute the harness to 0169 — stale since the
+    split; a dated correction repointing it to 0188 is part of closing this
+    story.
+- **External systems**: `gix` (gitoxide) and `jj-lib`, both crates.io. `jj-lib`
+  is pre-1.0 with an explicitly unstable API and this design leans on its loader
+  internals, so a version bump can break detection — hence the exact `=0.43`
+  pin. Adoption requires the `cli/deny.toml` licence exception above, a
+  `cli/`-workspace-wide dependency-policy change.
+  - **Ongoing cost, not just one-off**: both transitive trees enter `cargo
+    deny`'s `advisories` scope, so a future RustSec advisory anywhere in the
+    `gix`/`jj-lib` closure fails the workspace-wide check for every unrelated
+    change. And because `gix` is pinned to whatever `jj-lib` depends on, any
+    future `jj-lib` bump is a **coordinated two-crate bump** — the single-
+    version criterion will otherwise fail it. Both pins carry inline comments
+    saying so.
+- **Upstream toolchain preconditions**:
+  - **`jj` CLI ↔ `jj-lib` are now a lockstep pair.** The `bash-parity` fixtures
+    are built by the installed `jj` CLI and read by `jj-lib`, so a skew between
+    them fails in a way that reads as an adapter defect rather than a pin
+    mismatch. `mise.toml` pinned 0.36.0 against this story's `jj-lib` 0.43 — a
+    seven-version gap — so **the CLI pin was bumped to 0.43.0 (2026-08-02)**
+    with an inline comment tying the two together. Consequences: `mise install`
+    is required, and the shell suites that build jj fixtures
+    (`hooks/test-vcs-detect.sh`, and the work-item script suite under
+    `skills/work/scripts/`) were last green against 0.36 and must be re-run.
+    This is a CI-wide change.
+  - The symmetric git-side coupling holds too: the bare, linked-worktree and
+    submodule fixtures are built by the installed `git` CLI (2.54.0) and read by
+    the pinned `gix` 0.85. No format-boundary concern was identified, but both
+    CLI versions are recorded in Validation Results.
+  - **MSRV: resolved, fits** (2026-08-02). Pinned Rust 1.90.0; `jj-lib` 0.43
+    needs 1.89, `gix` 0.85 needs 1.85. One minor version of headroom, and
+    `jj-lib`'s MSRV has moved 1.85 → 1.88 → 1.89 over eight releases — so the
+    coordinated bump below is really a **three**-pin coupling: `jj-lib`, `gix`,
+    and the Rust toolchain.
+- **Shared-artefact contention**: this story edits `cli/deny.toml`,
+  `cli/pup.ron`, `cli/Cargo.lock` (committed in the same change, because clippy
+  runs `--locked`), `mise.toml` (the `jj` pin, above), and **`tasks/build.py`**
+  — `_assert_static_elf` and the cross-compile staging the reference artefact
+  needs live there. Contending siblings: **0168**, whose workspace
+  restructuring has in fact already landed — the residual contention is only
+  its possible move of the `cli/visualiser/server/` crate path; and
+  **0187**, which rewrites `validate_dispatch_coherence` in that same
+  `tasks/build.py`. (0187 does *not* contend on the three `cli/` artefacts — an
+  earlier draft listed it for the wrong reason.) More broadly, any epic-0136
+  item adding crates under `cli/` contends on the lock. No ordering is imposed,
+  but whichever lands second regenerates the lock rather than merging it, and
+  must re-verify the single-`gix`-version invariant afterwards.
+- **Related**: 0125 — this story dissolves its stated rationale for the shell
+  lexical fallback without closing it. Because 0188 lands first and is the
+  change that actually dissolves the rationale, **the hand-off note is owned
+  here** (see Acceptance Criteria), not by 0169 as originally recorded. Note the
+  dissolution is *conditional*: 0125's constraint is about `find_repo_root` and
+  `vcs_mode` and their ~26 shell call sites, which keep running in bash and
+  cannot reach this adapter until 0169 and the later epic-0136 phases migrate
+  them — which is why the required note is worded conditionally.
+- **Parent**: epic 0136.
+
+## Open Questions
+
+Two questions are open and gate planning. Two more are closed, kept for the
+record because their answers carry consequences.
+
+- **OPEN — who owns the CI job for the strong-form zero-spawn run, and does the
+  runner actually permit it?** The criterion is deliberately non-degradable:
+  the strong form (replacing or bind-mounting `/usr/bin/git` and friends) must
+  run somewhere, and "somewhere" is currently a Linux CI job that may not exist
+  and whose provider may forbid modifying `/usr/bin` without privileged
+  containers. This is the one gate in the story resting on an unconfirmed
+  infrastructure capability, and it has been raised in three consecutive
+  reviews. **Confirm in planning.** *Default if it cannot be arranged*: carve
+  the provisioning into its own small item that 0188 declares as `blocked_by`,
+  rather than silently weakening the criterion to `PATH`-only everywhere —
+  which would leave the property unproven on any platform.
+- **OPEN — who changes `vcs_adapters::facts`, 0169 or 0185, and in what order?**
+  This story deliberately leaves it hard-wired. Requirements say wiring
+  "belongs to 0169 and 0185"; the 0185 hand-off says the composition-root change
+  is a dependant's own work. Both are currently unblocked by 0188 alone, and
+  0185's Technical Notes assume 0169 goes first while its `blocked_by` does not
+  say so. **Assign one owner and record the ordering** before either is picked
+  up; leaving it implicit reintroduces the hidden ordering the split removed.
+
+- **Does `jj-lib` 0.43's (and `gix` 0.85's) MSRV fit the repo's pinned Rust
+  toolchain?** **ANSWERED 2026-08-02 — it fits; no bump needed.** Pinned
+  toolchain is Rust **1.90.0** (`mise.toml:8`); `jj-lib` 0.43.0 declares MSRV
+  **1.89** and `gix` 0.85.0 declares **1.85** (crates.io). The margin is one
+  minor version, and `jj-lib`'s MSRV has moved 1.85 → 1.88 → 1.89 across its
+  last eight releases, so a future `jj-lib` bump will likely drag the Rust pin
+  with it — recorded as the three-pin coupling in Dependencies.
+- **Does the installed `jj` CLI write a repository format `jj-lib` 0.43 can
+  read?** **RESOLVED BY ALIGNMENT 2026-08-02** — the question is retired rather
+  than answered. `mise.toml:12` pinned `jj = "0.36.0"` against this story's
+  `jj-lib` 0.43, a seven-minor-version gap the 2026-07-29 research never
+  exercised (it records the crate versions but not which CLI built its probe
+  fixtures). Rather than measure the skew, the CLI pin was **bumped to 0.43.0**
+  with an inline comment tying it to the crate pin, so CLI and library now match
+  and the coherence risk is designed out. Consequences carried into Dependencies
+  → Upstream toolchain preconditions: the two pins are now a lockstep pair, and
+  the shell suites that build jj fixtures were last green against 0.36.
+
+## Assumptions
+
+- Feasibility is **measured, not assumed** (2026-07-29): `gix 0.85` + `jj-lib
+  0.43` pass `cargo deny` for `bans`, `advisories` and `sources` against the
+  current `cli/deny.toml`; `jj-lib` no longer depends on `git2`/`libgit2-sys`;
+  and a binary calling both cross-compiles to a statically linked musl ELF that
+  `_assert_static_elf` accepts. The only licence rejection was `uluru`.
+- **Dependency facts re-verified 2026-08-02** against the crates.io index:
+  `jj-lib` 0.43.0 requires `gix ^0.85.0`, so "pin `gix` to the version `jj-lib`
+  depends on" resolves to 0.85 as stated — and the requirement is load-bearing,
+  because `gix` **0.86.0 now exists** and a caret range on a `0.x` crate will
+  not cross it, so pinning 0.86 here would produce exactly the two graphs the
+  requirement forbids. `jj-lib` 0.43.0 also depends on `gix-ignore ^0.21.0`
+  (non-optional), and carries no `git2`/`libgit2-sys` — confirming the
+  2026-07-29 finding.
+- **`gix` is an *optional* dependency of `jj-lib` 0.43** (feature-gated). The
+  single-graph requirement is written as though `jj-lib` always pulls `gix`; if
+  the gating feature is off in our configuration, `jj-lib` may pull no `gix` at
+  all and this story's direct dependency is the only one. That changes the
+  *reasoning* behind the pin, not the pin itself — but the plan should state
+  which `jj-lib` features are enabled and re-check the single-version assertion
+  under that configuration.
+- `jj-lib`'s loader API remains stable across **the pinned `jj-lib` version,
+  0.43**, which the exact pin holds fixed. Verified against 0.43; unstable by
+  the crate's own declaration.
+
+## Terminology
+
+- **`classify_checkout`** — the bash function in `scripts/vcs-common.sh` that
+  produces the current checkout taxonomy, emitting a `KEY=VALUE` record. It is
+  the behavioural oracle this story's queries are tested against.
+- **`BOUNDARY`** — that record's field for the active workspace root. **Not a
+  general-purpose root**: the contract documents it as empty for the `main` and
+  `none` arms (`vcs-common.sh:165`), and the `nested-git-in-jj` arm sets it to
+  the *git* worktree root (`:259`). It is therefore not a valid oracle for
+  "the jj workspace root" outside the `jj-secondary` arm.
+- **`JJ_PARENT`** — that record's field for the main jj repository directory,
+  which differs from `BOUNDARY` in a secondary workspace.
+- **"probe"** — used bare in this document **only** for the 2026-07-29
+  feasibility experiment. The identifiers `VcsProbe` (the port) and
+  `CommandProbe` (the retained subprocess adapter) are always written in full.
+
+## Technical Notes
+
+- **Starting points for the oracle mapping, not the mapping itself.** Per the
+  Acceptance Criteria preamble the mapping is established empirically in
+  planning; these are leads to test, not answers to assert. Git side:
+  `is_bare` (`vcs-common.sh:206`), the `--git-dir` vs `--git-common-dir`
+  worktree comparison (`:217-219`), superproject resolution
+  (`find_git_main_worktree_root`, `:127-155`). Note the first two are inline
+  locals that never reach the emitted record, and the third returns an ordinary
+  root for non-submodules — so in both cases the underlying `git rev-parse`
+  invocation, not the shell wrapper, is the likely oracle. jj side: the
+  `.jj/repo` dir-vs-file secondary rule (`_jj_workspace_is_secondary`, `:74-81`)
+  and the record fields (contract `:164-171`, emitted `:274-279`).
+- `jj_lib::workspace::DefaultWorkspaceLoaderFactory` is public, and its loader
+  implements the shell's `.jj/repo`-file-means-secondary rule verbatim (jj-lib
+  0.43 `src/workspace.rs:564-585`). The 2026-07-29 experiment probed it against
+  colocated, secondary, plain and nested fixtures and reported that
+  `workspace_root()` equals `BOUNDARY` and `repo_path()` minus `/.jj/repo`
+  equals `JJ_PARENT`. **Treat the `BOUNDARY` half as holding only for the
+  `jj-secondary` arm** — see the Terminology caveat; the equality cannot hold
+  where the shell emits an empty `BOUNDARY`. Re-establish both in planning.
+- The existing `bash-parity` feature gate means "needs real `jj`/`git` binaries
+  to build fixtures", not "shells out in production" — it stays relevant.
+- **`GIT_CEILING_DIRECTORIES` in fixtures: yes, with one exception.** Set it (as
+  `hooks/test-vcs-detect.sh:35-40` does) so a stray `.git` above the temp dir
+  cannot leak into a probe — *except* in the boundary-containment fixture, where
+  it must be unset or set above the parent repository, or the environment rather
+  than the adapter would be what stops the walk and the criterion would pass
+  vacuously.
+
+## Validation Results
+
+- **Platform the strong-form zero-spawn run held on** — _pending_; absolute
+  paths shadowed there — _pending_; paths not shadowable on each other platform
+  — _pending_.
+- **`gix` / `gix-*` versions resolved in `Cargo.lock`** — _pending_.
+- **`jj-lib` version resolved in `Cargo.lock`** — _pending_.
+- **MSRV of `gix` 0.85 and `jj-lib` 0.43 vs the pinned Rust toolchain** —
+  _resolved 2026-08-02_: pinned Rust 1.90.0; `jj-lib` 0.43.0 MSRV 1.89; `gix`
+  0.85.0 MSRV 1.85. Both fit, with one minor version of headroom.
+- **Installed `jj` CLI version the fixtures were built with** — _bumped
+  2026-08-02_: `mise.toml` now pins **0.43.0**, matching the `jj-lib` crate pin
+  (prior state: 0.36.0, seven minor versions behind — the skew this bump
+  designs out). Outstanding: `mise install` on each machine and CI, and a
+  re-run of the jj-fixture shell suites, which were last green against 0.36 —
+  _pending_.
+- **Installed `git` CLI version the fixtures were built with** — _recorded
+  2026-08-02_: 2.54.0, against `gix` 0.85. Coherence unverified but low-risk;
+  no format-boundary concern was identified.
+- **Adapter/shell divergences recorded** — the `GIT_DIR` scrub asymmetry in
+  `classify_checkout` (`:206-215` unscrubbed vs `:130-135` scrubbed), which the
+  adapter deliberately does not reproduce — _confirmed 2026-08-01_; any further
+  divergence found in implementation — _pending_.
+- **Non-vacuity demonstrations** — the deliberate `std::process` import failing
+  cargo-pup — _pending_; the deliberate `UserSettings` construction failing the
+  source guard — _pending_; the unscrubbed control diverging under the poisoned
+  `GIT_DIR` run — _pending_.
+- **Cost, against this story's pure-jj fixture** (reused by 0169; median of 20,
+  host and OS): library init — _pending_; warm per-call in-process — _pending_;
+  cold per-process via the reference artefact — _pending_; `CommandProbe`
+  baseline for the port methods — _pending_.
+- **Reference artefact size**, linked vs stubbed builds and the delta —
+  _pending_.
+
+## References
+
+- Extracted from: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+- Split rationale (scope lens, pass 4):
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`
+- Feasibility probe, API findings and the two traps:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §9
+- Behavioural oracle for the taxonomy queries: `scripts/vcs-common.sh`
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- ADRs: ADR-0053 (thin CLI over a hexagonal ports-and-adapters core)


### PR DESCRIPTION

# Split the VCS subdomain story into four independent work items

## Summary

0169 had accreted four concerns with very different risk profiles — the VCS subdomain and hooks migration itself, a bash micro-fix to the bootstrap, a build-system generalisation, and the adoption of two new Rust dependency trees. Review 2 returned `REVISE` on exactly that ground, unanimously across the scope, completeness and testability lenses. This PR records the split: 0169 keeps the subdomain and hooks work, three new siblings take the separable concerns, and a fourth takes the cleanup the split defers.

Documentation only — no code, no build-system changes.

## Changes

- **Four new work items.** 0185 (converge `corpus-adapters` on the library-backed VCS adapter), 0186 (remove the exec probe from the bootstrap warm path), 0187 (generalise the sub-binary registration surface), 0188 (library-backed VCS adapter over `gix` and `jj-lib`).
- **0169 substantially rewritten** (679 lines changed) — scope narrowed to the `vcs detect|status|log|guard` subdomain plus the hook migration, with new Terminology, "The guard's inputs", Sequencing Constraints and Validation Results sections. Its `blocked_by` gains 0186, 0187 and 0188; its `blocks` gains 0170, 0171 and 0173.
- **Reciprocal dependency edges recorded up front**, rather than at acceptance, so the coupling is visible from the consuming side while the blocking work is in flight: `blocked_by: 0187` plus a dated Dependencies bullet on 0170–0173, `blocks: 0187` on 0168, and `blocks: 0186` on 0182. 0170's bullet also carries the no-underscore dispatch-token constraint (`work-item`, not `work_item`, because the token derives `ACCELERATOR_<TOKEN>_BIN`).
- **Epic 0136's decomposition annotated** — the four new children placed in their phases, the acceptance criterion widened from "0162–0174" to include 0185–0188, and a note that 0178/0179/0180 are grandchildren via 0166.
- **Research document added** — the codebase research that drove the split.
- **Five review documents recorded** — 0169 reviews 2 (`REVISE`) and 3 (`APPROVE`), and review 1 for each of 0186, 0187 and 0188 (all `APPROVE`).

## Context

- Splits `meta/work/0169-vcs-subdomain-and-hooks-migration.md`, a child of epic 0136 (Migrate Shell Scripts into a Rust CLI).
- Driven by `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`, added here. Its four substantive findings are what forced the split: the `hooks.json` `${CLAUDE_PLUGIN_ROOT}` probe resolved in the story's favour; the PreToolUse envelope the story pinned as its golden fixture turned out to be the deprecated shape; the ~108 ms per-Bash-call cost was localised to `probe_dir` in the bootstrap rather than to the sub-binary choice; and the token `vcs` collides with the existing domain crate in both `tasks/manifest.py` and cargo-pup.
- The `gix`/`jj-lib` feasibility risk was retired empirically in that research (§9) — the combined tree passes `bans`, `advisories` and `sources` against a verbatim copy of `cli/deny.toml`, with `uluru` (MPL-2.0) the sole licence rejection, and a binary calling both cross-compiles to a static musl ELF that `_assert_static_elf` accepts.

## Testing

- [x] `./scripts/validate-corpus-frontmatter.sh meta` — exit 0 across the whole corpus, covering all 18 changed files' frontmatter and typed linkage.
- [x] Reciprocal edges checked by hand in both directions: every `blocked_by` added here has its matching `blocks` on the other item.
- [ ] CI on this PR. No code, build-system or shell files are touched, so no language toolchain check is exercised by this change.

## Notes for Reviewers

**The split boundaries are the thing to review, not the prose.** Each new sibling was carved out because it carries a risk the others do not: 0186 is a bash micro-change to a file 0182 is also editing; 0187 is a build-system generalisation five stories depend on; 0188 lands two dependency trees, a workspace-wide licence exception and a pre-1.0 API bet that should be revertable on its own terms. If any boundary looks wrong, it is cheaper to move it now than after planning starts.

**0188 ships unwired, and that is deliberate.** It adds an adapter without removing `CommandProbe` — no caller reaches the new code until 0169 and 0185 do the consumer work. The cost is that `vcs-adapters` carries two probe implementations until 0185 lands, and the zero-spawn guarantee holds only for the four hook paths in the interim. That trade is recorded in both items.

**One dependency is knowingly left unresolved.** 0186 removes the ~108 ms exec probe but leaves the verify shim's second `sha256_file` (~11.7 ms), because three existing tests in `tests/integration/entrypoint/test_accelerator_entrypoint.py` assert the planted-stub defence it provides. That leaves the warm bootstrap near 41 ms against 0169's `G ≤ 1.1 × B` gate of ≈ 38.6 ms — so 0186 is necessary but may not be sufficient for 0169's latency criterion. Rather than hide it, a dated hand-off note in 0169's Dependencies carries the obligation, and 0169 must either relax the threshold or accept the overrun with a stated rationale before acceptance. No work item owns the residual.

**0182's status changes twice across this stack.** This PR flips it `in-progress` → `ready`; PR #36 flips it `ready` → `done`. Reviewing the two in isolation makes that look like churn — it is the same closeout arriving in two steps.

**Stack position.** This is the base of a three-PR stack: #34 → #35 (jj pin bump) → #36 (close out 0167/0168/0182). Nothing below depends on this PR's content, only on its commits being in the ancestry.
