### PR TITLE
[0186] Probe the cache directory only on the bootstrap's cold path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
 
 ### Changed
 
+- **Warm `accelerator` invocations are substantially faster** — better than
+  halved on macOS, so session start and every skill's live-context command are
+  noticeably quicker. The bootstrap now tests the cache directory only on a
+  cold start; a `noexec` cache directory still fails with the same named error,
+  and a cache directory populated once may afterwards be read-only for warm
+  invocations (dispatching a subcommand to a separate binary still needs it
+  writable).
 - **Interactive option panels replace typed confirmations across 15 skills.**
   All `y/n` typed gates, plain-text "Shall I proceed?" prompts, and numbered
   action menus have been replaced with `AskUserQuestion` panels — the terminal

--- a/bin/accelerator
+++ b/bin/accelerator
@@ -10,6 +10,10 @@
 # before a `--` separator and passed through to the launcher unchanged. Bash 3.2
 # floor (no associative arrays, ${var,,}, mapfile).
 #
+# The cache directory must be writable and exec-capable on a cold start, which
+# is probed once. A warm start only reads and execs from it, so a populated
+# cache directory may be read-only.
+#
 # Test seams (unset in production): ACCELERATOR_UNAME_S/_M override host
 # detection; ACCELERATOR_BOOTSTRAP_DOWNLOADER injects a `downloader <url> <dest>`.
 #
@@ -276,9 +280,14 @@ sha256_file() {
 # The plugin root may be noexec, so run the shim from the cache dir, and by
 # absolute path so a PATH-planted decoy cannot stand in for the verifier.
 # Content-addressed by the source shim's own digest: a warm call re-hashes
-# (cheap) instead of re-copying 475KB, a uniquely-named file is never torn by a
-# concurrent reader, and skip-if-exists verifies the staged bytes against that
-# digest so a planted stub is re-staged rather than trusted by name.
+# instead of re-copying ~475KB — now the largest remaining warm-path cost,
+# retained deliberately because the digest check is what makes a planted stub
+# get re-staged rather than trusted by name
+# (test_planted_staged_shim_rehashed_then_succeeds,
+# test_planted_staged_shim_is_not_trusted,
+# test_planted_staged_shim_via_cache_dir_is_not_trusted) — a uniquely-named file
+# is never torn by a concurrent reader, and skip-if-exists verifies the staged
+# bytes against that digest.
 shim_digest=$(sha256_file "${shim_source}") ||
 	fail_integrity "could not hash the verify shim source: ${shim_source}"
 shim="${cache_dir}/accelerator-verify-${platform}-${shim_digest}"

--- a/bin/accelerator
+++ b/bin/accelerator
@@ -162,39 +162,53 @@ public_key="${plugin_root}/keys/accelerator-release.pub"
 [[ -f "${public_key}" ]] ||
 	fail_integrity "release public key missing: ${public_key}"
 
-# Probe write AND exec (a noexec mount passes a write-only check but breaks exec).
-probe_dir() {
-	mkdir -p "$1" 2>/dev/null || return 1
+# Kept a named function because a warm-path trace assertion uses the token to
+# prove the always-run half still runs; the -d guard keeps a warm call from
+# forking mkdir for a directory the launcher is about to be exec'd out of.
+ensure_dir() {
+	[[ -d "$1" ]] || mkdir -p "$1" 2>/dev/null
+}
+
+# Catches a noexec mount, which a write-only check would pass. Cold-path only:
+# a warm call proves the same capability for real by running the staged shim
+# and then the launcher out of this directory. 1 = cannot write, 2 = cannot
+# exec.
+probe_exec_capable() {
 	probe="$1/.accelerator-probe-$$"
-	printf '#!/bin/sh\nexit 0\n' >"${probe}" 2>/dev/null || return 1
-	chmod +x "${probe}" 2>/dev/null || {
+	if ! printf '#!/bin/sh\nexit 0\n' >"${probe}" 2>/dev/null ||
+		! chmod +x "${probe}" 2>/dev/null; then
 		rm -f "${probe}"
 		return 1
-	}
-	if "${probe}" >/dev/null 2>&1; then
-		rm -f "${probe}"
-		return 0
 	fi
+	"${probe}" >/dev/null 2>&1
+	status=$?
 	rm -f "${probe}"
-	return 1
+	[[ "${status}" -eq 0 ]] || return 2
 }
 
 # ${plugin_root}/bin or the ACCELERATOR_CACHE_DIR override; no XDG fallback
 # (an XDG-resident binary would break the allowed-tools glob match).
 resolve_cache_dir() {
 	if [[ -n "${ACCELERATOR_CACHE_DIR:-}" ]]; then
-		probe_dir "${ACCELERATOR_CACHE_DIR}" || return 1
+		ensure_dir "${ACCELERATOR_CACHE_DIR}" || return 1
 		printf '%s\n' "${ACCELERATOR_CACHE_DIR}"
 		return 0
 	fi
 	primary="${plugin_root}/bin"
-	probe_dir "${primary}" || return 1
+	ensure_dir "${primary}" || return 1
 	printf '%s\n' "${primary}"
 }
 
+# One definition of the substring, three causes: each site reports what it
+# actually detected, and the remediation hint stays attached to all of them.
+fail_no_cache_dir() {
+	fail "no writable, exec-capable cache directory: $1 $2; set \
+ACCELERATOR_CACHE_DIR to a writable, exec-capable directory (no XDG fallback)"
+}
+
 cache_dir=$(resolve_cache_dir) ||
-	fail "no writable, exec-capable cache directory: ${plugin_root}/bin \
-is not usable and no ACCELERATOR_CACHE_DIR override was given (no XDG fallback)"
+	fail_no_cache_dir "${ACCELERATOR_CACHE_DIR:-${plugin_root}/bin}" \
+		"could not be created"
 unverified_log="${cache_dir}/.accelerator-unverified.log"
 
 # ── Local-build override (skips fetch, cache and verification entirely) ──────
@@ -232,6 +246,22 @@ ${plugin_root}/cli/target/): ${ACCELERATOR_LAUNCHER_BIN}"
 	exec "${ACCELERATOR_LAUNCHER_BIN}" "$@"
 fi
 
+# Cold-path only, and below the dev override so the contributor path pays
+# nothing for it. `probed` is set only after a successful probe, so a cold run
+# reaching both call sites probes exactly once.
+probed=""
+
+require_exec_capable_cache() {
+	[[ -z "${probed}" ]] || return 0
+	probe_exec_capable "${cache_dir}"
+	case "$?" in
+	0) probed=1 ;;
+	2) fail_no_cache_dir "${cache_dir}" \
+		"rejected an executable file — possibly a noexec mount" ;;
+	*) fail_no_cache_dir "${cache_dir}" "is not writable" ;;
+	esac
+}
+
 # Portable full-digest sha256 (detection-based backend, matching the repo idiom);
 # inlined to keep this root-of-trust entry point self-contained (it sources
 # nothing else).
@@ -254,6 +284,9 @@ shim_digest=$(sha256_file "${shim_source}") ||
 shim="${cache_dir}/accelerator-verify-${platform}-${shim_digest}"
 if [[ ! -x "${shim}" ]] ||
 	[[ "$(sha256_file "${shim}" 2>/dev/null)" != "${shim_digest}" ]]; then
+	# This body is the first required write into the cache dir, so gating here
+	# covers every write. Anything that writes there earlier needs its own gate.
+	require_exec_capable_cache
 	cp "${shim_source}" "${shim}" 2>/dev/null ||
 		fail_integrity "could not stage the verify shim into ${cache_dir}"
 	chmod +x "${shim}" 2>/dev/null ||
@@ -336,6 +369,12 @@ fetch_and_verify() {
 if [[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]] && verify_launcher; then
 	: # cache hit — reuse without a lock or fetch
 else
+	# Staging was skipped (the staged shim already matched) but verification
+	# failed. Without this, an unwritable cache dir reaches acquire_lock, whose
+	# mkdir can never succeed and whose loop treats a missing pid file as an
+	# imminent competitor — burning its whole timeout budget and reporting a
+	# lock timeout instead of the real cause.
+	require_exec_capable_cache
 	acquire_lock
 	# Re-check under the lock in case another session populated the cache.
 	if ! { [[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]] &&

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -205,11 +205,22 @@ has no degraded mode. Two environment variables cover the awkward cases:
 | `ACCELERATOR_RELEASE_BASE_URL` | Where release artifacts are fetched from        |
 
 Both are trust-root inputs rather than ordinary conveniences. The cache
-directory is where the bootstrap writes and *executes* a probe file, so point it
-at a directory you own and that is not group-writable. The release base URL
-should be a host you trust not to serve an older signed release: the cache key
-carries no content hash, so a mirror can hand back an older validly-signed
-launcher for the current version.
+directory is where signed binaries are staged and executed from, so point it at
+a directory you own and that is not group-writable. The release base URL should
+be a host you trust not to serve an older signed release: the cache key carries
+no content hash, so a mirror can hand back an older validly-signed launcher for
+the current version.
+
+The bootstrap needs that directory to be writable and executable on a *cold*
+start — one where it has no verified launcher cached, which includes the first
+run after a version bump and any run where verification fails. It writes and
+*executes* a probe file there to check. A *warm* start neither writes nor
+probes; it runs the already-staged verifier and launcher instead, so a cache
+directory populated once may afterwards be read-only for warm bootstrap
+invocations. That exemption stops at the bootstrap: running any subcommand that
+dispatches to a separate binary makes the launcher probe the same directory, and
+that probe writes — so a permanently read-only cache directory is only viable if
+you never use those subcommands.
 
 `ACCELERATOR_PLUGIN_ROOT` is **exported by** the bootstrap for the launcher it
 runs; it is never read as an input. Setting it has no effect.

--- a/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -972,6 +972,13 @@ stale, and this plan itself adds eight cases to that file):
 Also correct `475KB` to `465KB` while the line is open — the shipped shim
 measures 465,568 bytes.
 
+**Deviation taken during implementation: not applied — the plan's correction is
+wrong.** 465,568 bytes is the **linux-x64** shim. The four vendored shims
+measure 486,672 (darwin-arm64), 496,896 (darwin-x64), 426,400 (linux-arm64) and
+465,568 (linux-x64) bytes, so the figure is per-triple and the original `475KB`
+was already right for the shipped darwin-arm64 shim (486,672 B = 475.3 KiB).
+Written as `~475KB` instead, since the comment is generic across triples.
+
 #### 4. Changelog
 
 **File**: `CHANGELOG.md`
@@ -993,7 +1000,7 @@ gate input. A ratio is safe to state because the gate enforces one.
 
 #### Automated Verification
 
-- [ ] Shell format and lint pass: `mise run scripts:check` — changes 2 and 3
+- [x] Shell format and lint pass: `mise run scripts:check` — changes 2 and 3
       edit `bin/accelerator`, which `tasks/shared/sources.py:110` puts in
       shfmt/ShellCheck/bashisms/exec-bits scope
 
@@ -1003,16 +1010,17 @@ maintained by hand.
 
 #### Manual Verification
 
-- [ ] `docs/internals.md` no longer claims the probe runs on every invocation,
+- [x] `docs/internals.md` no longer claims the probe runs on every invocation,
       both paragraphs read end-to-end as complete prose, the release-base-URL
       sentence survives verbatim, the trust guidance is not narrowed to cold
-      starts, and every line is within 80 columns
-- [ ] The read-only-cache statement names the dispatch limitation in both
+      starts, and every line is within 80 columns (the only over-80 lines in
+      the section are the pre-existing variable table)
+- [x] The read-only-cache statement names the dispatch limitation in both
       `docs/internals.md` and `CHANGELOG.md`
-- [ ] The changelog entry sits under the existing `## [Unreleased]` /
+- [x] The changelog entry sits under the existing `## [Unreleased]` /
       `### Changed` heading, describes user-visible behaviour, and states no
       figure Phase 4 has not measured
-- [ ] The staging comment no longer calls the re-hash "cheap" without
+- [x] The staging comment no longer calls the re-hash "cheap" without
       qualification, and cites test function names rather than line numbers
 
 ---

--- a/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -1,0 +1,1517 @@
+---
+type: plan
+id: "2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"
+title: "Remove the Exec Probe from the Bootstrap Warm Path Implementation Plan"
+date: "2026-08-02T22:01:31+00:00"
+author: "Toby Clemson"
+producer: create-plan
+status: ready
+work_item_id: "work-item:0186"
+parent: "work-item:0186"
+derived_from:
+  ["codebase-research:2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"]
+relates_to: ["work-item:0169", "work-item:0182", "work-item:0164"]
+tags: [shell, performance, bootstrap, bash-3.2, testing]
+revision: "4a68344cd2614f3bdd07223c8aeaf64583c036f0"
+repository: "accelerator"
+last_updated: "2026-08-03T10:31:13+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Remove the Exec Probe from the Bootstrap Warm Path Implementation Plan
+
+## Overview
+
+`bin/accelerator` runs a write-chmod-exec probe on every invocation, costing
+~108 ms of a ~149 ms warm call — almost all of it macOS's first-exec check on a
+freshly written binary. Split `probe_dir` into an always-run `ensure_dir` and a
+cold-path-only `probe_exec_capable`, so the warm path pays neither the write nor
+the exec.
+
+## Current State Analysis
+
+The probe reaches the warm path because `resolve_cache_dir` calls `probe_dir`
+and is itself invoked unconditionally at `bin/accelerator:195`, before any
+warm/cold decision. The execution order that matters:
+
+| Line | What happens | Runs warm? |
+| --- | --- | --- |
+| `:166-180` | `probe_dir` — `mkdir -p`, write, `chmod +x`, exec, `rm` | yes |
+| `:184-193` | `resolve_cache_dir` — override-or-default, calls it | yes |
+| `:195-197` | call site + `fail "no writable, exec-capable …"` | yes |
+| `:198` | `unverified_log` reassigned under `cache_dir` | yes |
+| `:207-233` | dev-launcher override (execs, never returns when taken) | yes |
+| `:252-253` | `sha256_file` #1 over `shim_source` | yes |
+| `:255-256` | staging **condition** — `-x` test + `sha256_file` #2 | yes |
+| `:257-260` | staging **body** — `cp` + `chmod` into `cache_dir` | cold only |
+| `:305-307` | `launcher`, `launcher_sig`, `base_url` assignments | yes |
+| `:336` | cache-hit test: `-x launcher` + `-f sig` + `verify_launcher` | yes |
+| `:339-347` | cold branch — `acquire_lock`, `fetch_and_verify` | cold only |
+| `:352` | `exec "${launcher}" "$@"` | yes |
+
+The probe never *chooses* a directory: `resolve_cache_dir` takes
+`ACCELERATOR_CACHE_DIR` if set, else `${plugin_root}/bin`, and returns 1 rather
+than falling back. Only the diagnostic's firing point moves.
+
+Verified against the post-0182 tree at revision `4a68344c`: every line number,
+every quoted test name, and the no-`build:cli:dev` guard are current.
+
+## Desired End State
+
+A warm `bin/accelerator` invocation execs no **freshly written** file — no
+probe write, no probe `chmod`, no probe exec. (It still execs `sed`, `uname`
+twice, the sha256 backend twice, and the staged shim and launcher; none of those
+pay macOS's first-exec penalty, which is the entire cost being removed.)
+Expected landing near ~41 ms against a ~149 ms pre-0182 reference.
+
+The `no writable, exec-capable cache directory` diagnostic still fires on every
+path that cannot use its cache dir, with no new hang, and now reports which of
+the three causes it actually detected. Verified by eight regression cases in the
+entrypoint suite plus a recorded same-session latency measurement.
+
+### Key Discoveries
+
+- **The probe must run before the staging `cp`, and the cheapest way to
+  guarantee that is to put it *inside* the staging `if` body.** Staging
+  (`:252-261`) precedes the warm/cold branch (`:336`). Measured on this host: a
+  `chmod -x` directory permits `mkdir -p` on an existing path but fails writes,
+  fails `cp`, and makes `[[ -x dir/file ]]` false. A probe placed only in the
+  `else` at `:339` never runs on that scenario — `cp` fails first with `could
+  not stage the verify shim into …`, so the acceptance criteria asserting the
+  cache-dir substring would fail.
+
+  The staging body is the **first required write into `cache_dir`** on every
+  path, so gating there covers every write without needing a separate
+  pre-staging gate, without hoisting `launcher`/`launcher_sig`, and without a
+  second copy of the cache-hit predicate. Two writes sit outside that
+  invariant, both benign and both worth naming so the invariant can be
+  re-verified by grepping for writes into `${cache_dir}`/`${unverified_log}`
+  rather than by trusting prose: `fail_integrity`'s append to
+  `.accelerator-unverified.log` (best-effort, failure paths only), and the
+  dev-override block's append at `:228-231` (guarded by `|| true`, and it
+  `exec`s immediately after).
+
+- **A staging gate alone introduces a ~30 second hang.** In the residual case —
+  launcher present and executable, signature present, staged shim present and
+  matching (so the staging body is skipped), *verification fails*, directory
+  unwritable — no staging gate fires and control reaches `acquire_lock` at
+  `:339` before `fetch_and_verify`. `mkdir "${lock_dir}"` can never succeed, no
+  pid file exists, so the loop takes the `else` arm and spins its full
+  300 × 0.1 s budget before failing with a lock-timeout message. Measured at a
+  reduced ceiling: `TIMEOUT after 31 iters, 3s`. Today that case fails
+  instantly with the correct diagnostic, so a second call site at the top of
+  the cold branch is required to avoid a regression, not merely to preserve a
+  nicer message. This supersedes the research's framing of the residual as a
+  cosmetic diagnostic narrowing.
+
+- **`PS4='+${FUNCNAME[0]}:'` is broken under the bootstrap's `set -u` on bash
+  3.2.** Measured: every top-level command emits `FUNCNAME[0]: unbound
+  variable` to stderr and PS4 stays literally unexpanded.
+  `'+${FUNCNAME[0]:-main}:'` is clean and labels the top-level frame usefully.
+  The plan adopts the fixed string; this is a deliberate deviation from the
+  acceptance criterion's literal wording. The failure mode differs by
+  interpreter — an unbound expansion aborts a non-interactive bash 5 outright —
+  so the `:-main` default is load-bearing on the linux lane for a different
+  reason than the one measured here.
+
+- **Trace depth is not stable.** `resolve_cache_dir` runs inside `$( )` at
+  `:195`, so its lines carry `++`; a top-level call site carries `+`.
+  Assertions must match the function token allowing one or more leading `+`,
+  never a fixed count.
+
+- **Redirections are invisible to xtrace.** The probe writes via `>` at `:169`,
+  so `+probe_dir:printf '#!/bin/sh\nexit 0\n'` appears with no filename. The
+  function name is the only reliable observable — confirmed empirically.
+
+- **The probe's exec IS observable**, as a line whose whole command word is the
+  probe path: `+probe_exec_capable:/…/.accelerator-probe-76236`. The matcher
+  must anchor on the `/` immediately after the PS4 colon, because xtrace also
+  emits the function's own `probe=/…/.accelerator-probe-76236` **assignment**
+  line. Measured against a real trace of the proposed function: the
+  unanchored form `…:\S*\.accelerator-probe-\S*$` matches **two** lines (the
+  assignment and the exec), so it passes on an implementation that never execs
+  anything; the anchored form matches exactly one. The `chmod +x …` and
+  `rm -f …` lines are excluded by both, and the top-level call line
+  (`+main:probe_exec_capable /dir`) by neither, since the function token must
+  follow the leading `+`s.
+
+- **A failed redirection reports through the shell, not the command.** The
+  probe's `printf … >"${probe}" 2>/dev/null` still emits
+  `bash: /…/.accelerator-probe-<pid>: Permission denied` on an unwritable
+  directory: the `2>/dev/null` applies to `printf`, but the shell fails the
+  redirection before `printf` runs. Pre-existing in `probe_dir` and unchanged
+  here, but worth knowing — the new cases assert a substring of combined
+  output, so this noise is harmless, and a reader should not expect the
+  redirection to be silent.
+
+- **`SHELLOPTS=xtrace` is not equivalent to `-x`** and is rejected. It is
+  exported and honoured by every **bash** descendant — non-bash children (the
+  injected Python downloader, the Rust shim and launcher) ignore it. The
+  operative hazard is that the probe's own `#!/bin/sh` *is* bash in posix mode
+  on macOS but dash on Linux, so a global trace mode would make trace content
+  lane-dependent; and it pollutes the same stderr the existing cases assert on.
+  `BASH_XTRACEFD` is bash 4.1+ and unusable at the floor. Hence the narrow
+  `xtrace` seam in the harness.
+
+- **The real-launcher route is free.** `launcher_bin` is module-scoped
+  (`test_accelerator_entrypoint.py:68`) and three tests (`:772`, `:787`,
+  `:801`) already trigger the cargo build, so `real_launcher=True` adds no
+  build cost. This reverses the research's recommendation of the stub route.
+
+- **`run_bootstrap` already converts a hang into a named failure.** Its
+  `timeout` keyword is wired to `pytest.fail(f"the bootstrap did not
+  terminate: {entry}")` (`installation.py:366-369`), so the anti-hang case
+  needs no new harness machinery — only an explicit `timeout=`.
+
+- **The cached-launcher path has an established idiom.**
+  `test_accelerator_entrypoint.py:219` and `:272` both build it directly from
+  the `host_platform` fixture (`:58`) as
+  `f"accelerator-launcher-{_VERSION}-{host_platform}"`. A `glob` plus a
+  `Path.suffix` filter is not equivalent: for the fixture's `9.9.9-test`
+  version, `Path("accelerator-launcher-9.9.9-test-darwin-arm64").suffix` is
+  `'.9-test-darwin-arm64'`, so a `!= ".minisig"` filter only works by accident,
+  and ruff-format rewrites the multi-line generator expression, reddening
+  `format:build-system:check`. Both verified.
+
+- **No `build:cli:dev` edge exists or may be added.**
+  `installation.py:149-157` builds the launcher in-fixture, and
+  `tests/unit/tasks/test_mise.py:104-109` fails if the edge appears. Adding
+  cases to the existing file needs no task wiring.
+
+- **The harness is shared** with
+  `tests/integration/skill-invocation/test_skill_invocation_conformance.py`, so
+  any `run_bootstrap` signature change must be backwards-compatible.
+
+- **`bin/accelerator` is tab-indented and must stay so.** `.editorconfig`'s
+  shell section is keyed `[*.sh]`, which does not match an extensionless file,
+  so shfmt applies its defaults. A space-indented function reddens
+  `format:scripts:check`. Note `bin/accelerator` is nonetheless in shell-source
+  scope: `tasks/shared/sources.py:110` adds it to `_EXTRA_SHELL_SOURCES` by
+  name, so any edit to it — including a comment — is gated by `scripts:check`.
+
+- **The sha256 residual depends on which backend resolves, and the figures in
+  circulation describe the wrong one.** On *this* host (darwin 25.3),
+  `command -v sha256sum` resolves to `/sbin/sha256sum`, an Apple-signed Mach-O
+  binary, so `sha256_file` never reaches its `shasum` fallback. Measured
+  against the real 465 K shim: `$(sha256sum … | awk …)` is **4.22 ms**; the Perl
+  `$(shasum -a 256 … | awk …)` variant is **12.97 ms**; `sha256sum` alone is
+  1.99 ms against a 1.48 ms fork+exec floor, so actual hashing is ~0.5 ms
+  (≈900 MB/s) and the rest is process startup. The ~11.7 ms per-call figure the
+  work item and 0169's hand-off quote matches the *Perl* variant.
+  **This is a single-host observation, not a darwin fact** — `/sbin/sha256sum`
+  is a comparatively recent macOS addition, so an older macOS or a minimal
+  image may resolve only `shasum`, which swings the two-hash residual roughly
+  3× (~8.4 ms versus ~26 ms). Phase 4 records the resolved backend and the OS
+  version, and hands 0169 the range rather than a point estimate.
+
+- **Batching the two hashes into one invocation saves ~2.5 ms**, measured on
+  this host: two `$(sha256sum f | awk …)` substitutions cost 7.05 ms against
+  4.57 ms for one `$(sha256sum f1 f2)` with no `awk` (bash-interpreter baseline
+  2.02 ms). Both digests are still computed and compared, so the planted-stub
+  defence is untouched — but it needs a branch to preserve today's
+  short-circuit (the second hash currently runs only when the staged shim is
+  executable, and a batched call would hash a nonexistent file on a cold run).
+  Recorded, not adopted: see What We're NOT Doing.
+
+- **Both CI lanes are verified unprivileged.** `.github/workflows/main.yml`
+  contains no `container:` key at all; `test-integration` (`:55-91`) is a plain
+  `runs-on: ${{ matrix.os }}` matrix over `ubuntu-latest`/`macos-latest`. The
+  single `docker` reference (`:145`, `test:e2e:visualiser:docker`) belongs to
+  the visual-regression job, which never reaches the entrypoint suite. So the
+  root guard will not fire in CI, and no lane exclusion is expected.
+
+- **The linux lane already exercises bash 5.** The harness pins
+  `BASH = "/bin/bash"` (`installation.py:41`) deliberately, to hold the 3.2
+  floor on darwin — and on `ubuntu-latest` that same path *is* bash 5.2. So the
+  trace assertions run under both interpreters on every CI run; the risk is
+  discovering a divergence in CI rather than locally, not an untested
+  mechanism.
+
+- **`v1.24.0-pre.21` has published signed darwin-arm64 release assets**
+  (published 2026-08-02, after 0182 merged), and `bin/accelerator-launcher-*`
+  is gitignored — so the measurement can use a genuine release asset without
+  dirtying the tree. `.gitignore:48` also already covers `bin/.tmp-*`, which is
+  why the measurement's pre-change copy is named `bin/.tmp-accelerator-before`
+  rather than `bin/.accelerator-before`: in a jj working copy an unignored file
+  is auto-snapshotted on virtually any `jj` command, so an executable copy of a
+  superseded trust-root bootstrap must not be left unignored in `bin/`.
+
+## What We're NOT Doing
+
+- **Not touching the shim staging block's hashes** (`:252-256`) or its second
+  `sha256_file`. Resolved during 0186's review-1: both hashes stay. Three tests
+  at `test_accelerator_entrypoint.py:584-644` assert the planted-stub defence it
+  provides. The measured ~8.4 ms cost remains on the warm path. The staging
+  `if` **body** gains one probe call — that is a cold-path-only addition and
+  does not touch the hashing or the copy.
+- **Not batching the two hashes into one `sha256sum` invocation**, despite the
+  measured ~2.5 ms saving above. It needs a branch to keep today's
+  short-circuit, and ~2.5 ms is close enough to 0169's ~2.4 ms shortfall that
+  it deserves its own item with its own before/after rather than riding along
+  here. Recorded in Phase 4 as a candidate follow-up with the figure attached.
+- **Not hoisting `launcher`/`launcher_sig`.** An earlier draft of this plan
+  moved them above the staging block to feed a pre-staging cache-hit gate.
+  Gating inside the staging body removes the need, so `:305-307` stays intact —
+  no ordering invariant between the assignments and the gate, and no third copy
+  of the `-x launcher` / `-f sig` predicate.
+- **Not mounting a genuinely `noexec` filesystem.** The exec-vs-write coverage
+  gap is recorded, not closed.
+- **Not changing 0169's latency threshold or its rationale.** This plan only
+  re-confirms the hand-off note's figures, correcting the residual it quotes.
+- **Not touching `cli/launcher/src/launch/outbound/resolve/cache_root.rs`** in
+  this work item — but see Phase 4's follow-up: the launcher runs the same
+  write-chmod-exec probe on every external-subcommand dispatch, so the saving
+  here does not reach `accelerator vcs guard`, and a read-only cache directory
+  is only usable for warm *bootstrap* invocations.
+- **Not fixing `acquire_lock`'s inability to distinguish contention from an
+  unusable directory.** The cold-branch gate masks the one instance reachable
+  today; a follow-up is raised in Phase 4.
+- **Not changing `sha256_file`'s backend detection.** Measurement shows the
+  native backend is already in use on this host and that `openssl dgst`
+  (4.53 ms) is slower than it; dropping the two `awk` execs alone saves
+  ~0.4 ms. The conclusion is host-conditional — see Key Discoveries — so Phase 4
+  records the resolved backend rather than closing the question globally.
+- **Not adding a `test:integration:*` leaf.** Cases go in the existing file.
+- **Not adding a pytest marker for the root guard.** Both lanes are verified
+  unprivileged, so no exclusion is expected; Phase 4 records the marker as the
+  escape to add *if* a root lane ever appears, and Phase 1's guard message
+  therefore does not promise a mechanism that does not exist.
+- **Not adding a `.gitignore` entry.** The measurement's temporary copy uses the
+  existing `bin/.tmp-*` rule; `bin/.accelerator-probe-*` is unchanged by this
+  work and the probe cleans up after itself (asserted in Phase 2).
+
+## Implementation Approach
+
+Split `probe_dir` into `ensure_dir` (the `mkdir -p`, still reached on every
+invocation via `resolve_cache_dir`) and `probe_exec_capable` (the
+write-chmod-exec-rm, now returning distinct statuses for a write failure and an
+exec failure), called from two cold-path sites through
+`require_exec_capable_cache`:
+
+- **The staging gate** — the first statement inside the shim-staging `if` body,
+  before the `cp`. The body is the first required write into `cache_dir` on
+  every path, so this covers every write, and it is never entered on a warm
+  call.
+- **The cold-branch gate** — at the top of the cold branch before
+  `acquire_lock`, covering the verification-failed residual where staging was
+  skipped.
+
+Both go through one idempotence flag, so a cold run reaching both probes exactly
+once. Neither is reached on a warm call, and because both sit below the
+dev-override block the contributor dev path stops paying for a probe it never
+needed.
+
+`fail_no_cache_dir` is defined **above** the `resolve_cache_dir` call site and
+takes the offending directory plus a cause clause, so the substring the tests
+assert has exactly one definition while each site reports what it actually
+detected — and the message keeps the `ACCELERATOR_CACHE_DIR` remediation hint
+the pre-change wording carried.
+
+Phases are ordered so each is independently green and mergeable. Phase 1 is the
+root-privilege guard, which closes a real false negative today and needs
+nothing from the rest. Phase 2 carries the trace seam, the trace helpers and
+the production change with its regression cases, written test-first. Phase 3 is
+documentation. Phase 4 is measurement and closeout.
+
+---
+
+## Phase 1: Root-Privilege Guard
+
+### Overview
+
+Add the root-privilege guard and retrofit it onto the three existing permission
+tests that would otherwise pass as false negatives under uid 0. This phase
+stands alone: it closes an existing false negative and needs nothing from the
+later phases. No production behaviour changes; the suite stays green.
+
+### Changes Required
+
+#### 1. Root-privilege guard
+
+**File**: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+**Changes**: A hard-failing guard, deliberately diverging from the `skipif`
+idiom at `tests/integration/hooks/test_launcher_link_refresh.py:275-293`.
+Docstring shaped like the file's others (`:79-83`).
+
+```python
+def _require_unprivileged() -> None:
+    """Hard-fail rather than skip under uid 0.
+
+    Root bypasses both the write permission and the execute bit, so these
+    assertions would hold whatever the code did; a skip would report green on a
+    lane that verified nothing.
+    """
+    assert os.getuid() != 0, (
+        "these cases assert on permission bits, which are advisory for uid 0; "
+        "run them unprivileged, or exclude them with a recorded privilege check"
+    )
+```
+
+#### 2. Retrofit onto existing permission tests
+
+**File**: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+**Changes**: Call `_require_unprivileged()` as the first statement of
+`test_readonly_root_with_override_runs_from_override` (`:253`),
+`test_readonly_root_without_override_is_a_named_error` (`:279`) and
+`test_a_record_is_always_one_line` (`:1060`).
+
+The asymmetry worth knowing when reading these: the cases asserting **success**
+under a restrictive mode are the ones that go silently green under uid 0, since
+root's write succeeds regardless of the implementation. The cases asserting
+**failure** would red under root instead — noisily, but for the wrong reason.
+Both are covered by the same guard.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Entrypoint suite passes: `mise run test:integration:entrypoint`
+- [ ] Python format, lint and types pass: `mise run build-system:check`
+- [ ] Full read-only gate passes: `mise run check`
+
+#### Manual Verification
+
+- [ ] `_require_unprivileged` reads as a deliberate divergence from the
+      neighbouring `skipif`, so a later reader does not "fix" it back
+
+---
+
+## Phase 2: Split the Probe and Relocate It Off the Warm Path
+
+### Overview
+
+The trace seam, the trace helpers, the production change and its eight
+regression cases. Write the cases first, observe each behaving as recorded
+below, then make them pass.
+
+### Changes Required
+
+#### 1. Trace capture seam
+
+**File**: `tests/integration/support/installation.py`
+**Changes**: Add a keyword-only `xtrace` flag to `run_bootstrap`, translate it
+into the interpreter flag inside the funnel, and default `PS4` alongside it so
+the capability is cohesive at the seam rather than split between a flag here and
+an env var each consumer must remember. A narrow boolean rather than an open
+`bash_args` passthrough: bash treats the first non-option operand as the script,
+so an arbitrary argument list could demote the validated `entry` to `$1` and
+defeat the `assert_hermetic` precondition this funnel exists to enforce. The
+`False` default keeps the shared skill-invocation consumer unaffected.
+
+```python
+def run_bootstrap(
+    root: Path,
+    server: Path,
+    downloader: Path,
+    *,
+    args: tuple[str, ...] = (),
+    xtrace: bool = False,
+    extra_env: dict[str, str] | None = None,
+    path: str | None = None,
+    entry: Path | None = None,
+    cwd: Path | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+```
+
+In the body, before the `with`:
+
+```python
+    bash_flags = ("-x",) if xtrace else ()
+    if xtrace:
+        env.setdefault("PS4", "+${FUNCNAME[0]:-main}:")
+```
+
+and at the `subprocess.run` call:
+
+```python
+                [BASH, *bash_flags, str(entry), *args],
+```
+
+Extend the existing docstring with one clause naming `xtrace`: tracing is
+per-call because the trace lands on stderr alongside the diagnostics every other
+case asserts on; `PS4` defaults to `+${FUNCNAME[0]:-main}:` because a bare
+`${FUNCNAME[0]}` is unbound at top level under the bootstrap's `set -u`; and
+`SHELLOPTS` is rejected because it is exported into bash descendants, and the
+probe's `#!/bin/sh` is bash on macOS but dash on Linux, which would make trace
+content lane-dependent.
+
+#### 2. Trace helpers and a mode-restoring context manager
+
+**File**: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+**Changes**: Add `import re` and `import contextlib` to the module imports, then
+open the new section (see Change 3) and place these immediately under its
+divider, ahead of the cases — matching the file's section-local helper
+convention at `:334-383` and `:706-760`.
+
+```python
+_PROBE_FN = "probe_exec_capable"
+_ENSURE_FN = "ensure_dir"
+
+
+@contextlib.contextmanager
+def _restricted(path: Path, mode: int) -> Iterator[None]:
+    """Apply a mode and always restore it: `tmp_path` teardown cannot remove an
+    unwritable directory, and an advisory-permission filesystem (a bind mount,
+    WSL drvfs, an inherited ACL) would silently void the case, so the mode is
+    verified to have bitten.
+    """
+    path.chmod(mode)
+    try:
+        assert not os.access(path, os.W_OK), (
+            f"chmod {mode:#o} did not take effect on {path}; permission bits "
+            "appear advisory on this filesystem — exclude it explicitly"
+        )
+        yield
+    finally:
+        path.chmod(0o755)
+
+
+def _traced(
+    harness: Harness,
+    downloader: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_bootstrap(
+        harness.root,
+        harness.server,
+        downloader,
+        xtrace=True,
+        extra_env=extra_env,
+        timeout=30,
+    )
+
+
+def _entered(trace: str, function: str) -> bool:
+    pattern = rf"^\++{re.escape(function)}:"
+    return re.search(pattern, trace, re.MULTILINE) is not None
+
+
+def _probe_execs(trace: str) -> int:
+    # The `:/` anchor is load-bearing: the function's own
+    # `probe=/…/.accelerator-probe-<pid>` assignment is traced too, and a looser
+    # pattern matches it — passing on an implementation that never execs.
+    # Counting rather than searching also pins the idempotence flag.
+    pattern = rf"^\++{re.escape(_PROBE_FN)}:/\S*\.accelerator-probe-\d+$"
+    return len(re.findall(pattern, trace, re.MULTILINE))
+```
+
+The `_restricted` mode check is what the work item's acceptance-criteria
+preamble asks for beyond `id -u`: on a filesystem where `chmod` is advisory the
+permission cases would otherwise fail (or, worse for the success-asserting case,
+pass) with no hint that the environment rather than the product was at fault.
+
+#### 3. Regression cases (written first)
+
+**File**: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+**Changes**: Eight cases under a new section divider.
+
+```python
+# ── Exec probe: cold-path only ───────────────────────────────────────────────
+
+
+def test_warm_path_survives_a_non_writable_cache_dir(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    launcher_bin: Path,
+) -> None:
+    # Equality against a direct launcher run proves the cached binary is the one
+    # the fixture built. It pins the vergen commit/build stamps too, so a
+    # relink between fixture setup and this call would fail it.
+    _require_unprivileged()
+    harness = make_harness(real_launcher=True)
+    root, server = harness.root, harness.server
+    warm = _run_bootstrap(root, server, downloader, args=("version",))
+    assert warm.returncode == 0, warm.stdout + warm.stderr
+    with _restricted(root / "bin", 0o555):
+        result = _run_bootstrap(root, server, downloader, args=("version",))
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    direct = subprocess.run(
+        [str(launcher_bin), "version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout == direct.stdout, output
+
+
+def test_warm_path_does_not_enter_the_probe(
+    make_harness: Callable[..., Harness], downloader: Path
+) -> None:
+    harness = make_harness()
+    warm = _run_bootstrap(harness.root, harness.server, downloader)
+    assert warm.returncode == 0, warm.stdout + warm.stderr
+    traced = _traced(harness, downloader)
+    assert traced.returncode == 0, traced.stdout + traced.stderr
+    trace = traced.stderr
+    # `verify_launcher` bounds the trace from the far end: `ensure_dir` alone
+    # only proves the run reached `resolve_cache_dir`, which is upstream of both
+    # gates, so a truncated trace would satisfy the negative assertion.
+    assert _entered(trace, _ENSURE_FN), trace
+    assert _entered(trace, "verify_launcher"), trace
+    assert not _entered(trace, _PROBE_FN), trace
+
+
+def test_cold_path_enters_and_executes_the_probe(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    harness = make_harness()
+    cache = tmp_path / "fresh-cache"
+    result = _traced(
+        harness, downloader, extra_env={"ACCELERATOR_CACHE_DIR": str(cache)}
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert cache.is_dir(), "the always-run ensure_dir half must create it"
+    assert _entered(result.stderr, _PROBE_FN), result.stderr
+    # Exactly one: a cold run reaches both gates, so a broken idempotence flag
+    # would probe twice.
+    assert _probe_execs(result.stderr) == 1, result.stderr
+    assert not list(cache.glob(".accelerator-probe-*")), "probe not cleaned up"
+
+
+def test_cold_happy_path_creates_a_missing_cache_dir(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    harness = make_harness(real_launcher=True)
+    cache = tmp_path / "absent" / "cache"
+    result = _run_bootstrap(
+        harness.root,
+        harness.server,
+        downloader,
+        args=("version",),
+        extra_env={"ACCELERATOR_CACHE_DIR": str(cache)},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert cache.is_dir(), output
+    assert result.stdout.startswith("accelerator "), output
+
+
+def test_cold_path_keeps_the_noexec_diagnostic(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "noexec-cache"
+    cache.mkdir()
+    with _restricted(cache, 0o666):
+        result = _run_bootstrap(
+            harness.root,
+            harness.server,
+            downloader,
+            extra_env={"ACCELERATOR_CACHE_DIR": str(cache)},
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+    assert str(cache) in output, output
+    assert "is not writable" in output, output
+
+
+def test_warmed_then_non_executable_cache_keeps_the_diagnostic(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "warm-cache"
+    cache.mkdir()
+    env = {"ACCELERATOR_CACHE_DIR": str(cache)}
+    first = _run_bootstrap(
+        harness.root, harness.server, downloader, extra_env=env
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    with _restricted(cache, 0o666):
+        result = _run_bootstrap(
+            harness.root, harness.server, downloader, extra_env=env
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+
+
+def test_unverifiable_launcher_in_readonly_cache_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    tmp_path: Path,
+    host_platform: str,
+) -> None:
+    # 0o555, not 0o666: keeping the search bit means the cached artefacts still
+    # stat and the staged shim still hashes equal, so staging is skipped and
+    # verification is genuinely reached. `timeout` sits between the sub-second
+    # pass and the ~30s lock-timeout budget the gate prevents.
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "readonly-cache"
+    cache.mkdir()
+    env = {"ACCELERATOR_CACHE_DIR": str(cache)}
+    first = _run_bootstrap(
+        harness.root, harness.server, downloader, extra_env=env
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    launcher = cache / f"accelerator-launcher-{_VERSION}-{host_platform}"
+    launcher.write_bytes(b"poisoned")
+    with _restricted(cache, 0o555):
+        result = _run_bootstrap(
+            harness.root, harness.server, downloader, extra_env=env, timeout=15
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+
+
+def test_uncreatable_cache_dir_is_a_named_error(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    # The cause clause is what distinguishes this site from the two probe
+    # gates, which emit the same leading substring.
+    _require_unprivileged()
+    harness = make_harness()
+    parent = tmp_path / "readonly-parent"
+    parent.mkdir()
+    with _restricted(parent, 0o555):
+        result = _run_bootstrap(
+            harness.root,
+            harness.server,
+            downloader,
+            extra_env={"ACCELERATOR_CACHE_DIR": str(parent / "nested")},
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+    assert "could not be created" in output, output
+```
+
+The two `0o666` cases clear the directory's search bit, which blocks *all* name
+resolution inside it — so the probe fails at its **write** step and its exec
+branch is never evaluated. No directory-permission combination can produce
+exec-without-write, so the exec half is covered only by
+`test_cold_path_enters_and_executes_the_probe`'s execution assertion, and
+Phase 4 records that limitation. Both cases are deterministic on both lanes:
+`ensure_dir`'s `[[ -d ]]` guard means `mkdir` never runs on an existing
+directory, so no `mkdir` implementation difference is reachable.
+
+#### 4. Split `probe_dir`
+
+**File**: `bin/accelerator`
+**Changes**: Replace `probe_dir` (`:166-180`) with two functions. Tab-indented,
+matching the file. `probe_exec_capable` returns 1 for a write or `chmod`
+failure and 2 for an exec failure, so the caller can report the cause it
+actually detected; every exit path removes the probe file.
+
+```bash
+# Kept a named function because a warm-path trace assertion uses the token to
+# prove the always-run half still runs; the -d guard keeps a warm call from
+# forking mkdir for a directory the launcher is about to be exec'd out of.
+ensure_dir() {
+	[[ -d "$1" ]] || mkdir -p "$1" 2>/dev/null
+}
+
+# Catches a noexec mount, which a write-only check would pass. Cold-path only:
+# a warm call proves the same capability for real by running the staged shim
+# and then the launcher out of this directory. 1 = cannot write, 2 = cannot
+# exec.
+probe_exec_capable() {
+	probe="$1/.accelerator-probe-$$"
+	if ! printf '#!/bin/sh\nexit 0\n' >"${probe}" 2>/dev/null ||
+		! chmod +x "${probe}" 2>/dev/null; then
+		rm -f "${probe}"
+		return 1
+	fi
+	"${probe}" >/dev/null 2>&1
+	status=$?
+	rm -f "${probe}"
+	[[ "${status}" -eq 0 ]] || return 2
+}
+```
+
+Verified against the project's gates and behaviourally: parses under bash
+3.2.57, passes `lint-bashisms.sh`, ShellCheck-clean, shfmt-stable, and returns
+0/1/2 with no probe file left behind in any of the three outcomes.
+
+#### 5. Reduce `resolve_cache_dir` to the always-run half
+
+**File**: `bin/accelerator`
+**Changes**: At `:184-193`, swap both `probe_dir` calls for `ensure_dir`,
+keeping the existing comment.
+
+```bash
+# ${plugin_root}/bin or the ACCELERATOR_CACHE_DIR override; no XDG fallback
+# (an XDG-resident binary would break the allowed-tools glob match).
+resolve_cache_dir() {
+	if [[ -n "${ACCELERATOR_CACHE_DIR:-}" ]]; then
+		ensure_dir "${ACCELERATOR_CACHE_DIR}" || return 1
+		printf '%s\n' "${ACCELERATOR_CACHE_DIR}"
+		return 0
+	fi
+	primary="${plugin_root}/bin"
+	ensure_dir "${primary}" || return 1
+	printf '%s\n' "${primary}"
+}
+```
+
+#### 6. Give the diagnostic one definition and three causes
+
+**File**: `bin/accelerator`
+**Changes**: Define the helper **above** the `resolve_cache_dir` call site and
+route every site through it. The substring the tests assert lives in one place,
+each site supplies the cause it detected, and the `ACCELERATOR_CACHE_DIR`
+remediation hint the pre-change wording carried is preserved. Note the
+pre-change message named `${plugin_root}/bin` even when an override was the
+thing that failed — the expansion below fixes that.
+
+```bash
+fail_no_cache_dir() {
+	fail "no writable, exec-capable cache directory: $1 $2; set \
+ACCELERATOR_CACHE_DIR to a writable, exec-capable directory (no XDG fallback)"
+}
+
+cache_dir=$(resolve_cache_dir) ||
+	fail_no_cache_dir "${ACCELERATOR_CACHE_DIR:-${plugin_root}/bin}" \
+		"could not be created"
+```
+
+#### 7. Add the two probe gates
+
+**File**: `bin/accelerator`
+**Changes**: Introduce the gate after `cache_dir` is resolved and below the
+dev-override block, then call it from two places. `probed` is set only after a
+successful probe, so the flag means what its name says rather than depending on
+`fail` never returning.
+
+```bash
+probed=""
+
+require_exec_capable_cache() {
+	[[ -z "${probed}" ]] || return 0
+	probe_exec_capable "${cache_dir}"
+	case "$?" in
+	0) probed=1 ;;
+	2) fail_no_cache_dir "${cache_dir}" \
+		"rejected an executable file — possibly a noexec mount" ;;
+	*) fail_no_cache_dir "${cache_dir}" "is not writable" ;;
+	esac
+}
+```
+
+The staging gate goes inside the existing `if` at `:255`, as the first
+statement of the body:
+
+```bash
+if [[ ! -x "${shim}" ]] ||
+	[[ "$(sha256_file "${shim}" 2>/dev/null)" != "${shim_digest}" ]]; then
+	# This body is the first required write into the cache dir, so gating here
+	# covers every write. Anything that writes there earlier needs its own gate.
+	require_exec_capable_cache
+	cp "${shim_source}" "${shim}" 2>/dev/null ||
+```
+
+The cold-branch gate goes at the top of the `else` at `:339`:
+
+```bash
+else
+	# Staging was skipped (the staged shim already matched) but verification
+	# failed. Without this, an unwritable cache dir reaches acquire_lock, whose
+	# mkdir can never succeed and whose loop treats a missing pid file as an
+	# imminent competitor — burning its whole timeout budget and reporting a
+	# lock timeout instead of the real cause.
+	require_exec_capable_cache
+	acquire_lock
+```
+
+#### 8. Pin the two function names cheaply
+
+**File**: `tests/unit/tasks/test_bootstrap_coverage.py`
+**Changes**: Two presence assertions, using the file's existing
+`assert _KEY in _BOOTSTRAP_SRC.read_text()` idiom. The trace cases assert on
+`ensure_dir` and `probe_exec_capable` by name; without this, a rename fails only
+after a cargo build and a full fetch-verify-cache round trip, reporting "probe
+not entered" rather than "the name moved" — and silently voids the warm-path
+negative assertion in the meantime.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Recorded during the red step, per case — the shape differs and the record
+      should say so rather than claim a uniform red. **Red before the change**:
+      `test_warm_path_survives_a_non_writable_cache_dir` (today's fatal probe
+      fails its write under `0o555`); `test_warm_path_does_not_enter_the_probe`
+      and `test_cold_path_enters_and_executes_the_probe` (the new function
+      names do not exist yet); `test_uncreatable_cache_dir_is_a_named_error`
+      (the `could not be created` cause clause does not exist yet).
+      **Green before and after** — preservation guards, which is a property
+      worth recording rather than a defect:
+      `test_cold_happy_path_creates_a_missing_cache_dir`,
+      `test_cold_path_keeps_the_noexec_diagnostic` (its cause assertion is new,
+      so it reds on that clause only),
+      `test_warmed_then_non_executable_cache_keeps_the_diagnostic`, and
+      `test_unverifiable_launcher_in_readonly_cache_fails_fast` — today's
+      unconditional probe already produces its asserted exit and substring.
+- [ ] **After the change**, confirm by mutation which case guards which gate,
+      and record it: deleting the staging gate reds
+      `test_cold_path_keeps_the_noexec_diagnostic`,
+      `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and
+      `test_readonly_root_without_override_is_a_named_error`; deleting the
+      cold-branch gate reds
+      `test_unverifiable_launcher_in_readonly_cache_fails_fast` via its
+      timeout. This is the only step that demonstrates the cold-branch gate is
+      guarded at all, since that case passes before the change.
+- [ ] Entrypoint suite passes: `mise run test:integration:entrypoint`
+- [ ] Skill-invocation suite unaffected:
+      `mise run test:integration:skill-invocation`
+- [ ] Launcher-edge guards still hold:
+      `uv run pytest tests/unit/tasks/test_mise.py`
+- [ ] Bootstrap coverage guard passes, including the two new name assertions:
+      `uv run pytest tests/unit/tasks/test_bootstrap_coverage.py`
+- [ ] Python format, lint and types pass: `mise run build-system:check`
+- [ ] Shell format, lint, bashisms and exec-bits pass:
+      `mise run scripts:check` (which folds `lint:scripts:bashisms:check`)
+- [ ] `mise run check` is green
+
+#### Manual Verification
+
+- [ ] A tampered cached launcher in an unwritable cache dir fails within a
+      second, not after the ~30 s lock budget (the automated case pins this,
+      but confirm the wall-clock once by hand)
+- [ ] The cold-run trace shows `probe_exec_capable` entered *and* the probe file
+      executed as its own command word exactly once — and confirm the `probe=`
+      assignment line is present in the same trace but not matched, so the
+      anchor is doing its job
+- [ ] Warm trace shows `ensure_dir` and `verify_launcher` but no
+      `probe_exec_capable`
+- [ ] Both interpreters are covered without extra work: the harness pins
+      `/bin/bash`, which is 3.2.57 on darwin and 5.2 on `ubuntu-latest`, so the
+      two trace cases run under both on every CI run. Confirm the ubuntu lane
+      green on them specifically rather than assuming (Phase 4 records it)
+
+---
+
+## Phase 3: Documentation
+
+### Overview
+
+Correct the statements this change falsifies, record the newly supported
+read-only cache with its real limit, and stop the staging comment misdirecting
+the next latency hunt.
+
+### Changes Required
+
+#### 1. Internals documentation
+
+**File**: `docs/internals.md`
+**Changes**: Replace the paragraph at `:207-212` with two paragraphs. The
+existing line 209 straddles a sentence boundary — the release-base-URL guidance
+begins on it — so the replacement must carry that sentence forward verbatim or
+it is orphaned. The trust guidance stays unconditional: the shim and the
+launcher are executed from that directory on every call, warm or cold, so
+ownership and group-writability matter permanently rather than only until the
+cache is populated. Wrapped at 80 columns.
+
+> Both are trust-root inputs rather than ordinary conveniences. The cache
+> directory is where signed binaries are staged and executed from, so point it
+> at a directory you own and that is not group-writable. The release base URL
+> should be a host you trust not to serve an older signed release: the cache
+> key carries no content hash, so a mirror can hand back an older
+> validly-signed launcher for the current version.
+>
+> The bootstrap needs that directory to be writable and executable on a *cold*
+> start — one where it has no verified launcher cached, which includes the first
+> run after a version bump and any run where verification fails. It writes and
+> *executes* a probe file there to check. A *warm* start neither writes nor
+> probes; it runs the already-staged verifier and launcher instead, so a cache
+> directory populated once may afterwards be read-only for warm bootstrap
+> invocations. That exemption stops at the bootstrap: running any subcommand
+> that dispatches to a separate binary makes the launcher probe the same
+> directory, and that probe writes — so a permanently read-only cache directory
+> is only viable if you never use those subcommands.
+
+#### 2. Bootstrap header contract
+
+**File**: `bin/accelerator`
+**Changes**: The header block at `:1-20` records this file's contract and is the
+first thing a reader of the changed code sees. It says nothing about the cache
+directory's capability requirements, which this change makes asymmetric and
+which `docs/internals.md` now promises. Add one clause: the cache directory must
+be writable and exec-capable on a cold start (probed once); a warm start only
+reads and execs from it, so a populated cache directory may be read-only.
+
+#### 3. Staging comment
+
+**File**: `bin/accelerator`
+**Changes**: At `:246-251` the comment says a warm call "re-hashes (cheap)".
+With the probe gone that re-hash is the largest remaining warm-path cost and
+0169's latency criterion turns on it, so the parenthetical now misdirects.
+Replace that clause with wording that records why the cost is retained, naming
+the guarding tests by **function name** rather than a line range (line ranges go
+stale, and this plan itself adds eight cases to that file):
+
+> …a warm call re-hashes instead of re-copying 465KB — now the largest
+> remaining warm-path cost, retained deliberately because the digest check is
+> what makes a planted stub get re-staged rather than trusted by name
+> (`test_planted_staged_shim_rehashed_then_succeeds`,
+> `test_planted_staged_shim_is_not_trusted`,
+> `test_planted_staged_shim_via_cache_dir_is_not_trusted`)…
+
+Also correct `475KB` to `465KB` while the line is open — the shipped shim
+measures 465,568 bytes.
+
+#### 4. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: An entry under the open `## [Unreleased]` / `### Changed` section,
+led by the observable effect. Deliberately **without** before/after
+milliseconds: Phase 4 is what measures them, and the ~150 ms figure in
+circulation is the pre-0182 reference the work item explicitly disclaims as a
+gate input. A ratio is safe to state because the gate enforces one.
+
+> - **Warm `accelerator` invocations are substantially faster** — better than
+>   halved on macOS, so session start and every skill's live-context command are
+>   noticeably quicker. The bootstrap now tests the cache directory only on a
+>   cold start; a `noexec` cache directory still fails with the same named
+>   error, and a cache directory populated once may afterwards be read-only for
+>   warm invocations (dispatching a subcommand to a separate binary still
+>   needs it writable).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Shell format and lint pass: `mise run scripts:check` — changes 2 and 3
+      edit `bin/accelerator`, which `tasks/shared/sources.py:110` puts in
+      shfmt/ShellCheck/bashisms/exec-bits scope
+
+There is no markdown formatter or linter anywhere in the task tree, so the
+Markdown edits have no automated gate; the 80-column convention for Markdown is
+maintained by hand.
+
+#### Manual Verification
+
+- [ ] `docs/internals.md` no longer claims the probe runs on every invocation,
+      both paragraphs read end-to-end as complete prose, the release-base-URL
+      sentence survives verbatim, the trust guidance is not narrowed to cold
+      starts, and every line is within 80 columns
+- [ ] The read-only-cache statement names the dispatch limitation in both
+      `docs/internals.md` and `CHANGELOG.md`
+- [ ] The changelog entry sits under the existing `## [Unreleased]` /
+      `### Changed` heading, describes user-visible behaviour, and states no
+      figure Phase 4 has not measured
+- [ ] The staging comment no longer calls the re-hash "cheap" without
+      qualification, and cites test function names rather than line numbers
+
+---
+
+## Phase 4: Measurement and Closeout
+
+### Overview
+
+Take both medians on one host in one session, record them and the coverage
+limitations in the work item's Validation Results, correct the stale residual
+figures wherever they appear, raise the follow-ups this work surfaced, and
+re-confirm 0169's hand-off note. No production source changes.
+
+### Changes Required
+
+#### 1. Measurement
+
+**Method**: authored fresh. Acceptance criterion 9 specifies "a bash loop over
+20 runs taking the median, matching how the Context table was produced"; this
+deviates deliberately and the deviation is recorded below, because that method
+cannot produce a usable figure. Two constraints drove the design.
+
+First, the clock must be read from a single process: bracketing each call with
+two `python3 -c` invocations puts a whole interpreter startup *inside* the
+measured interval, which on darwin is comparable to the ~41 ms being measured
+and biases the ratio toward failing a correct implementation. Second, the
+before/after variants must not be separated by a working-copy swap: taking one
+batch immediately after `jj new` rewrites and snapshots the tree aliases
+fsevents and file-watcher drift onto the result.
+
+So: copy the pre-change script alongside the new one and interleave the two
+sample-by-sample in a single revision, alternating which goes first so no
+variant is permanently second. `dir_of(self)/..` resolves the same plugin root,
+`plugin.json` gives the same `version`, and the cached launcher path is
+therefore identical — both variants provably exercise the same warm cache and
+the same binary. `v1.24.0-pre.21`'s signed `accelerator-darwin-arm64` asset is
+published and post-0182, so one warming call caches a genuine release binary.
+
+The copy is named `bin/.tmp-accelerator-before` because `.gitignore:48` already
+covers `bin/.tmp-*`. This matters more than tidiness: jj snapshots the working
+copy on virtually any command, so an unignored executable copy of a superseded
+trust-root bootstrap could be committed into `bin/` by any concurrent `jj`
+invocation during the run.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+before=bin/.tmp-accelerator-before   # bin/.tmp-* is already gitignored
+jj file show -r "$1" bin/accelerator >"${before}" ||
+	git show "$1:bin/accelerator" >"${before}"
+chmod +x "${before}"
+trap 'rm -f "${before}"' EXIT
+bin/accelerator version >/dev/null   # warm the shared cache
+ls -li bin/accelerator-launcher-*    # provenance, both sides share this
+python3 - "${before}" <<'PY'
+import statistics, subprocess, sys, time
+
+VARIANTS = [("before", sys.argv[1]), ("after", "bin/accelerator")]
+N = 50
+
+
+def timed(argv):
+    t = time.perf_counter()
+    p = subprocess.run(argv, capture_output=True, text=True)
+    return (time.perf_counter() - t) * 1000, p
+
+
+def sample(path):
+    dt, p = timed([path, "version"])
+    if p.returncode != 0 or not p.stdout.startswith("accelerator "):
+        raise SystemExit(
+            f"invalid sample from {path}: rc={p.returncode} {p.stderr}"
+        )
+    return dt
+
+
+# Two floors: /usr/bin/true isolates this harness's own per-call cost, and a
+# trivial bash script adds the interpreter startup that is inside both variants.
+floor_exec = statistics.median(timed(["/usr/bin/true"])[0] for _ in range(20))
+with open("bin/.tmp-accelerator-floor", "w") as fh:
+    fh.write("#!/usr/bin/env bash\nexit 0\n")
+subprocess.run(["chmod", "+x", "bin/.tmp-accelerator-floor"], check=True)
+floor_bash = statistics.median(
+    timed(["bin/.tmp-accelerator-floor"])[0] for _ in range(20)
+)
+
+samples = {name: [] for name, _ in VARIANTS}
+for i in range(N):
+    order = VARIANTS if i % 2 == 0 else list(reversed(VARIANTS))
+    for name, path in order:
+        samples[name].append(sample(path))
+
+print(f"harness floor (/usr/bin/true):     {floor_exec:7.2f} ms")
+print(f"+ bash interpreter startup:        {floor_bash:7.2f} ms")
+for name, xs in samples.items():
+    if len(xs) != N:
+        raise SystemExit(f"{name}: {len(xs)} samples, expected {N}")
+    xs.sort()
+    med = statistics.median(xs)
+    p90 = xs[-(-9 * len(xs) // 10) - 1]
+    print(
+        f"{name:7s} min {xs[0]:7.2f}  median {med:7.2f}  p90 {p90:7.2f}  "
+        f"median-minus-harness-floor {med - floor_exec:7.2f}  n={len(xs)}"
+    )
+PY
+rm -f bin/.tmp-accelerator-floor
+```
+
+`/usr/bin/true` is timed without the output check — it prints nothing, so
+validating stdout there would abort the run before a single sample. Its median
+must sit within a millisecond or two of a bare fork+exec; if it does not, the
+harness is measuring itself and the medians are not usable. The bash floor is
+the second calibration point: it is on the same critical path as both variants,
+so it converts part of the otherwise-unattributed residual into a measured term.
+
+`median − harness floor` is the figure to compare against the composition
+budget below; the raw median is the figure for the ratio gate, where the floor
+appears on both sides and cancels.
+
+**Gate**: `after ≤ 0.5 × before`. The delta is recorded but not gating. The
+gate has roughly 33 ms of slack against the ~41 ms expectation, so a pass alone
+does not prove the probe fully left — the composition check is what does.
+
+**Composition budget** to check the after-median against (all figures measured
+on this host unless marked): bash interpreter startup (measured by the bash
+floor), `uname -m` + `uname -s` as two substitutions, `sed` over `plugin.json`,
+two `cd -P`/`pwd -P` subshells for plugin-root resolution, the
+`resolve_cache_dir` command substitution, two `sha256_file` calls at ~4.2 ms
+each (**backend-dependent** — ~13.0 ms each if `shasum` resolves), the staged
+shim exec plus minisign at ~2.3 ms, and the launcher exec at ~3.0 ms. Record
+the observed total against this list; if the unexplained remainder exceeds ~25%
+of the after-median, attribute it before recording — a `bash -x` run with
+per-line timestamps is enough.
+
+**Re-derive the headline attribution while the harness is set up.** The plan's
+~108 ms probe cost and its ~97 ms "first-exec check" split are inherited from
+the work item's Context table, whose methodology was not recorded and whose
+"re-exec of a pre-existing probe file | 10.6 ms" row is seven times this
+harness's measured 1.48 ms fork+exec floor. Time three things directly: exec of
+a freshly written probe script, re-exec of the same file untouched, and the same
+probe in `/tmp` versus the repo `bin/`. Record whether the host runs an
+EndpointSecurity or anti-malware agent. This matters because a ~100 ms
+first-exec penalty is more characteristic of a scanning agent than of macOS
+generally — and if it is host-specific, the ratio gate is unsatisfiable on hosts
+without it and the extrapolation to the launcher-side probe does not transfer.
+
+#### 2. Validation Results
+
+**File**: `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md`
+**Changes**: Replace each _pending_ entry, naming the test function that
+discharges each behavioural criterion so the record traces to a permanent
+guard:
+
+- Warm-path exec-probe-free check —
+  `test_warm_path_survives_a_non_writable_cache_dir`.
+- Direct probe-absence check — `test_warm_path_does_not_enter_the_probe`.
+- Positive control — `test_cold_path_enters_and_executes_the_probe`.
+- `noexec` cold-path check — `test_cold_path_keeps_the_noexec_diagnostic`.
+- Cold happy-path (`ensure_dir`) check —
+  `test_cold_happy_path_creates_a_missing_cache_dir`.
+- Diagnostic preserved on a warmed-then-non-executable cache —
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic`. Note this is a
+  code-path duplicate of the `noexec` cold-path case: clearing the search bit
+  makes the staged shim unresolvable either way, so the populated cache has no
+  observable effect. The genuinely distinct warmed-then-unusable scenario is the
+  `0o555` case below.
+- Beyond the criteria: `test_unverifiable_launcher_in_readonly_cache_fails_fast`
+  (the cold-branch gate and its anti-hang property — the only cover for either)
+  and `test_uncreatable_cache_dir_is_a_named_error` (the retained
+  `resolve_cache_dir` failure, pinned by its `could not be created` cause).
+
+And record:
+
+- **Both medians, the delta, both instrument floors, min/median/p90, host model
+  and OS version**, plus launcher provenance with `ls -li` confirming both
+  variants used the same post-0182 binary.
+- **The measured composition** against the budget above, and **which sha256
+  backend `command -v sha256sum` resolved to**, with the macOS version. This is
+  load-bearing for 0169: `$(sha256sum … | awk …)` measured 4.22 ms on darwin
+  25.3 where `/sbin/sha256sum` exists, against 12.97 ms for the Perl `shasum`
+  fallback — so the two-hash residual is **~8.4 ms or ~26 ms depending on the
+  host**, and the ~11.7 ms figure previously quoted describes the fallback. Hand
+  0169 the range and the resolved backend, not a point estimate. Recording
+  `command -v sha256sum` on both CI lanes costs nothing and says whether the
+  fallback is reachable in CI at all.
+- **The re-derived probe attribution** from the third measurement above, with
+  the host's security-agent status.
+- **The lanes observed green** (darwin and linux), from the `test-integration`
+  matrix job in `.github/workflows/main.yml:55-91`. Confirmed to contain no
+  `container:` key, so both lanes run unprivileged and **no exclusion is
+  expected**. Record that the ubuntu lane's `/bin/bash` is 5.2, so the two trace
+  cases are covered on both interpreters by the standard CI run. If a root lane
+  is ever introduced, the escape to add is a registered `unprivileged` pytest
+  marker, so exclusion stays explicit and greppable rather than a silent skip.
+- **The exec-vs-write coverage limitation**: both `noexec` criteria create their
+  failure by clearing a directory's search bit, which blocks name resolution and
+  so fails the probe's *write* step — its exec branch is never evaluated, and no
+  directory-permission combination can produce exec-without-write. The exec half
+  is covered instead by the positive control's assertion that the probe file is
+  executed as its own command word. Both cases are lane-deterministic:
+  `ensure_dir`'s `[[ -d ]]` guard means `mkdir` never runs on an existing
+  directory, so no BSD/GNU `mkdir -p` difference is reachable. A genuine
+  `mount -o noexec` filesystem would close the gap and is explicitly out of
+  scope.
+- **The PS4 deviation**: criterion 2 mandates `PS4='+${FUNCNAME[0]}:'`, which is
+  broken under `set -u` on bash 3.2 — it emits `FUNCNAME[0]: unbound variable`
+  per top-level command and leaves PS4 unexpanded, and aborts a non-interactive
+  bash 5 outright. Implemented as `'+${FUNCNAME[0]:-main}:'`, defaulted inside
+  `run_bootstrap` when `xtrace` is set.
+- **The criterion-1 amendment**: the harness's default launcher prints nothing
+  and the real one prints `CARGO_PKG_VERSION`, not the fixture's `9.9.9-test`,
+  so "the version the harness fixture builds" was unachievable as literally
+  worded. Implemented against the real launcher, asserting stdout **equality**
+  with a direct `launcher_bin version` run.
+- **The criterion-3 split**: the criterion asks the positive control to ride on
+  criterion 6's cold happy-path run. Implemented as its own traced cold run
+  instead, because criterion 6's run uses the real launcher and is not traced.
+- **The criterion-9 method deviation**: 50 interleaved samples from a single
+  Python process with `perf_counter`, two instrument floors and
+  order-alternation, rather than a bash loop over 20. Reasons: a per-call
+  `python3` clock read puts an interpreter startup inside the interval; batching
+  either side of a `jj` working-copy swap aliases drift onto the difference; and
+  a fixed within-pair order biases whichever variant is always second. Note the
+  Context table's figures are therefore not method-comparable to these medians.
+- **The two probe call sites**: the staging gate covers every write into
+  `cache_dir` (the staging body being the first such write, with the two benign
+  exceptions named in Key Discoveries); the cold-branch gate covers the
+  verification-failed residual and prevents a ~30 s `acquire_lock` spin. Record
+  the reasoning so it survives anyone tempted to collapse them, and record the
+  post-change mutation results from Phase 2 showing which case guards which.
+- **The gate slack**: `after ≤ 0.5 × before` leaves ~33 ms of headroom against
+  the ~41 ms expectation, so the composition check is what confirms the probe
+  left.
+
+#### 3. Correct the stale residual figures in 0186 itself
+
+**File**: `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md`
+**Changes**: The ~11.7 ms / ~23 ms figures appear three more times in this work
+item — Dependencies ("~11.7 ms for the second `sha256_file` alone, or ~23 ms if
+staging were skipped entirely"), Assumptions ("while the ~11.7 ms cost
+remains"), and the double-hash entry in Validation Results. 0169's corrected
+hand-off note will point readers back at exactly these, so correct them here
+too, with the measured figure, its backend dependence and the range.
+
+#### 4. Follow-ups to raise
+
+**Changes**: Create work items and cross-reference them from 0186's Validation
+Results.
+
+- **The launcher runs the same probe on every external-subcommand dispatch.**
+  `cache_root::resolve` — and therefore `probe_writable_and_executable`, which
+  writes, `chmod`s, execs and removes `.accelerator-probe-<pid>` — runs from
+  `LazyProductionResolver::resolve` (`cli/launcher/src/main.rs:65`) *before*
+  the sub-binary cache-hit test. Built-ins (`version`, `config`) never reach
+  it, which is why today's SessionStart hook escapes and why this plan's
+  `version` measurement cannot see it. 0169 serves `vcs guard` as a dispatched
+  sub-binary, so it pays a fresh-file first-exec penalty of the same shape. The
+  same `ensure_dir` / lazy-probe split applies, gated on the cache miss inside
+  `FetchVerifyCacheResolver::resolve`. This is also what makes a read-only cache
+  directory unusable for dispatched subcommands, which Phase 3 documents.
+  **Necessary but not sufficient for 0169**: that item's own hand-off note
+  records the bootstrap alone landing near 41 ms against a ≈38.6 ms gate, so the
+  threshold decision is 0169's regardless and must not be deferred pending this.
+  While the measurement harness is set up, time
+  `probe_writable_and_executable` directly so the follow-up carries a figure
+  rather than an extrapolation.
+- **`acquire_lock` cannot distinguish contention from an unusable directory.**
+  The loop treats "no pid file" as "a competitor is about to write one" and has
+  no notion of an unrecoverable `mkdir`, so it burns its full budget. There is a
+  worse arm: when a pid file names a dead process, `:291-294` does
+  `rm -f`/`rmdir` then `continue` with no `sleep` and no `waited` increment — so
+  if the lock directory cannot be removed (created by another user), the loop
+  spins **unbounded** with no timeout at all, and neither gate prevents it (the
+  probe passes on a writable cache dir whose lock directory happens to be
+  foreign). The fix is small: after a failed `mkdir`, `[[ -d "${lock_dir}" ]]`
+  distinguishes EEXIST from a permission failure. Scope the item to classifying
+  `mkdir`/`rmdir` failures, not to re-wording the timeout.
+- **Batch the two shim hashes into one `sha256sum` invocation.** Measured on
+  this host at ~2.5 ms (7.05 ms for two `$(sha256sum f | awk …)` substitutions
+  versus 4.57 ms for one `$(sha256sum f1 f2)` with no `awk`), with both digests
+  still computed and compared so the planted-stub defence is untouched. Needs a
+  branch to preserve today's short-circuit, since the second hash currently runs
+  only when the staged shim is executable. ~2.5 ms is essentially 0169's whole
+  ~2.4 ms shortfall, so it deserves its own before/after rather than riding
+  along here. Confirm the multi-file output format and missing-file exit
+  semantics on both the Apple `/sbin/sha256sum` and GNU coreutils backends.
+
+Not raised, deliberately: a faster `sha256_file` *backend*. The native
+`sha256sum` is already in use on this host, actual hashing is ~0.5 ms,
+`openssl dgst` is slower, and dropping the two `awk` execs saves ~0.4 ms. If
+Phase 4 finds a lane resolving the Perl fallback, reopen it.
+
+#### 5. 0169 hand-off note
+
+**File**: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+**Changes**: Confirm the dated note in Dependencies still holds against the
+measured after-median. Correct the quoted residual — its figure derives from the
+Perl-`shasum` cost, not the backend the code uses on a host with
+`/sbin/sha256sum` — and hand over the measured **composition** plus the
+backend-dependent range rather than a single number, together with the
+launcher-side probe as the dominant unaddressed cost and the batched-hash lever
+as the cheapest remaining one. **Do not change 0169's threshold or its
+rationale** — that is 0169's own work.
+
+#### 6. Work item status
+
+**File**: `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md`
+**Changes**: Tick the discharged criteria and move `status` to `complete`.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mise run` is green end to end
+- [ ] Work item frontmatter validates:
+      `mise run test:integration:config` — the corpus validator
+      (`scripts/test-validate-corpus-frontmatter.sh`) is a by-name required
+      suite there (`tasks/test/integration.py:33-41`). It is **not** part of
+      `mise run check`
+
+#### Manual Verification
+
+- [ ] Both instrument floors are within expectation; if `/usr/bin/true` does not
+      read within a millisecond or two of a bare fork+exec, the medians are
+      discarded and the harness fixed
+- [ ] `after ≤ 0.5 × before` holds; both medians, the delta, both floors,
+      min/median/p90, host, OS version and launcher provenance are recorded
+- [ ] The measured composition is recorded against the budget, the resolved
+      sha256 backend is named, and any unexplained remainder over ~25% is
+      attributed
+- [ ] The probe attribution is re-derived on this harness and the host's
+      security-agent status recorded
+- [ ] Both CI lanes observed green on the new cases, and which were observed is
+      recorded — including the ubuntu lane's bash 5.2 coverage of the trace
+      cases
+- [ ] Every _pending_ entry in Validation Results is resolved, each behavioural
+      one naming the test function that discharges it
+- [ ] The stale ~11.7 ms / ~23 ms figures are corrected in 0186's Dependencies,
+      Assumptions and Validation Results, not only in 0169's note
+- [ ] All three follow-ups are raised and cross-referenced
+- [ ] 0169's note re-confirmed against the measured figure and handed the
+      backend-dependent range, with its threshold untouched
+- [ ] `bin/.tmp-accelerator-before` and `bin/.tmp-accelerator-floor` are gone
+      and `jj status` is clean of them
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+`tests/unit/tasks/test_mise.py` and
+`tests/unit/tasks/test_bootstrap_coverage.py` act as guards: no
+`build:cli:dev` edge may appear, `bin/accelerator` stays
+discoverable and executable, and it exports exactly `ACCELERATOR_PLUGIN_ROOT`.
+Phase 2 adds two presence assertions to the latter, pinning `ensure_dir` and
+`probe_exec_capable` so a rename fails in milliseconds rather than via a cargo
+build and a full fetch-verify-cache round trip.
+
+### Integration Tests
+
+Eight new cases in
+`tests/integration/entrypoint/test_accelerator_entrypoint.py`, run via
+`mise run test:integration:entrypoint`. Two assert on the xtrace, six on exit
+codes and diagnostics. Six are permission-dependent and hard-fail under uid 0.
+
+Coverage of the two gates is deliberate and asymmetric:
+
+- The **staging gate** is covered by
+  `test_cold_path_keeps_the_noexec_diagnostic`,
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` (a code-path
+  duplicate of the former — see Phase 4) and the pre-existing
+  `test_readonly_root_without_override_is_a_named_error`, all via the probe's
+  write step.
+- The **cold-branch gate** is covered *only* by
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast`, the one case
+  constructed to keep the search bit intact so the cached artefacts still stat
+  and staging is skipped. Note that case passes *before* the change too, so its
+  guard value is demonstrated by the post-change mutation step in Phase 2's
+  criteria rather than by a red step.
+
+The existing cases that exercise the changed region and must stay green:
+`test_readonly_root_without_override_is_a_named_error` (no staged shim, so the
+staging gate fires, the probe's write fails, same substring with a new cause
+clause), `test_readonly_root_with_override_runs_from_override` (fresh writable
+override, probe passes), `test_a_record_is_always_one_line` (probe passes,
+staging still fails as today, still one line),
+`test_tampered_cached_launcher_is_refused_and_healed` (staging is skipped, so
+this now reaches the cold-branch gate and runs a full probe, which *passes* on
+its writable cache dir — every verification failure pays one probe before
+fetching, which is the intended cost), and the three planted-shim tests (all
+cold, unaffected).
+
+A trace case must never be a global mode — xtrace goes to stderr, mixed with the
+bootstrap's own diagnostics, and would break every existing
+`assert … in result.stderr`. That is also why the seam is a per-call `xtrace`
+flag rather than `SHELLOPTS`, which is exported into bash descendants whose
+identity (`#!/bin/sh`) differs by platform.
+
+### Manual Testing Steps
+
+1. Warm the cache, `chmod 0o555` it, run `bin/accelerator version` — exits 0
+   with output identical to the launcher run directly.
+2. Poison a cached launcher, `chmod 0o555` the cache dir, invoke — fails within
+   a second with the cache-dir diagnostic, not after ~30 s with a lock timeout.
+3. Run a cold bootstrap under `bash -x` with `PS4='+${FUNCNAME[0]:-main}:'` —
+   trace shows `probe_exec_capable` entered and the probe file executed exactly
+   once as its own command word, with the `probe=` assignment line present but
+   unmatched.
+4. Re-run warm under the same trace — `ensure_dir` and `verify_launcher`
+   present, `probe_exec_capable` absent.
+5. Point the cache dir at a `noexec` mount if one is available and confirm the
+   cause clause reads `rejected an executable file` rather than
+   `is not writable` — the one path no automated case can construct.
+
+## Performance Considerations
+
+The whole point. Expected warm-path landing ~41 ms against a ~149 ms pre-0182
+reference, from removing ~108 ms of probe cost. That figure and its ~97 ms
+"first-exec check" attribution are inherited rather than re-derived, which is
+why Phase 4 re-measures them on its own harness — a ~100 ms penalty for exec'ing
+a newly created *script* (not a Mach-O; no code-signing is involved, and
+`/bin/sh` is already-signed) is at least as characteristic of a scanning agent
+as of macOS generally, and if it is host-specific then the ratio gate is
+unsatisfiable elsewhere. Linux savings will be materially smaller regardless, so
+darwin is the worst case and the one measured.
+
+The largest single residual is the shim staging condition's two `sha256_file`
+calls, deliberately retained — but at a measured ~4.2 ms each on this host they
+are roughly 20% of the ~41 ms landing, not the dominant term, and the figure is
+backend-dependent (~26 ms total if the Perl `shasum` fallback resolves). Actual
+hashing is ~0.5 ms; the rest is process startup. Phase 4 records a composition
+budget precisely because the remainder — bash interpreter startup, two `uname`
+substitutions, the `plugin.json` `sed`, two `cd -P`/`pwd -P` subshells and the
+`resolve_cache_dir` substitution — is larger than any single named term and was
+never measured.
+
+Remaining per-call forks and execs before `exec "${launcher}"`, for whoever
+picks up 0169: the `env` exec from the shebang; two `cd -P`/`pwd -P` subshells;
+`sed` over `plugin.json`; `uname -m` and `uname -s` as separate substitutions;
+the `resolve_cache_dir` command substitution (avoidable outright by assigning a
+global instead of capturing stdout); `mkdir` only when the cache dir is absent,
+after the `[[ -d ]]` guard; two `sha256_file` substitutions, each forking the
+backend plus `awk`; the staged shim exec; and the launcher exec. The cheapest
+untaken levers are collapsing the two `uname` calls into one `uname -sm`
+(keeping both `ACCELERATOR_UNAME_S`/`_M` seams independent) and batching the two
+hashes (~2.5 ms measured, raised as a follow-up).
+
+Warm-path cost of the change itself is zero: both gates sit in branches a warm
+call never enters, and the `[[ -d ]]` guard removes the `mkdir` fork the split
+would otherwise have left behind. Cold-path probe count is unchanged — at most
+one, via `probed` — and a cold run with an existing cache dir is one fork
+cheaper than today. One reordering is worth noting: because the staging gate
+sits inside the staging body, a cold invocation that is going to fail with the
+cache-dir diagnostic now spends ~8 ms hashing first, where previously
+`resolve_cache_dir` failed at `:195` before any hashing.
+
+**The saving does not reach the paths that motivated the work item.** The
+launcher runs the same write-chmod-exec probe on every external-subcommand
+dispatch, so a warm `accelerator vcs guard` still pays a first-exec penalty of
+the same shape, and `FetchVerifyCacheResolver::resolve` additionally re-verifies
+the cached sub-binary's signature on every dispatch. Phase 4 raises the probe as
+a follow-up and measures it; this plan's `version` measurement covers the
+bootstrap only, and says so.
+
+`tests/integration/skill-invocation/` also speeds up incidentally — it runs the
+real bootstrap once per `!`-site across 46 SKILL.md files, all warm after the
+first.
+
+## Migration Notes
+
+None. No on-disk format, cache layout or environment contract changes. A cache
+directory populated before the change is warm after it, and is now additionally
+allowed to be read-only for warm bootstrap invocations (dispatched subcommands
+still need it writable — see Phase 3). The change is invisible to the launcher
+and to every caller except in latency.
+
+## References
+
+- Original work item:
+  `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md`
+- Research:
+  `meta/research/codebase/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md`
+- Measurements and attribution:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §12
+- Work item review:
+  `meta/reviews/work/0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md`
+- Plan review:
+  `meta/reviews/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md`
+- Design being edited: `meta/work/0164-launcher-and-git-style-dispatch.md`
+- Downstream consumer of the measurement:
+  `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+- Rebase baseline:
+  `meta/work/0182-cli-derives-plugin-root-from-own-location.md`
+- Parent epic: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- ADR-0049 (bash 3.2 compatibility floor), ADR-0046 (static binary
+  distribution)
+- Probe to split: `bin/accelerator:166-180`
+- Resolution and diagnostic: `bin/accelerator:184-197`
+- Shim staging, which hosts the first gate: `bin/accelerator:252-261`
+- Warm/cold branch, which hosts the second: `bin/accelerator:336-348`
+- Lock loop the second gate protects: `bin/accelerator:275-303`
+- Harness funnel: `tests/integration/support/installation.py:324-369`
+- Cached-launcher path idiom:
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py:219`, `:272`
+- No-`build:cli:dev` invariant:
+  `tests/integration/support/installation.py:149-157`,
+  `tests/unit/tasks/test_mise.py:104-109`
+- Launcher-side probe (follow-up):
+  `cli/launcher/src/launch/outbound/resolve/cache_root.rs:80-94`,
+  `cli/launcher/src/main.rs:65`
+- CI lanes: `.github/workflows/main.yml:55-91`
+- Corpus frontmatter validator: `tasks/test/integration.py:33-41`
+- Shell-source scope for the extensionless entrypoint:
+  `tasks/shared/sources.py:110`

--- a/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -1334,8 +1334,8 @@ rationale** — that is 0169's own work.
 
 #### Automated Verification
 
-- [ ] `mise run` is green end to end
-- [ ] Work item frontmatter validates:
+- [x] `mise run` is green end to end
+- [x] Work item frontmatter validates:
       `mise run test:integration:config` — the corpus validator
       (`scripts/test-validate-corpus-frontmatter.sh`) is a by-name required
       suite there (`tasks/test/integration.py:33-41`). It is **not** part of
@@ -1343,27 +1343,27 @@ rationale** — that is 0169's own work.
 
 #### Manual Verification
 
-- [ ] Both instrument floors are within expectation; if `/usr/bin/true` does not
+- [x] Both instrument floors are within expectation; if `/usr/bin/true` does not
       read within a millisecond or two of a bare fork+exec, the medians are
       discarded and the harness fixed
-- [ ] `after ≤ 0.5 × before` holds; both medians, the delta, both floors,
+- [x] `after ≤ 0.5 × before` holds; both medians, the delta, both floors,
       min/median/p90, host, OS version and launcher provenance are recorded
-- [ ] The measured composition is recorded against the budget, the resolved
+- [x] The measured composition is recorded against the budget, the resolved
       sha256 backend is named, and any unexplained remainder over ~25% is
       attributed
-- [ ] The probe attribution is re-derived on this harness and the host's
+- [x] The probe attribution is re-derived on this harness and the host's
       security-agent status recorded
 - [ ] Both CI lanes observed green on the new cases, and which were observed is
       recorded — including the ubuntu lane's bash 5.2 coverage of the trace
       cases
-- [ ] Every _pending_ entry in Validation Results is resolved, each behavioural
+- [x] Every _pending_ entry in Validation Results is resolved, each behavioural
       one naming the test function that discharges it
-- [ ] The stale ~11.7 ms / ~23 ms figures are corrected in 0186's Dependencies,
+- [x] The stale ~11.7 ms / ~23 ms figures are corrected in 0186's Dependencies,
       Assumptions and Validation Results, not only in 0169's note
-- [ ] All three follow-ups are raised and cross-referenced
-- [ ] 0169's note re-confirmed against the measured figure and handed the
+- [x] All three follow-ups are raised and cross-referenced
+- [x] 0169's note re-confirmed against the measured figure and handed the
       backend-dependent range, with its threshold untouched
-- [ ] `bin/.tmp-accelerator-before` and `bin/.tmp-accelerator-floor` are gone
+- [x] `bin/.tmp-accelerator-before` and `bin/.tmp-accelerator-floor` are gone
       and `jj status` is clean of them
 
 ---

--- a/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -366,13 +366,13 @@ Both are covered by the same guard.
 
 #### Automated Verification
 
-- [ ] Entrypoint suite passes: `mise run test:integration:entrypoint`
-- [ ] Python format, lint and types pass: `mise run build-system:check`
-- [ ] Full read-only gate passes: `mise run check`
+- [x] Entrypoint suite passes: `mise run test:integration:entrypoint`
+- [x] Python format, lint and types pass: `mise run build-system:check`
+- [x] Full read-only gate passes: `mise run check`
 
 #### Manual Verification
 
-- [ ] `_require_unprivileged` reads as a deliberate divergence from the
+- [x] `_require_unprivileged` reads as a deliberate divergence from the
       neighbouring `skipif`, so a later reader does not "fix" it back
 
 ---
@@ -502,6 +502,17 @@ The `_restricted` mode check is what the work item's acceptance-criteria
 preamble asks for beyond `id -u`: on a filesystem where `chmod` is advisory the
 permission cases would otherwise fail (or, worse for the success-asserting case,
 pass) with no hint that the environment rather than the product was at fault.
+
+**Deviation taken during implementation**: the single `not os.access(path,
+os.W_OK)` assertion above is wrong for the two `0o666` cases. `0o666` keeps the
+owner write bit and clears only the search bit, so the assertion fires on a
+correctly-restricted directory — observed as a red on
+`test_cold_path_keeps_the_noexec_diagnostic` and
+`test_warmed_then_non_executable_cache_keeps_the_diagnostic` for the harness,
+not the product. Implemented instead as a loop over the two owner bits, checking
+`W_OK` only when the mode clears `0o200` and `X_OK` only when it clears `0o100`,
+which is what the docstring's "verified to have bitten" always meant and covers
+both shapes (`0o555` drops write, `0o666` drops search).
 
 #### 3. Regression cases (written first)
 
@@ -835,8 +846,9 @@ negative assertion in the meantime.
 
 #### Automated Verification
 
-- [ ] Recorded during the red step, per case — the shape differs and the record
-      should say so rather than claim a uniform red. **Red before the change**:
+- [x] Recorded during the red step, per case — the shape differs and the record
+      should say so rather than claim a uniform red. Observed 2026-08-03,
+      exactly as predicted: 5 failed, 3 passed. **Red before the change**:
       `test_warm_path_survives_a_non_writable_cache_dir` (today's fatal probe
       fails its write under `0o555`); `test_warm_path_does_not_enter_the_probe`
       and `test_cold_path_enters_and_executes_the_probe` (the new function
@@ -850,8 +862,9 @@ negative assertion in the meantime.
       `test_warmed_then_non_executable_cache_keeps_the_diagnostic`, and
       `test_unverifiable_launcher_in_readonly_cache_fails_fast` — today's
       unconditional probe already produces its asserted exit and substring.
-- [ ] **After the change**, confirm by mutation which case guards which gate,
-      and record it: deleting the staging gate reds
+- [x] **After the change**, confirm by mutation which case guards which gate,
+      and record it. Both mutations behaved exactly as predicted (2026-08-03):
+      deleting the staging gate reds
       `test_cold_path_keeps_the_noexec_diagnostic`,
       `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and
       `test_readonly_root_without_override_is_a_named_error`; deleting the
@@ -859,28 +872,29 @@ negative assertion in the meantime.
       `test_unverifiable_launcher_in_readonly_cache_fails_fast` via its
       timeout. This is the only step that demonstrates the cold-branch gate is
       guarded at all, since that case passes before the change.
-- [ ] Entrypoint suite passes: `mise run test:integration:entrypoint`
-- [ ] Skill-invocation suite unaffected:
-      `mise run test:integration:skill-invocation`
-- [ ] Launcher-edge guards still hold:
+- [x] Entrypoint suite passes: `mise run test:integration:entrypoint` (54)
+- [x] Skill-invocation suite unaffected:
+      `mise run test:integration:skill-invocation` (128)
+- [x] Launcher-edge guards still hold:
       `uv run pytest tests/unit/tasks/test_mise.py`
-- [ ] Bootstrap coverage guard passes, including the two new name assertions:
+- [x] Bootstrap coverage guard passes, including the two new name assertions:
       `uv run pytest tests/unit/tasks/test_bootstrap_coverage.py`
-- [ ] Python format, lint and types pass: `mise run build-system:check`
-- [ ] Shell format, lint, bashisms and exec-bits pass:
+- [x] Python format, lint and types pass: `mise run build-system:check`
+- [x] Shell format, lint, bashisms and exec-bits pass:
       `mise run scripts:check` (which folds `lint:scripts:bashisms:check`)
-- [ ] `mise run check` is green
+- [x] `mise run check` is green
 
 #### Manual Verification
 
-- [ ] A tampered cached launcher in an unwritable cache dir fails within a
-      second, not after the ~30 s lock budget (the automated case pins this,
-      but confirm the wall-clock once by hand)
-- [ ] The cold-run trace shows `probe_exec_capable` entered *and* the probe file
-      executed as its own command word exactly once — and confirm the `probe=`
-      assignment line is present in the same trace but not matched, so the
-      anchor is doing its job
-- [ ] Warm trace shows `ensure_dir` and `verify_launcher` but no
+- [x] A tampered cached launcher in an unwritable cache dir fails within a
+      second, not after the ~30 s lock budget — measured **27 ms**, ending in
+      `no writable, exec-capable cache directory: … is not writable`
+- [x] The cold-run trace shows `probe_exec_capable` entered *and* the probe file
+      executed as its own command word exactly once (1 match), with the
+      `probe=` assignment line present in the same trace and **not** matched by
+      the anchored pattern. `+main:require_exec_capable_cache` appears twice
+      and the probe runs once, so the idempotence flag is exercised
+- [x] Warm trace shows `ensure_dir` and `verify_launcher` but no
       `probe_exec_capable`
 - [ ] Both interpreters are covered without extra work: the harness pins
       `/bin/bash`, which is 3.2.57 on darwin and 5.2 on `ubuntu-latest`, so the

--- a/meta/prs/41-description.md
+++ b/meta/prs/41-description.md
@@ -1,0 +1,103 @@
+---
+type: pr-description
+id: "41"
+title: "Probe the cache directory only on the bootstrap's cold path"
+date: "2026-08-03T12:29:40+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+work_item_id: "0186"
+parent: "work-item:0186"
+relates_to:
+  [
+    "work-item:0169",
+    "work-item:0182",
+    "work-item:0189",
+    "work-item:0190",
+    "work-item:0191",
+  ]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/41"
+pr_number: 41
+tags: [shell, performance, bootstrap, bash-3.2, testing]
+revision: "e503155c7bdd7c2379448331bb0f81e1e251a219"
+repository: "accelerator"
+last_updated: "2026-08-03T12:29:40+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Probe the cache directory only on the bootstrap's cold path
+
+## Summary
+
+`bin/accelerator` wrote, `chmod +x`'ed, exec'ed and removed a probe file on **every** invocation — a capability check the warm path never needed, since a warm call proves the same capability for real by running the staged verify shim and the launcher out of that directory. On macOS the exec of a freshly written file pays a first-exec check that dominated the whole invocation. Splitting `probe_dir` into an always-run `ensure_dir` and a cold-path-only `probe_exec_capable` takes the warm median from **125.35 ms to 29.92 ms** on darwin-arm64. Every SessionStart hook and every skill's `!`-preprocessor site pays that cost, so it is the most-executed path in the plugin.
+
+## Changes
+
+- **`bin/accelerator` — the split.** `ensure_dir` keeps the `mkdir -p` (guarded by `[[ -d ]]`, so a warm call does not even fork `mkdir`) and stays reachable on every invocation via `resolve_cache_dir`. `probe_exec_capable` keeps the write-`chmod`-exec-`rm` and now returns **1** for a write failure and **2** for an exec failure, so the caller can report the cause it actually detected. Every exit path removes the probe file.
+- **Two gates, not one.** `require_exec_capable_cache` sits behind a `probed` flag and is called from (a) the first statement of the shim-staging `if` **body**, which is the first required write into the cache directory on every path, and (b) the top of the cold branch, before `acquire_lock`. Both sit below the dev-launcher override, so the contributor path stops paying for a probe it never needed. A cold run reaching both probes exactly once.
+- **One diagnostic, three causes.** `fail_no_cache_dir` gives `no writable, exec-capable cache directory` a single definition; each site supplies what it detected (`could not be created` / `is not writable` / `rejected an executable file — possibly a noexec mount`). It also fixes a pre-existing wart: the message named `${plugin_root}/bin` even when an `ACCELERATOR_CACHE_DIR` override was the thing that failed.
+- **New supported configuration** — a cache directory populated once may afterwards be **read-only for warm bootstrap invocations**. Documented in `docs/internals.md` and `CHANGELOG.md` together with the limit that matters: dispatching a subcommand to a separate binary makes the *launcher* probe the same directory, and that probe writes.
+- **Test harness gains a per-call `xtrace` seam** (`run_bootstrap(..., xtrace=True)`), defaulting `PS4` alongside it, so probe absence can be asserted by function name rather than by residue.
+- **Eight new entrypoint cases plus three retrofits**, and a hard-failing `_require_unprivileged()` guard.
+- **Three follow-ups raised** — 0189, 0190, 0191 — and 0169's hand-off note re-confirmed against the measured figures.
+
+Production surface is small: `bin/accelerator` (+82/-…), `docs/internals.md`, `CHANGELOG.md`. Tests are +279 across three files. The remaining ~6,000 lines are `meta/` artefacts (research, plan, plan review, work items, validation report).
+
+## Context
+
+Work item [`0186`](../work/0186-remove-exec-probe-from-bootstrap-warm-path.md), under epic 0136, unblocked by 0182 and blocking [`0169`](../work/0169-vcs-subdomain-and-hooks-migration.md). Plan and its review are in `meta/plans/` and `meta/reviews/plans/`; the validation report is `meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md`.
+
+### Why two call sites
+
+A single gate in the staging body is not enough. In the residual case — launcher present and executable, signature present, staged shim present and matching (so staging is skipped), *verification fails*, directory unwritable — control reaches `acquire_lock`, whose `mkdir` can never succeed and whose loop treats a missing pid file as an imminent competitor. It then burns its full 300 × 0.1 s budget and reports a **lock timeout** instead of the real cause. That case fails instantly today, so the second gate prevents a regression rather than merely preserving a nicer message. It is measured at 27 ms with the gate in place.
+
+Equally, a gate placed only in the cold branch would miss the `chmod -x` scenarios: `cp` fails first with `could not stage the verify shim into …`, losing the cache-dir substring entirely.
+
+### Measured result
+
+50 interleaved samples per variant in one Python process, order alternated, on darwin-arm64 (Apple M4 Max, macOS 26.3 build 25D125). Both variants shared one pre-cached signed release launcher, confirmed by inode across the run.
+
+| Variant | min | median | p90 | median − harness floor |
+| --- | --- | --- | --- | --- |
+| before | 119.02 | **125.35** | 234.15 | 123.75 |
+| after | 27.18 | **29.92** | 32.44 | 28.32 |
+
+All ms. Gate `after ≤ 0.5 × before` passes at a ratio of **0.239** — materially better than the ~41 ms the plan expected. Instrument floors: 1.60 ms (`/usr/bin/true`) and 6.10 ms (a trivial bash script). The remaining ~30 ms is accounted for term by term in the work item's Validation Results, with ~10% unexplained (under the 25% threshold that would have triggered a per-line attribution).
+
+### Two figures in circulation were wrong, and are corrected here
+
+- **The retained double-hash residual is backend-dependent.** The ~11.7 ms per `sha256_file` call quoted in 0186 and 0169's hand-off note describes the **Perl `shasum` fallback**. On a host where `command -v sha256sum` resolves to Apple's `/sbin/sha256sum` — as it does on the measuring host — a call costs **~3.5 ms**, so the two-hash residual is **~7 ms or ~24 ms depending on the host**. 0169 is handed the range and the backend, not a point estimate. Corrected in 0186's Dependencies, Assumptions and Validation Results, not only in 0169's note.
+- **The probe's first-exec penalty is re-derived rather than inherited.** The Context table's methodology was unrecorded and its "re-exec of a pre-existing probe file | 10.6 ms" row is seven times this harness's fork+exec floor. Measured directly: 1.41 ms bare fork+exec, 3.72 ms to re-exec a probe file left in place, 107.15 ms to write+`chmod`+exec+`rm` in `/tmp`, 131.97 ms in the repo's `bin/`. The host runs **no third-party EndpointSecurity or anti-malware agent** (only Apple's `xprotectd`, SIP and Gatekeeper on), so the penalty is stock macOS behaviour rather than a machine artefact — which means the ratio should transfer to other macOS hosts, and the extrapolation to the launcher-side probe (0189) holds.
+
+## Testing
+
+- [x] `mise run test:integration:entrypoint` — **54 passed**, including all eight new cases.
+- [x] `mise run test:integration:skill-invocation` — **128 passed**. The `run_bootstrap` seam is shared with this suite; the `xtrace=False` default keeps it unaffected.
+- [x] `uv run pytest tests/unit/tasks/test_bootstrap_coverage.py tests/unit/tasks/test_mise.py` — 33 passed, including the new name-pin assertion and the standing no-`build:cli:dev` guard.
+- [x] `mise run check` — green end to end across all four components.
+- [x] `mise run scripts:check` — shfmt, ShellCheck, bashisms and exec-bits clean over `bin/accelerator` (which `tasks/shared/sources.py:110` puts in shell-source scope despite being extensionless, and which is tab-indented because `.editorconfig`'s `[*.sh]` section does not match it).
+- [x] `mise run build-system:check` — format, lint and types clean.
+- [x] `mise run test:integration:config` — 58 passed; the corpus frontmatter validator accepts the amended items and the three new ones.
+- [x] **Written test-first, with the red step recorded per case** — 5 failed / 3 passed before the change, exactly as predicted. Three of the eight are green before *and* after: they are preservation guards, which the record says explicitly rather than claiming a uniform red.
+- [x] **Both gates confirmed by mutation after the change.** Deleting the staging gate reds `test_cold_path_keeps_the_noexec_diagnostic`, `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and `test_readonly_root_without_override_is_a_named_error`; deleting the cold-branch gate reds only `test_unverifiable_launcher_in_readonly_cache_fails_fast`, via its timeout. That mutation is the only demonstration the cold-branch gate is guarded at all, since its case passes before the change too.
+- [x] **Manual**: a tampered cached launcher in an unwritable cache dir fails in **27 ms** with the cache-dir diagnostic, not after the ~30 s lock budget. Cold trace shows the probe entered and the probe file executed as its own command word exactly once, with `+main:require_exec_capable_cache` appearing twice — so the idempotence flag is exercised, not merely present. Warm trace shows `ensure_dir` and `verify_launcher` but no `probe_exec_capable`.
+- [ ] **The linux lane.** Not observed — this branch has not had a CI run. See below.
+
+## Notes for Reviewers
+
+**The one genuinely outstanding item is the ubuntu lane, and 0186 stays `in-progress` until it is seen.** The harness pins `BASH = "/bin/bash"`, which is 3.2.57 on darwin and **5.2** on `ubuntu-latest`, so the two trace cases exercise both interpreters on every CI run with no extra wiring — but that also means a trace-format divergence surfaces in CI rather than locally. `.github/workflows/main.yml` has no `container:` key and `test-integration` is a plain `runs-on: ${{ matrix.os }}` matrix, so both lanes run unprivileged and `_require_unprivileged` should not fire; no lane exclusion is expected. The work item's own Drafting Notes call this observation "a genuine closure condition, not a formality", which is why the status is held rather than moved to `complete`. Worth also capturing `command -v sha256sum` on both lanes while CI runs — it costs nothing and tells 0169 whether the Perl fallback is reachable in CI at all.
+
+**One of the three diagnostic causes ships untested, deliberately.** No directory-permission combination can produce exec-without-write: clearing a directory's search bit blocks name resolution, so the probe fails at its *write* step and the exec branch is never evaluated. The exec **half** is covered by the positive control's assertion that the probe file is executed as its own command word; the `rejected an executable file` **cause clause** is not covered by any automated case. Closing it needs a genuine `mount -o noexec` filesystem, which is explicitly out of scope. If you would rather have a cheap seam than an untested branch, say so — but note 0189 will face the identical gap on the launcher side, so it may be better solved once, there.
+
+**The trace matcher's `:/` anchor is load-bearing and easy to "simplify" wrongly.** `probe_exec_capable`'s own `probe=/…/.accelerator-probe-<pid>` **assignment** is traced too. The unanchored form `…:\S*\.accelerator-probe-\S*$` matches **two** lines and therefore passes on an implementation that never execs anything; the anchored form matches exactly one. Verified against a real trace. Relatedly, `PS4` is `'+${FUNCNAME[0]:-main}:'` rather than the acceptance criterion's literal `'+${FUNCNAME[0]}:'` — a bare `${FUNCNAME[0]}` is unbound at top level under the bootstrap's `set -u`, which on bash 3.2 emits `FUNCNAME[0]: unbound variable` per command and leaves PS4 literally unexpanded, and aborts a non-interactive bash 5 outright. And trace depth is not stable (`resolve_cache_dir` runs inside `$( )`, so its lines carry `++`), which is why every matcher allows one *or more* leading `+`.
+
+**`_require_unprivileged` asserts where the neighbouring idiom skips, and that is intentional.** `tests/integration/hooks/test_launcher_link_refresh.py:275-293` uses `skipif`. Root bypasses both the write permission and the execute bit, so a skip would report green on a lane that verified nothing. The asymmetry worth knowing when reading these: cases asserting **success** under a restrictive mode go silently green under uid 0; cases asserting **failure** red noisily but for the wrong reason. One guard covers both.
+
+**Two deviations from the plan are corrections *to* the plan, both recorded in place.** `_restricted`'s mode check: the plan's single `not os.access(path, os.W_OK)` assertion is wrong for the two `0o666` cases, which keep the owner write bit and clear only search — it fired on correctly-restricted directories. Implemented as a loop over both owner bits, checking each probe only when the mode clears the corresponding bit. And the staging comment's byte figure: the plan instructed correcting `475KB` to `465KB`, but 465,568 B is the **linux-x64** shim — the four vendored shims measure 486,672 / 496,896 / 426,400 / 465,568 bytes, so `475KB` was already right for darwin-arm64 and the comment now reads `~475KB`.
+
+**One reordering to be aware of.** Because the staging gate sits inside the staging body, a cold invocation destined to fail with the cache-dir diagnostic now spends ~7 ms hashing first, where `resolve_cache_dir` previously failed before any hashing. No test depends on the old ordering, and it only affects a path that is about to abort.
+
+**The saving does not reach the paths that motivated the work item, and 0169 must not wait for it.** `cache_root::resolve` runs the identical write-`chmod`-exec probe on **every** external-subcommand dispatch, before the sub-binary cache-hit test — so a warm `accelerator vcs guard` still pays a first-exec penalty of the same shape (measured 131.97 ms in the repo's `bin/`). Built-ins like `version` never reach it, which is why this PR's measurement cannot see it. Raised as **0189**; **0190** covers `acquire_lock`'s inability to classify an unusable lock directory (one arm spins *unbounded* — `rm -f`/`rmdir` then `continue` with no `sleep` and no `waited` increment); **0191** covers batching the two shim hashes (~2.5 ms measured, essentially 0169's whole shortfall). 0169's hand-off note is re-confirmed with **its threshold and rationale untouched** — that decision remains 0169's own.
+
+**Not done here, deliberately**: the shim staging block's two hashes stay (three tests assert the planted-stub defence they provide); no `launcher`/`launcher_sig` hoisting; no `sha256_file` backend change (the native backend is already in use and `openssl dgst` is slower); no new `test:integration:*` leaf; no pytest marker for the root guard until a root lane actually exists.

--- a/meta/research/codebase/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/research/codebase/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -1,0 +1,648 @@
+---
+type: codebase-research
+id: "2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"
+title: "Research: Remove the Exec Probe from the Bootstrap Warm Path"
+date: "2026-08-02T21:21:52+00:00"
+author: "Toby Clemson"
+producer: research-codebase
+status: complete
+work_item_id: "0186"
+parent: "work-item:0186"
+relates_to:
+  [
+    "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration",
+    "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface",
+    "codebase-research:2026-07-03-0164-launcher-and-git-style-dispatch",
+  ]
+topic: "Remove the exec probe from the bin/accelerator warm path"
+tags: [research, codebase, bootstrap, shell, performance, testing, bash-3.2]
+revision: "dcf0eff40119220db91dd607de3b9089aa479b6b"
+repository: "accelerator"
+last_updated: "2026-08-02T21:21:52+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Research: Remove the Exec Probe from the Bootstrap Warm Path
+
+**Date**: 2026-08-02T21:21:52+00:00
+**Author**: Toby Clemson
+**Git Commit**: `dcf0eff40119220db91dd607de3b9089aa479b6b`
+**Branch**: working copy on `main` (no bookmark; `main` @ `9b3eab92b3`)
+**Repository**: accelerator
+
+## Research Question
+
+What is the implementation surface for work item 0186 — removing the
+write-chmod-exec probe from `bin/accelerator`'s warm path while retaining it on
+the cold path — and does the work item's stated mechanism, its acceptance
+criteria, and its premises hold against the post-0182 codebase?
+
+## Summary
+
+The change itself is small and the work item's core argument is sound: the
+probe is redundant on the warm path, `resolve_cache_dir` has no fallback, and
+the diagnostic is the only thing that moves. All three of the premises 0186
+flagged for re-checking after the 0182 rebase were checked. **Two hold, one is
+wrong.**
+
+Six findings materially affect the plan. Three are defects in the work item as
+written:
+
+1. **The stated mechanism breaks two of its own acceptance criteria.** "Call the
+   probe only on the cold path before fetching" is under-specified: the shim
+   staging block (`cp` + `chmod` into `cache_dir`) runs *before* the warm/cold
+   branch is even decided. On a `chmod -x` cache dir the `cp` fails first and
+   emits `could not stage the verify shim into …`, not `no writable,
+   exec-capable cache directory` — so criteria 4 and 6 fail. The probe must be
+   gated on a cheap cache-hit pre-test placed **above** the staging block, which
+   requires hoisting the `launcher`/`launcher_sig` assignments. See
+   [Finding 1](#finding-1-the-probe-must-move-above-shim-staging-not-into-the-cold-branch).
+
+2. **`PS4='+${FUNCNAME[0]}:'` — the exact string criterion 2 mandates — is
+   broken under the bootstrap's `set -u` on the bash 3.2 floor.** Measured: it
+   emits `FUNCNAME[0]: unbound variable` to stderr for every top-level command
+   and leaves PS4 literally unexpanded on those lines. `PS4='+${FUNCNAME[0]:-main}:'`
+   works cleanly. The criterion needs the two-character fix. See
+   [Finding 2](#finding-2-the-mandated-ps4-string-is-broken-under-set--u-on-bash-32).
+
+3. **Criterion 1's assertion target does not exist.** It asks for "the expected
+   `version` output — the version the harness fixture builds, asserted exactly".
+   The harness's default launcher is a Python stub that prints **nothing**; the
+   opt-in real launcher prints `CARGO_PKG_VERSION` (`1.24.0-pre.21`), not the
+   fixture's `9.9.9-test`. Neither reading is achievable. See
+   [Finding 3](#finding-3-criterion-1s-version-output-assertion-is-unachievable-as-worded).
+
+Three are premise checks and capability findings:
+
+4. **The `build:cli:dev` premise is wrong, and there is an active guard against
+   it.** The suite builds its launcher in-fixture via `installation.build_launcher()`.
+   `tests/unit/tasks/test_mise.py:104-109` fails if `test:integration:entrypoint`
+   ever gains the edge. The 0186 review's own suggestion of a pre-warmed harness
+   "needing `build:cli:dev`" must be re-litigated. See [Finding 4](#finding-4-no-buildclidev-edge--and-a-guard-forbidding-one).
+
+5. **The cache-dir premise holds**, with a wording caution: `resolve_cache_dir`
+   has two candidates in strict precedence (override, else `${plugin_root}/bin`)
+   and returns 1 rather than falling through. "Override-or-default, no fallback"
+   is accurate; "a single cache dir" reads as wrong. See [Finding 5](#finding-5-cache-dir-premise-holds-with-a-wording-caution).
+
+6. **The trace capability needs no harness change at all.** `SHELLOPTS=xtrace`
+   threaded through the existing `extra_env` parameter enables xtrace in bash 3.2
+   — verified. A `bash_args` keyword on `run_bootstrap` is a cleaner two-line
+   alternative. `BASH_XTRACEFD` is bash 4.1+ and therefore unusable. See
+   [Finding 7](#finding-7-trace-capture-needs-no-harness-change-though-two-lines-would-be-cleaner).
+
+**Every line number in the work item is still correct.** The work item warns
+they "predate 0182" and must be re-resolved — but research §12 was written on
+the 0182 lineage, and 0182 did not shift the region. `probe_dir` is at
+`:166-180`, `resolve_cache_dir` at `:184-193`, the call site at `:195-197`,
+staging at `:255-261`, `verify_launcher` at `:310-312`, the final `exec` at
+`:352`. All six test names quoted in the work item still exist verbatim.
+
+## Detailed Findings
+
+### The production change surface
+
+`bin/accelerator` is 352 lines. The relevant sequence, in execution order:
+
+| Line | What happens | Warm? |
+| --- | --- | --- |
+| `:110-115` | self-locate `plugin_root`, `export ACCELERATOR_PLUGIN_ROOT` | yes |
+| `:158-163` | verify-shim + public-key gates (`fail_integrity`) | yes |
+| `:166-180` | **`probe_dir`** — `mkdir -p`, write, `chmod +x`, exec, `rm` | — |
+| `:184-193` | `resolve_cache_dir` — calls `probe_dir`, no fallback | yes |
+| `:195-197` | call site + `fail "no writable, exec-capable cache directory: …"` | yes |
+| `:198` | `unverified_log` reassigned to `${cache_dir}/…` | yes |
+| `:207-233` | dev-launcher override (execs and never returns when taken) | yes |
+| `:252-253` | `sha256_file` #1 over `shim_source` (~11.7 ms) | yes |
+| `:255-256` | staging **condition** — `-x` test + `sha256_file` #2 (~11.7 ms) | yes |
+| `:257-260` | staging **body** — `cp` + `chmod` into `cache_dir` | cold only |
+| `:305-307` | `launcher`, `launcher_sig`, `base_url` assignments | yes |
+| `:336` | cache-hit test: `-x launcher` && `-f sig` && `verify_launcher` | yes |
+| `:339-347` | cold branch — `acquire_lock`, `fetch_and_verify` | cold only |
+| `:352` | `exec "${launcher}" "$@"` | yes |
+
+The probe body writes via `>` redirection (`bin/accelerator:169`), which is why
+xtrace cannot see the filename — bash prints expanded command words but not
+redirections. Confirmed empirically (Finding 2).
+
+#### Finding 1: the probe must move above shim staging, not into the cold branch
+
+The work item's Requirements say to call the probe "only on the cold path before
+fetching". Read literally — inside the `else` at `:339` — this breaks criteria 4
+and 6.
+
+Measured primitives on darwin (this host, bash 3.2):
+
+```
+chmod -x dir:  mkdir -p on existing dir: OK
+               write into it:            FAILED (permission denied)
+               cp into it:               FAILED
+               [ -x dir/file ]:          false  (cannot stat through it)
+chmod 0555:    mkdir -p:                 OK
+               write new file:           FAILED
+               [ -f dir/existing ]:      true
+```
+
+So on criterion 4's scenario — empty cache dir, `chmod -x`, cold invocation —
+control reaches the staging block at `:255` before the branch at `:336`. The
+`-x "${shim}"` test is false, the `sha256_file` mismatches, and the body's `cp`
+at `:257` fails, producing `fail_integrity "could not stage the verify shim into
+${cache_dir}"`. The criterion asserts the substring `no writable, exec-capable
+cache directory`, which never appears. Criterion 6 (warmed-then-`chmod -x`)
+fails the same way: `-x "${launcher}"` goes false, so the run is cold and hits
+staging first.
+
+The probe therefore has to fire **before** `:252`. Warm/cold is not yet known
+there — but a cheap, side-effect-free approximation is:
+
+```bash
+launcher="${cache_dir}/accelerator-launcher-${version}-${platform}"
+launcher_sig="${launcher}.minisig"
+
+# The exec probe is a cold-path concern: a warm call proves the same capability
+# for real by running the staged shim and then the launcher out of this
+# directory. Gate on the cached artefacts, not on verification, because the
+# verifier itself has to be staged into the directory first.
+if [[ ! -x "${launcher}" ]] || [[ ! -f "${launcher_sig}" ]]; then
+	probe_exec_capable "${cache_dir}" || fail_no_cache_dir
+fi
+```
+
+`launcher`/`launcher_sig` depend only on `cache_dir` (`:195`), `version`
+(`:134`) and `platform` (`:130`), so hoisting them from `:305-306` to just below
+`:198` is safe. Placing the gate *after* the dev-override block (`:207-233`)
+additionally stops the dev path paying for a probe it never needed — a small
+improvement over today.
+
+Walked against every existing test in the suite, this shape keeps all of them
+green:
+
+- `test_readonly_root_without_override_is_a_named_error` — `bin/` at `0o555`,
+  no launcher → gate fires → probe's write fails → same diagnostic. ✓
+- `test_readonly_root_with_override_runs_from_override` — override dir is fresh
+  and writable → probe passes → cold fetch. ✓
+- `test_a_record_is_always_one_line` — cache dir writable, a `0o555` *directory*
+  planted at the staging path → probe passes, staging still fails as today,
+  still one line. ✓
+- concurrency, stale-lock, host-detection, dev-override, planted-shim tests —
+  all cold or unaffected. ✓
+
+**One residual diagnostic narrowing**, worth recording rather than fixing
+silently: launcher present and executable, signature present, but *verification
+fails* (tampered) **and** the directory is unwritable. The gate does not fire,
+so the failure surfaces at `fetch_and_verify` as `could not fetch and verify the
+accelerator launcher` instead of today's cache-dir message. Restoring it costs a
+second call site in the `else` at `:339`, made idempotent by a `probed=""` flag
+so a genuinely cold run does not pay ~108 ms twice. Both call sites stay strictly
+off the warm path, so criterion 2 is unaffected either way.
+
+#### Naming constraints for the split
+
+Criterion 2 keys the assertion on the probe function's name, so the names chosen
+by the split are load-bearing:
+
+- `ensure_dir` (the `mkdir -p` half) **does** appear in every warm trace. The
+  criterion must name the probe half, not this one.
+- The probe's own temp file is `.accelerator-probe-$$` — the string `probe`
+  appears in the trace as a path component regardless. A naive `"probe" not in
+  trace` assertion would be wrong. Assert on the PS4-delimited function token
+  (`+probe_exec_capable:`), not a bare substring.
+- Keeping the name `probe_dir` for the split-off half is workable but muddier:
+  it shares a prefix with the file, and the name now describes only part of what
+  it used to do. `probe_exec_capable` reads better and greps unambiguously.
+
+#### Shell-tooling constraints on the edit
+
+- **`bin/accelerator` is tab-indented, and must stay so.** `.editorconfig`'s
+  shell section is keyed `[*.sh]` (`.editorconfig:36-39`), which does not match
+  an extensionless file — so shfmt formats it under its defaults: tabs, and
+  `case` arms *not* extra-indented. The file has 132 tab-indented lines and zero
+  two-space ones. A new function written with spaces reddens
+  `format:scripts:check`.
+- Discovery is by literal name: `tasks/shared/sources.py:106-110` carries
+  `_EXTRA_SHELL_SOURCES = ("bin/accelerator",)`, and `scripts/lint-bashisms.sh:22-34`
+  has its own fallback append. Both are pinned by
+  `tests/unit/tasks/test_bootstrap_coverage.py:29-35`.
+- `scripts/lint-bashisms.sh` denylist (`:48-55`), first match per line:
+  `declare/local/typeset -A`; namerefs `-*n`; escaped brace in a
+  `${x:-…}` default; `mapfile`/`readarray`; case-modification `${x^^}`/`${x,,}`;
+  `&>>`; `|&`; negative array subscripts. Per-line escape hatch:
+  `# lint-bashisms: ignore`. The header says it is `KNOWN-INCOMPLETE` — it
+  cannot prove 3.2 compatibility. The suite's `_BASH = /bin/bash` pin plus
+  `test_the_suite_runs_the_bootstrap_on_the_bash_floor` is the real enforcement.
+- `lint:claude-coupling:check` (`tasks/lint/claude_coupling.py:31-38`) fails on
+  **any** `CLAUDE_[A-Z0-9_]*` token in `bin/accelerator`, and
+  `test_bootstrap_coverage.py:54-67` asserts the file exports **exactly**
+  `{ACCELERATOR_PLUGIN_ROOT}`.
+- Route every new abort through `fail()` or `fail_integrity()` — never a bare
+  `exit 1`. `abort_status` (`:28-39`) is the `--fail-safe` contract.
+- `unverified_log` is assigned twice (`:113` pre-resolution, `:198`
+  post-resolution) because the shim and key gates fire *before*
+  `resolve_cache_dir`. Any restructuring must keep both coherent.
+
+### The test surface
+
+The harness is **not** in the test file. It lives in
+`tests/integration/support/installation.py` (379 lines) and is **shared with
+`tests/integration/skill-invocation/test_skill_invocation_conformance.py`** —
+so a harness change touches two suites.
+
+`run_bootstrap` (`installation.py:324-369`):
+
+```python
+def run_bootstrap(
+    root: Path, server: Path, downloader: Path, *,
+    args: tuple[str, ...] = (),
+    extra_env: dict[str, str] | None = None,
+    path: str | None = None,
+    entry: Path | None = None,
+    cwd: Path | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+```
+
+- Builds a **complete replacement** environment (`PATH`, `HOME`,
+  `ACCELERATOR_BOOTSTRAP_DOWNLOADER`, `ACCELERATOR_RELEASE_BASE_URL`,
+  `SERVER_DIR`, `DL_LOG`), then `env.update(extra_env)`. Neither root variable
+  is injected — the bootstrap self-locates from `entry`.
+- Invokes `[BASH, str(entry), *args]` — argv list, `shell=False`. `BASH` is
+  `/bin/bash` where it exists (`installation.py:41`), i.e. macOS's 3.2.
+- **stdout and stderr are captured separately.** Tests concatenate by hand
+  (`result.stdout + result.stderr`).
+- `assert_hermetic` (`:301-321`) enforces the injected downloader, a `.invalid`
+  base-URL hostname, and that the entry is not the repo's own bootstrap. A
+  session-autouse `repo_bin_is_untouched` fixture
+  (`test_accelerator_entrypoint.py:77-87`) fails if the suite writes into the
+  shipped `bin/`.
+
+There is no HTTP server: `serve_launcher` writes files into a directory and the
+injected downloader copies from it, logging each URL to `DL_LOG`. Minisign is
+genuinely exercised — real `minisign` CLI keygen and signing, real cargo-built
+`accelerator-verify` shim doing verification. `require()` (`:97-104`) **skips
+locally but `pytest.fail`s in CI** when a tool is missing.
+
+#### Finding 2: the mandated PS4 string is broken under `set -u` on bash 3.2
+
+Measured on this host (`GNU bash 3.2.57(1)-release, arm64-apple-darwin25`),
+running a script that carries the bootstrap's `set -uo pipefail`:
+
+```
+$ PS4='+${FUNCNAME[0]}:' /bin/bash -x t1.sh …
++:set -uo pipefail
+t1.sh: line 11: FUNCNAME[0]: unbound variable
++${FUNCNAME[0]}:echo 'top level before'
+t1.sh: line 12: FUNCNAME[0]: unbound variable
++${FUNCNAME[0]}:probe_dir /…/cdA
++probe_dir:mkdir -p /…/cdA
++probe_dir:probe=/…/cdA/.accelerator-probe-68245
++probe_dir:printf '#!/bin/sh\nexit 0\n'
++probe_dir:chmod +x /…/cdA/.accelerator-probe-68245
++probe_dir:/…/cdA/.accelerator-probe-68245
++probe_dir:rm -f /…/cdA/.accelerator-probe-68245
++probe_dir:return 0
+```
+
+At top level `FUNCNAME` is unset, so under `set -u` each top-level command emits
+an error line to stderr and PS4 stays literally unexpanded. The run does not
+abort (there is no `set -e`), but for a 352-line script this is dozens of
+spurious stderr lines interleaved with the bootstrap's own diagnostics. The fix
+is a default expansion:
+
+```
+$ PS4='+${FUNCNAME[0]:-main}:' /bin/bash -x t1.sh …
++main:set -uo pipefail
++main:probe_dir /…/cdA
++probe_dir:mkdir -p /…/cdA
+…
+```
+
+Zero unbound-variable errors, and `main` labels the top-level frame usefully.
+
+Three further observations from the same traces, all bearing on criteria 2 and 3:
+
+- **The probe's execution IS observable**, as a trace line whose whole command
+  word is the probe path: `+probe_dir:/…/.accelerator-probe-68245`. That is the
+  signal criterion 3's exec half needs — a line matching
+  `^\++<probe-fn>:.*\.accelerator-probe-`.
+- **The redirection is NOT observable**: `+probe_dir:printf '#!/bin/sh\nexit 0\n'`
+  — the `>"${probe}"` is absent. Pass 3's reasoning is confirmed empirically.
+- **`FUNCNAME[0]` is the innermost frame**, and command substitution adds a `+`
+  to the prefix depth. Today `resolve_cache_dir` runs inside `$( )` at `:195`,
+  so its trace lines are `++resolve_cache_dir:` / `++exec_probe:`. If the split
+  moves the probe to a top-level call site the depth becomes `+`. **Assertions
+  must not anchor on the number of `+` characters** — match the function token,
+  allowing one or more leading `+`.
+
+#### Finding 3: criterion 1's "version output" assertion is unachievable as worded
+
+The default launcher served by the harness is a **Python stub**
+(`installation.py:55-71`) that writes its argv to `LAUNCHER_ARGS_OUT`, its
+environment to `LAUNCHER_ENV_OUT`, and exits with `LAUNCHER_EXIT`. It prints
+nothing to stdout or stderr for any argv, `version` included.
+
+The opt-in real launcher (`make_harness(real_launcher=True)`, used by exactly
+three tests) prints, per `cli/launcher/src/version/inbound/cli.rs:7-20`:
+
+```
+accelerator {version}
+commit: {sha}
+built:  {date}
+target: {triple}
+```
+
+where `version` is `env!("CARGO_PKG_VERSION")`
+(`cli/launcher/src/version/outbound/build_metadata.rs:17`) — currently
+`1.24.0-pre.21` from `cli/Cargo.toml:7`. The fixture's `VERSION = "9.9.9-test"`
+(`installation.py:45`) only reaches `plugin.json` and the cached-artefact
+filenames; it is never printed.
+
+So "the version the harness fixture builds, asserted exactly" is wrong on both
+readings, and asserting the real launcher's exact version would couple the test
+to a bumping workspace version. Two workable amendments:
+
+- **Stub route** (cheapest, no cargo launcher build): assert `returncode == 0`
+  and `args_out.read_text().splitlines() == ["version"]`. This still proves the
+  warm path completed through to `exec`.
+- **Real-launcher route**: `make_harness(real_launcher=True)` and assert
+  `result.stdout.startswith("accelerator ")` plus the presence of the
+  `commit: ` / `built:  ` / `target: ` line prefixes.
+
+The stub route is sufficient for what criterion 1 actually tests (a fatal probe
+would fail its write and exit non-zero) and avoids a cargo launcher build.
+
+#### Finding 4: no `build:cli:dev` edge — and a guard forbidding one
+
+`mise.toml:183-186` declares `test:integration:entrypoint` with
+`depends = ["deps:install:python"]` only; `tasks/test/integration.py:106-113`
+runs `uv run pytest tests/integration/entrypoint -v`. The launcher and shim are
+built **in-fixture** by `installation.py:123-157` (`cargo build --quiet`,
+`--manifest-path cli/Cargo.toml`), lazily, from module-scoped fixtures.
+
+The docstring at `installation.py:149-157` states the invariant:
+
+> Built here rather than behind a `mise` build edge so a suite using it still
+> runs standalone under a bare `uv run pytest`. A suite that calls this must
+> therefore *not* also gain a `build:cli:dev` dependency: the two would contend
+> on cargo's target lock and the asserted edge would be inert.
+
+And it is asserted: `tests/unit/tasks/test_mise.py:36-56` classifies
+`"test:integration:entrypoint": "builds it in-fixture, mirroring shim_bin"` in
+`_NO_LAUNCHER_NEEDED`, with `test_task_needing_no_launcher_omits_the_build_edge`
+(`:104-109`) failing if the edge appears.
+
+The 0186 review (`…-review-1.md:133`, `:332`) suggests a pre-warmed-cache
+harness "needs `build:cli:dev`". **That suggestion conflicts with the invariant
+and should be re-litigated as `build_launcher()`** — or avoided entirely by the
+stub route in Finding 3.
+
+Consequence for planning: adding **cases to the existing file** requires no task
+wiring at all. Adding a new `test:integration:*` **leaf** would require
+classification in both `test_mise.py` sets plus `test:integration.depends` (or
+`_NOT_IN_INTEGRATION_ROLLUP` with a reason). There is no reason to add one.
+
+#### Finding 5: cache-dir premise holds, with a wording caution
+
+`resolve_cache_dir` (`:184-193`) changed only by the `${CLAUDE_PLUGIN_ROOT}` →
+`${plugin_root}` rename; `probe_dir` (`:166-180`) is byte-for-byte pre-0182.
+0182's plan explicitly declined to touch the resolution
+(*"Removing `cache_root.rs`'s refusal of an XDG fallback … `<root>/bin` always
+exists; only the variable name changes."*).
+
+The premise — the probe never *chooses* a directory — holds. But the phrasing
+"a single `cache_dir` with no fallback" invites a reviewer's correction: there
+are two candidates in **strict precedence** (`ACCELERATOR_CACHE_DIR`, else
+`${plugin_root}/bin`), and if the override's probe fails the function returns 1
+rather than falling back to the default. "Override-or-default, no fallback" is
+the accurate form.
+
+#### Finding 6: three permission tests exist; the root guard diverges from precedent
+
+Existing permission manipulation in the suite, all with `finally` restore (which
+is mandatory — `tmp_path` teardown cannot remove an unwritable directory):
+
+- `:253-276` `test_readonly_root_with_override_runs_from_override` — `bin/` at `0o555`
+- `:284-292` `test_readonly_root_without_override_is_a_named_error` — `bin/` at `0o555`
+- `:1070-1085` `test_a_record_is_always_one_line` — a `0o555` directory planted at
+  the staging path
+- `:505-508` `test_dev_override_refused_when_not_executable` — `chmod 0o644` on a file
+
+**There is no root guard anywhere in `tests/integration/entrypoint/` or in
+`installation.py`** — so today's three `0o555` tests would silently pass as
+false negatives under uid 0. The precedent lives in a neighbouring suite,
+`tests/integration/hooks/test_launcher_link_refresh.py:275-293`:
+
+```python
+@pytest.mark.skipif(os.getuid() == 0, reason="mode bits are advisory for uid 0")
+```
+
+0186's preamble mandates the opposite disposition — **hard-fail, not skip** —
+so the new cases must assert rather than copy this idiom. Worth a comment at the
+call site explaining the deliberate divergence, or the next reader will
+"fix" it back to a skipif. Whether to retrofit the same assertion onto the three
+existing tests is a judgement call the plan should make explicitly; it is
+arguably in scope as they share the exact hazard, and arguably scope creep.
+
+CI runs unprivileged: `.github/workflows/main.yml:55-91` (`test-integration`,
+matrix `[ubuntu-latest, macos-latest]`, `fail-fast: false`) has **no `container:`
+key anywhere in the workflow**, so both lanes run as the `runner` user. Criterion
+10's "both shipped lanes" is satisfied by that one job. `id -u` on this darwin
+host returns `501`.
+
+#### Finding 7: trace capture needs no harness change, though two lines would be cleaner
+
+Measured: bash 3.2 honours `SHELLOPTS` from the environment at startup, for
+non-interactive scripts, with no `-x` flag:
+
+```
+$ env SHELLOPTS=xtrace PS4='+${FUNCNAME[0]:-main}:' /bin/bash t2.sh
++main:set -uo pipefail
++main:f
++f:echo 'in f'
+in f
+```
+
+So a trace test can be written today with `extra_env={"SHELLOPTS": "xtrace",
+"PS4": "+${FUNCNAME[0]:-main}:"}` and no harness edit. The cleaner alternative
+the work item anticipates is a keyword-only `bash_args` on `run_bootstrap` —
+two lines (`installation.py:334` signature, `:360` argv → `[BASH, *bash_args,
+str(entry), *args]`), safe for the shared skill-invocation consumer because of
+the empty default.
+
+Constraints either way:
+
+- **Trace goes to stderr**, mixed with the bootstrap's own `accelerator: …`
+  diagnostics. A trace case must be its own test — never a global mode — or
+  every existing `assert … in result.stderr` breaks.
+- **`BASH_XTRACEFD` is bash 4.1+**, so "trace to a separate fd, keep stderr
+  clean" is not portable to the 3.2 floor. Filtering stderr lines by the PS4
+  prefix is the portable approach.
+- Tracing stops at `exec "${launcher}"` (`:352`) — exactly the desired scope.
+- `PS4` must be passed as a **literal single-quoted string** so bash expands it
+  per-command; pre-expanding it in Python would freeze one value.
+
+### Latency measurement
+
+**The methodology behind the Context table was never recorded.** Research §12
+says only "Measured on darwin-arm64, warm cache, 20 iterations each" — there is
+no bash loop, no `hyperfine` call, no script anywhere in `:617-708`. The
+document does not even say the statistic is a median; "median" enters the record
+retroactively via 0186's criterion, which describes it as "matching how the
+Context table was produced". Host model, OS version and launcher provenance are
+likewise unrecorded.
+
+This is precisely why criterion 8 re-measures the before-median in the same
+session and makes the gate a pure ratio (`after ≤ 0.5 × before`). Practical
+consequence for the plan: **the measurement command must be authored fresh and
+written into Validation Results** — there is nothing to reproduce.
+
+Numbers not to confuse:
+
+| Quantity | Value | Source |
+| --- | --- | --- |
+| Shell guard baseline B | 35.1 ms | research §12 `:624` |
+| 0169's gate ceiling | 1.1 × B ≈ 38.6 ms | 0169 `:331` |
+| Warm bootstrap, pre-0182 | 149.1 ms | §12 `:625` |
+| Probe: fresh vs re-exec | 107.9 vs 10.6 ms → ~97 ms is first-exec | §12 `:628-629` |
+| Expected after-median | ~41 ms | 149.1 − 107.9 |
+| Residual retained | **~11.7 ms** (second hash) — *not* ~23 ms | §12 `:630` |
+| Fully-addressable ceiling (rejected) | ~131 of 149 ms → ~18 ms | §12 `:644-645` |
+
+The ~23 ms figure belongs to a *different* change (skipping staging entirely
+when `shim_source`'s directory and `cache_dir` coincide), which is out of scope
+and closed. Both medians must use the same **post-0182** launcher binary: the
+bootstrap now exports only `ACCELERATOR_PLUGIN_ROOT`, so a pre-rename launcher
+finds no root and silently degrades.
+
+Incidental: the change also speeds up `tests/integration/skill-invocation/`,
+which runs the real bootstrap once per `!`-site across 46 SKILL.md files — all
+warm after the first.
+
+### Surfaces the acceptance criteria do not mention
+
+- **`docs/internals.md:208`** documents the behaviour being changed: *"…is where
+  the bootstrap writes and *executes* a probe file, so point it at a directory
+  you own and that is not group-writable."* After the split this is true only of
+  the cold path. Small edit; not currently in any criterion.
+- **`CHANGELOG.md`** has an open `## [Unreleased]` section with `### Added` and
+  `### Changed`. A user-visible warm-path latency improvement plausibly belongs
+  under `### Changed`; the criteria are silent on it.
+- **`.gitignore`** has no `bin/.accelerator-probe-*` entry (the `bin/.tmp-*`
+  pattern does not match it). The probe is created and removed within one
+  invocation so this has never mattered — and it is unchanged by this work —
+  but a probe leaked by a `SIGKILL` mid-cold-run would be untracked and
+  un-ignored. Noting for completeness, not proposing action.
+- **`cli/launcher/src/launch/outbound/resolve/cache_root.rs`** is the Rust mirror
+  of `resolve_cache_dir`/`probe_dir`, with its own write+exec probe. It is *not*
+  in scope — the launcher's probe is on a different (already-exec'd) path — but
+  it is the obvious place a reader will ask "shouldn't that change too?". The
+  answer is no: by the time the launcher runs, exec capability is proven.
+
+## Code References
+
+- `bin/accelerator:166-180` — `probe_dir`, the function to split
+- `bin/accelerator:184-193` — `resolve_cache_dir`, override-or-default, no fallback
+- `bin/accelerator:195-197` — call site and the `no writable, exec-capable cache directory` diagnostic
+- `bin/accelerator:198` — post-resolution `unverified_log` reassignment
+- `bin/accelerator:252-261` — shim staging; `:255-256` condition (two hashes), `:257-260` body
+- `bin/accelerator:305-307` — `launcher`/`launcher_sig`/`base_url` (hoist candidates)
+- `bin/accelerator:336-348` — warm/cold branch
+- `bin/accelerator:352` — final `exec`
+- `tests/integration/support/installation.py:324-369` — `run_bootstrap`, the single funnel
+- `tests/integration/support/installation.py:301-321` — `assert_hermetic` preconditions
+- `tests/integration/support/installation.py:55-71` — the Python launcher stub (prints nothing)
+- `tests/integration/support/installation.py:149-157` — `build_launcher` and the no-`build:cli:dev` invariant
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:100-134` — `make_harness` factory
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:253-292` — the two `0o555` permission tests
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:584-644` — the three planted-shim tests protecting the second hash
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:709-720` — the bash-3.2-floor self-check
+- `tests/integration/hooks/test_launcher_link_refresh.py:275-293` — the `os.getuid() == 0` skipif precedent
+- `tests/unit/tasks/test_mise.py:36-56,104-117` — launcher-edge classification guards
+- `tests/unit/tasks/test_bootstrap_coverage.py:29-67` — discovery, exec bit, single `*PLUGIN_ROOT` export
+- `tasks/shared/sources.py:106-135` — `_EXTRA_SHELL_SOURCES` discovery of the extensionless bootstrap
+- `scripts/lint-bashisms.sh:22-55` — fallback discovery and the bash-4 denylist
+- `mise.toml:183-186` — `test:integration:entrypoint`
+- `.github/workflows/main.yml:55-91` — the two-lane integration job
+- `docs/internals.md:204-214` — the documented probe behaviour and env-var table
+- `cli/launcher/src/version/inbound/cli.rs:7-20` — real launcher `version` output shape
+
+## Architecture Insights
+
+- **The probe was never a selection mechanism.** The 0164 plan
+  (`meta/plans/2026-07-03-0164-…:145-153`, `:662-669`) specifies the cache root
+  as "`${CLAUDE_PLUGIN_ROOT}` only, **probed** for writable+exec-capable", with
+  an override as the only alternate terminus and no XDG fallback. The probe
+  buys a *named error at resolution time* instead of an obscure downstream
+  failure. That is the whole of what moves.
+- **The warm path's real exec tests are stronger than the probe.** `verify_launcher`
+  (`:310-312`) execs the staged shim from `cache_dir`, and `:352` execs the
+  launcher from the same directory. A `noexec` mount fails both, routing to the
+  cold branch where the probe belongs. The redundancy argument depends on both
+  running from `cache_dir` and nowhere else — which is still true post-0182.
+- **The trust boundary and the latency budget are in genuine tension**, and the
+  resolution is recorded rather than optimised away: the second `sha256_file`
+  costs ~11.7 ms on every warm call and is asserted by three tests. 0186
+  deliberately leaves it, and hands the consequence to 0169 as a dated note
+  rather than a work item.
+- **Verification-by-trace is a deliberate second-best.** A real `noexec` mount
+  would close the exec-vs-write gap completely but needs privileged per-platform
+  CI setup dwarfing the production change. The gap is recorded, not hidden.
+- **The suite deliberately runs on the oldest bash available.** 0182 discovered
+  the entrypoint suite had been running on Homebrew bash 5.3 and pinned it to
+  `/bin/bash`; the 3.2 floor is now genuinely enforced for anything touching
+  this file.
+
+## Historical Context
+
+- `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §12 (`:617-708`) — the measurement table, the attribution, the
+  "split `probe_dir` into `ensure_dir` + probe" suggestion (`:654-664`), and the
+  fallback position *"if in doubt, fix `probe_dir` alone (the ~108 ms) and leave
+  the ~23 ms"* (`:665-678`), which is what 0186 became.
+- `meta/reviews/work/0169-…-review-2.md` — pass 4 (`:735-826`) carved 0186 out.
+  The decisive measurement: *"Eleven of pass 4's fourteen majors are defects in
+  pass 3's fixes"*, leading to *"stop editing this document. Split it."* The
+  grounds are scope and risk profile, not technical dependency.
+- `meta/reviews/work/0186-…-review-1.md` — three passes, `verdict: APPROVE` set
+  by the author on 2026-08-01 over a mechanical REVISE. Pass 3's headline finding
+  (`:1196-1207`) killed a vacuous positive control: a generic
+  `chmod`-or-write trace pattern also matches the cold path's own shim staging.
+  That is why criterion 2 keys on the function name — and why this research
+  checked whether the mandated `PS4` actually works (it does not, quite).
+- `meta/work/0169-…:395-406` — the dated hand-off note, present and accurate as
+  written; `:327-334` — the `G ≤ 1.1 × B` criterion, whose B is measured live per
+  session rather than fixed at 35.1 ms.
+- `meta/plans/2026-07-27-0182-…` and its validation — 0182 fully landed
+  (`status: done`, `mise.local.toml` closing step done 2026-07-29); only
+  release-gated manual checks remain, and none of them block this item.
+- `meta/decisions/ADR-0049` (bash 3.2 floor), `ADR-0046` (zero-setup static
+  binary distribution) — the constraints behind the shape of the file.
+
+## Related Research
+
+- `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md` — source of §12
+- `meta/research/codebase/2026-07-27-0182-plugin-root-self-location-implementation-surface.md` — the rebase baseline
+- `meta/research/codebase/2026-07-03-0164-launcher-and-git-style-dispatch.md` — the design being edited
+- `meta/research/codebase/2026-07-06-0165-multi-binary-distribution-release-pipeline.md` — release-asset provenance for the measurement
+
+## Open Questions
+
+1. **Should the second probe call site be added to the cold branch?** Without
+   it, a tampered launcher in an unwritable cache dir reports "could not fetch
+   and verify" instead of the cache-dir diagnostic. With it, a `probed=""` flag
+   is needed to avoid probing twice. Small either way; the plan should decide
+   deliberately rather than leaving it to fall out of the edit.
+2. **Should the three existing `0o555` tests gain the root assertion?** They
+   share the exact hazard the criteria preamble identifies, and today they would
+   pass as false negatives under uid 0. In scope by principle, scope creep by
+   letter.
+3. **Which criterion-1 route?** The stub route avoids a cargo launcher build and
+   tests the same thing; the real-launcher route exercises more. Recommend the
+   stub, but the work item's author intent may have been the latter.
+4. **Does the `PS4` unbound-variable behaviour differ on bash 5 (the Linux
+   lane)?** Not testable on this host. `${FUNCNAME[0]:-main}` is safe on both, so
+   the question is moot if the fix is adopted — but if the criterion's literal
+   string is kept, the linux lane's behaviour must be checked before criterion 10
+   can be discharged.
+5. **`docs/internals.md:208` and the `CHANGELOG` entry** — in scope for this item
+   or deferred? Neither appears in any criterion.

--- a/meta/reviews/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md
+++ b/meta/reviews/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-review-1.md
@@ -1,0 +1,3209 @@
+---
+type: plan-review
+id: "2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-review-1"
+title: "Plan Review: Remove the Exec Probe from the Bootstrap Warm Path"
+date: "2026-08-02T22:25:30+00:00"
+author: "Toby Clemson"
+producer: review-plan
+status: complete
+parent: "work-item:0186"
+target: "plan:2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses:
+  [
+    correctness,
+    test-coverage,
+    code-quality,
+    architecture,
+    performance,
+    portability,
+    standards,
+    documentation,
+  ]
+review_number: 1
+review_pass: 2
+tags: [shell, performance, bootstrap, bash-3.2, testing]
+last_updated: "2026-08-03T10:31:13+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Remove the Exec Probe from the Bootstrap Warm Path
+
+**Verdict:** REVISE
+
+The production change at the heart of this plan is sound and well-evidenced:
+the `ensure_dir` / `probe_exec_capable` split is the right cohesion boundary,
+Gate A plus Gate B is a logically complete cover of the cold branch, the
+`probed` flag is safe under `set -uo pipefail`, the hoist of
+`launcher`/`launcher_sig` is provably free of dependencies, and the plan
+correctly supersedes its own research on the ~30 s `acquire_lock` regression.
+Two things need fixing before implementation. First, the verification apparatus
+does not verify what it claims: the exec-half positive control's regex also
+matches the probe's own `probe=…` assignment line (so it passes on a write-only
+implementation), and Gate B — the line the plan itself calls a hang-regression
+guard — has no automated case, no code comment, and would fail as a 30 s stall
+rather than a red test. Second, Phase 4's measurement instrument puts a full
+`python3` interpreter startup *inside* every timed interval, biasing the
+`after ≤ 0.5 × before` ratio toward failing a correct implementation and
+inflating the absolute figure that 0169's ≈ 38.6 ms decision rests on.
+Separately, three lenses independently found that the saving does not reach the
+paths that motivated the work item — the Rust launcher runs the identical
+write-chmod-exec probe on every external-subcommand dispatch, and Phase 4
+measures `version`, the one command that never traverses it.
+
+### Cross-Cutting Themes
+
+- **Gate B is load-bearing, unguarded and unexplained** (flagged by:
+  test-coverage, portability, documentation, correctness, architecture) — the
+  plan's own Key Discoveries call the second probe call site "required to avoid
+  a regression, not merely to preserve a nicer message", yet no automated case
+  reaches it (all five cold cases route through Gate A; the sixth is warm), the
+  proposed code carries no comment naming the residual it covers, and
+  `run_bootstrap`'s `timeout` defaults to `None` — so removing it turns the
+  suite from green into a 30 s stall, not into a failure. Portability adds that
+  the uncovered shape is precisely the Linux-prevalent one: a real `noexec`
+  mount leaves the mode bits intact, so `-x launcher` and `-f sig` both hold and
+  only Gate B fires.
+
+- **The `no_cache_dir` paragraph states an edit and retracts it** (flagged by:
+  code-quality, architecture, standards, documentation, correctness) — five
+  lenses independently flagged Phase 2 item 4's "is rewritten to call the same
+  wording via `no_cache_dir` so the substring has one definition", immediately
+  followed by "the `:195` call site keeps its own literal … message". An
+  implementer working top-down performs the first edit before reaching the
+  retraction. Correctness adds that the stated reason is also wrong: `cache_dir`
+  is *set-but-empty* at `:195` (command substitution assigns on failure), not
+  unset, so a hoisted `no_cache_dir` would emit an empty path rather than
+  tripping `set -u`.
+
+- **Phase 4's measurement cannot be trusted as written** (flagged by:
+  performance, test-coverage, portability, architecture) — four distinct
+  defects in one 10-line script: a `python3` startup inside the interval
+  (~25–80 ms against a ~41 ms target), no per-iteration exit-status or
+  warmth assertion (empty `start`/`end` arithmetic yields `0 ms` and passes the
+  gate trivially), both batches taken sequentially across a `jj new`
+  working-copy swap so drift aliases onto the result, and `version` — a clap
+  built-in — chosen as the workload when every consumer uses external-subcommand
+  dispatch.
+
+- **The saving does not reach the paths that motivated it** (flagged by:
+  architecture, portability) — `cli/launcher/src/launch/outbound/resolve/cache_root.rs`
+  runs the same write-chmod-exec-rm probe from `LazyProductionResolver::resolve`
+  on every external subcommand, *before* the cache-hit test. The plan declares
+  it out of scope on a *redundancy* argument — the same argument it uses to
+  relocate the bash probe, which applies verbatim to the launcher — and says
+  nothing about cost. Phase 3's "A warm start neither writes nor probes" is
+  therefore false at the system level once a hook dispatches `vcs guard`.
+
+- **Phase 1 is not the independently-green slice it claims** (flagged by:
+  correctness, architecture, standards) — `_entered` calls `re.search` while
+  `import re` is deferred to Phase 2; `F821` is live on the test tree, so
+  Phase 1 fails its own `mise run build-system:check` and `mise run check`
+  criteria. Architecture adds that three of Phase 1's four additions have no
+  consumer until Phase 2 (`_traced`, `_ran_probe_file`, `_PROBE_FN` naming a
+  shell function that does not yet exist).
+
+- **The residual handed to 0169 is understated and mis-framed** (flagged by:
+  performance, architecture, documentation) — Performance Considerations says
+  "~11.7 ms for the second `sha256_file`", but the plan's own Current State
+  table marks *both* hashes as running warm, and the 41 ms arithmetic only
+  closes with ~23 ms in it. The ~11.7 ms figure is the size of an out-of-scope
+  *change*, not of the residual. Worse, at ~40 MB/s for a 475 K file that cost
+  is process startup (macOS `shasum` is a Perl script, plus two `awk` execs),
+  not cryptography — so it is recoverable by tool selection without touching the
+  planted-stub defence, which reframes 0169's choice from "relax the threshold"
+  to "meet it".
+
+- **The trace assertions are less load-bearing than claimed** (flagged by:
+  correctness, portability, test-coverage) — three independent weaknesses in
+  the same mechanism: the exec-half regex matches the `probe=` assignment
+  (vacuous), all trace-shape evidence is from darwin/bash 3.2 while the
+  assertions must also pass on the ubuntu lane's bash 5.2, and the production
+  function names are hard-coded in the test with no fast guard, so a rename
+  produces a slow misleading integration failure while silently voiding the
+  negative assertion.
+
+- **Both documentation phases claim gates that do not exist** (flagged by:
+  standards, documentation) — `mise run check` composes format/lint over four
+  components only; there is no markdown linter anywhere in the task tree and
+  corpus-frontmatter validation lives in the `test:integration:config` shell
+  suites. Phase 3 and Phase 4 each rest their sole automated criterion on it.
+
+### Tradeoff Analysis
+
+- **Performance vs Security (the retained double hash)**: the work item
+  resolved during review-1 to keep both `sha256_file` calls because three tests
+  assert the planted-stub defence — a correct call. The performance lens shows
+  the framing is nonetheless wrong: most of the ~23 ms is interpreter and
+  process startup, recoverable by preferring `openssl dgst -sha256` over
+  macOS's Perl `shasum` and replacing `| awk '{print $1}'` with parameter
+  expansion. **Recommendation**: keep the scope closure, but record the finding
+  and raise the follow-up — both hashes and both defences survive untouched, and
+  0169 needs to know the lever exists before it decides to relax its gate.
+
+- **Coverage vs an already-disproportionate verification burden**: the work
+  item explicitly accepts that its criteria outweigh the production change
+  "several times over", and this review proposes yet more cases. **Recommendation**:
+  add only the two that guard behaviour nothing else does — the Gate B anti-hang
+  case and the `ensure_dir`-fails case covering the retained `:195` diagnostic —
+  and take the cheap one-liners (probe-file cleanup, warm-up return code) inside
+  existing cases rather than as new ones.
+
+- **Hard-fail vs skip under uid 0**: correctness and the plan want a hard fail
+  so a root lane cannot report green on assertions root satisfies regardless;
+  test-coverage, portability and standards note that this turns a currently-green
+  root container into six hard failures with no sanctioned way out, inviting the
+  ad-hoc `-k` workaround the guard exists to prevent. **Recommendation**: keep
+  the hard fail and add a registered `unprivileged` marker, with the assertion
+  message naming `-m 'not unprivileged'` as the recordable exclusion — that is
+  exactly what the work item's "excluded explicitly, never skipped silently"
+  rule asks for.
+
+- **Precondition gates vs failure classification**: architecture proposes
+  probing *reactively* from the failure branches that already know the cache dir
+  is suspect, which needs no hoist, no flag, no duplicated cache-hit predicate,
+  and additionally removes the probe from the cold *happy* path. The plan's
+  fail-fast shape matches the file's existing idiom and keeps a trust-root
+  script linear. **Recommendation**: keep the plan's shape — but record why the
+  alternative was rejected, so a future editor tempted to "simplify away" Gate B
+  or the flag can see it was weighed.
+
+### Findings
+
+#### Critical
+
+- 🔴 **Test Coverage / Portability**: Gate B — the anti-hang guard — has no
+  automated coverage on either lane
+  **Location**: Phase 2, item 4 (Gate B); Success Criteria — Manual Verification
+  Gate B exists solely to stop a ~30 s `acquire_lock` spin in the residual case
+  (launcher `-x`, signature present, verification fails, cache dir unwritable),
+  yet no automated case reaches that state: cases 5 and 6 use `chmod 0o666`,
+  which clears the search bit and makes `[[ -x "${launcher}" ]]` false, so they
+  route through Gate A. Deleting Gate B leaves all six new cases and the entire
+  existing suite green — and because `run_bootstrap`'s `timeout` defaults to
+  `None`, the regression manifests as a stall rather than a failure. Portability
+  adds that this is the Linux-prevalent shape: a real `noexec` mount leaves mode
+  bits intact, so only Gate B fires.
+
+- 🔴 **Performance**: the timing harness includes a full `python3` interpreter
+  startup inside every measured interval
+  **Location**: Phase 4, item 1: Measurement
+  `start` is read at the end of the first interpreter's startup but `end` at the
+  end of the *second*, so each interval is `bin/accelerator version` **plus one
+  complete `python3` process start** — plausibly 25–80 ms on darwin against the
+  ~41 ms being measured. An additive constant on both sides pulls the ratio
+  toward 1.0 (0.40 at b=30 ms, 0.53 and a **failed gate** at b=80 ms), and the
+  inflated absolute after-median is the figure Phase 4 §3 hands to 0169, whose
+  ceiling is ≈ 38.6 ms and whose decision turns on a ~2.4 ms overrun.
+
+#### Major
+
+- 🟡 **Correctness**: the exec-half positive control is vacuous — its regex also
+  matches the probe's own variable assignment
+  **Location**: Phase 1, item 2 (`_ran_probe_file`); Phase 2 (`test_cold_path_enters_and_executes_the_probe`)
+  `probe_exec_capable`'s first statement is `probe="$1/.accelerator-probe-$$"`,
+  and xtrace emits assignments — the research records the exact line
+  `+probe_dir:probe=/…/.accelerator-probe-68245`. `\S*` happily consumes
+  `probe=/…/`, so the assertion passes even with the `if "${probe}"` block
+  deleted. This is the *only* verification the retained cold-path probe's exec
+  half gets, by the plan's own admission.
+
+- 🟡 **Architecture / Portability**: the launcher re-incurs the identical probe
+  on every warm sub-binary dispatch, so the saving misses the motivating paths
+  **Location**: What We're NOT Doing (`cache_root.rs`); Phase 3; Phase 4 §1
+  `cache_root::probe_writable_and_executable` runs from
+  `LazyProductionResolver::resolve` (`main.rs:65`) on every external subcommand,
+  *before* the cache-hit test. Built-ins (`version`, `config`) never reach it —
+  which is why today's SessionStart hook escapes and why Phase 4's `version`
+  measurement cannot see it. 0169 serves `vcs guard` as a dispatched sub-binary,
+  so it pays a fresh-file first-exec penalty of the same shape and plausibly the
+  same ~97 ms magnitude on darwin. The out-of-scope justification is a
+  redundancy argument that applies verbatim to the launcher.
+
+- 🟡 **Performance**: the residual warm-path cost is stated as ~11.7 ms when
+  ~23 ms remains
+  **Location**: Performance Considerations; Phase 4 §3 (0169 hand-off)
+  The plan's own Current State table marks `:252-253` (`sha256_file` #1) *and*
+  `:255-256` (the condition containing #2) as running warm, and research §12
+  records "`sha256_file` ×2 … ~23 ms". The ~11.7 ms figure is the size of a
+  different, out-of-scope change. The 41 ms arithmetic only closes with 23 ms in
+  it. Phase 4 instructs the implementer to update 0169's quoted residual — with
+  a number that halves the only remaining lever.
+
+- 🟡 **Performance**: the retained ~23 ms is process-startup cost in
+  `sha256_file`, not an unavoidable trust trade-off
+  **Location**: What We're NOT Doing (shim staging / double hash)
+  11.7 ms to SHA-256 a 475 KB file is ~40 MB/s — one to two orders below
+  arm64's hardware-accelerated throughput, so essentially none of it is
+  cryptographic. On darwin `sha256sum` is absent, so `sha256_file` falls to
+  `shasum -a 256`, a **Perl script**, plus a command-substitution subshell and
+  an `awk` exec per call. Roughly 15–20 ms is recoverable by tool selection
+  alone, hashing the same files with the same algorithm and keeping every
+  assertion intact — which would put the warm bootstrap near ~21 ms, inside
+  0169's ceiling.
+
+- 🟡 **Performance**: the latency gate can pass on a measurement that measured
+  nothing
+  **Location**: Phase 4, item 1 (Gate: `after ≤ 0.5 × before`)
+  Under `set -uo pipefail` with no `-e`, a failed `python3` leaves `start`/`end`
+  set to the empty string — `set -u` does not catch this — and
+  `$(( (end - start) / 1000000 ))` evaluates empty operands as 0, so every
+  iteration prints `0` and the gate passes trivially. Nothing verifies the timed
+  invocation succeeded or was warm, and the launcher filename embeds
+  `${version}` from `plugin.json`, so the "cached launcher survives the `jj new`
+  swap" premise holds only if both revisions carry the same version string. The
+  awk median reads `v[10]`/`v[11]` without checking 20 samples arrived.
+
+- 🟡 **Code Quality / Architecture / Standards / Documentation / Correctness**:
+  the `no_cache_dir` paragraph contradicts itself and the wording ends up
+  duplicated anyway
+  **Location**: Phase 2, item 4
+  "is rewritten to call the same wording via `no_cache_dir` so the substring has
+  one definition" is retracted by the next sentence. Only the second reading is
+  implementable (the helper is defined past line 233, below `:195`), and the
+  stated reason is wrong: `cache_dir` is set-but-empty at `:195`, so a hoisted
+  helper would emit `… cache directory:  is not usable …` with an empty path
+  rather than tripping `set -u`. Net result: two independent literal copies of a
+  substring four tests assert, and a helper whose stated purpose is unmet.
+
+- 🟡 **Code Quality / Documentation**: after the split the `:195` diagnostic
+  names conditions its call site no longer tests
+  **Location**: Phase 2, item 3
+  `resolve_cache_dir` is reduced to `mkdir -p`, so
+  `no writable, exec-capable cache directory` now fires for "could not be
+  created" — neither a writability nor an exec-capability result — and the same
+  string is reused by the gates for a genuinely different cause. Three root
+  causes (unreachable path, unwritable directory, `noexec` mount) collapse into
+  one message, with errno discarded by `2>/dev/null` at every site.
+
+- 🟡 **Architecture / Code Quality / Documentation**: `bash_args` widens a
+  deliberately strict shared funnel enough to bypass its own preconditions
+  **Location**: Phase 1, item 1
+  `installation.py`'s docstring states `run_bootstrap` "is the single funnel
+  every invocation passes … a caller cannot opt out of [its preconditions]", and
+  `assert_hermetic` specifically refuses the repo's own `bin/accelerator`.
+  Because bash treats the first non-option operand as the script, any
+  `bash_args` entry not starting with `-` silently becomes the script and demotes
+  the validated `entry` to `$1` — the funnel then validates a path it did not
+  execute. The plan's own research shows no interface change is needed
+  (`extra_env={"SHELLOPTS": "xtrace"}` works at the 3.2 floor), and the plan
+  never reconciles the two.
+
+- 🟡 **Correctness / Architecture / Standards**: Phase 1 cannot meet its own
+  exit criteria — `import re` is deferred to Phase 2
+  **Location**: Phase 1, item 2 vs Phase 2, item 1
+  `_entered` and `_ran_probe_file` call `re.search`; the module imports no `re`,
+  and `pyproject.toml`'s `tests/**` ignores drop only `S/ANN/D/PLR2004/SLF001/PT/INP001`
+  — `F821` is live. Phase 1 therefore fails `mise run build-system:check` and
+  `mise run check`, breaking the stated "each phase is independently green and
+  mergeable" invariant. Three of Phase 1's four additions also have no consumer
+  until Phase 2.
+
+- 🟡 **Test Coverage**: "all six new cases fail before the production change"
+  is unachievable as written
+  **Location**: Phase 2, Overview and Success Criteria
+  Read against today's `bin/accelerator`, three of the six already pass:
+  `test_cold_happy_path_creates_a_missing_cache_dir` (today's `mkdir -p` already
+  creates the nested override), `test_cold_path_keeps_the_noexec_diagnostic` and
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` (the existing
+  probe's *write* fails, producing exactly the asserted exit and substring). Of
+  the rest, two red only because the new function names do not exist yet — a
+  rename artefact. Only case 1 reds behaviourally.
+
+- 🟡 **Test Coverage**: after the change the retained `:195` diagnostic is
+  reachable by no test
+  **Location**: Phase 2, items 3 and 4
+  Its only current cover,
+  `test_readonly_root_without_override_is_a_named_error`, reroutes through Gate A
+  once `mkdir -p` starts succeeding on the existing `0o555` `bin/`. Every other
+  test either creates its cache dir or uses the default `bin/`, which
+  `make_installation` always creates. Mutating that message to garbage would
+  leave `mise run check` green — and it is one of two hand-maintained copies of a
+  user-facing string.
+
+- 🟡 **Standards / Documentation**: the `docs/internals.md` replacement quotes a
+  range that ends mid-sentence and orphans the release-base-URL trust warning
+  **Location**: Phase 3, item 1
+  Line 209 reads `at a directory you own and that is not group-writable. The
+  release base URL`. A literal `:207-209` replacement leaves the survivor
+  starting `should be a host you trust not to serve an older signed release: …`
+  with no subject — deleting or mangling the mirror-downgrade warning, the more
+  security-relevant half of the paragraph. The quoted prose is also not wrapped
+  to 80 columns.
+
+- 🟡 **Standards / Documentation**: `mise run check` performs neither markdown
+  lint nor frontmatter validation, so Phases 3 and 4 have no real automated gate
+  **Location**: Phase 3 and Phase 4 Success Criteria
+  `check` folds `frontend|server|cli|deny|pup|build-system|scripts:check` only.
+  No markdown formatter or linter exists in `mise.toml` or `tasks/`, and
+  meta-corpus frontmatter validation lives in
+  `scripts/test-validate-corpus-frontmatter.sh`, run from the
+  `test:integration:config` shell suites.
+
+- 🟡 **Documentation**: the rationales for Gate B and the hoisted launcher paths
+  never reach the script
+  **Location**: Phase 2, item 4 / Key Discoveries
+  Both facts a future editor of `bin/accelerator` must know — that the second
+  call site prevents a ~30 s lock spin, and that the hoist is load-bearing for
+  Gate A — are destined only for the plan and Validation Results. In a file
+  where every non-obvious construct already carries a why-comment (`${dir:-/}`,
+  the 16-hop bound, `cd -P` vs `cd`, content-addressed staging), `probe_once`
+  appearing twice unexplained is the single most likely thing here to be
+  "tidied" into one call site.
+
+- 🟡 **Portability**: all trace-shape evidence is darwin/bash 3.2; nothing
+  verifies the assertions under the ubuntu lane's bash 5.2 before Phase 2 is
+  declared green
+  **Location**: Key Discoveries (PS4/trace bullets); Phase 1, item 2
+  `BASH = "/bin/bash"` is 3.2.57 on darwin and 5.2 on ubuntu. The `set -u`
+  failure mode differs in kind (bash 5 aborts a non-interactive shell on an
+  unbound expansion), so `:-main` is load-bearing on Linux for a different
+  reason than the one recorded. Phase 2's criteria list only local darwin tasks;
+  cross-lane observation is deferred to Phase 4.
+
+- 🟡 **Documentation**: the newly supported read-only warm cache is left
+  undocumented in the section that exists for it
+  **Location**: Phase 3
+  After the change a read-only cache directory with a pre-populated launcher
+  works warm — `test_warm_path_survives_a_non_writable_cache_dir` pins exactly
+  that, and today the same invocation aborts. The section being edited is titled
+  "Offline, mirrored and read-only installs", yet neither the replacement text
+  nor the changelog states the operator-visible consequence.
+
+- 🟡 **Performance**: `ensure_dir` forks an external `mkdir` on every warm
+  invocation for a directory that always exists
+  **Location**: Phase 2, item 2
+  `mkdir` is not a builtin, so every warm call pays a fork+exec (~1–3 ms) to
+  create a directory the launcher is about to be exec'd out of. Guarding it
+  changes no behaviour — `mkdir -p` on an existing directory is already a no-op,
+  and a path existing as a *file* still fails `[[ -d ]]`, still runs `mkdir -p`,
+  and still returns 1. 1–3 ms is the same order as 0169's entire projected
+  shortfall.
+
+- 🟡 **Performance**: sequential batches across a `jj` working-copy swap alias
+  drift onto the result and ease the gate
+  **Location**: Phase 4, item 1 (Sequence)
+  All 20 `before` samples are taken immediately after `jj new` rewrites and
+  snapshots the working copy — peak fsevents/Spotlight activity — then all 20
+  `after` samples once the machine has settled, biasing in the *permissive*
+  direction. Bare medians truncated to whole milliseconds, no dispersion
+  recorded, for a figure 0169 compares against a 38.6 ms ceiling.
+
+#### Minor
+
+- 🔵 **Correctness / Portability**: the `chmod 0o666` rationale contradicts the
+  plan's own Key Discoveries — those cases never reach the exec branch
+  **Location**: Phase 2, item 1 (paragraph after the code block)
+  A directory with no search bit blocks all name resolution inside it, so the
+  probe's `printf … >"$1/.accelerator-probe-$$"` fails with EACCES at the
+  *write* step; `0o666` on a directory **is** `chmod -x`, making the stated
+  contrast vacuous. Portability adds that whether `ensure_dir` succeeds at all
+  is userland-dependent (BSD `mkdir -p` tolerates it; GNU's `chdir`-based
+  ancestor walk may not), so the two lanes may discharge these cases through
+  different code paths while both stay green.
+
+- 🔵 **Correctness**: Gate A does not cover shim staging when the launcher is
+  cached but the staged shim is not
+  **Location**: Desired End State; Phase 2, item 4
+  Cache dir `0o555`, launcher and signature present (Gate A quiet), staged shim
+  absent or digest-mismatched: control reaches the staging `cp` *before* Gate B
+  and dies with `could not stage the verify shim into …` plus a
+  `could not record to …` line. Today the `:195` probe fires first with the
+  cache-dir message. This falsifies the "fires on **every** path" claim. A third
+  `probe_once` as the first statement of the staging `if` body is free on the
+  warm path and no-ops via `probed`.
+
+- 🔵 **Correctness**: the shared diagnostic asserts "no ACCELERATOR_CACHE_DIR
+  override was given" on paths where one was
+  **Location**: Phase 2, item 4 (`no_cache_dir` message body)
+  Both gates run after `resolve_cache_dir`, so `${cache_dir}` *is* the override
+  when set — the message names the override directory and simultaneously denies
+  one exists. Both `noexec` cases hit this wording and pass only because they
+  assert the leading substring. Carried forward from the pre-change message
+  rather than newly introduced, but now propagated to a new site.
+
+- 🔵 **Correctness / Test Coverage**: the warming invocations are unchecked or
+  rest on an unpinned contract
+  **Location**: Phase 2, item 1 (cases 1 and 2)
+  Case 1 warms with a **bare** real-launcher invocation whose exit code depends
+  on whether clap's derive implies `arg_required_else_help` at the root — nothing
+  in the repo pins it, all three existing `real_launcher=True` tests pass an
+  explicit subcommand — and the assertion carries no output. Case 2 does not
+  assert its warm-up at all, so a failed warm-up silently turns the "warm" trace
+  into a cold one and surfaces as a confusing "probe was entered". Warm with
+  `args=("version",)` and attach `stdout + stderr`.
+
+- 🔵 **Code Quality / Architecture**: Gate A adds a third copy of the
+  cached-artefact predicate, in the least readable rendering
+  **Location**: Phase 2, item 4
+  `[[ -x launcher ]] && [[ -f sig ]]` already appears at `:336` and `:341-342`;
+  Gate A adds a hand-maintained De Morgan negation ~30 lines away. Drift makes
+  Gate A either probe on a warm call (giving back the latency win) or skip on a
+  cold one (moving the diagnostic behind the staging `cp`) — silently.
+  Extracting `cached_artefacts_present()` and reusing it at all three sites makes
+  the plan's own word "approximation" literally true.
+
+- 🔵 **Code Quality**: `_traced`'s `**kwargs: object` plus two `# type: ignore`s
+  is generality neither call site uses
+  **Location**: Phase 1, item 2
+  Both call sites pass only `extra_env`. The suppressions blind the checker to
+  the whole forwarded set, so a future keyword typo reaches `run_bootstrap` as a
+  runtime `TypeError` rather than a pyrefly error.
+  `def _traced(harness, downloader, *, extra_env: dict[str, str] | None = None)`
+  needs neither.
+
+- 🔵 **Code Quality / Standards**: `no_cache_dir` and `probe_once` read as a
+  predicate and a cheap guard, but both terminate the process
+  **Location**: Phase 2, item 4
+  The file's abort helpers are `fail` and `fail_integrity`; every other
+  bare-noun/verb helper returns a value or a status. `no_cache_dir` is also a
+  noun phrase in a uniformly verb-led file. Rename to `fail_no_cache_dir` and
+  something honest for the gate (`require_exec_capable_cache`).
+
+- 🔵 **Code Quality**: both halves of the split are left untidy
+  **Location**: Phase 2, item 2
+  `ensure_dir`'s `|| return 1` is dead control flow (`mkdir`'s status is already
+  the function's), and every caller writes `|| return 1` anyway;
+  `probe_exec_capable` carries forward three separate `rm -f` sites for one
+  temporary file. Collapse to `chmod +x … && "${probe}"`, capture `status=$?`,
+  `rm -f`, `return "${status}"`. Also state why `ensure_dir` is a function at all
+  (the `_entered(trace, "ensure_dir")` assertion needs a stable token).
+
+- 🔵 **Test Coverage**: the trace cases hard-code production function names with
+  no fast guard
+  **Location**: Phase 2, item 1 (`_PROBE_FN`); Testing Strategy — Unit Tests
+  A rename fails `test_cold_path_enters_and_executes_the_probe` only after a
+  cargo build and a full fetch-verify-cache round trip, reporting "probe not
+  entered" rather than "the name moved", while the negative assertion silently
+  goes vacuous. `tests/unit/tasks/test_bootstrap_coverage.py` already uses
+  exactly the right idiom (`assert _KEY in _BOOTSTRAP_SRC.read_text()`).
+
+- 🔵 **Test Coverage**: nothing asserts the probe file is cleaned up
+  **Location**: Phase 2, items 1 and 2
+  The split rewrites cleanup across three exits and no assertion checks removal.
+  A dropped `rm -f` would litter `.accelerator-probe-<pid>` into every user's
+  plugin `bin/` on each cold start — and the plan explicitly declines a
+  `.gitignore` entry for the pattern. One line in the existing cold case:
+  `assert not list(cache.glob(".accelerator-probe-*"))`.
+
+- 🔵 **Test Coverage**: the criterion-1 assertion is looser than the available
+  evidence allows
+  **Location**: Phase 2, item 1 (case 1); Phase 4 criterion-1 amendment
+  `startswith("accelerator ")` plus three prefixes would pass on truncated,
+  reordered or empty field values. `launcher_bin` is already in scope — run it
+  directly with `version` and assert **stdout equality**, which satisfies the
+  criterion's "exactly" without hard-coding a version and additionally proves
+  the cached binary is the one the fixture built.
+
+- 🔵 **Architecture**: `acquire_lock`'s inability to distinguish contention from
+  an unusable directory is masked at the call site, not fixed
+  **Location**: Key Discoveries (~30 s hang); Phase 2, item 4
+  The loop treats "no pid file" as "a competitor is about to write one" and has
+  no notion of an unrecoverable `mkdir`. Gate B fixes the one instance reachable
+  today; any future call site, retry, or the narrow TOCTOU window between the
+  gates re-exposes the hang. Note that with `probed` already set by a successful
+  Gate A, Gate B is a no-op — so a directory that becomes unusable *between* the
+  gates still spins.
+
+- 🔵 **Architecture**: the hoist creates an ordering invariant the new tests
+  deliberately cannot catch
+  **Location**: Phase 2, item 4; Testing Strategy
+  The design depends on hoisted assignments → Gate A → first write into
+  `cache_dir`, spanning ~50 lines. Inserting a *new* write above Gate A — exactly
+  the situation the research found with the staging `cp` — is silent, and the two
+  `noexec` cases are constructed with `0o666` specifically so "any preceding
+  write still succeed[s]". Only the pre-existing `readonly_root` test would catch
+  it, incidentally.
+
+- 🔵 **Architecture**: no alternative to the precondition-gate shape is recorded
+  **Location**: Implementation Approach
+  A failure-classification shape — probe only from the failure branches that
+  already know the directory is suspect — needs no hoist, no flag, no duplicated
+  predicate, and removes the probe from the cold *happy* path too. Whether or not
+  it is adopted, recording why it was rejected is what protects Gate B and the
+  flag from a later "simplification".
+
+- 🔵 **Portability**: only the uid-0 half of the mandated environment check is
+  implemented
+  **Location**: Phase 1, item 3
+  The work item requires `id -u` **and**, for filesystems that ignore permission
+  bits, a temp-dir capability check. On WSL `drvfs` without `metadata`, Docker
+  Desktop bind mounts, `vboxsf`/9p shares, or a macOS directory with an
+  inherited ACL, `chmod(0o666)` silently succeeds and two cases fail on
+  `returncode != 0` with no hint that the environment is at fault.
+
+- 🔵 **Code Quality / Standards**: comment placement and stale cross-references
+  **Location**: Phase 2, items 1, 3 and 4
+  The "Gate on the cached artefacts…" comment is attached to `probe_once` but
+  explains the `if` two lines below; three test comments name sibling tests by
+  hand (which will go stale on rename exactly as AC references do); and the
+  `resolve_cache_dir` snippet is shown *without* the existing `:182-183`
+  no-XDG-fallback comment, which plan snippets get transcribed verbatim.
+
+- 🔵 **Test Coverage / Portability / Standards**: the retrofit turns a
+  root-green suite into six hard failures with no sanctioned deselect
+  **Location**: Phase 1, items 3 and 4
+  Two of the three retrofitted tests pass today under uid 0; the repo's existing
+  idiom for the pre-existing set is `skipif`. In a root devcontainer — a normal
+  local configuration — a contributor cannot get a meaningful signal from
+  `mise run test:integration:entrypoint` at all, which invites the ad-hoc `-k`
+  workaround the hard fail exists to prevent. Register an `unprivileged` marker
+  and name `-m 'not unprivileged'` in the failure message.
+
+- 🔵 **Standards / Documentation**: the changelog entry is mechanism-heavy and
+  contradicts its own success criterion
+  **Location**: Phase 3, item 2
+  The phase's manual criterion reads "describes user-visible behaviour, not the
+  mechanism", while the draft spends three clauses on the probe file, `chmod`,
+  the first-exec check and the staged verifier — and omits both the size of the
+  win and where a user notices it. Neighbouring entries lead with the observable
+  effect; earlier releases use `### Improved` for exactly this kind of change.
+
+- 🔵 **Documentation**: six of eleven pending Validation Results entries get no
+  stated evidence shape, and the criterion-3 split is undocumented
+  **Location**: Phase 4, item 2
+  Phase 4 enumerates five recordings and leaves the six per-check entries
+  unguided, with no criterion-to-test-name mapping anywhere. The work item's
+  criterion 3 requires the positive control to ride on criterion 6's *cold
+  happy-path run*; the plan splits it into a traced default-launcher run and an
+  untraced `real_launcher` run without recording that as a deviation, though
+  smaller deviations each get a bullet.
+
+- 🔵 **Documentation**: the staging comment's "(cheap)" becomes misleading once
+  the probe is gone
+  **Location**: What We're NOT Doing; Performance Considerations
+  `bin/accelerator:246-251` says a warm call "re-hashes (cheap)". After this
+  change that re-hash is the *dominant* remaining warm-path cost and 0169's
+  criterion turns on it, yet the block and its comment are left untouched —
+  steering the next latency hunt away from the biggest remaining item.
+
+- 🔵 **Standards**: the plan document carries 16 lines over 80 columns
+  **Location**: Plan document (frontmatter through References)
+  `.editorconfig` sets `max_line_length = 80` for `[*]`, and the work item this
+  plan derives from has **zero** over-long lines, wrapping even its long
+  `meta/…` path references. With no markdown linter, drift in the
+  highest-traffic planning artefacts is how the convention erodes.
+
+#### Suggestions
+
+- 🔵 **Performance**: record an expected-composition budget — the `0.5×` gate
+  leaves ~33 ms of unnoticed slack
+  **Location**: Desired End State; Phase 4 Success Criteria
+  Against a ~149 ms before, the ceiling is 74.5 ms versus a ~41 ms expectation.
+  An implementation leaving a third of the probe behind, or adding 33 ms of new
+  work, clears the gate unremarked — and there is no diagnostic path if the
+  after-median lands at 60 ms. Record the predicted composition (~23 ms hashing,
+  ~2.3 ms verify, ~3 ms launcher, ~12 ms bash+`uname`×2+`sed`) and require any
+  >25% deviation to be attributed before the figure is recorded.
+
+- 🔵 **Performance**: enumerate the remaining per-call fork inventory for 0169
+  **Location**: Performance Considerations
+  A warm call still performs ~6 forks / 5 execs before `exec "${launcher}"`:
+  `mkdir`, `sed` over `plugin.json`, `uname -m` and `uname -s` as two separate
+  substitutions, `shasum`+`awk` twice, and two nested subshells for plugin-root
+  resolution. Two cheap levers worth naming for a follow-up: collapse to one
+  `uname -sm` (keeping both test seams independent), and drop the two `awk`
+  execs in favour of parameter expansion.
+
+- 🔵 **Code Quality**: encode the mandatory permission-restore invariant once
+  **Location**: Phase 2, item 1
+  The plan calls the `finally` restore "mandatory — `tmp_path` teardown cannot
+  remove an unwritable directory", then hand-writes the shape in three new cases
+  on top of three existing ones. A small
+  `@contextlib.contextmanager restored_mode(path, mode)` removes the sixth-site
+  risk, whose failure mode is a leaked directory breaking teardown for the whole
+  session.
+
+- 🔵 **Code Quality**: hoisting two of three lines splits a cohesive block for
+  no stated reason
+  **Location**: Phase 2, item 4
+  `launcher`, `launcher_sig` and `base_url` are one block at `:305-307`;
+  `base_url` depends only on `version` and could move too. Move all three, or
+  state why (keeping `base_url` adjacent to its only consumer).
+
+- 🔵 **Standards**: invoke the bash-3.2 gate through its mise leaf
+  **Location**: Phase 2 Success Criteria
+  `scripts/lint-bashisms.sh` has a leaf (`lint:scripts:bashisms:check`) and is
+  already folded into the next criterion's `mise run scripts:check`. The raw
+  script also discovers files via `git ls-files '*.sh'`, blind inside a jj
+  workspace — it happens to work only because `bin/accelerator` is appended
+  unconditionally.
+
+- 🔵 **Portability**: pin the extensionless entry point's formatter settings
+  **Location**: Key Discoveries (tab indentation)
+  The file's format is currently an accident of shfmt's defaults. An explicit
+  `[bin/accelerator]` section in `.editorconfig` (`indent_style = tab`,
+  `switch_case_indent = false`) makes today's shape intentional and stable
+  without reformatting anything, and stops the next contributor rediscovering
+  the trap.
+
+### Strengths
+
+- ✅ The bottleneck is identified by measurement, not speculation, and the
+  attribution is genuinely causal: 107.9 ms for a freshly-written probe against
+  10.6 ms to re-exec an existing one isolates macOS's first-exec check rather
+  than blaming filesystem work or the fetch-verify design generally.
+- ✅ The ~41 ms prediction is arithmetically supported end-to-end — research
+  §12's decomposition sums to ~149 ms, so removing 108 leaves ~41 with no
+  unexplained residue.
+- ✅ Gate A and Gate B are a logically complete cover of the cold branch: Gate A
+  is the correct De Morgan negation of the cheap half of the warm test at
+  `:336`, and Gate B fires on a superset of Gate A's set, so nothing stages,
+  locks or fetches without a probe having run.
+- ✅ The plan independently re-derived and *corrected* its own research on the
+  residual case: `acquire_lock` really does burn its full 300 × 0.1 s budget
+  when `mkdir` can never succeed, so Gate B is a genuine regression guard rather
+  than a cosmetic one.
+- ✅ The `probed` flag is safe under `set -uo pipefail` — assigned before either
+  read, both call sites top-level so the assignment persists, and `probe_once`
+  can only return 0 or terminate.
+- ✅ The hoist is provably free: `launcher`/`launcher_sig` depend only on
+  `cache_dir`, `version` and `platform`, and their consumers are function bodies
+  resolved at call time.
+- ✅ Every claim about existing tests staying green checks out on reading them,
+  including the three planted-shim cases, the dev-override family,
+  `test_tampered_cached_launcher_is_refused_and_healed` (which newly traverses
+  Gate B), and `test_stale_lock_is_reclaimed`.
+- ✅ The probe-absence assertion is protected against vacuity from two
+  directions — an in-run `ensure_dir` presence check and a cross-test positive
+  control — so a silently broken xtrace or PS4 cannot turn it green.
+- ✅ Line and test references are accurate against the current post-0182 tree:
+  every `bin/accelerator` range, `installation.py:149-157` and `:324-369`, the
+  entrypoint suite's `:253`/`:279`/`:584-644`/`:772`/`:787`/`:801`/`:1060`, the
+  `skipif` at `test_launcher_link_refresh.py:275-293`, and `main.yml:55-91`.
+- ✅ The unprivileged-lane assumption is *verified* rather than assumed — the
+  `test-integration` matrix has no `container:` key, so both GitHub-hosted lanes
+  run as a non-root user.
+- ✅ The `.editorconfig` trap is correctly diagnosed: `[*.sh]` does not match an
+  extensionless file, `tasks/shared/sources.py:110` adds `bin/accelerator` to
+  scope explicitly, and shfmt runs with no formatting flags — so tabs and
+  `>"${probe}"` with no space are both right.
+- ✅ No construct anywhere in the diff is bash-4-only or on
+  `lint-bashisms.sh`'s denylist, and `${FUNCNAME[0]:-main}` is valid at the 3.2
+  floor.
+- ✅ Phase 3's single documentation target is complete: an exhaustive grep for
+  `probe`, `ACCELERATOR_CACHE_DIR`, `noexec` and `exec-capable` across `docs/`,
+  `README.md`, `skills/`, `hooks/`, `scripts/` and the ADRs finds no other
+  shipped statement this change falsifies.
+- ✅ Every `mise run` task name quoted in the Success Criteria exists, and the
+  plan correctly declines to add a `test:integration:*` leaf that would have
+  needed the no-`build:cli:dev` invariant re-checked.
+- ✅ The split gives each function one reason to change and names them the way a
+  domain expert would, replacing a `probe_dir` whose name described neither half.
+- ✅ `probed`/`probe_once` mirrors the file's existing `lock_held`/`acquire_lock`
+  idiom, so the new mutable state is not a new pattern to absorb.
+- ✅ The plan refuses to buy latency by weakening the staging block's tested
+  planted-stub defence, and carries the shortfall forward as a dated hand-off
+  rather than absorbing it silently.
+- ✅ The latency gate is host-relative rather than a fixed delta, and the
+  before-median is deliberately re-measured post-0182 rather than reusing the
+  stale 149.1 ms reference.
+- ✅ Placing Gate A after the dev-override block removes the 108 ms from the
+  contributor dev-launcher path too — a real per-SessionStart win claimed
+  correctly as a bonus.
+- ✅ The incidental win is spotted and quantified in kind:
+  `tests/integration/skill-invocation/` runs the real bootstrap once per
+  `!`-site across 46 SKILL.md files, all warm after the first.
+- ✅ `_require_unprivileged`'s docstring is aimed squarely at the future reader
+  who would "fix" it back to the neighbouring `skipif`, and Phase 1 adds a
+  manual criterion to that effect.
+- ✅ Each new test carries an inline comment stating what it does *and does not*
+  prove, which is this module's existing convention.
+- ✅ Deliberate deviations are named and justified rather than taken silently —
+  the PS4 fix, the real-launcher route, the hard-fail guard — each with a
+  recording obligation in Phase 4.
+- ✅ The shared-harness coupling with `tests/integration/skill-invocation/` is
+  identified up front and the extension designed backwards-compatible.
+- ✅ "What We're NOT Doing" is precise and keeps the production diff tiny, and
+  Migration Notes correctly state that no on-disk format, cache layout or
+  environment contract changes.
+
+### Recommended Changes
+
+1. **Add an automated Gate B case, and comment Gate B in the script**
+   (addresses: the Gate B critical; the Gate-B-rationale major; the
+   `acquire_lock` and ordering minors)
+   Warm the cache, overwrite the cached launcher bytes so `verify_launcher`
+   fails while `-x` and `-f` stay true, `chmod 0o555` the cache dir (**not**
+   `0o666` — the search bit must stay so Gate A remains quiet), invoke with an
+   explicit `timeout=10`, and assert non-zero plus the cache-dir substring under
+   `_require_unprivileged()` with a `finally` restore. Pass an explicit
+   `timeout=` to the other permission cases too, so any re-introduced lock spin
+   reports as a hang. Add a one-line comment above Gate B naming the residual
+   case and the ~30 s spin it prevents, one on `probed` noting both gates are
+   reachable in a single cold run, and one at the hoisted assignments recording
+   that Gate A reads them and must precede the first write into `cache_dir`.
+
+2. **Fix `_ran_probe_file` so the exec-half control is not vacuous**
+   (addresses: the exec-half major)
+   Anchor the probe path as the whole command word —
+   `rf"^\++{re.escape(_PROBE_FN)}:/\S*\.accelerator-probe-\d+$"` — so the
+   `probe=…` assignment line no longer matches, and add a red-step check that
+   the assertion fails when the `if "${probe}"` branch is stubbed out.
+
+3. **Rebuild the Phase 4 measurement instrument**
+   (addresses: the timing critical; the gate-can-pass-on-nothing, drift and
+   `version`-workload majors; the composition-budget suggestion)
+   Drive the whole batch from a single interpreter (`time.perf_counter` around
+   `subprocess.run`), asserting per iteration that the call exits 0 and stdout
+   begins with `accelerator `. Calibrate the harness against `/usr/bin/true`
+   first (must read ≲ 2 ms) and paste that figure alongside the medians. Remove
+   the revision switch: copy the pre-change script to `bin/accelerator-before`
+   in the same directory so `plugin_root`, `version` and the cached launcher are
+   identical, and interleave the two variants sample-by-sample in one revision.
+   Raise n to 50, record min/median/p90 at 0.1 ms resolution, assert `NR == 50`
+   in the reduction, record the launcher's `ls -li` on both sides, and record
+   the predicted composition so a >25% deviation must be attributed.
+
+4. **Resolve the `no_cache_dir` contradiction by parameterising the helper**
+   (addresses: the `no_cache_dir` major; the stale-conditions major; the naming,
+   override-wording and comment minors)
+   Delete the retracted sentence. Define `fail_no_cache_dir() { fail "no
+   writable, exec-capable cache directory: $1 …"; }` **above** `:195` and call it
+   from all three sites with the relevant directory — that genuinely gives the
+   asserted substring one definition, removes the hidden `${cache_dir}` global
+   coupling, and lets each site append its real cause ("could not be created" vs
+   "rejected an executable file (noexec?)") while keeping the substring
+   byte-identical. Use `${ACCELERATOR_CACHE_DIR:+ (from ACCELERATOR_CACHE_DIR)}`
+   so the message stops denying an override that was given. Keep the existing
+   `:182-183` no-XDG comment in the snippet.
+
+5. **Repair the phase boundary and the false gates**
+   (addresses: the Phase-1-not-green major; the `mise run check` major)
+   Move `import re` into Phase 1 with the helpers that need it. Either reduce
+   Phase 1 to `_require_unprivileged` plus its retrofit (the one change with
+   standalone value) and move the trace scaffolding into Phase 2, or state that
+   Phase 1 is deliberately a test-infrastructure slice. Replace Phase 3's
+   "Markdown format and lint pass: `mise run check`" with honest manual criteria,
+   and name `mise run test:integration:config` (or the corpus validator
+   directly) where Phase 4 currently claims `check` validates frontmatter.
+
+6. **Correct the residual accounting handed to 0169**
+   (addresses: the ~11.7 ms major; the process-startup major; the fork-inventory
+   suggestion)
+   State the residual as the full post-change composition — ~23 ms hashing
+   (both `:252` and `:256`), ~2.3 ms verify, ~3 ms launcher, ~12 ms
+   bash+`uname`×2+`sed` — and hand 0169 that composition rather than a single
+   number. Record in Validation Results that most of the hashing cost is
+   interpreter/process startup rather than cryptography, and raise a follow-up
+   for a faster `sha256_file` backend plus parameter-expansion field slicing —
+   both hashes and both defences survive untouched. Fix the Desired End State to
+   say "no exec of a *freshly written* file".
+
+7. **Address the launcher-side probe explicitly rather than by redundancy
+   argument** (addresses: the launcher/dispatch major)
+   Replace the out-of-scope justification with the cost one. Take a second
+   median in the same session against a real external-subcommand dispatch,
+   record both with an explicit note that the `version` figure covers bootstrap
+   cost only, scope Phase 3's docs and changelog wording to the bootstrap
+   ("resolving an external subcommand still probes the cache directory once"),
+   raise a sibling work item for `cache_root.rs`, and add the launcher-side
+   residual to the 0169 hand-off note.
+
+8. **Fix the `docs/internals.md` edit and add the read-only-cache sentence**
+   (addresses: the orphaned-sentence major; the read-only-cache major; the
+   changelog minor)
+   Quote the whole `:207-212` paragraph as it should read after the edit,
+   including the unchanged release-base-URL sentence, pre-wrapped to 80 columns.
+   Add one sentence stating that a cache directory populated once may afterwards
+   be read-only for warm invocations, while cold starts still need it writable
+   and exec-capable. Rewrite the changelog entry to lead with the observable
+   effect and a figure, keep one sentence of mechanism, and mention the
+   read-only case.
+
+9. **Correct the `chmod 0o666` rationale and record what it actually proves**
+   (addresses: the `0o666` minor; the Gate-A-vs-staging minor; the
+   advisory-filesystem minor)
+   Say plainly that clearing the search bit makes the probe fail at its *write*
+   step in both cases, so the exec half is covered only by the trace control —
+   keeping Phase 4's recorded limitation authoritative — and note that BSD and
+   GNU `mkdir -p` may discharge these cases through different code paths. Add
+   the mandated temp-dir capability check next to `_require_unprivileged` so an
+   advisory-permission filesystem reports itself rather than looking like a
+   product regression. Either add a third `probe_once` at the top of the staging
+   `if` body or soften the "every path" claim and record the residual.
+
+10. **Verify the trace assertions on bash 5 before declaring Phase 2 green**
+    (addresses: the bash-5 major; the function-name-guard minor)
+    Add a cross-interpreter step to Phase 2 — an opt-in interpreter override in
+    the harness defaulting to `/bin/bash`, plus a recorded run of the two trace
+    cases under a bash 5.x — and note in a comment why `SHELLOPTS` was rejected
+    (it is exported, so it leaks into descendant shells whose identity differs
+    by platform). Add the one-line `test_bootstrap_coverage.py` guard asserting
+    both function names exist in `bin/accelerator`.
+
+11. **Narrow the harness seam** (addresses: the `bash_args` major)
+    Replace `bash_args: tuple[str, ...]` with a keyword-only `xtrace: bool =
+    False` that the funnel translates into `-x`; if a generic passthrough is
+    genuinely wanted, assert every element starts with `-` so the script operand
+    can never be hijacked. Add one clause to `run_bootstrap`'s docstring naming
+    the parameter and the shared-consumer constraint, and record why the
+    discovered `SHELLOPTS` route was not taken.
+
+12. **Tighten the test bodies and the recorded closeout** (addresses: the
+    warming, cleanup, criterion-1, `:195`-coverage, red-step, marker,
+    Validation-Results and comment minors)
+    Warm case 1 with `args=("version",)` and assert stdout equality against a
+    direct `launcher_bin version` run; assert case 2's warm-up return code; add
+    the probe-cleanup glob assertion; add one `ensure_dir`-fails case (a
+    `0o555` parent with a nested `ACCELERATOR_CACHE_DIR`) so the retained `:195`
+    diagnostic is reachable. Reword the red-step criterion to name which cases
+    red pre-change and which are green-before/green-after preservation guards.
+    Register an `unprivileged` marker and name `-m 'not unprivileged'` in the
+    guard's message. In Phase 4, list all eleven Validation Results entries with
+    the test function discharging each, and record the criterion-3 split as a
+    deviation. Drop the sibling-test cross-references from the test comments and
+    move the gating rationale above the `if` it explains.
+
+13. **Tidy the mechanical items** (addresses: the `ensure_dir` fork major; the
+    `_traced` typing, predicate-duplication, cleanup-shape, `(cheap)`-comment
+    and 80-column minors; the `restored_mode`, `base_url`, bashisms-leaf and
+    `.editorconfig` suggestions)
+    `ensure_dir() { [[ -d "$1" ]] || mkdir -p "$1" 2>/dev/null || return 1; }`;
+    give `_traced` a real signature and drop both `# type: ignore`s; extract
+    `cached_artefacts_present()` and reuse it at all three sites; collapse
+    `probe_exec_capable` to one cleanup path; amend the staging comment's
+    "(cheap)" to record that the re-hash is now the dominant warm-path cost and
+    why it is retained; rewrap the plan's 16 over-long lines; add
+    `restored_mode`; move `base_url` with the other two or say why not; call
+    `mise run lint:scripts:bashisms:check` or drop it as redundant; and add a
+    `[bin/accelerator]` section to `.editorconfig`.
+
+## Per-Lens Results
+
+### Correctness
+
+**Summary**: The core routing logic is sound: Gate A (`¬(-x launcher ∧ -f
+sig)`) plus Gate B (top of the cold branch) is a complete cover of the cold
+branch, the `probed` idempotence flag behaves correctly under `set -uo
+pipefail` because both call sites are top-level and the flag is initialised
+before first read, and I independently confirmed the plan's correction of the
+research — without Gate B the residual case does spin `acquire_lock`'s full
+300 × 0.1 s budget (empty `owner` takes the `else` arm at
+`bin/accelerator:295-300`). I also re-traced every existing test the plan
+claims stays green and all of them do. The significant defect is in the
+verification apparatus rather than the production change: the
+`_ran_probe_file` regex also matches `probe_exec_capable`'s own
+variable-assignment trace line, which makes the load-bearing positive control
+for the probe's *exec* half vacuous. Several supporting paragraphs also
+contradict the plan's own Key Discoveries and its source research about
+directory-permission semantics, and one paragraph contradicts itself about
+where `no_cache_dir` is used.
+
+**Strengths**:
+
+- The gate conditions are logically complete. Gate A is the correct De Morgan
+  negation of the cheap half of the warm test at `bin/accelerator:336`, and
+  Gate B fires on exactly the cold branch, which is a superset of Gate A's set
+  — so no path that stages, locks, or fetches proceeds without a probe having
+  run, and the warm path runs none.
+- The plan correctly supersedes the research's framing of the residual case. I
+  traced `acquire_lock` (`bin/accelerator:275-303`) by hand: with an unwritable
+  cache dir `mkdir "${lock_dir}"` always fails, `owner` is empty, so control
+  takes the `waited=$((waited + 1))` arm and burns the full 30 s budget before
+  emitting a lock-timeout message. The research's claim that it surfaces as
+  `could not fetch and verify` is wrong; the plan's is right, and Gate B is
+  genuinely a regression guard rather than a cosmetic one.
+- The `probed` idempotence flag is correct under `set -uo pipefail`: it is
+  assigned `""` before either read so `[[ -z "${probed}" ]]` cannot trip
+  `set -u`; both `probe_once` call sites are top-level (not in a subshell or
+  command substitution) so `probed=1` persists; and `probe_once` can only
+  return 0 or terminate the shell via `fail`, so no caller has to handle a
+  non-zero return.
+- The claims about existing tests staying green check out. I re-traced
+  `test_readonly_root_without_override_is_a_named_error`,
+  `test_readonly_root_with_override_runs_from_override`,
+  `test_a_record_is_always_one_line`, the three planted-shim cases, plus
+  `test_tampered_cached_launcher_is_refused_and_healed` (which newly routes
+  through Gate B), `test_stale_lock_is_reclaimed`,
+  `test_concurrent_cold_cache_slow_downloader_all_succeed` and the dev-override
+  family — all still pass under the proposed ordering.
+- Hoisting `launcher`/`launcher_sig` above shim staging is provably safe: they
+  depend only on `cache_dir`, `version` and `platform`, all resolved earlier,
+  and their only consumers (`verify_launcher`, `fetch_and_verify`) are function
+  bodies whose expansions resolve at call time.
+- The trace-observability reasoning is empirically grounded and correct —
+  redirections are invisible to xtrace, so the function token is the only
+  reliable observable, and anchoring on `\++` rather than a fixed prefix depth
+  correctly accommodates the command-substitution frame that
+  `resolve_cache_dir` runs in.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *The exec-half positive control is vacuous:
+  its regex also matches the probe's own variable assignment*
+  **Location**: Phase 1, Change 2: Trace helpers (`_ran_probe_file`) — and
+  Phase 2's use of it in `test_cold_path_enters_and_executes_the_probe`
+  The plan's matcher for "the probe file was executed" is
+  `rf"^\++{re.escape(_PROBE_FN)}:\S*\.accelerator-probe-\S*$"`, but
+  `probe_exec_capable`'s first statement is `probe="$1/.accelerator-probe-$$"`,
+  and bash's xtrace emits variable assignments too. The plan's own source
+  research records the measured trace verbatim:
+  `+probe_dir:probe=/…/cdA/.accelerator-probe-68245` sits three lines above the
+  exec line `+probe_dir:/…/cdA/.accelerator-probe-68245`. The regex matches the
+  assignment line as well — `\S*` happily consumes `probe=/…/cdA/` — so the
+  assertion passes even if the `if "${probe}" >/dev/null 2>&1` block were
+  deleted entirely.
+  **Impact**: This is the plan's only verification of the retained cold-path
+  probe's exec half (Phase 2 comments and Phase 4's recorded coverage
+  limitation both say so explicitly, because the `chmod 0o666` cases cannot
+  distinguish write from exec). As written, an implementation that regressed
+  `probe_exec_capable` to a write-only check would keep the whole suite green —
+  precisely the regression the work item calls load-bearing.
+  **Suggestion**: Require the probe path to be the entire command word by
+  anchoring immediately after the PS4 colon, e.g.
+  `rf"^\++{re.escape(_PROBE_FN)}:/\S*\.accelerator-probe-\d+$"` — `probe=`
+  after the colon then fails to match, while `rm -f …` and `chmod +x …` already
+  fail on the embedded space. Add a red-step check that the assertion fails
+  when the `if "${probe}"` branch is stubbed out, so the control is proven
+  non-vacuous.
+
+- 🔵 **minor** (confidence: high) — *Phase 1 introduces `re.search` but defers
+  `import re` to Phase 2, so Phase 1 is not independently green*
+  **Location**: Phase 1, Change 2: Trace helpers vs Phase 2, Change 1 ("Add
+  `import re` to the module imports")
+  Phase 1 adds `_entered` and `_ran_probe_file` to
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py`, both of which
+  call `re.search`, but the instruction to add `import re` appears only in
+  Phase 2, Change 1. The module currently imports `concurrent.futures`,
+  `hashlib`, `os`, `platform`, `shutil` and `subprocess` — not `re`.
+  **Impact**: Phase 1's own success criteria include `mise run
+  build-system:check` and `mise run check`, and `pyproject.toml` sets
+  `select = ["ALL"]` with `"tests/**"` ignoring only
+  `["S", "ANN", "D", "PLR2004", "SLF001", "PT", "INP001"]` — Pyflakes `F821`
+  (undefined name) is live on the test tree. Phase 1 would therefore land red,
+  breaking the plan's stated "each phase is independently green and mergeable"
+  property.
+  **Suggestion**: Move `import re` into Phase 1, Change 2 alongside the helpers
+  that use it, and drop the sentence from Phase 2.
+
+- 🔵 **minor** (confidence: high) — *The `no_cache_dir` paragraph contradicts
+  itself, and its stated reason is factually wrong*
+  **Location**: Phase 2, Change 4 (the `no_cache_dir` paragraph)
+  The paragraph opens "The existing `fail` at `:195-197` **is rewritten** to
+  call the same wording via `no_cache_dir` so the substring has one definition"
+  and then, in the very next sentence, concludes "the `:195` call site **keeps
+  its own literal** `${plugin_root}/bin` message and only the two probe gates
+  route through `no_cache_dir`". Only the second reading is implementable,
+  since the plan places `no_cache_dir` after the dev-override block (past line
+  233) — far below the `:195` call site, where calling it would be a
+  `command not found`. The reason the plan actually gives is also wrong:
+  `cache_dir` is not *unset* at `:195`, because `cache_dir=$(resolve_cache_dir)`
+  assigns the (empty) substitution output even when the command substitution
+  exits non-zero, so under `set -u` it is set-but-empty.
+  **Impact**: An implementer who takes the first sentence at face value and
+  hoists `no_cache_dir` above `:195` to "fix" the contradiction gets a
+  diagnostic reading `no writable, exec-capable cache directory:  is not usable
+  …` with an empty path — silently degrading the message that three acceptance
+  criteria assert on. The paragraph also claims a single definition of the
+  substring while delivering two.
+  **Suggestion**: Delete the first sentence, state plainly that there are two
+  `fail` sites sharing one substring, and give the real reason (definition
+  order relative to `:195`). If one definition is genuinely wanted, define
+  `no_cache_dir` above `resolve_cache_dir` and pass the offending directory as
+  `$1` rather than closing over `${cache_dir}`.
+
+- 🔵 **minor** (confidence: high) — *The `chmod 0o666` rationale contradicts the
+  plan's own Key Discoveries: those cases never reach the exec branch*
+  **Location**: Phase 2, Change 1: Regression cases — the paragraph justifying
+  `chmod 0o666`
+  The plan justifies the two `noexec` cases with "Both reach the probe's exec
+  branch, but `0o666` leaves the directory writable, so `ensure_dir`'s
+  `mkdir -p` and any preceding write still succeed". A directory with mode
+  `0666` has no search bit, so no pathname inside it can be resolved and
+  `printf … >"$1/.accelerator-probe-$$"` fails with EACCES. The plan's own Key
+  Discoveries say exactly this ("a `chmod -x` directory permits `mkdir -p` on
+  an existing path but fails writes"), as does the measured table in the source
+  research (`write into it: FAILED (permission denied)`). So the probe fails at
+  its *write* step and the `if "${probe}"` branch is never evaluated, and
+  `0o666` on a directory *is* `chmod -x`, making the stated contrast with
+  "`chmod -x` on the plugin root's `bin/`" vacuous.
+  **Impact**: Both tests still pass (non-zero exit, correct substring), so
+  nothing breaks — but the paragraph asserts coverage the cases do not provide,
+  and directly contradicts the exec-vs-write limitation Phase 4 is required to
+  record as acceptance criterion 5. An implementer trusting this paragraph
+  could reasonably weaken or drop that record.
+  **Suggestion**: Rewrite the paragraph to say the probe fails at its *write*
+  step in both cases (which is why the exec half needs the trace positive
+  control), and keep Phase 4's recorded limitation as the authoritative
+  statement. Note that no directory-permission combination can produce
+  exec-without-write, so this gap is inherent short of a real `noexec` mount.
+
+- 🔵 **minor** (confidence: medium) — *Gate A does not cover shim staging when
+  the launcher is cached but the staged shim is not*
+  **Location**: Desired End State / Implementation Approach (Gate A's
+  condition) and Phase 2, Change 4
+  The Desired End State claims the `no writable, exec-capable cache directory`
+  diagnostic "still fires on **every** path that cannot use its cache dir". One
+  reachable state escapes both gates: cache dir unwritable-but-searchable
+  (`0o555`), launcher present and `-x`, signature present — so Gate A does not
+  fire — but the content-addressed staged shim absent or byte-mismatched.
+  Control then reaches the staging body at `bin/accelerator:257` *before* Gate
+  B, `cp` fails, and the run dies with `could not stage the verify shim into …`
+  plus a `could not record to …` line from `fail_integrity`'s best-effort
+  append into the same unwritable directory. Today the probe at `:195` fires
+  first and produces the cache-dir message. This is the exact failure mode the
+  plan identifies as the reason Gate A must precede staging — Gate A just does
+  not cover this variant of it.
+  **Impact**: A diagnostic regression (no hang) in a narrow but reachable
+  state, e.g. a cache directory whose staged shim was pruned or manually
+  deleted and which has since become read-only. It also falsifies the plan's
+  own "every path" invariant, which future readers will rely on.
+  **Suggestion**: Either soften the Desired End State claim and record this
+  residual explicitly alongside the others in Phase 4, or add a third
+  `probe_once` as the first statement inside the staging `if` body (before
+  `cp`). That is free on the warm path — the body is never entered — and no-ops
+  via `probed` on any run where Gate A already fired, so it breaks none of the
+  existing tests I traced.
+
+- 🔵 **minor** (confidence: medium) — *The shared diagnostic asserts "no
+  ACCELERATOR_CACHE_DIR override was given" on paths where it was*
+  **Location**: Phase 2, Change 4: `no_cache_dir` message body
+  `no_cache_dir` interpolates `${cache_dir}` and then states "… is not usable
+  and no ACCELERATOR_CACHE_DIR override was given (no XDG fallback)". Because
+  the two probe gates run after `resolve_cache_dir`, `${cache_dir}` is the
+  override whenever one is set — so the message now names the override
+  directory and simultaneously claims no override was given.
+  `test_cold_path_keeps_the_noexec_diagnostic` and
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` both set
+  `ACCELERATOR_CACHE_DIR` and both hit this wording; they pass only because
+  they assert on the leading substring.
+  **Impact**: A self-contradictory operator-facing diagnostic on the two paths
+  the plan is specifically preserving the diagnostic for. The pre-change
+  message was wrong in a different way (it hardcoded `${plugin_root}/bin`), so
+  this is a carried-forward defect the plan is now propagating to a new call
+  site rather than a new bug.
+  **Suggestion**: Split the trailing clause on whether `ACCELERATOR_CACHE_DIR`
+  is set — e.g. `${ACCELERATOR_CACHE_DIR:+ (from ACCELERATOR_CACHE_DIR)}` —
+  keeping the asserted `no writable, exec-capable cache directory` prefix
+  byte-identical so the three criteria still match.
+
+- 🔵 **minor** (confidence: low) — *The warming call asserts exit 0 from a real
+  launcher invoked with no subcommand*
+  **Location**: Phase 2, Change 1:
+  `test_warm_path_survives_a_non_writable_cache_dir`
+  The test's first statement is
+  `assert _run_bootstrap(root, server, downloader).returncode == 0` against
+  `make_harness(real_launcher=True)` — i.e. the real `accelerator` binary
+  invoked with **no arguments**. `Cli` declares a required subcommand
+  (`pub command: Command`, `cli/launcher/src/launch/inbound/cli.rs:11-14`), so
+  the exit code depends on whether clap's derive implies
+  `arg_required_else_help` at the root: if it does, `handle_parse_error` maps
+  `DisplayHelpOnMissingArgumentOrSubcommand` to `ExitCode::SUCCESS`; if it does
+  not, the `_` arm returns `ExitCode::from(1)`. Nothing in the repo pins this —
+  all three existing `real_launcher=True` tests pass explicit subcommands, and
+  the launcher's own tests only exercise `try_parse_from` with a subcommand
+  present.
+  **Impact**: If the second reading holds, Phase 2's first regression case
+  fails on its warming line, for a reason unrelated to the probe. Low impact
+  (trivially fixed during the red step) but it costs a debug cycle on a test
+  whose whole point is a clean before/after signal.
+  **Suggestion**: Warm with `args=("version",)` — the same built-in the test
+  then asserts on. That removes the dependency on clap's missing-subcommand
+  exit code and on the root-help path entirely.
+
+- 🔵 **suggestion** (confidence: medium) — *Gate B — the anti-hang guard — has
+  no automated case, and a regression would hang the suite rather than fail it*
+  **Location**: Testing Strategy / Phase 2 Manual Verification step 2
+  Gate B exists solely to keep the residual case (launcher `-x`, signature
+  present, verification fails, cache dir unwritable) from spinning
+  `acquire_lock` for ~30 s, and the plan's Key Discoveries call it "required to
+  avoid a regression, not merely to preserve a nicer message". None of the six
+  automated cases exercises it: five run cold (Gate A fires first) and the
+  sixth is warm. The property is left to Manual Verification step 2 only.
+  **Impact**: `run_bootstrap`'s `timeout` parameter defaults to `None`, so if a
+  later change removes Gate B the suite does not go red — it stalls for the
+  full lock budget on every affected invocation, which is a much harder failure
+  to attribute than an assertion. The plan's own Performance Considerations
+  note the residual is the reasoning most likely to be "removed by someone
+  tempted to", making an automated pin worth its cost.
+  **Suggestion**: Add a seventh case modelled on
+  `test_tampered_cached_launcher_is_refused_and_healed`: warm the cache,
+  overwrite the cached launcher with garbage (preserving its execute bit so
+  Gate A stays quiet), `chmod 0o555` the cache dir in a `try/finally`, invoke
+  with `timeout=10`, and assert non-zero plus the cache-dir substring. That
+  fails fast today with the timeout and would fail fast if Gate B were removed.
+
+### Test Coverage
+
+**Summary**: The plan's six cases give solid coverage of the *warm-path*
+behaviour change and, unusually well, guard the trace assertions against
+vacuity with both an in-run control (`ensure_dir` entered) and a cross-test
+positive control (the probe file observed executing). But the coverage is
+lopsided: Gate B — the second probe call site the plan itself says prevents a
+~30 second `acquire_lock` spin — has no automated case at all and would survive
+deletion with all six cases green, and three of the six cases already pass
+against today's `bin/accelerator`, so the Phase 2 success criterion "all six
+new cases fail before the production change" cannot be met as written. A
+secondary gap: after the change the `:195` `resolve_cache_dir` failure
+diagnostic (kept as a second, duplicated copy of the message string) is
+reachable by no test in the suite.
+
+**Strengths**:
+
+- The probe-absence assertion is protected against vacuity from two
+  directions: `_entered(trace, "ensure_dir")` in the same run proves the trace
+  mechanism is live, and `test_cold_path_enters_and_executes_the_probe` proves
+  the token can match at all. A silently broken xtrace or PS4 cannot turn the
+  negative assertion green.
+- `_ran_probe_file`'s anchored regex genuinely isolates the probe's *exec* half
+  from `chmod +x …` and `rm -f …` (both of which contain a space before the
+  path). [Reviewer's note: the correctness lens found it does **not** isolate
+  it from the `probe=…` assignment line — see that lens's major finding, which
+  supersedes this strength.]
+- The plan's claims about which existing tests stay green hold on reading
+  them: `test_readonly_root_without_override_is_a_named_error` reroutes cleanly
+  through Gate A, `test_a_record_is_always_one_line` still reaches the staging
+  diagnostic, `test_tampered_cached_launcher_is_refused_and_healed` traverses
+  Gate B without incident, and the dev-override tests are untouched because
+  Gate A sits below the dev block.
+- `_require_unprivileged()` is applied to exactly the three
+  permission-dependent new cases (0o555 warm, and both 0o666 cases) and to a
+  complete retrofit list — `test_dev_override_refused_when_not_executable` is
+  correctly left alone, since a 0644 file has no execute bit for `-x` to find
+  even as root.
+- Using `chmod 0o666` on an override cache dir rather than `chmod -x` on the
+  plugin `bin/` is a deliberate isolation choice: `ensure_dir`'s `mkdir -p`
+  still succeeds on an existing directory, so the probe is unambiguously the
+  failing step.
+- Choosing a `bash_args` seam over the research's `SHELLOPTS=xtrace` avoids
+  exporting xtrace into the injected downloader and the shim/launcher children.
+- Every permission case restores modes in a `finally`, matching the established
+  idiom in this suite and keeping `tmp_path` teardown viable.
+- The exec-vs-write coverage limitation is recorded as a limitation rather than
+  papered over, with the substitute (the positive control's execution
+  assertion) named explicitly.
+
+**Findings**:
+
+- 🔴 **critical** (confidence: high) — *Gate B has no automated coverage*
+  **Location**: Phase 2, item 4: Gate B / Success Criteria — Manual Verification
+  The plan identifies Gate B (a second `probe_exec_capable` call site at the
+  top of the cold branch, before `acquire_lock`) as necessary to stop a ~30
+  second lock-timeout spin in the residual case — cached launcher present and
+  executable, signature present, verification failing, cache dir unwritable —
+  yet gives it **only a manual verification step** ("A tampered cached launcher
+  in an unwritable cache dir fails within a second") and manual testing step 2.
+  None of the six automated cases reaches that state: cases 5 and 6 use
+  `chmod 0o666`, which makes `[[ -x "${launcher}" ]]` false and therefore
+  routes through Gate A, and the existing
+  `test_tampered_cached_launcher_is_refused_and_healed` uses a writable cache
+  dir so Gate B succeeds trivially. Deleting Gate B leaves all six new cases
+  and the whole existing suite green.
+  **Impact**: The single riskiest line of the production change — the one whose
+  absence turns an instant, correctly-named failure into a 30 second hang, on a
+  file every SessionStart hook executes — has zero regression protection, and
+  the plan's own Desired End State claims "no new hang … Verified by six
+  regression cases". A future reader with no test to red will delete Gate B as
+  redundant (the plan's own code comment anticipates exactly that temptation).
+  **Suggestion**: Add a seventh case; the state is cheap to construct and
+  `run_bootstrap` already turns a hang into a named failure via its `timeout`
+  parameter. Warm the cache, poison the launcher in place
+  (`launcher.write_text("poisoned")` keeps its executable bit and leaves the
+  `.minisig` present), then `bin_dir.chmod(0o555)` — 0o555 rather than 0o666 is
+  essential so the directory stays traversable and `-x launcher` remains true,
+  bypassing Gate A — and run with `timeout=15`, asserting a non-zero exit and
+  the `no writable, exec-capable cache directory` substring. Restore the mode in
+  `finally` and gate the case with `_require_unprivileged()`. While there, pass
+  an explicit `timeout=` to the other permission cases so any future
+  re-introduction of the lock spin reports as a hang rather than a slow pass.
+
+- 🟡 **major** (confidence: high) — *"All six new cases fail before the
+  production change" is unachievable*
+  **Location**: Phase 2, Overview and Success Criteria
+  The plan commits to writing the six cases first and observing each fail "for
+  the right reason", and makes that a Phase 2 automated success criterion. Read
+  against today's `bin/accelerator`, three of the six already pass:
+  `test_cold_happy_path_creates_a_missing_cache_dir` passes because
+  `probe_dir`'s `mkdir -p` already creates the nested override directory and the
+  cold fetch already prints real `version` output;
+  `test_cold_path_keeps_the_noexec_diagnostic` passes because `mkdir -p`
+  succeeds on an existing 0o666 directory and the probe's *write* then fails,
+  producing exactly the asserted exit code and substring; and
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` passes for the
+  same reason (the plan admits this one, but not the other two). Of the
+  remaining three, `test_warm_path_does_not_enter_the_probe` and
+  `test_cold_path_enters_and_executes_the_probe` fail only because the function
+  names `ensure_dir` and `probe_exec_capable` do not exist yet — a rename
+  artefact, not a behavioural discriminator. Only
+  `test_warm_path_survives_a_non_writable_cache_dir` reds for a behavioural
+  reason.
+  **Impact**: The stated red step is unachievable, so Phase 2 either stalls on
+  a criterion that cannot be ticked or the record gets fudged. More importantly
+  it obscures the real coverage shape: four of the six cases are
+  characterisation tests that pin behaviour the change must *preserve*, not
+  regression guards for the change itself, and the plan's framing ("six
+  regression cases") over-states the confidence they buy.
+  **Suggestion**: Reword the criterion to name which cases are expected to red
+  pre-change (case 1 behaviourally; cases 2 and 3 on the new function names) and
+  which are pre-existing-behaviour guards that must be green on both sides
+  (cases 4, 5, 6) — the latter is a genuine and useful property to record, since
+  a green-before/green-after case proves the change preserved the diagnostic
+  rather than merely that it fires.
+
+- 🟡 **major** (confidence: high) — *After the change the `:195` diagnostic is
+  reachable by no test*
+  **Location**: Phase 2, items 3 and 4: `resolve_cache_dir` and the two
+  diagnostic call sites
+  After the split, `resolve_cache_dir` fails only when `mkdir -p` fails, and
+  the plan deliberately keeps the `:195` `fail` with its own hand-written copy
+  of the `no writable, exec-capable cache directory` wording. No test in the
+  suite reaches that branch any more: its only current cover,
+  `test_readonly_root_without_override_is_a_named_error`, reroutes through Gate
+  A's `no_cache_dir` once `mkdir -p` starts succeeding on the existing 0o555
+  `bin/`, and every other test either creates its cache dir first or uses the
+  default `bin/`, which `make_installation` always creates.
+  **Impact**: A new behaviour (the diagnostic now firing on an *uncreatable*
+  directory) ships with no coverage, and one of two duplicated definitions of a
+  user-facing diagnostic string is unreachable by any assertion — it can
+  silently drift from the other, or be broken outright, with nothing red.
+  Mutating the `:195` message to garbage would leave `mise run check` green.
+  **Suggestion**: Add one cheap case that makes `mkdir -p` fail: create
+  `parent = tmp_path / "ro"`, `parent.mkdir()`, `parent.chmod(0o555)`, set
+  `ACCELERATOR_CACHE_DIR=str(parent / "nested")`, restore in `finally`, and
+  assert a non-zero exit plus the `no writable, exec-capable cache directory`
+  substring under `_require_unprivileged()`. That covers both the retained
+  `:195` diagnostic and `ensure_dir`'s failure return in a single test.
+
+- 🔵 **minor** (confidence: high) — *Trace cases hard-code production function
+  names with no fast guard*
+  **Location**: Phase 2, item 1: trace helpers (`_PROBE_FN`) / Testing Strategy
+  — Unit Tests
+  The two trace cases assert on hard-coded production function names
+  (`_PROBE_FN = "probe_exec_capable"` and the literal `"ensure_dir"`) with
+  nothing tying those constants to `bin/accelerator`. The Testing Strategy
+  leaves the unit tests "untouched". If the production function is renamed,
+  `test_cold_path_enters_and_executes_the_probe` fails after a full cargo build
+  and a real fetch-verify-cache round trip, reporting "probe not entered" rather
+  than "the name moved", while `test_warm_path_does_not_enter_the_probe`'s
+  negative assertion silently becomes vacuous.
+  **Impact**: A rename produces a slow, misleading integration failure instead
+  of a fast, self-explaining one, and half the pair degrades to a no-op in the
+  meantime.
+  **Suggestion**: Add a one-line guard to
+  `tests/unit/tasks/test_bootstrap_coverage.py`, which already uses exactly
+  this idiom (`assert _KEY in _BOOTSTRAP_SRC.read_text()`): assert that both
+  `probe_exec_capable()` and `ensure_dir()` appear as function definitions in
+  `bin/accelerator`, with a comment naming the trace assertions that depend on
+  them. It runs in milliseconds and turns a rename into a pinpointed failure.
+
+- 🔵 **minor** (confidence: medium) — *Warming invocations are barely checked*
+  **Location**: Phase 2, item 1:
+  `test_warm_path_survives_a_non_writable_cache_dir` and
+  `test_warm_path_does_not_enter_the_probe`
+  In the first, the warming call is
+  `assert _run_bootstrap(root, server, downloader).returncode == 0` — a **bare**
+  invocation of the *real* launcher with no subcommand, and with no output
+  attached to the assertion. Its exit status rests on clap mapping a missing
+  required subcommand to `DisplayHelpOnMissingArgumentOrSubcommand`, which
+  `cli/launcher/src/main.rs` maps to `ExitCode::SUCCESS`; no test anywhere pins
+  that bare-invocation contract. In the second the warming call's return code is
+  not asserted at all, so a failed warm-up silently turns the "warm" trace into
+  a cold trace and the failure surfaces as a confusing "probe was entered".
+  **Impact**: Two of the three genuinely discriminating cases can fail or
+  mislead for reasons unrelated to the probe, with no diagnostic output attached
+  — expensive to debug in an integration suite that builds the launcher and runs
+  a full fetch-verify-cache chain.
+  **Suggestion**: Warm with `args=("version",)` in case 1 (the same invocation
+  the case then asserts on) and attach `result.stdout + result.stderr` to the
+  assertion message, as every other test in the file does; and assert the
+  warming run's return code in case 2 the way
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` already does for
+  its own first run.
+
+- 🔵 **minor** (confidence: medium) — *Criterion-1 assertion is looser than it
+  needs to be*
+  **Location**: Phase 2, item 1 / Phase 4, criterion-1 amendment
+  Acceptance criterion 1 asks for the `version` output to be "asserted
+  exactly"; the plan weakens this to `stdout.startswith("accelerator ")` plus
+  the presence of the `commit: `, `built:  ` and `target: ` prefixes, and
+  records the weakening as a deviation on the grounds that the real launcher
+  prints `CARGO_PKG_VERSION` rather than the fixture's `9.9.9-test`. That
+  reasoning is sound, but the resulting assertion would pass on truncated,
+  reordered or partially-empty field values.
+  **Impact**: The case's job is to prove the warm path actually ran the cached
+  launcher end to end; a prefix-and-substring check leaves room for a degraded
+  launcher run to pass, and the recorded deviation reads as accepting less
+  coverage than was available.
+  **Suggestion**: The `launcher_bin` fixture is already in scope (the case sets
+  `real_launcher=True`). Run `launcher_bin` directly with `version` once and
+  assert **stdout equality** between that and the bootstrap's stdout. That
+  satisfies the criterion's "exactly" without hard-coding a version, and
+  additionally proves the cached binary is the same one the fixture built.
+
+- 🔵 **minor** (confidence: medium) — *Nothing checks the probe file is removed*
+  **Location**: Phase 2, item 2: `probe_exec_capable` / Phase 2, item 1:
+  `test_cold_path_enters_and_executes_the_probe`
+  The split rewrites the probe's cleanup entirely — `rm -f "${probe}"` now
+  appears at three separate exits of the new `probe_exec_capable` — and no
+  assertion anywhere checks that the probe file is actually removed. Nothing in
+  the suite would catch a lost `rm -f`, because every test uses fixture roots
+  (the session-scoped `repo_bin_is_untouched` fixture only guards the repo's own
+  shipped `bin/`).
+  **Impact**: A dropped cleanup path would leave `.accelerator-probe-<pid>`
+  litter in every real user's plugin `bin/` on each cold start, and the plan
+  explicitly declines to add a `.gitignore` entry for that pattern — so the
+  litter would be visible in contributors' working trees with no test to have
+  caught it.
+  **Suggestion**: Add one line to
+  `test_cold_path_enters_and_executes_the_probe`, which already owns the
+  cold-probe run:
+  `assert not list(cache.glob(".accelerator-probe-*")), "the probe must clean up after itself"`.
+
+- 🔵 **minor** (confidence: medium) — *Measurement loop's clock reads add a
+  constant to every sample*
+  **Location**: Phase 4, item 1: Measurement
+  The measurement loop reads the clock with a separate
+  `python3 -c 'import time; print(time.time_ns())'` process on each side of the
+  timed call. The interval therefore includes the *second* interpreter's startup
+  (the clock is read only after Python has booted), adding a constant ~25-50 ms
+  to every sample — comparable to the ~41 ms figure being measured.
+  **Impact**: Both medians are inflated by roughly the same constant. The
+  `after ≤ 0.5 × before` ratio is biased toward *failing* a correct
+  implementation (0.41 rather than 0.28 on the plan's own expected figures), and
+  the recorded before-median will visibly disagree with the Context table's
+  149.1 ms, which the acceptance criterion asks the method to match — making the
+  recorded delta and gate hard to interpret for whoever re-confirms 0169's
+  hand-off note against them.
+  **Suggestion**: Take the timestamps from a single process outside the loop —
+  e.g. drive the 20 iterations from one `python3 -c` script using
+  `subprocess.run` and `time.perf_counter` — or use `hyperfine` if available,
+  and record the method verbatim in Validation Results so the next measurement
+  is reproducible (the plan already notes the original methodology was never
+  recorded).
+
+- 🔵 **suggestion** (confidence: medium) — *The hard-fail retrofit offers no
+  sanctioned exclusion path*
+  **Location**: Phase 1, items 3 and 4: `_require_unprivileged` and the retrofit
+  The hard-fail-over-skip decision is well argued for the three new permission
+  cases, and the retrofit list is complete. But retrofitting the same hard fail
+  onto three *existing* tests converts a suite that currently passes under uid 0
+  into one that reds six tests there, and the plan provides no mechanism for the
+  "excluded explicitly by the implementer" escape the work item's
+  acceptance-criteria preamble requires — the only recourse is editing the file
+  or ad-hoc `--deselect`.
+  **Impact**: Anyone running the entrypoint suite as root (a Docker devcontainer
+  is the common case) hits six hard failures whose message names no supported
+  way out, and a future lane exclusion has to be improvised rather than
+  recorded.
+  **Suggestion**: Keep the hard fail, but make the exclusion a first-class,
+  greppable operation: mark the six cases with a named marker (e.g.
+  `@pytest.mark.unprivileged`, registered in `pyproject.toml`) and have
+  `_require_unprivileged`'s failure message name `-m 'not unprivileged'` as the
+  sanctioned exclusion. That satisfies the criterion's demand for explicit
+  exclusion without reintroducing a silent skip.
+
+### Code Quality
+
+**Summary**: The plan is unusually well-reasoned for its size: the split into
+`ensure_dir` + `probe_exec_capable` is the right shape, the new state (`probed`)
+mirrors the file's existing `lock_held` mutable-flag idiom, the tab-indent and
+no-`local` conventions of `bin/accelerator` are respected, and the trace
+assertions are wrapped in small named predicates with a positive control so a
+rename reddens rather than silently passing. The main maintainability problems
+are concentrated in Phase 2's Change 4: a self-contradiction about whether the
+`no writable, exec-capable cache directory` wording is shared or duplicated, a
+diagnostic that no longer describes the failure it now reports, a third copy of
+the `-x launcher && -f sig` condition, and two helper names (`no_cache_dir`,
+`probe_once`) that hide the fact they terminate the process. On the test side
+the proposed `_traced` helper carries `**kwargs: object` plus two
+`# type: ignore` suppressions that its own two call sites do not need.
+
+**Strengths**:
+
+- The `probed` flag plus `probe_once` mirrors the file's existing `lock_held` /
+  `acquire_lock` / `release_lock` idiom, so the new mutable module-level state is
+  not a new pattern for a reader to absorb.
+- The plan explicitly records that `bin/accelerator` is tab-indented
+  (`.editorconfig`'s `[*.sh]` does not match an extensionless file) and that the
+  new functions must match — a genuine trap caught before implementation.
+- The negative trace assertion is paired with a positive control
+  (`test_cold_path_enters_and_executes_the_probe`) and an `ensure_dir` presence
+  assertion, so renaming either half of the split reddens instead of quietly
+  turning the absence check vacuous.
+- The trace observables are wrapped in two small named predicates (`_entered`,
+  `_ran_probe_file`) rather than inline regexes at each assertion site, and the
+  traps behind them (redirections invisible to xtrace, the `probe` substring
+  appearing in the filename regardless, variable `+` depth under command
+  substitution) are each recorded.
+- `_require_unprivileged`'s docstring is aimed squarely at the future reader who
+  would 'fix' it back to the neighbouring `skipif` — exactly the kind of
+  extremely-non-obvious signal the project's low-comment standard is meant to
+  leave room for.
+- Test-level comments follow the existing style in
+  `test_accelerator_entrypoint.py` (a leading comment inside the test body
+  stating why the case exists, e.g. at `:608`, `:629`, `:1067`) rather than
+  inventing a new convention.
+- 'What We're NOT Doing' is precise and keeps the production diff tiny — the
+  shim staging block and its second `sha256_file` stay untouched, with the cost
+  consciously retained.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *The `no_cache_dir` helper's purpose is
+  contradicted in adjacent sentences, and the outcome duplicates the diagnostic
+  wording*
+  **Location**: Phase 2, Change 4
+  The plan first states "The existing `fail` at `:195-197` is rewritten to call
+  the same wording via `no_cache_dir` so the substring has one definition", then
+  in the very next sentence states the opposite: "the `:195` call site keeps its
+  own literal `${plugin_root}/bin` message and only the two probe gates route
+  through `no_cache_dir`". The stated blocker is that `no_cache_dir` interpolates
+  the global `${cache_dir}`, which is unset at `:195` — a problem created purely
+  by the helper reading a global instead of taking the directory as an argument.
+  **Impact**: An implementer cannot tell which shape to build, and the shape the
+  plan lands on leaves the load-bearing string
+  `no writable, exec-capable cache directory` written out twice in a 350-line
+  script — with four new tests asserting on it as a substring, so a future reword
+  of one site silently degrades the other's coverage.
+  **Suggestion**: Delete the first sentence and parametrise the helper —
+  `fail_no_cache_dir() { fail "no writable, exec-capable cache directory: $1 …"; }`
+  — defined before `:195` and called as `fail_no_cache_dir "${plugin_root}/bin"`
+  there and `fail_no_cache_dir "${cache_dir}"` from the gates. That genuinely
+  gives the substring one definition and removes the hidden global coupling.
+
+- 🟡 **major** (confidence: medium) — *After the split the diagnostic describes a
+  capability the failing code no longer tests*
+  **Location**: Phase 2, Change 3
+  The plan keeps the wording `no writable, exec-capable cache directory` at
+  `:195` while `resolve_cache_dir` is reduced to `mkdir -p` only — so that
+  message now fires for "the directory could not be created", which is neither a
+  writability nor an exec-capability result. The same string is then reused by
+  the two probe gates for a genuinely different cause, and both paths swallow the
+  OS error (`2>/dev/null` plus a bare `return 1`), so no errno reaches the
+  operator.
+  **Impact**: Three distinct root causes (path unreachable/ENOTDIR, unwritable
+  directory, `noexec` mount) collapse into one message with no distinguishing
+  detail, which is the diagnostic an operator has to work from at 3am for a
+  failure mode that only occurs in awkward environments.
+  **Suggestion**: Keep the asserted substring as a shared prefix and append the
+  actual cause per site — e.g. `… cache directory: <dir> could not be created`
+  versus `… cache directory: <dir> rejected an executable file (noexec?)`. The
+  tests assert a substring, so both still pass, and consider letting the
+  underlying `mkdir`/`chmod` stderr through rather than discarding it.
+
+- 🔵 **minor** (confidence: high) — *`_traced`'s `**kwargs: object` plus two
+  `# type: ignore`s is generality neither call site uses*
+  **Location**: Phase 1, Change 2
+  The proposed `_traced(harness, downloader, **kwargs: object)` pops `extra_env`
+  out of an untyped kwargs bag and needs two `# type: ignore[arg-type]`
+  suppressions to forward it. Both of its call sites in Phase 2 pass only
+  `extra_env` — nothing else is ever forwarded. (The pattern is copied from
+  `_run_and_capture_env` at `test_accelerator_entrypoint.py:723-745`, which has
+  the same suppressions, so it will read as established rather than accidental.)
+  **Impact**: Two type-checker suppressions are added to a brand-new helper for
+  flexibility that is never exercised, and they blind the checker to the whole
+  forwarded argument set — so a future typo in a keyword reaches `run_bootstrap`
+  as a `TypeError` at run time rather than a `pyrefly` error.
+  **Suggestion**: Give it the signature it actually needs:
+  `def _traced(harness: Harness, downloader: Path, *, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]`
+  and build the env inline (`{**(extra_env or {}), "PS4": _PS4}`). No `pop`, no
+  suppressions, fully checked.
+
+- 🔵 **minor** (confidence: high) — *`no_cache_dir` and `probe_once` read as a
+  predicate and a no-op guard, but both can terminate the process*
+  **Location**: Phase 2, Change 4
+  `bin/accelerator` has an established naming family for process-terminating
+  helpers — `fail` and `fail_integrity` — and every other bare-noun/verb helper
+  (`dir_of`, `dev_launcher_contained`, `verify_launcher`, `ensure_dir`) either
+  returns a value or a status. The proposed `no_cache_dir` reads as a condition
+  test but calls `fail` and exits; `probe_once` reads as a cheap memoised probe
+  but exits the process when the probe fails.
+  **Impact**: A reader scanning the two new gates (`probe_once` on its own line
+  inside an `if`, and again as the first statement of the cold branch) gets no
+  signal that control may not return, which is exactly the kind of hidden effect
+  that makes later restructuring of this region risky.
+  **Suggestion**: Rename to join the existing family — `fail_no_cache_dir` for
+  the diagnostic, and something honest for the gate such as
+  `require_exec_capable_cache` (keeping the once-only behaviour inside it).
+
+- 🔵 **minor** (confidence: high) — *Gate A adds a third copy of the
+  cached-artefact condition, written in De Morgan form*
+  **Location**: Phase 2, Change 4
+  The test `[[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]]` already
+  appears twice in `bin/accelerator` — at the cache-hit branch (`:336`) and again
+  in the re-check under the lock (`:341-342`). Gate A adds a third instance,
+  negated into `[[ ! -x "${launcher}" ]] || [[ ! -f "${launcher_sig}" ]]`, which
+  is the least readable of the three renderings of the same idea.
+  **Impact**: "The cached artefacts are present" — a trust-relevant condition —
+  would be encoded in three places, so adding or renaming a cached artefact means
+  finding all three, and the plan's own framing of Gate A as "the cheap,
+  side-effect-free cache-hit approximation" is only true by inspection of two
+  distant sites.
+  **Suggestion**: Extract a predicate alongside `verify_launcher`, e.g.
+  `cached_artefacts_present() { [[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]]; }`,
+  then write Gate A as `cached_artefacts_present || probe_once` and collapse
+  `:336`/`:341` onto it too. The word "approximation" then becomes literally true
+  — the gate and the branch share one definition.
+
+- 🔵 **minor** (confidence: high) — *Both halves of the split are left untidy: a
+  redundant `|| return 1` and three `rm -f` cleanup sites*
+  **Location**: Phase 2, Change 2
+  `ensure_dir() { mkdir -p "$1" 2>/dev/null || return 1; }` is a one-statement
+  wrapper whose `|| return 1` is pure noise — `mkdir`'s status is already the
+  function's status — and every caller writes `ensure_dir … || return 1` anyway.
+  `probe_exec_capable` is copied verbatim from `probe_dir`, carrying forward
+  three separate `rm -f "${probe}"` cleanup sites for one temporary file.
+  **Impact**: The plan's headline abstraction is a name over a single builtin
+  call with dead control flow attached, and the retained probe keeps a three-way
+  cleanup shape that is easy to break when edited — both are being written fresh
+  here, so the tidying is free now and awkward later.
+  **Suggestion**: Drop the `|| return 1` from `ensure_dir`, and state in the plan
+  why it is a function at all (the `_entered(trace, "ensure_dir")` assertion
+  needs a stable token — otherwise inline the `mkdir -p` at its two call sites
+  and assert on `resolve_cache_dir` instead). In `probe_exec_capable`, collapse
+  to one cleanup path: run `chmod +x … && "${probe}"`, capture `status=$?`,
+  `rm -f`, `return "${status}"`.
+
+- 🔵 **minor** (confidence: medium) — *`bash_args` widens a deliberately strict
+  shared funnel, and contradicts the plan's own discovery*
+  **Location**: Phase 1, Change 1
+  The plan's Key Discoveries state "`SHELLOPTS=xtrace` enables tracing on bash
+  3.2 with no `-x` flag, **via the existing `extra_env`**", yet Phase 1 still
+  adds a general `bash_args: tuple[str, ...]` passthrough to `run_bootstrap` — a
+  helper whose module docstring says it "is the single funnel every invocation
+  passes… a caller cannot opt out of [its preconditions]" and which is shared
+  with the skill-invocation suite.
+  **Impact**: An arbitrary-interpreter-flags hole is opened in a deliberately
+  narrow shared API without the plan reconciling it against its own finding that
+  no signature change is needed, so the next reader cannot tell whether the seam
+  was necessary or incidental.
+  **Suggestion**: Either use the existing `extra_env` seam, or keep `-x` and
+  record the reason (`SHELLOPTS` is exported and would trace the shim, downloader
+  and launcher too, polluting the trace and the timings) — and in that case
+  prefer a narrow `trace: bool = False` over an open `bash_args`.
+
+- 🔵 **minor** (confidence: medium) — *Comment placement and cross-references:
+  one comment sits above the wrong construct, three name other tests, and an
+  existing rationale comment is dropped*
+  **Location**: Phase 2, Changes 1, 3 and 4 (proposed snippets)
+  Judged against the project's very-low tolerance for comments, most of the
+  proposed comments earn their place (the `noexec` rationale on
+  `probe_exec_capable`, the `_PS4` bash-3.2 note, the positive-control note).
+  Three details do not: the "Gate on the cached artefacts rather than on
+  verification…" comment is attached to `probe_once` but explains the `if`
+  condition two lines below it; three test comments name sibling tests
+  (`test_warm_path_does_not_enter_the_probe`,
+  `test_cold_path_enters_and_executes_the_probe`) which will go stale on rename
+  exactly as ADR/AC references do; and the `resolve_cache_dir` snippet is shown
+  without the existing `:182-183` comment explaining the no-XDG-fallback choice.
+  **Impact**: Plan snippets get transcribed close to verbatim, so a misfiled
+  comment and a silently deleted rationale comment both ship — and the dropped
+  `no XDG fallback` note is the one piece of genuinely non-obvious context on
+  that function.
+  **Suggestion**: Move the gating rationale directly above the `if`, replace the
+  test-name cross-references with what they actually convey ("a non-fatal
+  surviving probe is ruled out by the trace assertion, not by this case"), and
+  show the `:182-183` comment as retained in the snippet.
+
+- 🔵 **suggestion** (confidence: high) — *The mandatory permission-restore
+  invariant is left to six hand-written `finally` blocks*
+  **Location**: Phase 2, Change 1
+  The plan notes that restoring modes in a `finally` "is mandatory — `tmp_path`
+  teardown cannot remove an unwritable directory", then hand-writes that `chmod`
+  / `try` / `finally` / `chmod` shape in three new cases, on top of the three
+  existing ones (`test_accelerator_entrypoint.py:265-276`, `:286-292`,
+  `:1076-1085`).
+  **Impact**: A mandatory invariant enforced by convention across six sites will
+  eventually be forgotten in the seventh, and the failure mode is a leaked
+  unwritable directory that breaks teardown for the whole session rather than a
+  clean test failure.
+  **Suggestion**: Encode it once — a small
+  `@contextlib.contextmanager def restored_mode(path: Path, mode: int)` that
+  chmods on entry and back to `0o755` in its own `finally` — and use
+  `with restored_mode(cache, 0o666):` in the new cases (retrofitting the existing
+  three is optional).
+
+- 🔵 **suggestion** (confidence: medium) — *Hoisting two of three lines splits a
+  cohesive assignment block for no stated reason*
+  **Location**: Phase 2, Change 4
+  `launcher`, `launcher_sig` and `base_url` are one three-line block at
+  `bin/accelerator:305-307`. The plan moves the first two up past the
+  dev-override block and explicitly leaves `base_url` behind, without saying why;
+  `base_url` depends only on `version` (set at `:137`) and so could move with
+  them.
+  **Impact**: Release-artefact path construction ends up at two sites roughly 100
+  lines apart, so a later change to the naming scheme has two places to find
+  rather than one.
+  **Suggestion**: Move all three together, or state the reason for splitting them
+  (e.g. keeping `base_url` adjacent to its only consumer, `fetch_and_verify`) so
+  the next reader does not treat the split as an oversight.
+
+### Architecture
+
+**Summary**: The core split (`ensure_dir` for the always-run `mkdir -p`,
+`probe_exec_capable` for the cold-path-only write-chmod-exec) is a genuine
+cohesion improvement: `resolve_cache_dir` stops conflating path selection with
+capability validation, and the trust chain (shim staging, signature
+verification) is deliberately left untouched. The dominant architectural concern
+is not inside `bin/accelerator` but at the boundary the plan draws around it:
+the Rust launcher's `cli/launcher/src/launch/outbound/resolve/cache_root.rs` runs
+the *same* write-chmod-exec probe unconditionally on every external-subcommand
+dispatch, before its own cache-hit test — so the ~108 ms this plan removes from
+bash returns in Rust on exactly the path the epic (0169's hook migration, and
+every sub-binary after it) needs fast, and the plan's chosen measurement command
+(`version`, a built-in) never traverses it. Secondary concerns: the
+two-gates-plus-flag shape introduces an unguarded ordering coupling and a
+duplicated cache-hit predicate where a failure-classification design would need
+neither, and Phase 1 is not the independently-green slice it claims.
+
+**Strengths**:
+
+- The split into `ensure_dir` and `probe_exec_capable` gives each function one
+  reason to change and names them the way a domain expert would ('make the
+  directory exist' vs 'prove it can execute'), replacing a function whose name
+  (`probe_dir`) described neither half accurately.
+- The plan correctly refuses to touch the shim staging block and its second
+  `sha256_file`, keeping a latency optimisation from eroding a trust boundary
+  that three existing tests assert — an explicitly acknowledged and
+  well-reasoned tradeoff rather than an optimised-away one.
+- The shared-harness coupling is identified up front
+  (`tests/integration/support/installation.py` also serves
+  `tests/integration/skill-invocation/`) and the extension is designed to be
+  backwards-compatible via a keyword-only parameter with an empty default.
+- The new helper functions follow the file's established idiom (module-scope
+  functions closing over resolved globals, aborts routed through
+  `fail`/`fail_integrity` so the `--fail-safe` contract holds), so the change is
+  architecturally consistent with the surrounding bootstrap rather than
+  introducing a new style.
+- Gate B is justified by a measured failure mode (a ~30 s `acquire_lock` spin)
+  rather than by taste, and the plan explicitly supersedes the research's weaker
+  'cosmetic diagnostic narrowing' framing — a good example of a resilience
+  regression being caught during planning.
+- The latency gate is expressed host-relative (`after ≤ 0.5 × before`, both
+  medians in one session on the same launcher binary) rather than as a fixed
+  delta, so it survives a faster or slower host.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *The launcher re-incurs the identical probe
+  on every warm sub-binary dispatch, so the saving does not reach the paths that
+  motivated it*
+  **Location**: What We're NOT Doing — "Not touching
+  cli/launcher/src/launch/outbound/resolve/cache_root.rs"
+  The plan removes the write-chmod-exec probe from the bash bootstrap's warm path
+  but declares the Rust launcher's own copy out of scope on the grounds that "the
+  launcher's own probe runs after exec capability is already proven". In
+  `cli/launcher/src/main.rs:65`, `cache_root::resolve` — and therefore
+  `probe_writable_and_executable`, which writes `.accelerator-probe-<pid>`,
+  `chmod`s it, execs it and removes it (`cache_root.rs:80-94`) — runs inside
+  `LazyProductionResolver::resolve` on **every** external-subcommand dispatch,
+  *before* `FetchVerifyCacheResolver`'s cache-hit test (`resolve/mod.rs:190`).
+  Today's SessionStart hook escapes this because `hooks/config-detect.sh:13`
+  invokes `config summary`, an in-process built-in; but 0169 serves
+  `vcs guard`/`vcs detect` as dispatched sub-binaries (0169 work item
+  `:193-194`), as do 0170/0171/0173. The out-of-scope justification is a
+  *redundancy* argument — which is precisely the argument this plan uses to
+  relocate the bash probe, and which applies verbatim to the launcher (a warm
+  dispatch proves exec capability by exec'ing the cached sub-binary) — and it
+  says nothing about cost.
+  **Impact**: The work item's stated rationale ("Every SessionStart hook pays
+  this cost today … and every future CLI-backed hook will") is only
+  half-discharged: after this change a warm `accelerator vcs guard` still pays a
+  fresh-file first-exec penalty of the same shape and, on darwin, plausibly the
+  same ~97 ms magnitude — which would put 0169's `G ≤ 1.1 × B ≈ 38.6 ms` gate out
+  of reach by a multiple, not by the ~2 ms the hand-off note anticipates. Phase
+  3's documentation change ("A warm start neither writes nor probes") also
+  becomes false at the system level once sub-binary dispatch is involved.
+  **Suggestion**: Keep the Rust change out of this item if desired, but replace
+  the redundancy justification with the cost one and act on it: measure one
+  dispatched-subcommand invocation during Phase 4, raise a sibling work item for
+  `cache_root.rs` (the same `ensure_dir` / lazy-probe split applies, gated on the
+  sub-binary cache miss inside `FetchVerifyCacheResolver::resolve`), and add the
+  launcher-side residual to the 0169 hand-off note alongside the ~11.7 ms staging
+  residual.
+
+- 🟡 **major** (confidence: high) — *The measurement command exercises a
+  built-in, not the dispatch path the epic depends on*
+  **Location**: Phase 4, §1 Measurement and §3 0169 hand-off note
+  Phase 4 measures the median of 20 `bin/accelerator version` invocations and
+  uses that figure both to clear the `after ≤ 0.5 × before` gate and to
+  re-confirm 0169's hand-off note. `version` is a clap built-in dispatched
+  in-process (`cli/launcher/src/main.rs:139-144, 191-201`); it never constructs
+  `LazyProductionResolver`'s cache root, never resolves a sub-binary, and never
+  execs a second binary. Every consumer the work item cites as the beneficiary —
+  0169's `vcs guard` hook, and the sub-binaries in 0170/0171/0173 — goes through
+  the external-subcommand route instead, which adds cache-root resolution (with
+  its own probe), manifest/signature re-verification and a sub-binary exec.
+  **Impact**: The gate can pass and 0169's note can be "re-confirmed" against a
+  figure that structurally under-represents the warm cost of every path that will
+  actually run in production, so the obligation the note exists to carry forward
+  would be discharged on the wrong evidence.
+  **Suggestion**: Take a second median in the same session against an
+  external-subcommand invocation (any dispatched token available at the time, or
+  `--help` augmentation as a proxy for resolver construction), record both, and
+  state explicitly in Validation Results that the `version` figure covers
+  bootstrap cost only — so 0169 inherits a number it can compare against its own
+  `G`.
+
+- 🟡 **major** (confidence: high) — *`bash_args` widens the shared harness funnel
+  enough to bypass its own preconditions*
+  **Location**: Phase 1, §1 Trace capture seam (`installation.py` `bash_args`)
+  Phase 1 adds an unconstrained `bash_args: tuple[str, ...]` to `run_bootstrap`
+  and splices it as `[BASH, *bash_args, str(entry), *args]`.
+  `tests/integration/support/installation.py`'s module docstring states that
+  `run_bootstrap` "is the single funnel every invocation passes, and it carries
+  the network and working-tree preconditions — a caller cannot opt out of them",
+  and `assert_hermetic` (`:301-321`) specifically refuses to run the repo's own
+  `bin/accelerator` because doing so fetches the real release into the working
+  tree. Because bash treats the first non-option operand as the script to run,
+  any `bash_args` entry that does not begin with `-` silently becomes the script
+  and demotes the validated `entry` to `$1` — the funnel then validates a path
+  that is not the one executed. The research also showed the capability needs no
+  interface change at all (`extra_env={"SHELLOPTS": "xtrace"}` works on the 3.2
+  floor).
+  **Impact**: A shared seam consumed by two suites gains an interface broader
+  than the one thing it is needed for, and the broader form can defeat the
+  precondition that exists to stop a test suite writing into the shipped `bin/`.
+  **Suggestion**: Narrow the parameter to intent — a keyword-only
+  `xtrace: bool = False` that the funnel translates into `-x` — or, if a generic
+  passthrough is wanted, assert inside `run_bootstrap` that every `bash_args`
+  element starts with `-` so the script operand can never be hijacked.
+
+- 🟡 **major** (confidence: high) — *Phase 1 cannot meet its own exit criteria
+  and is not an independently valuable slice*
+  **Location**: Phase 1 (Overview, §2 Trace helpers) and Implementation Approach
+  ("each is independently green and mergeable")
+  The plan claims "Phases are ordered so each is independently green and
+  mergeable", but Phase 1's `_entered` helper calls `re.search` while the
+  instruction to "Add `import re` to the module imports" appears in Phase 2 §1;
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py` imports no `re`
+  today (its import block is lines 1-47). Phase 1 as specified therefore fails
+  its own success criteria (`mise run build-system:check`, `mise run check`) on
+  an undefined name. Beyond that, three of Phase 1's four additions have no
+  consumer until Phase 2 — `_traced`, `_ran_probe_file`,
+  `_PROBE_FN = "probe_exec_capable"` (naming a shell function that does not yet
+  exist) and the `bash_args` parameter — so the slice ships scaffolding for
+  behaviour that is not there.
+  **Impact**: The phase boundary gives the appearance of an independently
+  mergeable increment while actually being a broken prefix of Phase 2, which
+  undermines the review/merge gate the phase decomposition exists to provide.
+  **Suggestion**: Reduce Phase 1 to the genuinely independent change —
+  `_require_unprivileged` plus its retrofit onto the three existing permission
+  tests, which closes a real false-negative today — and move the trace helpers,
+  `_PROBE_FN`, the `re` import and the harness seam into Phase 2 where their
+  first consumer lives.
+
+- 🔵 **minor** (confidence: high) — *Gate A duplicates the cache-hit predicate,
+  giving two places that encode "is the cache warm?"*
+  **Location**: Phase 2, §4 (Gate A)
+  Gate A tests `[[ ! -x "${launcher}" ]] || [[ ! -f "${launcher_sig}" ]]` while
+  the warm/cold branch at `bin/accelerator:336` tests
+  `[[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]] && verify_launcher`.
+  After the change, the knowledge "which cached artefacts constitute a warm
+  cache" lives in two textually independent places ~30 lines apart, one being a
+  hand-maintained negation of the other's first two clauses. Any future change to
+  the cached artefact set (an added file, a renamed launcher, a third
+  precondition at `:336`) updates one and not the other.
+  **Impact**: Drift makes Gate A either probe on a warm call (silently giving
+  back the latency win) or skip the probe on a cold one (moving the diagnostic
+  back behind the staging `cp`), and the failure is a slow, quiet regression
+  rather than a hard break.
+  **Suggestion**: Extract the shared predicate once — e.g.
+  `cached_launcher_present() { [[ -x "${launcher}" ]] && [[ -f "${launcher_sig}" ]]; }`
+  — and write Gate A as `cached_launcher_present || probe_once` and the branch as
+  `if cached_launcher_present && verify_launcher; then`, so the artefact set has
+  one definition and the branch reads as "present *and* verified".
+
+- 🔵 **minor** (confidence: medium) — *No alternative to the precondition-gate
+  shape is considered; failure-classification would need neither the hoist, the
+  flag, nor two gates*
+  **Location**: Implementation Approach (two gates plus the `probed` flag)
+  The plan settles directly on "keep the probe as a precondition, replicated at
+  two chokepoints, made idempotent by a mutable global `probed`", which requires
+  hoisting `launcher`/`launcher_sig` past unrelated code, a duplicated cache-hit
+  predicate, and a second gate whose only reachable scenario is the
+  verification-failed residual. An alternative shape is not discussed: make the
+  capability check *reactive* — leave `probe_exec_capable` uncalled on every
+  success path, and invoke it only from the existing failure branches that
+  already know the cache dir is suspect (the staging `cp`/`chmod` failures at
+  `:257-260`, and `acquire_lock`'s unrecoverable `mkdir`), to classify the failure
+  and emit the `no writable, exec-capable cache directory` diagnostic instead of
+  the generic one. That form needs no hoist, no flag, no cache-hit approximation,
+  and additionally removes the ~108 ms probe from the cold *happy* path, where it
+  is equally redundant (a successful cold run proves write and exec capability by
+  staging and running the shim).
+  **Impact**: The chosen shape adds hidden state and an ordering constraint to a
+  linear 352-line trust-root script and leaves the probe on the cold happy path,
+  when a smaller-footprint design appears to satisfy the same acceptance
+  criteria.
+  **Suggestion**: Either adopt the failure-classification shape or record in the
+  plan why it was rejected (e.g. more failure sites to touch, or a preference for
+  fail-fast preconditions in a security-sensitive entry point) — so a future
+  editor tempted to "simplify away" Gate B or the flag can see the alternative
+  was weighed.
+
+- 🔵 **minor** (confidence: high) — *The lock component's inability to
+  distinguish contention from an unusable directory is masked at the call site,
+  not fixed*
+  **Location**: Key Discoveries ("A pre-staging gate alone introduces a ~30
+  second hang") and Phase 2 §4 (Gate B)
+  The plan discovered that `acquire_lock` (`bin/accelerator:275-303`) spins its
+  full 300 × 0.1 s budget when `mkdir "${lock_dir}"` can never succeed, because
+  the loop treats "no pid file" as "a competitor is about to write one" and has
+  no notion of an unrecoverable `mkdir`. Gate B fixes the one instance reachable
+  today by probing at the call site immediately before `acquire_lock`, leaving
+  the defect inside the component untouched. Note also that with the `probed`
+  flag set by Gate A, Gate B is a no-op whenever Gate A already probed
+  successfully, so a directory that becomes unusable between the two gates still
+  reaches the 30 s spin.
+  **Impact**: A resilience defect stays latent in the locking component; any
+  future path that reaches `acquire_lock` without passing a gate (a new call
+  site, a retry, or the narrow TOCTOU window) re-exposes a 30 s hang in a script
+  that runs at every SessionStart.
+  **Suggestion**: Classify the failure where it occurs — on the first `mkdir`
+  failure with no pid file present, distinguish "cannot create anything here"
+  (fail immediately via the cache-dir diagnostic) from genuine contention — so
+  the timeout budget only ever applies to contention; at minimum, record the
+  residual as a known limitation next to `acquire_lock`.
+
+- 🔵 **minor** (confidence: medium) — *The hoist creates an ordering invariant
+  that the new tests deliberately cannot catch*
+  **Location**: Phase 2, §4 (hoisting `launcher`/`launcher_sig` above shim
+  staging) and Testing Strategy
+  The design depends on a three-way ordering that spans ~50 lines of otherwise
+  unrelated code: the hoisted `launcher`/`launcher_sig` assignments, then Gate A,
+  then the first write into `cache_dir` (shim staging at `:252-261`). A
+  reordering that leaves `${launcher}` unset would fail loudly under `set -u`,
+  but the more likely edit — inserting a *new* write into `cache_dir` above Gate
+  A, exactly the situation the research found with the staging `cp` — is silent.
+  The plan's own two `noexec` cases deliberately use `chmod 0o666` so that
+  "`ensure_dir`'s `mkdir -p` and any preceding write still succeed", i.e. they
+  are constructed not to notice a write moved above the gate; only the
+  pre-existing `test_readonly_root_without_override_is_a_named_error` (`0o555`,
+  default cache dir) would catch it, and only incidentally.
+  **Impact**: The invariant that makes the diagnostic correct is recorded in
+  prose and a comment on the gate, but is not expressed where a future editor
+  would look (the hoisted assignments) nor pinned by an intentional test — so it
+  can regress into the exact bug this plan was written to avoid.
+  **Suggestion**: Put a one-line comment at the hoisted assignments stating "must
+  precede Gate A, which must precede the first write into `cache_dir`", and
+  either add a `0o555` override-dir case that pins the ordering or name the
+  existing `readonly_root` test in the Testing Strategy as the ordering guard so
+  its role is visible.
+
+- 🔵 **suggestion** (confidence: high) — *The `no_cache_dir` helper does not
+  achieve the single definition it is introduced for, and the plan contradicts
+  itself about it*
+  **Location**: Phase 2, §4 (`no_cache_dir` helper)
+  Phase 2 §4 introduces `no_cache_dir` and states "The existing `fail` at
+  `:195-197` is rewritten to call the same wording via `no_cache_dir` so the
+  substring has one definition", then in the next sentence concludes the
+  opposite: "the `:195` call site keeps its own literal `${plugin_root}/bin`
+  message and only the two probe gates route through `no_cache_dir`". The net
+  result is two copies of the test-asserted substring
+  `no writable, exec-capable cache directory` with different interpolations, plus
+  a helper whose stated purpose is unmet.
+  **Impact**: The plan reads as undecided at the point of implementation, and a
+  diagnostic string asserted by several tests ends up with two owners that can
+  drift independently.
+  **Suggestion**: Pick one shape and say so — either parameterise the helper
+  (`no_cache_dir "${1}"`, defined before `:195` and called from all three sites
+  with the relevant directory) so the wording genuinely has one definition, or
+  drop the helper and duplicate the literal deliberately with a comment naming
+  the other copy.
+
+### Performance
+
+**Summary**: This is a measurement-led change that targets the right bottleneck:
+the ~108 ms probe is isolated by a clean attribution experiment (107.9 ms for a
+freshly-written probe vs 10.6 ms to re-exec an existing one), and the ~41 ms
+landing point is arithmetically consistent with research §12's full warm-path
+decomposition (108 + 23 + 2.3 + 3 + 12 ≈ 149). The production change itself is
+sound and adds essentially zero new warm-path work. The weak link is Phase 4:
+the measurement harness brackets each timed call with two `python3 -c`
+interpreter startups, one of which falls *inside* the timed interval and is
+plausibly comparable in size to the ~41 ms it is trying to measure; and the
+plan's residual accounting hands 0169 half the real retained cost (~11.7 ms
+instead of the ~23 ms of double hashing its own Current State table says runs
+warm), while mis-framing that cost as a security trade-off when it is dominated
+by interpreter/process startup in `sha256_file`.
+
+**Strengths**:
+
+- The bottleneck is identified by measurement, not speculation, and the
+  attribution is genuinely causal: the 107.9 ms vs 10.6 ms pair isolates macOS's
+  first-exec check on a freshly written file rather than blaming filesystem work
+  or the fetch-verify design generally.
+- The ~41 ms prediction is arithmetically supported end-to-end — research §12's
+  decomposition (probe ~108, sha256 ×2 ~23, verify ~2.3, launcher ~3,
+  bash+uname+sed ~12) sums to ~149, so removing 108 leaves ~41 with no
+  unexplained residue.
+- The gate is a host-relative ratio rather than a fixed ms delta, which is the
+  correct choice given the probe cost is itself host-specific, and the
+  before-median is deliberately re-measured post-0182 rather than reusing the
+  stale 149.1 ms reference.
+- The production change adds no measurable warm-path cost: Gate A is two builtin
+  `[[ ]]` stat tests, the hoisted `launcher`/`launcher_sig` assignments are pure
+  parameter expansion, and cold-path cost is preserved exactly once via the
+  `probed` idempotence flag.
+- Placing Gate A after the dev-override block removes the 108 ms from the
+  contributor dev-launcher path as well — a real per-SessionStart and
+  per-Bash-tool-call win the plan correctly claims as a bonus.
+- The plan declines to buy latency by weakening the staging block's tested
+  planted-stub defence, and carries the residual forward as a dated hand-off to
+  0169 rather than silently absorbing it.
+- The incidental win is spotted and quantified in kind:
+  `tests/integration/skill-invocation/` runs the real bootstrap once per `!`-site
+  across 46 SKILL.md files, all warm after the first, so the suite gets
+  materially faster for free.
+
+**Findings**:
+
+- 🔴 **critical** (confidence: high) — *Timing harness includes a full python3
+  interpreter startup inside every measured interval*
+  **Location**: Phase 4, item 1: Measurement (the bash timing loop)
+  The Phase 4 measurement loop brackets each timed call with
+  `start=$(python3 -c '…time_ns()')` and `end=$(python3 -c '…time_ns()')`. The
+  `start` timestamp is taken at the *end* of the first interpreter's startup, but
+  the `end` timestamp is taken at the end of the *second* interpreter's startup —
+  so the measured interval is `bin/accelerator version` **plus one complete
+  `python3` process startup** (fork, exec, dynamic linking, `site` processing,
+  and — under this repo's mise-pinned Python 3.14 with an auto-activated `.venv`
+  — possibly a mise shim exec in front of it). That overhead is plausibly 25–80
+  ms on darwin, i.e. comparable to or larger than the ~41 ms after-median the
+  plan is trying to measure.
+  **Impact**: Two consequences, both damaging. (1) An additive constant `b` on
+  both sides pulls the ratio toward 1.0: with a true 149 → 41 ms improvement and
+  `b` = 30 ms the gate reads 0.40, with `b` = 80 ms it reads 0.53 and **fails a
+  correct implementation**, consuming exactly the slack the gate was calibrated
+  with. (2) The *absolute* after-median is the figure Phase 4 §3 hands to 0169,
+  whose acceptance ceiling is ≈ 38.6 ms and whose decision turns on a ~2.4 ms
+  overrun — an after-median inflated by tens of milliseconds would make that
+  ceiling look wildly unreachable and push 0169 to relax its threshold far
+  further than the evidence warrants.
+  **Suggestion**: Drive the whole loop from a single interpreter —
+  `python3 - <<'PY'` with `time.perf_counter()` around
+  `subprocess.run(["bin/accelerator","version"], …)` — so there is exactly one
+  startup for the whole batch and the timed interval contains only fork+exec+run.
+  Alternatively use `$EPOCHREALTIME` from a bash 5 (the measurement script is not
+  shipped, so the bash 3.2 floor does not apply to it). Whichever is chosen,
+  validate the instrument first by timing `/usr/bin/true` in the same harness: it
+  must read ≲ 2 ms, and that calibration figure should be pasted into Validation
+  Results alongside the medians.
+
+- 🟡 **major** (confidence: high) — *Residual warm-path cost stated as ~11.7 ms
+  when both `sha256_file` calls stay, ~23 ms*
+  **Location**: Performance Considerations (and the Current State Analysis
+  table); Phase 4 §3 (0169 hand-off)
+  Performance Considerations states "The residual warm-path cost is the shim
+  staging condition's second `sha256_file` at ~11.7 ms". The plan's own Current
+  State Analysis table contradicts this: it lists `:252-253` `sha256_file` **#1**
+  over `shim_source` as "runs warm: yes" *and* `:255-256` (the condition
+  containing `sha256_file` #2) as "runs warm: yes". Research §12 agrees — its
+  decomposition row reads "`sha256_file` ×2 over the 475 K shim (`:252`, `:256`)
+  | ~23 ms". So the retained hashing cost after this change is ~23 ms, not ~11.7
+  ms; the ~11.7 ms figure is the size of a *different, out-of-scope change*
+  (dropping the second hash), not the size of the residual. The plan's own 41 ms
+  arithmetic only closes with 23 ms in it (23 + 2.3 + 3 + 12 ≈ 40); with 11.7 ms
+  there is ~12 ms unaccounted for. Relatedly, the Desired End State sentence
+  "performs no write, no `chmod` and no exec beyond the staged shim and the
+  launcher itself" is not literally true after the change — the warm path still
+  execs `mkdir`, `sed`, `uname` ×2, `shasum`/`sha256sum` ×2 and `awk` ×2; the
+  accurate and load-bearing claim is "no exec of a *newly created* file".
+  **Impact**: Phase 4 §3 instructs the implementer to "update the quoted residual
+  figure if it moved" in 0169's Dependencies note. Handing 0169 an 11.7 ms
+  residual when the real retained cost is ~23 ms halves the apparent size of the
+  only remaining lever, and 0169's choice is precisely between relaxing its
+  `G ≤ 1.1 × B` gate and removing residual cost.
+  **Suggestion**: State the residual as the full post-change budget — ~23 ms
+  hashing (both `:252` and `:256`), ~2.3 ms `verify_launcher` shim exec, ~3 ms
+  launcher exec, ~12 ms bash startup + `uname` ×2 + `plugin.json` `sed` — and
+  hand that composition, not a single number, to 0169. Fix the Desired End State
+  wording to "no exec of a freshly written file".
+
+- 🟡 **major** (confidence: high) — *The retained ~23 ms is process-startup cost
+  in `sha256_file`, not an unavoidable trust trade-off*
+  **Location**: What We're NOT Doing (shim staging / double hash); Performance
+  Considerations
+  The plan, the work item and 0169's hand-off all frame the retained hashing cost
+  as a security trade-off: recovering it means weakening the tested planted-stub
+  defence, so it stays. But 11.7 ms to SHA-256 a 475 KB file is ~40 MB/s — one to
+  two orders of magnitude below arm64's hardware-accelerated SHA-256 throughput,
+  so essentially none of that time is cryptographic work. It is process startup:
+  on darwin `sha256sum` does not exist (coreutils is not in `mise.toml`'s
+  `[tools]`), so `sha256_file` falls through to `shasum -a 256`, which on macOS
+  is a **Perl script**, and each call additionally forks a command-substitution
+  subshell and execs `awk '{print $1}'` to slice one field.
+  **Impact**: The epic has concluded that ~23 ms of a ~41 ms warm path is only
+  recoverable by dropping a hash — i.e. by weakening a trust boundary — when
+  roughly 15–20 ms of it is recoverable by *tool selection alone*, hashing
+  exactly the same two files with exactly the same algorithm and keeping every
+  existing assertion intact. That would put the warm bootstrap near ~21 ms,
+  comfortably inside 0169's ≈ 38.6 ms ceiling, and it changes 0169's decision
+  from "relax the threshold or accept the overrun" to "meet the threshold".
+  **Suggestion**: Do not absorb it here — the scope closure is correct — but
+  record the finding in Validation Results and in the 0169 hand-off, and raise a
+  follow-up: add a faster backend to `sha256_file`'s existing detection chain
+  (e.g. prefer `openssl dgst -sha256`, a C binary, ahead of `shasum`) and replace
+  `| awk '{print $1}'` with pure parameter expansion on the captured output
+  (`${out%%[[:space:]]*}` / `${out##* }`), eliminating two `awk` execs. Both
+  hashes and both defences survive untouched.
+
+- 🟡 **major** (confidence: high) — *The latency gate can pass silently on a
+  measurement that measured nothing*
+  **Location**: Phase 4, item 1 (Gate: `after ≤ 0.5 × before`)
+  The measurement script runs under `set -uo pipefail` with no `-e`, discards
+  both streams with `>/dev/null 2>&1`, and never checks an exit status. If
+  `python3` fails or is unresolvable, `start` and `end` are set to the *empty
+  string* — `set -u` does not catch this, because they are set — and
+  `$(( (end - start) / 1000000 ))` evaluates empty operands as 0, so every
+  iteration prints `0` and the awk median prints `0 ms`, trivially satisfying
+  `after ≤ 0.5 × before`. Equally, nothing verifies that the timed invocation
+  succeeded or was actually *warm*: the launcher filename embeds `${version}`
+  read from `.claude-plugin/plugin.json`, so the plan's premise that the cached
+  launcher survives the `jj new` revision switch ("measure the after-median
+  without re-warming") holds only if both revisions carry the same version string
+  — otherwise one batch times a cold fetch or a fast failure. The awk median also
+  reads `v[10]`/`v[11]` without checking that 20 samples arrived.
+  **Impact**: The gate is this plan's only quantitative acceptance condition and
+  the sole input to a downstream decision in 0169; as written it can report a
+  green pass on a harness that produced no valid samples, or on batches that
+  measured different code paths.
+  **Suggestion**: Assert per iteration that the invocation exits 0 and its stdout
+  begins with `accelerator `; assert `NR == 20` in the awk stage and fail loudly
+  otherwise; and before/after each batch record the cached launcher's path, size
+  and inode (`ls -li`) so "same post-0182 binary, warm on both sides" is
+  *verified* rather than assumed.
+
+- 🟡 **major** (confidence: medium) — *Sequential batches across a jj working-copy
+  swap alias drift onto the result and ease the gate*
+  **Location**: Phase 4, item 1 (Sequence: `jj new`, warm, before; return, after)
+  The protocol takes all 20 `before` samples immediately after `jj new` onto the
+  pre-change revision — i.e. immediately after jj rewrites the working copy and
+  snapshots it, when fsevents/Spotlight and any file-watcher activity are at
+  their peak — then switches back and takes all 20 `after` samples once the
+  machine has settled. Bare medians are recorded, truncated to whole
+  milliseconds, with no dispersion.
+  **Impact**: Any monotonic drift between the two batches is aliased entirely
+  onto the before/after difference, and the specific ordering here biases in the
+  *permissive* direction: post-swap background activity inflates `before`, making
+  `after ≤ 0.5 × before` easier to clear. For the gate that is tolerable given a
+  3.6× expected effect, but the absolute after-median is what 0169 compares
+  against a 38.6 ms ceiling, where 1 ms quantisation and unknown run-to-run
+  spread are not adequate.
+  **Suggestion**: Remove the revision switch from the measurement entirely — copy
+  the pre-change script to `bin/accelerator-before` (same directory, so
+  `BASH_SOURCE`-derived `plugin_root`, `version` and the cached launcher path are
+  all identical) and interleave the two variants sample-by-sample in one
+  revision, deleting the copy afterwards. If the switch is kept, run the batches
+  ABBA (before, after, after, before) and require the two `before` medians to
+  agree within a few percent as a drift check, and let the working copy settle
+  (`jj st`, brief pause) before timing. Raise n to 50 — the after batch is only
+  ~2 s — and record min, median and p90 at 0.1 ms resolution rather than a single
+  truncated integer.
+
+- 🟡 **major** (confidence: medium) — *`ensure_dir` forks an external `mkdir` on
+  every warm invocation for a directory that always exists*
+  **Location**: Phase 2, Change 2 (`ensure_dir`)
+  The plan's new `ensure_dir` is `mkdir -p "$1" 2>/dev/null || return 1`, and it
+  is deliberately kept on the unconditional path via `resolve_cache_dir`. `mkdir`
+  is an external binary, not a shell builtin, so every warm invocation pays a
+  fork+exec (~1–3 ms on darwin) to create a directory that is guaranteed to exist
+  — the launcher being execed out of it is proof. Guarding it costs nothing and
+  changes no behaviour: `mkdir -p` on an existing directory is already a no-op,
+  and a path existing as a *file* still fails `[[ -d ]]`, still runs `mkdir -p`,
+  and still returns 1, so the failure mode and the diagnostic are identical.
+  **Impact**: 1–3 ms of a ~41 ms budget is small in isolation, but this plan is
+  authoring that exact function, and the downstream consumer (0169) is currently
+  projected to miss its ≈ 38.6 ms ceiling by ~2.4 ms — this one guard is of the
+  same order as the entire shortfall.
+  **Suggestion**: Write
+  `ensure_dir() { [[ -d "$1" ]] || mkdir -p "$1" 2>/dev/null || return 1; }` —
+  bash-3.2-safe, tab-indented, behaviourally identical, and it removes the last
+  fork the always-run half performs on a warm call.
+
+- 🔵 **suggestion** (confidence: medium) — *No expected-composition budget, and
+  the 0.5x gate leaves ~33 ms of unnoticed slack*
+  **Location**: Desired End State; Performance Considerations; Phase 4 Success
+  Criteria
+  The plan predicts ~41 ms from `149.1 − 107.9` while simultaneously recording
+  (via its research) that the Context table's methodology "was never recorded" —
+  so the 107.9 ms subtrahend may itself carry unknown per-iteration harness
+  overhead, giving the prediction several milliseconds of untracked uncertainty.
+  Meanwhile the gate is `after ≤ 0.5 × before`: against a ~149 ms before that is
+  a 74.5 ms ceiling versus a ~41 ms expectation, i.e. ~33 ms of slack. An
+  implementation that left a third of the probe cost behind, or that introduced
+  33 ms of new warm-path work, would clear the gate unremarked.
+  **Impact**: A pass on the gate does not by itself confirm the probe was fully
+  removed, and there is no diagnostic path if the after-median lands at, say, 60
+  ms — it would be impossible to tell a partial removal from instrument overhead
+  from a new cost.
+  **Suggestion**: Record a predicted composition in Phase 4 (~23 ms hashing,
+  ~2.3 ms verify, ~3 ms launcher, ~12 ms bash+`uname` ×2+`sed`, ≈ 41 ms total)
+  and add a manual criterion that a deviation of more than ~25% from the
+  prediction must be attributed before the figure is recorded — a `bash -x` run
+  with per-line timestamps, or `sample`/`dtrace`, is enough. That turns the gate
+  from a floor into a check that the expected cost actually left.
+
+- 🔵 **suggestion** (confidence: medium) — *Remaining per-call fork inventory is
+  unenumerated despite being the next lever for 0169*
+  **Location**: Performance Considerations
+  After this change a warm `bin/accelerator` call still performs roughly six
+  forks and five execs before it reaches `exec "${launcher}"`: `mkdir` (inside
+  `resolve_cache_dir`'s own command-substitution subshell), `sed` over
+  `plugin.json`, `uname -m` and `uname -s` as two separate command substitutions,
+  `shasum`/`sha256sum` + `awk` twice, and two nested subshells for the
+  `cd -P`/`pwd -P` plugin-root resolution. Research §12 labelled the
+  `bash startup + uname ×2 + sed` bucket (~12 ms) "partly" addressable and
+  computed a ~18 ms fully-optimised floor, but neither the work item nor this
+  plan enumerates what is left or how big each piece is.
+  **Impact**: 0169 must decide whether to relax its `G ≤ 1.1 × B` gate on the
+  strength of what this plan records. Without an inventory of the remaining
+  levers and their sizes, that decision is made against a single aggregate
+  number.
+  **Suggestion**: Add the fork inventory to Phase 4's Validation Results entry
+  alongside the medians, calling out the two obvious cheap ones for a future
+  item: collapsing `uname -m` + `uname -s` into one `uname -sm` (or preferring
+  bash's `$OSTYPE`/`$MACHTYPE` with a `uname` fallback) while keeping both
+  `ACCELERATOR_UNAME_S`/`_M` test seams independent, and dropping the two `awk`
+  execs from `sha256_file` in favour of parameter expansion. Neither belongs in
+  this plan; both belong in the record 0169 reads.
+
+### Portability
+
+**Summary**: The plan is unusually careful about the environment it targets: it
+verifies the CI matrix has no `container:` key before relying on unprivileged
+lanes, spots the `.editorconfig` `[*.sh]` glob not matching the extensionless
+`bin/accelerator` (so tabs are required), keeps the probe's `#!/bin/sh`
+internals untouched, and writes a depth-tolerant trace regex plus a
+`${FUNCNAME[0]:-main}` default instead of assuming one interpreter's xtrace
+shape. I could not find a bash-4-only construct anywhere in the proposed diff —
+nothing in it trips `scripts/lint-bashisms.sh`'s denylist, and the
+backslash-continued double-quoted `fail` string matches the existing
+bash-3.2-safe idiom at `bin/accelerator:196`. The residual risks are all about
+the two environments the new tests must span: every empirical claim in Key
+Discoveries was measured on darwin/bash 3.2 with BSD userland, the `chmod 0o666`
+proxy for `noexec` behaves differently from a real `noexec` mount (the
+Linux-prevalent case) and routes through a different gate, and the Phase 4
+measurement uses `version` — the one command that by design never reaches the
+launcher's own write-chmod-exec cache-root probe, which still pays the same
+macOS first-exec penalty on every path a hook actually takes.
+
+**Strengths**:
+
+- The unprivileged-lane assumption is verified against the workflow rather than
+  assumed: `.github/workflows/main.yml`'s `test-integration` matrix is
+  `ubuntu-latest`/`macos-latest` with no `container:` key, so both GitHub-hosted
+  lanes genuinely run as a non-root user.
+- The `.editorconfig` interaction is correctly diagnosed: `[*.sh]`
+  (space/2/switch_case_indent) does not match the extensionless
+  `bin/accelerator`, `tasks/shared/sources.py:110` adds it to the shfmt/ShellCheck
+  scope explicitly, and shfmt is invoked with no formatting flags — so shfmt
+  defaults (tabs, no case indent) apply and the plan's tab-indented snippets are
+  right. `>"${probe}"` with no space also matches shfmt's default `-sr=off`.
+- No construct in the diff is bash-4-only or on `lint-bashisms.sh`'s denylist (no
+  associative arrays, namerefs, `mapfile`, case-modification expansions, `&>>`,
+  `|&`, negative subscripts, or escaped braces in a `:-` default), and
+  `${FUNCNAME[0]:-main}` is valid in 3.2.
+- The trace matcher allows one-or-more `+` rather than a fixed prefix depth,
+  which is the right defence against bash's PS4 first-character replication
+  differing by nesting context and interpreter version.
+- The probe's internals are unchanged — same `printf '#!/bin/sh\nexit 0\n'`,
+  `chmod +x`, exec, `rm` — so no new interpreter, shebang, or filesystem
+  assumption is introduced; only the call sites move.
+- Every permission-mutating test restores the mode in a `finally`, which is what
+  keeps pytest's `tmp_path` teardown working identically on macOS and Linux.
+- The new `version`-output assertions are triple-agnostic (`accelerator ` prefix
+  plus `commit: `/`built:  `/`target: ` prefixes), and
+  `cli/launcher/src/version/inbound/cli.rs:9` renders all four lines
+  unconditionally with `unknown` fallbacks — so the same case passes on
+  darwin-arm64 and linux-x64.
+- Migration Notes are correct that no on-disk format or environment contract
+  changes, so a cache populated before the change stays warm afterwards in any
+  environment.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *Gate B — the only guard for a real noexec
+  mount on a warm cache — gets no automated coverage on either lane*
+  **Location**: Phase 2, Section 1 (the two `noexec` cases); and Section 4 (Gate
+  B)
+  The plan retains a second probe call site (Gate B, at the top of the cold
+  branch) but no new automated case reaches it. Both `chmod 0o666` cases clear
+  the directory's *search* bit, which makes `[[ -x "${launcher}" ]]` and
+  `[[ -f "${launcher_sig}" ]]` fail to stat and therefore routes them through
+  **Gate A**. A genuine `noexec` mount is the opposite shape: the mode bits are
+  intact, so `[[ -x launcher ]]` is true and `[[ -f sig ]]` is true, Gate A does
+  not fire, `verify_launcher`'s exec of the staged shim fails, and only Gate B
+  produces the named diagnostic. Real `noexec` mounts (hardened `/tmp`, container
+  volumes, NFS, `ACCELERATOR_CACHE_DIR` pointed at a noexec path) are far more
+  common on Linux than on macOS, so the code path with zero automated coverage is
+  precisely the Linux-relevant one — and the plan itself relegates it to Manual
+  Testing Step 2.
+  **Impact**: A future edit that removes or reorders Gate B would silently
+  restore both the ~30 s `acquire_lock` spin and the loss of the
+  `no writable, exec-capable cache directory` diagnostic on Linux hosts with a
+  noexec cache dir, with the entire suite still green on both lanes.
+  **Suggestion**: Add one automated case that reaches Gate B without touching the
+  search bit — warm the cache, overwrite the launcher bytes so `verify_launcher`
+  fails while `-x`/`-f` stay true, `chmod 0o555` the cache dir so the probe's
+  write fails, then assert a non-zero exit with the cache-dir substring under a
+  short `timeout=` (which also pins the anti-hang property the plan justifies
+  Gate B with). That is the manual step, automated, and it is the only case that
+  distinguishes Gate B from Gate A.
+
+- 🟡 **major** (confidence: medium) — *All trace-shape evidence is from macOS bash
+  3.2; nothing in Phase 2 verifies the assertions under the linux lane's bash 5.x*
+  **Location**: Key Discoveries (PS4/trace bullets) and Phase 1, Section 2
+  The test harness pins `BASH = "/bin/bash"`
+  (`tests/integration/support/installation.py:41`), which is **bash 3.2.57 on the
+  darwin lane and bash 5.2 on the ubuntu lane**. Every trace observation in Key
+  Discoveries — the `set -u`/`FUNCNAME[0]` breakage, the `+probe_dir:printf …`
+  shape, the exec line as its own command word, the `++` depth inside `$( )` — is
+  measured on this darwin host only, yet the two trace assertions are the
+  load-bearing criteria (work-item criteria 2 and 3) and must pass on both lanes.
+  The `set -u` failure mode in particular is not merely noisier on bash 5: an
+  unbound expansion in a non-interactive bash 5 aborts the shell, so the `:-main`
+  default is load-bearing on Linux for a *different* reason than the one
+  recorded, and Phase 2's Success Criteria list only local darwin tasks while
+  cross-lane observation is deferred to Phase 4. Note also that the recorded
+  alternative, `SHELLOPTS=xtrace`, is **not** equivalent to `bash_args=("-x",)`:
+  `SHELLOPTS` is exported, so it is inherited by nested shells (including the
+  probe's own `#!/bin/sh`, which is bash on macOS and dash on Linux) and appears
+  in the launcher env dumps — making trace content platform-dependent in a way
+  the `-x` flag is not.
+  **Impact**: A bash-5-specific difference in traced-word quoting, prefix depth,
+  or the set of traced lines would only surface as a red ubuntu lane after Phase
+  2 has been declared "independently green and mergeable" on darwin.
+  **Suggestion**: Add a cross-interpreter verification step to Phase 2 rather
+  than Phase 4 — e.g. an opt-in interpreter override in the harness (defaulting
+  to `/bin/bash` so the floor is still the default) and a recorded run of the two
+  trace cases under a bash 5.x (Homebrew bash or a `bash:5` container). Keep `-x`
+  and note in a comment that `SHELLOPTS` is rejected because it leaks into
+  descendant shells whose identity differs by platform.
+
+- 🟡 **major** (confidence: medium) — *The same write-chmod-exec probe still runs
+  in the launcher for every external subcommand, so the docs claim and the
+  `version`-based measurement do not describe the paths hooks take*
+  **Location**: Phase 3, Sections 1 & 2; Phase 4, Section 1
+  The cost being removed is a macOS-specific first-exec penalty, and an identical
+  write-chmod-exec-rm probe remains in
+  `cli/launcher/src/launch/outbound/resolve/cache_root.rs:80-94`, invoked by
+  `LazyProductionResolver` in `cli/launcher/src/main.rs:65` for **every** external
+  subcommand dispatch. Built-ins (`version`, `config`) deliberately never reach it
+  ("built-ins never touch the cache root", `main.rs:50-53`). Phase 4 measures
+  `bin/accelerator version` — the one command that skips the launcher-side probe
+  — so the recorded after-median describes a path no hook uses, while
+  `accelerator vcs guard` (0169's gate) pays the macOS first-exec penalty again
+  inside the launcher. Phase 3's docs edit ("A warm start neither writes nor
+  probes; it runs the already-staged shim and launcher") and the changelog entry
+  ("Warm `accelerator` invocations are substantially faster") are therefore
+  accurate only for the bash bootstrap layer and only for built-in commands.
+  **Impact**: The recorded figure will overstate the improvement for the hook
+  path on darwin, and 0169's `≤ 1.1 × 35.1 ms` criterion is likely still
+  unreachable for a reason this plan's measurement cannot reveal.
+  **Suggestion**: Scope the docs and changelog wording explicitly to the
+  bootstrap ("the bootstrap no longer probes on a warm start; resolving an
+  external subcommand still probes the cache directory once"), and record a
+  second median for a real external-subcommand dispatch alongside the `version`
+  figure in Validation Results, naming `cache_root::resolve` as the next residual
+  so the 0169 hand-off note carries the whole picture.
+
+- 🔵 **minor** (confidence: high) — *The `chmod 0o666` rationale misstates POSIX
+  directory semantics, and the route it claims was measured only under BSD
+  userland*
+  **Location**: Phase 2, Section 1 — the paragraph justifying `chmod 0o666`
+  The plan justifies `chmod 0o666` over `chmod -x` with "`0o666` leaves the
+  directory writable, so `ensure_dir`'s `mkdir -p` and any preceding write still
+  succeed and the probe is genuinely the thing that fails". Clearing a
+  directory's execute (search) bit blocks **all** name resolution inside it
+  regardless of the write bit, so `printf … > "$dir/.accelerator-probe-$$"` fails
+  with `EACCES` on both platforms: the probe fails at its *write* step, never at
+  its exec step. Worse, whether `ensure_dir` succeeds at all is
+  userland-dependent — the "measured on this host" claim that `mkdir -p` tolerates
+  an existing search-bit-less directory comes from BSD `mkdir` on darwin; GNU
+  coreutils' `mkdir -p` uses a `chdir`-based ancestor walk and may fail instead,
+  in which case the case is discharged by `resolve_cache_dir` returning 1 at
+  `bin/accelerator:195` rather than by either probe gate. The substring assertion
+  passes either way, so the cases stay green while proving different things on the
+  two lanes.
+  **Impact**: A future reader takes the recorded rationale at face value and
+  believes the exec half is exercised, or believes both lanes exercise the same
+  gate; the exec-vs-write gap is then wider than the recorded limitation admits.
+  **Suggestion**: Correct the rationale to say the search bit is what fails
+  (write, not exec), and pin the route rather than inferring it — e.g. assert
+  `probe_exec_capable` appears in the trace for these two cases, or record
+  explicitly in Validation Results that the discharging code path may differ
+  between BSD and GNU `mkdir`.
+
+- 🔵 **minor** (confidence: high) — *Only the uid-0 half of the mandated
+  environment check is implemented; permission-advisory filesystems are left
+  undiagnosed*
+  **Location**: Phase 1, Section 3
+  The work item's Acceptance Criteria preamble requires two environment checks —
+  `id -u` **and**, "for a filesystem that ignores the permission bits, a temp-dir
+  check (`chmod 0o555` then assert file creation inside fails; `chmod -x` then
+  assert traversal fails)". `_require_unprivileged()` implements only
+  `os.getuid() != 0`. On filesystems where `chmod` is advisory or ignored — WSL
+  `drvfs` mounts without `metadata`, Docker Desktop bind mounts
+  (virtiofs/gRPC-FUSE), VirtualBox `vboxsf`/`9p` shares, and macOS directories
+  carrying an inherited ACL that grants write despite the mode —
+  `cache.chmod(0o666)` silently succeeds and the bootstrap still works, so
+  `test_cold_path_keeps_the_noexec_diagnostic` and
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` fail on
+  `assert result.returncode != 0` with no hint that the environment, not the
+  product, is at fault.
+  **Impact**: Contributors whose `TMPDIR` lands on such a filesystem see two hard
+  failures that look like a bootstrap regression, and the plan offers no
+  diagnosis path.
+  **Suggestion**: Add the mandated temp-dir capability check next to
+  `_require_unprivileged` (create a dir, `chmod 0o555`, assert a write inside
+  raises `PermissionError`) and call it from the three permission-dependent
+  cases, failing with a message that names the filesystem as the cause and points
+  at the recorded-exclusion rule.
+
+- 🔵 **minor** (confidence: high) — *The measurement loop puts a `python3`
+  interpreter start inside the timed interval, making both medians host-specific
+  and the ratio gate harder to clear*
+  **Location**: Phase 4, Section 1
+  The loop reads the clock with
+  `start=$(python3 -c 'import time; print(time.time_ns())')` before and
+  `end=$(…)` after each call, so each measured interval contains one full
+  `python3` process start (fork/exec plus interpreter init) in addition to the
+  `bin/accelerator` call. That constant is highly host- and
+  environment-specific: ~20-40 ms for a normal CPython, more when `python3`
+  resolves through a `mise` shim or macOS's Xcode CLT stub. Because it is added
+  to *both* medians, it inflates the ratio (`(41+c)/(149+c)`) — at c ≈ 60 ms the
+  gate `after ≤ 0.5 × before` is marginal for a fully correct implementation.
+  There is also no exit-status check per iteration (`set -uo pipefail`, no `-e`,
+  output discarded), so a warm call that fails fast is timed as a fast call.
+  **Impact**: The recorded figures are not comparable with the 2026-07-30 Context
+  table or reproducible on another host, and the gate can fail a correct change
+  or pass a broken one.
+  **Suggestion**: Drive the whole loop from a single `python3` process
+  (`subprocess.run` timed with `time.perf_counter_ns`, asserting
+  `returncode == 0`), or keep bash and time with `perl -MTime::HiRes` once per
+  run — noting in the recorded method *why* bash alone cannot do it (bash 3.2 has
+  no `EPOCHREALTIME` and BSD `date` has no `%N`), so the next person does not
+  reinvent the same biased loop.
+
+- 🔵 **suggestion** (confidence: medium) — *Root containers lose the whole
+  entrypoint suite with no documented deselect path*
+  **Location**: Phase 1, Sections 3 and 4
+  `_require_unprivileged()` hard-fails under uid 0 (deliberately, and correctly
+  for the reason given), and Phase 1 retrofits it onto three cases that pass
+  today. Running the integration suite as root is a normal local configuration —
+  a plain `docker run` on the repo, many devcontainer base images, and any GitHub
+  Actions job that later gains a `container:` key. In those environments six
+  cases become hard failures, and the plan provides no supported way to run the
+  remainder: the assertion is unconditional, so a root user cannot deselect it
+  without editing the file.
+  **Impact**: A contributor working in a root container cannot get a meaningful
+  signal from `mise run test:integration:entrypoint` at all, which invites
+  exactly the silent local `-k` workaround the hard-fail is meant to prevent.
+  **Suggestion**: Put the guard behind a pytest marker (e.g.
+  `@pytest.mark.requires_unprivileged`, registered in `pyproject.toml`) as well
+  as the assert, so the exclusion is `-m 'not requires_unprivileged'` — explicit,
+  greppable, and recordable in Validation Results per the work item's exclusion
+  rule — while an unmarked default run still hard-fails under uid 0.
+
+- 🔵 **suggestion** (confidence: high) — *Pin the extensionless entry point's
+  formatter settings in `.editorconfig` instead of relying on shfmt defaults*
+  **Location**: Key Discoveries — "`bin/accelerator` is tab-indented and must
+  stay so"
+  The plan correctly identifies that `.editorconfig`'s `[*.sh]` section does not
+  match the extensionless `bin/accelerator`, so shfmt falls back to its own
+  defaults (tabs, `switch_case_indent` off) for the single most-executed shell
+  file in the repo — which is why its `case` arms sit at column 0 while every
+  `.sh` file's are indented. The plan handles this by hand for its own snippets,
+  but the underlying config gap stays: the file's format is an accident of
+  shfmt's defaults rather than a declared setting, and a future shfmt default
+  change or a well-meaning `[*.sh]` edit would reformat the trust-root entry
+  point wholesale.
+  **Impact**: The next contributor touching `bin/accelerator` re-discovers the
+  trap the same way, or a toolchain bump produces a large unrelated diff in the
+  file every hook executes.
+  **Suggestion**: Add an explicit `[bin/accelerator]` section to `.editorconfig`
+  declaring the current shape (`indent_style = tab`,
+  `switch_case_indent = false`) with a one-line comment that shfmt's
+  `.editorconfig` matching is extension-based and this file has none — making
+  today's formatting intentional and stable without reformatting anything.
+
+### Standards
+
+**Summary**: The plan is unusually disciplined about project conventions: every
+`mise run` task name it quotes exists, every line reference I spot-checked into
+`bin/accelerator`, `installation.py`, the entrypoint suite, the hooks suite and
+`main.yml` is accurate against the current tree, and the proposed Python and bash
+both match their host files' established idioms (leading-underscore helpers,
+harness-first helper signature, the `kwargs.pop("extra_env")` + `# type: ignore`
+pattern, tab indentation reasoned correctly from `.editorconfig`'s `[*.sh]` not
+matching an extensionless file). Three convention defects are load-bearing: the
+`docs/internals.md` replacement text silently drops the release-base-URL trust
+guidance that shares the quoted line range; Phase 1 introduces regex helpers
+while deferring `import re` to Phase 2, so Phase 1 alone fails `ruff` and is not
+independently mergeable as claimed; and `mise run check` is credited with
+markdown lint and work-item frontmatter validation that it does not perform (no
+markdown linter exists anywhere in the task tree), leaving Phase 3 with no real
+automated gate. Smaller items: `no_cache_dir` breaks the file's verb-led
+function-naming convention, the plan contradicts itself on whether the diagnostic
+string gets a single definition, and the plan document itself carries 16
+over-80-column lines where the work item it derives from has zero.
+
+**Strengths**:
+
+- Every `mise run` task name quoted in the Success Criteria exists in
+  `mise.toml`: `test:integration:entrypoint`, `test:integration:skill-invocation`,
+  `build-system:check`, `scripts:check` and `check` are all real leaves, and the
+  plan correctly declines to add a new `test:integration:*` leaf (which would also
+  have needed the no-`build:cli:dev` invariant re-checked).
+- Line references are accurate against the current post-0182 tree —
+  `bin/accelerator:166-180` (probe_dir), `:184-193` (resolve_cache_dir),
+  `:195-197` (diagnostic), `:252-261` (shim staging), `:305-307`, `:336-348`,
+  `:352`; `installation.py:149-157` (build_launcher) and `:324-369`
+  (run_bootstrap); the entrypoint suite's `:253`, `:279`, `:584-644`,
+  `:772`/`:787`/`:801`, `:1060`; `hooks/test_launcher_link_refresh.py:275-293`
+  (the skipif it deliberately diverges from); and `main.yml:55-91` (the
+  `test-integration` matrix, correctly noted as having no `container:` key).
+- The proposed Python follows the entrypoint suite's conventions closely:
+  leading-underscore module-level helpers, a harness-first
+  `_traced(harness, downloader, **kwargs)` signature mirroring the existing
+  `_run_and_capture_env`, the identical
+  `dict(kwargs.pop("extra_env", None) or {})  # type: ignore[arg-type]` idiom,
+  `os.getuid()` matching the neighbouring guard's expression,
+  `finally`-restored modes matching the existing `chmod` tests, and snippets that
+  are ruff-format-stable within 80 columns.
+- The new section divider drops the stale `Phase 0:` prefix the four existing
+  dividers carry, matching the phase-free `# ── Self-location ──` form —
+  consistent with the project's stance against embedding planning references in
+  code.
+- The proposed bash matches `bin/accelerator`'s own idiom: tab indentation
+  (correctly derived from `.editorconfig`'s `[*.sh]` section not matching an
+  extensionless file, so shfmt falls back to tab defaults), bare globals with no
+  `local`, a `probed=""` / `probed=1` boolean shape mirroring `lock_held`, a
+  backslash-continued `fail` message mirroring `:196-197` and `:224-225`, and
+  mid-script function definitions as the file already does for `sha256_file`,
+  `acquire_lock` and `verify_launcher`.
+- The CHANGELOG target exists exactly as claimed — `## [Unreleased]` with an open
+  `### Changed` — and the proposed bullet's bold lead-in sentence followed by
+  explanatory prose matches the shape of every neighbouring entry.
+- Deliberate convention deviations are named and justified rather than taken
+  silently: the `PS4='+${FUNCNAME[0]:-main}:'` fix against the criterion's literal
+  wording, the real-launcher route against the fixture-version assertion, and the
+  hard-fail guard against the neighbouring `skipif` — each with a recording
+  obligation in Phase 4.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *The `docs/internals.md` replacement drops the
+  release-base-URL guidance that shares its line range*
+  **Location**: Phase 3, Change 1: Internals documentation
+  The plan instructs the implementer to replace `docs/internals.md:207-209` with
+  a three-sentence block, but the current text at 207-212 is *two* sentences
+  sharing those lines: the probe sentence ends mid-line-209 ("…not
+  group-writable.") and the release-base-URL trust guidance ("The release base URL
+  should be a host you trust not to serve an older signed release: the cache key
+  carries no content hash, so a mirror can hand back an older validly-signed
+  launcher for the current version.") begins on the same line and runs to 212. The
+  proposed replacement omits that second sentence entirely, and the quoted prose
+  is also not wrapped to the repo-wide 80-column width set in `.editorconfig`
+  `[*]` (its first line is 81 characters as written).
+  **Impact**: Applied literally, the edit either deletes the mirror-downgrade
+  warning for the other trust-root environment variable documented in the same
+  paragraph, or leaves a mangled paragraph — and there is no markdown linter in
+  the task tree to catch either.
+  **Suggestion**: Quote the replacement as the full 207-212 paragraph including
+  the unchanged release-base-URL sentence, pre-wrapped at 80 columns, and state
+  the range as `:207-212` so the boundaries land on line ends.
+
+- 🟡 **major** (confidence: high) — *Phase 1 adds regex helpers but defers
+  `import re` to Phase 2, so Phase 1 fails ruff*
+  **Location**: Phase 1, Change 2 (vs Phase 2, Change 1)
+  Phase 1 adds `_entered` and `_ran_probe_file` to
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py`, both of which
+  call `re.search`, but the instruction "Add `import re` to the module imports"
+  appears only at the end of Phase 2's regression-case section. The module
+  currently imports `concurrent.futures`, `hashlib`, `os`, `platform`, `shutil`,
+  `subprocess` — not `re`. `lint:build-system:check` runs `uv run ruff check` from
+  the repo root over the whole tree, and the `"tests/**"` per-file-ignores in
+  `pyproject.toml` drop only `S`, `ANN`, `D`, `PLR2004`, `SLF001`, `PT`, `INP001`
+  — `F` stays enabled, so `F821 undefined-name: re` fires.
+  **Impact**: Phase 1 as specified fails its own `mise run build-system:check`
+  and `mise run check` criteria, breaking the plan's stated invariant that each
+  phase is independently green and mergeable.
+  **Suggestion**: Move the `import re` instruction into Phase 1 alongside the
+  helpers that need it, and drop it from Phase 2.
+
+- 🟡 **major** (confidence: high) — *`mise run check` performs neither markdown
+  lint nor frontmatter validation*
+  **Location**: Phase 3 Success Criteria; Phase 4 Success Criteria
+  Phase 3's sole automated criterion is "Markdown format and lint pass:
+  `mise run check`" and Phase 4's is "Work item frontmatter validates:
+  `mise run check`". Neither is true: `check` folds `frontend:check`,
+  `server:check`, `cli:check`, `deny:check`, `pup:check`, `build-system:check` and
+  `scripts:check` only — there is no markdown formatter or linter anywhere in
+  `mise.toml` or `tasks/` (the `.md` references in `tasks/` are all SKILL.md
+  content guards), and meta-corpus frontmatter validation lives in
+  `scripts/test-validate-corpus-frontmatter.sh`, run from the
+  `test:integration:config` shell suites, not from `check`.
+  **Impact**: Phase 3 (a docs + changelog phase) has no real automated
+  verification while appearing to have one, and Phase 4 claims a frontmatter gate
+  that will never run — so a malformed `## [Unreleased]` bullet or work-item
+  frontmatter would ship green.
+  **Suggestion**: Drop the false attributions — make Phase 3's verification purely
+  manual (or add `mise run test:integration:config` if the corpus validator is
+  genuinely wanted), and for Phase 4 name the suite that actually validates meta
+  frontmatter rather than `check`.
+
+- 🔵 **minor** (confidence: high) — *`no_cache_dir` breaks the file's verb-led
+  function-naming convention*
+  **Location**: Phase 2, Change 4
+  The new shell helper is named `no_cache_dir`, a noun phrase, in a file whose
+  functions are uniformly verb-led — `fail`, `fail_integrity`, `dir_of`,
+  `probe_dir`, `resolve_cache_dir`, `sha256_file`, `acquire_lock`, `release_lock`,
+  `verify_launcher`, `fetch_and_verify`, `dev_launcher_contained` — and whose two
+  existing abort helpers in particular are `fail` and `fail_integrity`. Read at
+  the call site (`probe_exec_capable "${cache_dir}" || no_cache_dir`) it looks
+  like a predicate rather than the fatal exit it is.
+  **Impact**: A reader scanning `bin/accelerator` — the plugin's trust root, and a
+  file every SessionStart hook executes — cannot tell from the name that control
+  never returns.
+  **Suggestion**: Name it `fail_no_cache_dir` (or `fail_cache_dir`), matching the
+  existing `fail_*` abort-helper family.
+
+- 🔵 **minor** (confidence: high) — *The same paragraph gives contradictory
+  instructions about the diagnostic string*
+  **Location**: Phase 2, Change 4
+  It first says "The existing `fail` at `:195-197` is rewritten to call the same
+  wording via `no_cache_dir` so the substring has one definition", then
+  immediately retracts it: "`no_cache_dir` … interpolates `${cache_dir}` — which
+  is unset at that point — so the `:195` call site keeps its own literal
+  `${plugin_root}/bin` message". The end state is two independent literal copies
+  of `no writable, exec-capable cache directory`, which four of the plan's tests
+  assert as a substring.
+  **Impact**: An implementer working top-down performs the first edit before
+  reading the retraction, and the plan's stated "one definition" property is not
+  what the design actually delivers — a later edit to one copy silently diverges
+  from the other with tests still green.
+  **Suggestion**: Delete the retracted sentence so only the final shape is
+  stated, and say explicitly that the substring exists twice by construction (with
+  the `${cache_dir}`-unset reason) so nobody "fixes" the duplication later.
+
+- 🔵 **minor** (confidence: medium) — *The retrofit extends the hard-fail rule
+  beyond the work item's scope, past the repo's own `skipif` idiom*
+  **Location**: Phase 1, Change 4
+  Phase 1 retrofits the hard-failing `_require_unprivileged()` onto three
+  *pre-existing* tests (`test_readonly_root_with_override_runs_from_override`,
+  `test_readonly_root_without_override_is_a_named_error`,
+  `test_a_record_is_always_one_line`). The work item's hard-fail rule is scoped to
+  "three automated criteria [that] are permission-dependent" among the new cases;
+  the repo's established idiom for the pre-existing set is
+  `@pytest.mark.skipif(os.getuid() == 0, reason="mode bits are advisory for uid 0")`
+  (`tests/integration/hooks/test_launcher_link_refresh.py:275-277`), and two of
+  the three retrofitted tests pass today under uid 0.
+  **Impact**: `mise run test:integration:entrypoint` becomes a hard failure in any
+  root context (a root Docker dev container, for example) where it currently runs
+  green, and the file ends up carrying two competing privilege idioms without the
+  work item having mandated the change for the existing cases.
+  **Suggestion**: Either scope the hard-fail guard to the new cases the work
+  item's rule governs and use the neighbouring `skipif` for the retrofit, or state
+  explicitly in the plan that the retrofit deliberately extends the rule beyond
+  the work item's scope and record the consequence for root-privileged lanes.
+
+- 🔵 **minor** (confidence: medium) — *Test comments cross-reference sibling tests
+  and restate acceptance-criteria rationale*
+  **Location**: Phase 2, Change 1
+  Three of the six proposed test bodies open with comments that cross-reference
+  other tests by name — "`test_warm_path_does_not_enter_the_probe` covers that",
+  "Routing is pinned by `test_cold_path_enters_and_executes_the_probe`", "see
+  criterion 5" — and largely restate acceptance-criteria rationale already
+  recorded in the work item and the plan's own Testing Strategy. The project's
+  plan-authoring standard has a very low tolerance for comments and explicitly
+  bans references that "can go stale fast"; a hard-coded sibling test name is
+  exactly that.
+  **Impact**: Renaming or splitting one case leaves dangling references in two
+  others, and the duplicated rationale drifts from the work item that owns it.
+  **Suggestion**: Keep only the comments that signal something genuinely
+  non-obvious to a reader of the code (the bash 3.2 / `set -u` PS4 note
+  qualifies), and drop the test-name cross-references and criterion numbers — the
+  Testing Strategy section already carries the coverage argument.
+
+- 🔵 **minor** (confidence: medium) — *The changelog entry is mechanism-heavy and
+  cannot pass its own verification step*
+  **Location**: Phase 3, Change 2
+  The drafted `## [Unreleased]` / `### Changed` entry is mostly mechanism — it
+  names the probe file, `chmod`, the macOS first-exec check, the cold/warm split
+  and the staged verifier — while the same phase's own manual criterion reads "The
+  changelog entry describes user-visible behaviour, not the mechanism".
+  Neighbouring entries ("Interactive option panels replace typed confirmations
+  across 15 skills", "Migration framework — more robust and resilient") lead with
+  the observable effect and keep internals to a minimum.
+  **Impact**: As drafted the entry cannot pass its own verification step, and it
+  exposes bootstrap internals in the user-facing changelog where the surrounding
+  entries do not.
+  **Suggestion**: Reduce the entry to the observable change (warm invocations, and
+  therefore every SessionStart hook, are substantially faster; a `noexec` cache
+  directory still fails with the same named error) and move the probe/first-exec
+  attribution to the work item's Validation Results, which already records it.
+
+- 🔵 **minor** (confidence: high) — *The plan document carries 16 lines over 80
+  characters*
+  **Location**: Plan document (frontmatter through References)
+  `.editorconfig` sets `max_line_length = 80` for `[*]`, and the work item this
+  plan derives from has **zero** lines over 80 — including its own long
+  `meta/work/...` and `meta/research/...` path references, which it wraps. The
+  over-long lines here are the Current State Analysis table rows, several Success
+  Criteria bullets such as "`mise run test:integration:skill-invocation`", the
+  `docs/internals.md` quote, and most of the References list.
+  **Impact**: The repo-wide 80-column convention is hand-maintained with no
+  automated check for markdown, so drift in the highest-traffic planning artefacts
+  is how it erodes; it also makes the plan harder to diff and review side-by-side.
+  **Suggestion**: Rewrap the over-long lines the way the work item does — split
+  table cells, put long task names on their own continuation line under the
+  criterion, and wrap reference paths onto the following indented line.
+
+- 🔵 **suggestion** (confidence: medium) — *The bash-3.2 gate is invoked raw
+  rather than through its mise leaf, and is redundant with the next criterion*
+  **Location**: Phase 2 Success Criteria
+  The criterion "Bash 3.2 gate passes: `scripts/lint-bashisms.sh`" invokes the raw
+  script when a mise leaf exists for it (`lint:scripts:bashisms:check`), and the
+  very next criterion (`mise run scripts:check`) already folds it via
+  `lint:scripts:check`. `CLAUDE.md` states all dev tasks run through
+  `mise run <task>`, and the one sanctioned exception is dropping to the
+  underlying runner to filter a single *test*. Note also that a bare
+  `scripts/lint-bashisms.sh` discovers its file list via `git ls-files '*.sh'`,
+  which is blind inside a jj workspace checkout (it still scans `bin/accelerator`,
+  which is appended unconditionally, so the criterion happens to work — but for
+  the wrong reason).
+  **Impact**: A criterion that bypasses the task tree teaches the wrong entry
+  point and hides the fact that the check is already covered by the following
+  line.
+  **Suggestion**: Replace it with `mise run lint:scripts:bashisms:check` if a
+  standalone bash-3.2 gate is wanted, or drop it as redundant with
+  `mise run scripts:check`.
+
+### Documentation
+
+**Summary**: The plan's documentation work is unusually well-targeted for its
+size: I grepped the whole shipped tree (`docs/`, `README.md`, `skills/`,
+`hooks/`, `scripts/`, ADRs, `CHANGELOG.md`) and `docs/internals.md:207-209`
+really is the only prose site that this change falsifies, so Phase 3 has not
+missed a second paragraph. The weaknesses are elsewhere: the durable record of
+this change's two hardest-won rationales (why the second `probe_once` call site
+exists, why the launcher-path hoist is load-bearing) lives only in the plan and
+the work item, not in `bin/accelerator` — a file whose own convention is a dense
+why-comment on every non-obvious construct; the `docs/internals.md` edit
+instruction quotes a replacement block that stops mid-paragraph and would orphan
+the trust-relevant release-base-URL sentence; and Phase 2 item 4 contains a
+paragraph that states one edit and then retracts it, which an implementer reading
+top-down will get wrong. The changelog entry is also inverted against its own
+success criterion — mostly mechanism, no quantification, and silent about the
+newly supported read-only-cache configuration.
+
+**Strengths**:
+
+- Phase 3's single documentation target is correct and complete: an exhaustive
+  grep for `probe`, `ACCELERATOR_CACHE_DIR`, `noexec` and `exec-capable` across
+  `docs/`, `README.md`, `skills/`, `hooks/`, `scripts/` and `meta/decisions/`
+  finds no other shipped statement about the probe or per-invocation bootstrap
+  behaviour, so the plan has not under-scoped the prose work.
+- `bin/accelerator`'s file header (lines 3-20) documents the fetch-verify-cache
+  contract and the test seams but never mentions the probe, so the plan is right
+  that no header rewrite is forced by this change.
+- The new `probe_exec_capable` comment is why-focused and states both the hazard
+  it catches (a noexec mount a write-only check would pass) and why the warm path
+  needs no equivalent (the staged shim and launcher prove the same capability for
+  real).
+- `_require_unprivileged`'s docstring records why it hard-fails instead of
+  skipping, and Phase 1 adds a manual criterion that a later reader does not "fix"
+  it back to the neighbouring `skipif` idiom — exactly the kind of decision that
+  otherwise gets silently reverted.
+- The bash-3.2 `PS4`/`set -u` discovery is captured as a comment at its point of
+  use above the `_PS4` constant, not only in the plan.
+- Each new test carries an inline comment stating what it does *and does not*
+  prove (e.g. the warm `chmod 0o555` case cannot catch a non-fatal surviving
+  probe; the warmed-then-non-executable case is an end-state guard, not proof of
+  routing) — this is the project's existing convention in this module and it is
+  followed.
+- Migration Notes correctly and briefly states that no on-disk format, cache
+  layout or environment contract changes, which is the right answer for the
+  changelog audience.
+- The new test section banner (`# ── Exec probe: cold-path only ──`) matches the
+  module's existing banner convention, keeping the suite navigable.
+
+**Findings**:
+
+- 🟡 **major** (confidence: high) — *Phase 2 item 4 states an edit and then
+  retracts it in the same paragraph*
+  **Location**: Phase 2, Change 4
+  The paragraph after the code block first says "The existing `fail` at
+  `:195-197` is rewritten to call the same wording via `no_cache_dir` so the
+  substring has one definition", then in the next sentence says the opposite: "so
+  the `:195` call site keeps its own literal `${plugin_root}/bin` message and only
+  the two probe gates route through `no_cache_dir`". An implementer reading the
+  phase top-down performs the first edit before reaching the retraction, and the
+  first sentence's stated goal (one definition of the
+  `no writable, exec-capable cache directory` substring that six tests assert on)
+  is not what the plan actually lands.
+  **Impact**: The most delicate instruction in the production phase is
+  self-contradictory, so the diagnostic wording — asserted as a literal substring
+  by two of the six new tests and one existing test — can be edited into a state
+  the plan did not intend, and the reviewer of the resulting diff cannot tell
+  which shape was chosen deliberately.
+  **Suggestion**: Delete the retracted first sentence and state the outcome once:
+  two `fail` sites, the `:195` one keeping its literal `${plugin_root}/bin`
+  message because `cache_dir` is not yet bound, and `no_cache_dir` covering both
+  probe gates — then add the reason the duplication is accepted, and pair the two
+  sites with a short cross-referencing comment in the script so the shared
+  substring is not drifted apart by a later edit.
+
+- 🟡 **major** (confidence: high) — *The rationales for Gate B and the hoisted
+  launcher paths never reach the script*
+  **Location**: Phase 2, Change 4 / Key Discoveries
+  The plan's Key Discoveries record two facts that a future editor of
+  `bin/accelerator` must know — that the second `probe_once` call site in the cold
+  branch exists to stop a ~30 second `acquire_lock` spin in the
+  verification-failed/unwritable-directory case, and that the
+  `launcher`/`launcher_sig` assignments were hoisted above shim staging *because
+  Gate A depends on them* — but both are destined only for the plan and the work
+  item's Validation Results ("so the reasoning survives for anyone tempted to
+  remove it"). The proposed code has no comment on Gate B, none on the `probed`
+  flag explaining why idempotence matters (both gates can fire in one cold
+  invocation, which would otherwise pay the ~108 ms probe twice), and none marking
+  the hoisted assignments' position as load-bearing.
+  **Impact**: `bin/accelerator` is a 350-line file where every non-obvious
+  construct already carries a why-comment (the `dir_of` `${dir:-/}` arm, the
+  16-hop bound, `cd -P` vs `cd`, the content-addressed shim staging); a maintainer
+  will read the script and not the plan, so `probe_once` appearing twice with no
+  explanation is the most likely thing in this change to be "tidied" back into a
+  single call site, silently reintroducing the 30-second hang.
+  **Suggestion**: Add three short comments to the Phase 2 snippets: one above Gate
+  B naming the residual case and the lock-spin it prevents, one on `probed`
+  stating that the two gates are mutually reachable in a single cold run, and one
+  line on the hoisted assignments noting Gate A reads them (and that `base_url`
+  deliberately stays behind). Consider also one clause in the file header contract
+  summary recording the cold/warm capability-check asymmetry, since the header is
+  the first thing a reader of the changed file sees.
+
+- 🟡 **major** (confidence: medium) — *The quoted `internals.md` replacement would
+  orphan the release-base-URL sentence*
+  **Location**: Phase 3, Change 1
+  Phase 3 says "At `:207-209`, qualify the probe as a cold-path behaviour" and
+  then quotes a three-sentence replacement block that ends at "…runs the
+  already-staged shim and launcher from that directory instead." But
+  `docs/internals.md:209` reads
+  `at a directory you own and that is not group-writable. The release base URL` —
+  the line straddles a sentence boundary, and the quoted block does not carry the
+  release-base-URL sentence forward. A literal 207-209 replacement leaves the
+  surviving text starting
+  `should be a host you trust not to serve an older signed release: …`, with no
+  subject.
+  **Impact**: The dropped sentence is the trust-root warning about mirrors serving
+  an older validly-signed launcher — the more security-relevant half of the
+  paragraph — and the resulting fragment would ship as broken prose in the
+  user-facing internals guide.
+  **Suggestion**: Quote the whole paragraph as it should read after the edit,
+  including the unchanged release-base-URL sentence, rather than a partial block
+  against a line range that ends mid-sentence.
+
+- 🟡 **major** (confidence: medium) — *The newly supported read-only warm cache is
+  left undocumented in the section that exists for it*
+  **Location**: Phase 3: Documentation
+  After this change a fully read-only cache directory with a pre-populated
+  launcher works on the warm path — `mkdir -p` succeeds on an existing directory,
+  Gate A does not fire, and no write occurs; the plan's own
+  `test_warm_path_survives_a_non_writable_cache_dir` (`chmod 0o555`) pins exactly
+  that, and today the same invocation fails with
+  `no writable, exec-capable cache directory`. The section Phase 3 edits is titled
+  "Offline, mirrored and read-only installs", yet the proposed replacement only
+  says a warm start "neither writes nor probes" and never states the
+  operator-visible consequence, and the changelog entry does not mention it
+  either.
+  **Impact**: The one audience most affected by this change — operators running
+  mirrored or locked-down installs, who are already reading that exact section —
+  cannot learn from the docs that a configuration which previously aborted is now
+  supported, and will keep provisioning a writable cache directory they no longer
+  need for steady-state use.
+  **Suggestion**: Add one sentence to the edited paragraph stating that a cache
+  directory populated once may afterwards be read-only for warm invocations (cold
+  starts — a new plugin version, or a failed verification — still need it writable
+  and exec-capable), and reflect the same fact in the changelog entry.
+
+- 🟡 **minor** (confidence: high) — *The retained `:195` diagnostic now names
+  conditions its call site no longer tests*
+  **Location**: Phase 2, Change 3
+  The plan keeps the `:195-197` message
+  `no writable, exec-capable cache directory: … is not usable and no ACCELERATOR_CACHE_DIR override was given`
+  unchanged, while reducing that call site to `ensure_dir`, i.e. a bare
+  `mkdir -p`. After the change this failure can only mean "the directory could not
+  be created"; writability of an existing directory and exec capability are tested
+  later, at the probe gates, which emit the same words.
+  **Impact**: A user hitting the `:195` failure is told the directory is not
+  writable or not exec-capable when neither was checked, and a maintainer
+  diagnosing the message cannot tell which of two call sites produced it since the
+  wording is now identical at both.
+  **Suggestion**: Keep the asserted substring (the tests depend on it) but
+  distinguish the tails — e.g. append "could not be created" at the `:195` site —
+  or, if the wording must stay byte-identical, add a comment at both sites
+  recording that the substring is deliberately shared and which condition each
+  site actually detects.
+
+- 🔵 **minor** (confidence: high) — *Changelog entry is mechanism-heavy,
+  unquantified, and contradicts its own success criterion*
+  **Location**: Phase 3, Change 2
+  The drafted entry opens with one user-facing sentence and then spends three
+  clauses on mechanism (probe file, `chmod`, macOS first-exec check, `noexec`
+  cache directory, staged verifier), while Phase 3's own manual criterion says
+  "The changelog entry describes user-visible behaviour, not the mechanism". It
+  also omits the two things a reader of `CHANGELOG.md` can act on: the size of the
+  win (~108 ms of a ~149 ms warm call on darwin, per the work item's measured
+  table) and where they will notice it (every SessionStart hook and every skill
+  `!`-site that shells out to the CLI).
+  **Impact**: The entry reads as an internal note rather than a release note, so
+  users cannot judge whether the change matters to them, and the phase ships with
+  a manual criterion its own artefact fails.
+  **Suggestion**: Lead with the observable effect and a figure ("warm invocations
+  drop from roughly 150 ms to roughly 40 ms on macOS, so session start and every
+  skill's live-context command are noticeably faster"), keep one sentence of
+  mechanism, and drop the rest. `### Changed` is a defensible home given the
+  section already exists, though earlier releases in this file use `### Improved`
+  for exactly this kind of entry.
+
+- 🔵 **minor** (confidence: medium) — *The documentation phases' automated checks
+  verify nothing about the files they edit*
+  **Location**: Phase 3 and Phase 4: Success Criteria / Automated Verification
+  Phase 3's only automated criterion is "Markdown format and lint pass:
+  `mise run check`", and Phase 4 claims "Work item frontmatter validates:
+  `mise run check`". `mise run check` composes `format:check` and `lint:check`
+  over exactly the frontend, server, cli, build-system and scripts components,
+  with no markdown formatter or linter and no corpus-frontmatter validation; the
+  markdown 80-column convention is enforced by hand.
+  **Impact**: Both documentation phases appear gated when they are not, so a
+  mis-wrapped paragraph, a broken cross-reference, or a truncated
+  `docs/internals.md` paragraph (see the related Phase 3 finding) would pass every
+  stated check.
+  **Suggestion**: Replace those criteria with honest manual ones — e.g. re-read
+  the edited `docs/internals.md` section end-to-end for a complete paragraph and
+  80-column wrapping, and confirm the changelog entry sits under the existing
+  `## [Unreleased]` / `### Changed` heading — or name the specific task that
+  actually validates the corpus if one exists.
+
+- 🔵 **minor** (confidence: medium) — *New shared-harness seam added without
+  recording its contract or the rejected alternative*
+  **Location**: Phase 1, Changes 1-2
+  `run_bootstrap` in `tests/integration/support/installation.py` carries a prose
+  docstring that exists specifically to record non-obvious behaviour for its
+  consumers, and Phase 1 adds a `bash_args` keyword to it without touching that
+  docstring. Three constraints stay in the plan only: that the empty default must
+  remain because `tests/integration/skill-invocation/` shares the funnel; that
+  xtrace must never be a global mode because it lands on stderr and would break
+  every existing `assert … in result.stderr`; and that the plan measured a simpler
+  route it then did not take (`SHELLOPTS=xtrace` through the existing `extra_env`,
+  needing no harness change at all) with no rationale for preferring the new
+  parameter.
+  **Impact**: The next author to add a trace-based case has no in-repo signal that
+  per-call tracing is deliberate rather than incidental, and the funnel gains an
+  undocumented parameter that a second suite silently depends on defaulting to
+  empty.
+  **Suggestion**: Add one clause to `run_bootstrap`'s docstring naming
+  `bash_args` and the shared-consumer constraint, give `_traced` a one-line
+  docstring stating why tracing is per-call and never global, and record in the
+  plan why `bash_args` was chosen over the discovered `SHELLOPTS` route.
+
+- 🔵 **minor** (confidence: medium) — *Six of the eleven pending Validation
+  Results entries get no stated evidence shape*
+  **Location**: Phase 4, Change 2
+  Phase 4 says "Replace each _pending_ entry" and then enumerates only the
+  measurement, the lanes, the exec-vs-write limitation, the PS4 deviation, the
+  criterion-1 amendment and the second call site. The work item's other pending
+  entries — warm-path exec-probe-free check, direct probe-absence check, positive
+  control, `noexec` cold-path check, cold happy-path (`ensure_dir`) check, and
+  diagnostic-preserved-on-warmed-then-non-executable — get no guidance on what to
+  record, and nothing anywhere states the criterion-to-test-name mapping (six
+  criteria, six new test functions with different names). The plan also splits the
+  work item's criterion 3, which requires the positive control to ride on the
+  *cold happy-path run* of criterion 6, into two separate tests (a traced
+  default-launcher run and an untraced `real_launcher` run) without recording that
+  as a deviation, although smaller deviations get their own bullet.
+  **Impact**: Validation Results is the durable record a later reader consults to
+  know which permanent guard discharges which criterion; without the mapping the
+  closeout can be ticked with prose that no longer traces to a test, and the
+  criterion-3 split is an undocumented reinterpretation of a load-bearing
+  criterion.
+  **Suggestion**: List the six per-check entries with the test function name that
+  discharges each, and add a bullet recording that the positive control was
+  implemented as its own cold run rather than sharing criterion 6's run, with the
+  reason (the real-launcher run is not traced).
+
+- 🔵 **minor** (confidence: medium) — *The staging comment's "(cheap)" becomes
+  misleading once the probe is gone*
+  **Location**: What We're NOT Doing / Performance Considerations
+  The comment above shim staging (`bin/accelerator:246-251`) says the
+  content-addressed scheme means "a warm call re-hashes (cheap) instead of
+  re-copying 475KB". After this change that re-hash is the single largest
+  remaining warm-path cost — the plan itself puts it at ~11.7 ms of a ~41 ms warm
+  call, and 0169's latency criterion turns on it — yet the plan explicitly leaves
+  the block and its comment untouched.
+  **Impact**: A future reader hunting warm-path latency (0169 is already queued to
+  do exactly that) is steered away from the dominant remaining cost by a
+  parenthetical that was true only while the probe absorbed 108 ms, and the
+  decision to keep the second hash for its planted-stub defence is recorded only
+  in the work item.
+  **Suggestion**: Amend the parenthetical to note the re-hash is now the dominant
+  warm-path cost and retained deliberately for the planted-stub defence, with a
+  pointer to the three tests that assert it — a one-line edit that belongs in
+  Phase 3 alongside the other documentation corrections.
+
+---
+
+## Re-Review (Pass 2) — 2026-08-03
+
+**Verdict:** REVISE
+
+All eight lenses re-ran against the revised plan, briefed on which areas
+changed but not on the previous findings or verdict. The pass-1 substance is
+resolved: the redesigned two-gate placement was independently traced by both
+correctness and test-coverage and found complete (no reachable state writes to
+`cache_dir` or reaches `acquire_lock` without a probe), the anti-hang case was
+verified to genuinely reach `verify_launcher` with staging skipped, the
+anchored trace matcher was confirmed to discriminate the exec line from the
+`probe=` assignment, and dropping the hoist removed an ordering invariant and a
+duplicated predicate outright. The verdict stays REVISE because the revision
+introduced a fresh crop of defects — five of them mechanical certainties I
+verified by running the code — plus one substantive miss: the newly promised
+read-only cache directory is contradicted by the launcher's own *writing*
+probe on every external-subcommand dispatch.
+
+### Previously Identified Issues
+
+- 🔴 **Test Coverage / Portability**: Gate B has no automated coverage —
+  **Resolved.** Both lenses independently traced
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast` and confirmed
+  `0o555` keeps the search bit, the staged shim still hashes equal (staging
+  skipped), `[[ -x launcher ]]` stays true, and the poisoned launcher fails at
+  `verify_launcher` — so the case genuinely reaches the cold-branch gate.
+- 🔴 **Performance**: interpreter startup inside the measured interval —
+  **Resolved, but the replacement is broken.** Single-interpreter timing is
+  right; the calibration line crashes (see New Issues).
+- 🟡 **Correctness**: `_ran_probe_file` vacuous — **Resolved.** Verified
+  empirically against a real trace: the old pattern matched 2 lines (including
+  `probe=…`), the anchored one matches exactly the exec line.
+- 🟡 **Code Quality / Architecture / Standards / Documentation / Correctness**:
+  the `no_cache_dir` self-contradiction — **Resolved.** One parameterised
+  definition above `:195`, three call sites, and the pre-existing
+  hardcoded-`${plugin_root}/bin`-under-override bug fixed as a side effect.
+- 🟡 **Architecture / Code Quality / Documentation**: `bash_args` widens the
+  shared funnel — **Resolved.** Narrowed to `xtrace: bool`.
+- 🟡 **Correctness / Architecture / Standards**: Phase 1 not independently
+  green — **Resolved.** `import re` moved with its helpers; Phase 1 reduced to
+  the privilege guard, which architecture confirmed is a genuine prerequisite
+  for five of Phase 2's cases.
+- 🟡 **Test Coverage**: "all six cases fail before the change" unachievable —
+  **Partially resolved.** Reworded per-case, but case 7 is now misclassified
+  (see New Issues).
+- 🟡 **Test Coverage**: the `:195` diagnostic unreachable by any test —
+  **Partially resolved.** A case was added; it is vacuous as written.
+- 🟡 **Standards / Documentation**: `internals.md` orphans the
+  release-base-URL sentence — **Resolved.** Verified as a faithful `:207-212`
+  substitution with nothing dropped or duplicated.
+- 🟡 **Standards / Documentation**: `mise run check` false gates — **Partially
+  resolved.** The markdown and frontmatter attributions are now correct
+  (`test:integration:config` verified to run the corpus validator by name), but
+  Phase 3 now claims *no* automated verification while editing
+  `bin/accelerator`.
+- 🟡 **Documentation**: Gate/hoist rationale never reaches the script —
+  **Partially resolved.** The cold-branch gate is commented; the staging gate —
+  whose placement carries the load-bearing "first write into `cache_dir`"
+  invariant — still has no comment. Flagged again by three lenses.
+- 🟡 **Portability**: bash-5 trace evidence missing — **Partially resolved.** A
+  manual check was added, but it has no mechanism and is largely redundant.
+- 🟡 **Documentation**: read-only warm cache undocumented — **Resolved then
+  over-promised.** Now documented, but incorrectly.
+- 🟡 **Performance**: residual stated as ~11.7 ms — **Resolved in the plan,
+  incompletely propagated.** Corrected to a measured ~8.4 ms, but 0186's own
+  body keeps the old figures and the corrected number leaves the composition
+  unexplained.
+- 🟡 **Performance**: retained hashing framed as a trust trade-off —
+  **Resolved.** Measured, `openssl` rejected on evidence, follow-up correctly
+  not raised — though the conclusion is host-conditional and a different,
+  untried lever surfaced.
+- 🟡 **Performance**: gate can pass on a measurement that measured nothing —
+  **Mostly resolved.** Per-sample and sample-count assertions added; they are
+  `assert` statements, so `-O` silently removes them.
+- 🟡 **Performance**: sequential batches alias drift — **Resolved.**
+  Interleaved, and the `jj` swap removed entirely.
+- 🟡 **Performance**: `ensure_dir` forks `mkdir` on warm calls — **Resolved.**
+- 🟡 **Architecture / Portability**: the launcher re-incurs the probe —
+  **Partially resolved.** Raised as a follow-up and the docs scoped, but
+  overstated as decisive for 0169 and contradicted by the read-only promise.
+- 🔵 Minor items from pass 1 largely resolved: the `chmod 0o666` rationale
+  corrected to the write step, the Gate-A/staging gap closed by the redesign,
+  the third predicate copy and hoist ordering invariant eliminated, `_traced`
+  typed, naming joined the `fail_*` family, criterion-1 tightened to stdout
+  equality, the probe-cleanup assertion added, `acquire_lock` masking recorded
+  as a follow-up, the alternative-design rationale recorded, and the plan
+  rewrapped to 80 columns.
+- 🔵 **Still present from pass 1**: hard-coded production function names in the
+  tests (the fast `test_bootstrap_coverage.py` guard is still only an optional
+  manual bullet — re-flagged by three lenses); advisory-permission filesystems
+  undiagnosed; `test_warm_path_does_not_enter_the_probe` still does not assert
+  its *traced* run succeeded; `probe_exec_capable`'s write path still skips
+  cleanup; the `(no XDG fallback)` clause still reads awkwardly and now drops
+  the `ACCELERATOR_CACHE_DIR` remediation hint.
+
+### New Issues Introduced
+
+Verified mechanically (I ran these):
+
+- 🟡 **Correctness / Performance**: **the measurement script crashes on its
+  first statement.** `once()` asserts `stdout.startswith("accelerator ")`, and
+  the calibration line is `once("/usr/bin/true")` — which prints nothing. Under
+  `set -euo pipefail` the run dies before a single sample. Phase 4's only
+  quantitative gate cannot be evaluated as written.
+- 🟡 **Standards / Code Quality / Test Coverage**: **the launcher glob is not
+  `ruff format`-stable and works by accident.** Confirmed: ruff reformats the
+  generator expression (so `format:build-system:check` reds), and
+  `Path("accelerator-launcher-9.9.9-test-darwin-arm64").suffix` is
+  `'.9-test-darwin-arm64'` — the `!= ".minisig"` filter passes for a reason no
+  reader would guess. The file already has the deterministic idiom at `:219`
+  and `:272`: `cache / f"accelerator-launcher-{_VERSION}-{host_platform}"`.
+- 🟡 **Architecture / Portability / Standards**: **`bin/.accelerator-before` is
+  not gitignored, and jj auto-snapshots.** `.gitignore:42-48` enumerates every
+  generated `bin/` artefact; this is not among them. jj snapshots the working
+  copy on virtually every command, so any concurrent `jj` call during the
+  multi-minute run commits an executable copy of a superseded trust-root
+  bootstrap into `bin/`. The stated protection (a dot prefix) is not the
+  operative mechanism either — shell-source discovery is an explicit allowlist.
+  `bin/.tmp-accelerator-before` is already covered by the existing
+  `bin/.tmp-*` rule.
+- 🟡 **Correctness / Test Coverage**: **case 7 is misclassified as red-before.**
+  Pre-change, `probe_dir` runs unconditionally in `resolve_cache_dir`, its write
+  into the `0o555` dir fails, and the run already exits non-zero with the
+  asserted substring. It is green-before, like the other preservation guards —
+  so under the recorded procedure the cold-branch gate gets no verification at
+  all.
+- 🟡 **Test Coverage**: **`test_uncreatable_cache_dir_is_a_named_error` is
+  vacuous.** If the `resolve_cache_dir` failure branch were deleted, the staging
+  gate would emit the identical asserted substring. It needs
+  `assert "could not be created" in output` — the only token distinguishing
+  that site.
+
+Found by reasoning, and I agree with each:
+
+- 🟡 **Portability / Correctness / Test Coverage**: **the BSD/GNU `mkdir -p`
+  hedge is now unreachable** — my own `[[ -d ]]` guard means `mkdir` never runs
+  when the directory exists, so both lanes discharge the two `0o666` cases
+  identically through the probe's write step. Phase 4 would write a false
+  limitation into the work item, and it understates real coverage.
+- 🟡 **Documentation**: **the read-only-cache promise is wrong for dispatch.**
+  `cache_root.rs:80-94` *writes*, `chmod`s and execs a probe on every external
+  subcommand, so a locked-down cache dir gives a working `version` and a hard
+  failure on `vcs guard`. The internals paragraph mentions the launcher probe
+  two sentences later without reconciling it; the changelog omits it entirely.
+- 🟡 **Architecture / Standards / Documentation**: **the changelog commits to
+  figures Phase 4 has not measured**, derived from the ~150 ms baseline the work
+  item explicitly disclaims as a pre-0182 reference — with no Phase 4 step to
+  reconcile them.
+- 🟡 **Standards / Documentation**: **Phase 3 declares no automated
+  verification while editing `bin/accelerator`**, which is in shell-source
+  discovery (`tasks/shared/sources.py:110`) and gated by `scripts:check`.
+- 🟡 **Correctness / Code Quality**: **the gate reports "noexec mount?" for
+  what is a write failure in every tested scenario** — the plan's own analysis
+  says the exec branch is never evaluated by any case, so the most reachable
+  failure is misdiagnosed.
+- 🟡 **Documentation**: **0186's own body keeps the ~11.7/~23 ms figures.**
+  Phase 4 corrects only 0169's note — and 0169's corrected note will point
+  readers back at 0186's uncorrected Dependencies, Assumptions and Validation
+  Results.
+- 🟡 **Correctness / Standards / Documentation**: **the criterion-9 method
+  deviation is unrecorded, on a false premise.** Criterion 9 *does* state the
+  method (a bash loop over 20 runs); the plan substitutes 50 interleaved
+  single-process samples and asserts nothing was recorded — the one deviation
+  on the *gating* criterion, and the only one missing from the deviation list.
+- 🟡 **Performance**: **with hashing at ~8.4 ms, ~27–33 ms of the predicted
+  41 ms is unattributed**, yet the plan still calls the residual "dominated" by
+  hashing (~20% of ~41 ms). The composition check is nominated as the real
+  confirmation but no composition budget is written down.
+- 🟡 **Portability / Architecture**: **`/sbin/sha256sum` is a single-host,
+  darwin-version-dependent observation stated as a darwin fact**, and it is
+  load-bearing for the figure handed to 0169 — the Perl fallback swings the
+  residual ~3× (~8.4 ms → ~26 ms).
+- 🟡 **Portability**: **the cross-interpreter check has no mechanism** —
+  `installation.py:41` pins `BASH` as a module constant precisely to hold the
+  3.2 floor. It is also largely redundant: `ubuntu-latest`'s `/bin/bash` *is*
+  bash 5.2, so the two trace cases already run under bash 5 on every CI run.
+- 🟡 **Architecture**: **the launcher follow-up is overstated as decisive.**
+  0169's own hand-off note already records the bootstrap alone at ~41 ms
+  against a ≈38.6 ms gate, so the launcher fix is necessary but not sufficient
+  — and framing it as decisive invites 0169 to defer an unavoidable decision.
+- 🔵 Minor: `probe_exec_capable`'s write path returns before the single
+  `rm -f` (partial-write leak); p90 index is off by one (`xs[45]` of 50 ≈ p92);
+  sample-validity rests on `assert`, removed under `-O`; the interleave keeps a
+  fixed within-pair order so `after` is always second; the floor is measured but
+  never subtracted, so the composition check compares instrument-inclusive
+  against instrument-exclusive quantities;
+  `test_tampered_cached_launcher_is_refused_and_healed` is described as
+  no-opping when it actually runs a full probe; `probed=1` is set before the
+  probe succeeds; and four new comments embed staleness vectors (`~108ms`,
+  `300 x 0.1s`, "after the split", a test-file line range) against the
+  project's explicit standard.
+
+### Assessment
+
+The plan's *design* is now in good shape and materially better than pass 1 —
+the two-gate placement was independently verified complete by two lenses, and
+the redesign eliminated three pass-1 findings structurally rather than
+patching them. What needs another iteration is execution detail, concentrated
+in two places: the Phase 4 measurement script (which cannot run as written, and
+carries four smaller instrumentation defects plus a working-tree hazard), and
+the accuracy of user-facing text (a read-only promise the launcher contradicts,
+changelog figures that precede their measurement, and a stale coverage
+limitation that would be written into the permanent record).
+
+Two substantive items are worth a decision rather than a fix: whether to hand
+0169 a *range* for the hashing residual rather than a single host's figure, and
+whether to raise a follow-up for batching the two hashes into one
+`sha256_file` invocation — an option no earlier pass considered, measured at
+roughly 4–4.5 ms of the ~41 ms landing, with no change to the trust boundary
+since both digests are still computed and compared.
+
+---
+
+## Disposition — 2026-08-03
+
+**Verdict moved to APPROVE by the author after the pass-2 findings were
+addressed. No third review pass was run**, so the frontmatter verdict reflects a
+judgement call rather than a lens result. Recorded explicitly so a later reader
+does not read `verdict: APPROVE` as the output of a review.
+
+The pass-2 findings were addressed in the plan (see its revision history), and
+the fixes were verified mechanically rather than by re-review:
+
+- The four new bash functions parse under bash 3.2.57, pass
+  `scripts/lint-bashisms.sh`, are ShellCheck-clean and shfmt-stable.
+- `probe_exec_capable` was exercised in all three outcomes — success, write
+  failure, exec failure — returning 0/1/2 with no probe file left behind on any
+  path, closing the partial-write leak the earlier single-early-return form had.
+- `ensure_dir`'s `[[ -d ]]` guard was checked against an existing directory, an
+  absent nested path, an unwritable parent, and a path occupied by a regular
+  file; failure modes are unchanged from `probe_dir`.
+- All six Python blocks in the plan are `ruff format`-stable as written (the
+  earlier launcher-glob generator expression was not, and was replaced with the
+  file's established deterministic path idiom).
+- The revised measurement script was dry-run end to end: both instrument floors
+  compute, the sample loop completes, and a deliberately failing variant aborts
+  the run rather than being recorded as a fast sample. The p90 index was checked
+  to be nearest-rank (index 44 of 50).
+- The trace matcher was verified against a real captured trace: the anchored
+  pattern matches exactly the exec line, where the previous pattern also matched
+  the function's own `probe=…` assignment.
+- The batched-hash follow-up carries a figure measured here (~2.5 ms), not an
+  estimate inherited from a review agent.
+
+**Known open assumption, deliberately carried into Phase 4 rather than closed:**
+the ~108 ms probe cost and its ~97 ms "macOS first-exec check" attribution are
+inherited from the work item's Context table and were not re-derived. The probe
+writes a `#!/bin/sh` *script* rather than a Mach-O, so no binary code-signing is
+involved, and the table's "re-exec of a pre-existing probe file | 10.6 ms" row is
+roughly seven times the 1.48 ms fork+exec floor measured on this host. If that
+penalty proves host-specific (a scanning agent rather than a platform
+characteristic), the `after ≤ 0.5 × before` gate is unsatisfiable on hosts
+without it and will need replacing. Phase 4 is instructed to re-derive the
+attribution and record the host's security-agent status.
+
+---
+
+*Review generated by /accelerator:review-plan*

--- a/meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md
+++ b/meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md
@@ -1,0 +1,189 @@
+---
+type: plan-validation
+id: "2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation"
+title: "Validation Report: Remove the Exec Probe from the Bootstrap Warm Path"
+date: "2026-08-03T12:23:32+00:00"
+author: "Toby Clemson"
+producer: validate-plan
+status: complete
+result: "partial"
+parent: "work-item:0186"
+target: "plan:2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"
+tags: [shell, performance, bootstrap, bash-3.2, testing]
+last_updated: "2026-08-03T12:23:32+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Remove the Exec Probe from the Bootstrap Warm Path
+
+### Implementation Status
+
+✓ Phase 1: Root-Privilege Guard — fully implemented (`oqzoztqs`)
+✓ Phase 2: Split the Probe and Relocate It Off the Warm Path — fully
+implemented (`rpzsskwo`)
+✓ Phase 3: Documentation — fully implemented (`oqkknkry`)
+⚠️ Phase 4: Measurement and Closeout — implemented (`vwkmolqw`); one
+criterion outstanding by construction (see below)
+
+Every code, test and documentation change the plan specifies is present in the
+working tree and committed. `jj status` is clean. The single unresolved item is
+the cross-lane CI observation, which cannot be discharged locally: the change
+sits on an unnamed change with no bookmark and no pushed branch, so CI has not
+run against it at all.
+
+### Automated Verification Results
+
+All run locally on darwin-arm64 at revision `dec6502d`:
+
+✓ `mise run test:integration:entrypoint` — 54 passed in 32.87s (matches the
+plan's expected count; all eight new cases named and passing)
+✓ `mise run test:integration:skill-invocation` — 128 passed in 66.07s (matches
+the plan's expected count; the shared `run_bootstrap` consumer is unaffected)
+✓ `uv run pytest tests/unit/tasks/test_bootstrap_coverage.py
+tests/unit/tasks/test_mise.py` — 33 passed, including the new
+`test_the_cache_dir_helpers_keep_the_names_the_traces_assert_on`
+✓ `mise run build-system:check` — format, lint and types clean (0 errors)
+✓ `mise run scripts:check` — shfmt, ShellCheck, bashisms and exec-bits clean
+over the edited `bin/accelerator`
+✓ `mise run check` — green end to end (all four components)
+✓ `mise run test:integration:config` — 58 passed, 0 failed; the corpus
+frontmatter validator accepts the amended 0186/0169 items and the three new
+follow-ups
+
+Not re-run here: the bare `mise run` default task. Its constituent read-only
+gate (`mise run check`) and all three affected test suites are green, and the
+plan records it as observed green during Phase 4.
+
+### Code Review Findings
+
+#### Matches Plan
+
+- **`bin/accelerator:169-191`** — `probe_dir` is split exactly as specified.
+  `ensure_dir` carries the `[[ -d ]]` guard; `probe_exec_capable` returns 1 for
+  a write/`chmod` failure and 2 for an exec failure, and removes the probe file
+  on all three exit paths.
+- **`bin/accelerator:193-204`** — `resolve_cache_dir` calls `ensure_dir` at both
+  sites; the XDG comment is preserved verbatim.
+- **`bin/accelerator:206-215`** — `fail_no_cache_dir` is defined above the
+  `resolve_cache_dir` call site, holds the single definition of the asserted
+  substring, keeps the `ACCELERATOR_CACHE_DIR` remediation hint, and the call
+  site expands the override rather than hard-coding `${plugin_root}/bin`.
+- **`bin/accelerator:253-267`** — `require_exec_capable_cache` sits below the
+  dev-override block, `probed` is set only on a successful probe, and the three
+  causes map to the planned messages.
+- **Both gates are in the planned positions**: the staging gate is the first
+  statement of the shim-staging `if` body (`:296-298`), the cold-branch gate is
+  the first statement of the `else` (`:381-386`).
+- **`tests/integration/support/installation.py`** — keyword-only `xtrace: bool
+  = False`, `PS4` defaulted alongside it, `bash_flags` spliced into the
+  `subprocess.run` argv, and the docstring extended with the three rationales
+  the plan names (per-call tracing, the `:-main` default, the `SHELLOPTS`
+  rejection). The `False` default preserves the shared consumer's behaviour.
+- **All eight regression cases** are present with the planned names, assertions
+  and comments, under the `# ── Exec probe: cold-path only ──` divider with the
+  helpers directly beneath it.
+- **`_require_unprivileged`** is retrofitted onto exactly the three existing
+  cases the plan names (`:274`, `:298`, `:1086`) and used by six of the eight
+  new ones.
+- **Documentation** — `docs/internals.md:205-223` carries both paragraphs with
+  the release-base-URL sentence intact and the trust guidance unnarrowed; the
+  bootstrap header gains the cold/warm asymmetry clause (`:13-15`); the staging
+  comment cites the three test function names instead of line ranges
+  (`:280-290`); the CHANGELOG entry sits under `## [Unreleased]` / `### Changed`
+  and states no unmeasured figure.
+- **Phase 4's record is unusually complete** — both medians with min/p90, both
+  instrument floors, host and OS build, launcher provenance confirmed by inode,
+  a measured composition table with the unexplained remainder at ~10%, the
+  resolved sha256 backend named with its fallback range, and the probe
+  attribution re-derived (including the security-agent check that rules out a
+  host artefact). All three follow-ups (0189, 0190, 0191) exist and
+  cross-reference 0186; 0169's hand-off note is re-confirmed with its threshold
+  untouched.
+
+#### Deviations from Plan
+
+All are recorded in the plan and the work item at the point of deviation, with
+reasoning — none is silent.
+
+- **`_restricted`'s mode check** — the plan's single `not os.access(path,
+  os.W_OK)` assertion is wrong for the two `0o666` cases (which keep the owner
+  write bit and clear only search). Implemented as a loop over both owner bits,
+  checking each probe only when the mode clears the corresponding bit. This is a
+  correction, not a weakening: it still fails loudly on an advisory-permission
+  filesystem.
+- **The staging comment's byte figure** — the plan instructed correcting `475KB`
+  to `465KB`; the implementation established that 465,568 B is the *linux-x64*
+  shim and that `475KB` was already right for darwin-arm64 (486,672 B). Written
+  as `~475KB`, which is the correct generic form. Verified: the comment at
+  `bin/accelerator:283` reads `~475KB`.
+- **PS4** — `'+${FUNCNAME[0]:-main}:'` rather than the acceptance criterion's
+  literal `'+${FUNCNAME[0]}:'`, which is broken under `set -u`. Anticipated by
+  the plan and recorded in the work item.
+- **Criteria 1, 3 and 9** — the version assertion became stdout equality against
+  a direct launcher run, the positive control got its own traced cold run, and
+  the measurement method became 50 interleaved single-process samples. All three
+  were specified by the plan and are recorded as deviations in the work item.
+- **Work item status** — Phase 4 change 6 says "move `status` to `complete`";
+  it is `in-progress`, with an explicit note at the top of the item explaining
+  that the item's own Drafting Notes make the cross-lane observation "a genuine
+  closure condition, not a formality". This is the correct call, not a miss.
+
+#### Potential Issues
+
+- **The linux lane is entirely unobserved.** The two trace cases
+  (`test_warm_path_does_not_enter_the_probe`,
+  `test_cold_path_enters_and_executes_the_probe`) are the most
+  environment-sensitive in the suite, and the plan's own reasoning is that the
+  harness's pinned `/bin/bash` is 3.2.57 on darwin but 5.2 on `ubuntu-latest` —
+  so a trace-format divergence would surface only in CI. The change is not on a
+  bookmark and has not been pushed, so nothing has run there.
+- **The exec-vs-write coverage gap remains open**, as the plan intends. No
+  directory-permission combination produces exec-without-write, so
+  `probe_exec_capable`'s `return 2` branch — and the `rejected an executable
+  file` cause clause it emits — is exercised by no automated case. The exec
+  *half* is covered by the positive control's execution assertion; the *cause
+  clause* is not. This is recorded in both the plan and the work item and
+  explicitly scoped out, but it means one of the three diagnostic causes ships
+  unverified by test.
+- **`probe_exec_capable` uses unscoped globals** (`probe`, `status`). Checked:
+  neither name is used anywhere else in `bin/accelerator`, and the file declares
+  no `local` at all, so this matches the established idiom rather than
+  introducing a hazard.
+- **Cold-path failure ordering changed** — a cold invocation destined to fail
+  with the cache-dir diagnostic now hashes first (~7 ms) before the gate fires,
+  where `resolve_cache_dir` previously failed before any hashing. Noted in the
+  plan's Performance Considerations and in the work item; no test depends on the
+  old ordering.
+
+### Manual Testing Required
+
+1. CI observation (the only genuinely blocking item):
+  - [ ] Push the change and confirm the `test-integration` matrix is green on
+        `ubuntu-latest`, specifically on `test_warm_path_does_not_enter_the_probe`
+        and `test_cold_path_enters_and_executes_the_probe` (bash 5.2 coverage of
+        the trace assertions)
+  - [ ] Confirm no lane exclusion was needed — `_require_unprivileged` should
+        not fire on either runner
+  - [ ] Record `command -v sha256sum` on both lanes, so 0169 learns whether the
+        Perl `shasum` fallback is reachable in CI at all
+
+2. Optional, out of scope but worth noting if an opportunity arises:
+  - [ ] Point `ACCELERATOR_CACHE_DIR` at a genuine `mount -o noexec` filesystem
+        and confirm the cause clause reads `rejected an executable file` rather
+        than `is not writable` — the one path no automated case can construct
+
+### Recommendations
+
+- **Push the branch and let CI discharge the last criterion**, then tick the
+  two remaining boxes (Phase 2 manual item 4, Phase 4 manual item 5), fill the
+  "Lanes observed green" entry in the work item's Validation Results, and move
+  0186 to `complete`. Nothing else stands between the change and closure.
+- **Leave the work item at `in-progress` until then.** The deliberate hold is
+  correct and the note explaining it should stay until CI replaces it with an
+  observation.
+- **Consider whether the `return 2` cause clause deserves a cheap seam** rather
+  than staying untested indefinitely — for example an injectable probe command
+  in a test-only env var. Not required by this plan, and the trade-off (a new
+  seam in a trust-root script) may well favour leaving it; worth a sentence in
+  0189, which will face the same gap on the launcher side.

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -404,6 +404,48 @@ segment matches; the first matching segment names the reported subcommand.
   exec and verify on top. **Resolve this before acceptance**: either relax the
   threshold, or accept the overrun with a stated rationale. See 0186's
   Dependencies and Validation Results.
+- **Hand-off note re-confirmed with measured figures (2026-08-03).** The note
+  above still holds in shape, but three of its numbers were wrong and the
+  headline moved in this story's favour. **This story's threshold and its
+  rationale are untouched — that decision remains 0169's own work.**
+  - **The warm bootstrap lands at ~30 ms, not ~41 ms.** Measured on
+    darwin-arm64 (Apple M4 Max, macOS 26.3), 50 interleaved samples per variant
+    in one process: median **125.35 ms before**, **29.92 ms after**, gate
+    `after ≤ 0.5 × before` passed at a ratio of 0.239. Instrument floors 1.60 ms
+    (`/usr/bin/true`) and 6.10 ms (a trivial bash script). The 149.1 ms in
+    0186's Context table is a pre-0182 reference produced by an unrecorded
+    method and is **not** method-comparable to these medians.
+  - **The retained residual is backend-dependent, and the ~11.7 ms figure
+    describes the wrong backend.** Where `command -v sha256sum` resolves to
+    Apple's `/sbin/sha256sum` — as it does on the measuring host — one
+    `sha256_file` call costs **~3.5 ms** and both together **~7 ms**. Where only
+    the Perl `shasum` fallback exists it is **~12 ms** per call and **~24 ms**
+    for both. Take the range and check `command -v sha256sum` on the target
+    host; do not carry a point estimate.
+  - **The measured composition of the ~30 ms**, for budgeting the sub-binary
+    dispatch on top: 6.1 ms bash interpreter startup, ~7 ms for the two hashes,
+    ~6.8 ms for the staged shim exec plus minisign verify (note: not the 2.3 ms
+    the Context table quotes for minisign alone — the shim's own startup and its
+    read of the 7.6 MB launcher dominate), ~2.4 ms for the launcher exec, and
+    ~4.6 ms across two `uname` substitutions, the `plugin.json` `sed`, two
+    `cd -P`/`pwd -P` subshells and the `resolve_cache_dir` substitution. ~2.9 ms
+    (≈10%) unexplained.
+  - **The dominant unaddressed cost is now the launcher-side probe, raised as
+    0189.** `cache_root::resolve` runs the identical write-chmod-exec probe on
+    **every** external-subcommand dispatch, before the sub-binary cache-hit
+    test — so a warm `accelerator vcs guard` still pays a first-exec penalty of
+    the same shape, measured at **131.97 ms** in the repo's `bin/` (107.15 ms in
+    `/tmp`) against a 3.72 ms re-exec of a file left in place. Built-ins never
+    reach it, which is why 0186's `version`-based measurement cannot see it.
+    **0189 is necessary but not sufficient for this story either, and this
+    story's threshold decision must not be deferred pending it.**
+  - **The cheapest remaining lever is 0191**: batching the two shim hashes into
+    one `sha256sum f1 f2` with no `awk`, measured at ~2.5 ms — essentially this
+    story's whole shortfall. It needs a branch to preserve today's
+    short-circuit, which is why it was not absorbed into 0186.
+  - The host runs no third-party EndpointSecurity or anti-malware agent (only
+    Apple's `xprotectd`, SIP and Gatekeeper on), so the first-exec penalty is
+    stock macOS behaviour rather than a machine artefact and should transfer.
 - **In-flight dependency**: 0182 (plugin-root self-location — **`in-progress`**,
   code landed). It delivers the `ACCELERATOR_PLUGIN_ROOT` regime the new
   `cli/**` code must use, and `hooks/launcher-link-refresh.sh`, which must

--- a/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -5,15 +5,23 @@ title: "Remove the Exec Probe from the Bootstrap Warm Path"
 date: "2026-07-31T10:41:51+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: ready
+status: in-progress
 kind: task
 priority: high
 parent: "work-item:0136"
 blocked_by: ["work-item:0182"]
 blocks: ["work-item:0169"]
-relates_to: ["work-item:0164", "work-item:0165", "work-item:0167"]
+relates_to:
+  [
+    "work-item:0164",
+    "work-item:0165",
+    "work-item:0167",
+    "work-item:0189",
+    "work-item:0190",
+    "work-item:0191",
+  ]
 tags: [shell, performance, bootstrap]
-last_updated: "2026-07-31T12:34:00+00:00"
+last_updated: "2026-08-03T00:00:00+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -21,9 +29,15 @@ schema_version: 1
 # 0186: Remove the Exec Probe from the Bootstrap Warm Path
 
 **Kind**: Task
-**Status**: Ready
+**Status**: In Progress
 **Priority**: High
 **Author**: Toby Clemson
+
+> **Implemented and measured 2026-08-03.** Every criterion is discharged except
+> the cross-lane observation, which needs a CI run this branch has not had yet.
+> This item's own Drafting Notes call that observation "a genuine closure
+> condition, not a formality", so the status stays short of `done` until the
+> linux lane is seen green on the new cases. Nothing else is outstanding.
 
 ## Summary
 
@@ -129,7 +143,7 @@ check (`chmod 0o555` then assert file creation inside fails; `chmod -x` then
 assert traversal fails). The check's command and output are pasted into
 Validation Results for any exclusion claimed.
 
-- [ ] **Warm path performs no fatal exec probe** — verified **behaviourally**,
+- [x] **Warm path performs no fatal exec probe** — verified **behaviourally**,
       not by looking for the probe's residue (it is created and removed within
       one invocation, so a post-hoc check passes either way). Sequence: run a
       full bootstrap against the harness to populate the cache dir,
@@ -140,7 +154,7 @@ Validation Results for any exclusion claimed.
       surviving probe fails its write and the invocation exits non-zero. It
       does **not** catch a probe kept and made non-fatal, which still exits 0;
       that variant is ruled out only by the next criterion.
-- [ ] **Probe absent from the warm path, asserted directly** — the criterion
+- [x] **Probe absent from the warm path, asserted directly** — the criterion
       that actually pins probe absence, and therefore load-bearing rather than
       supplementary. Run the bootstrap under `bash -x` with
       `PS4='+${FUNCNAME[0]}:'` and assert the **probe function's name** (as
@@ -154,7 +168,7 @@ Validation Results for any exclusion claimed.
       Note bash's xtrace prints expanded command words but **not** redirections,
       so a probe that creates its file via `>` emits no cache-dir path at all —
       another reason the function name is the only reliable observable.
-- [ ] **Positive control for the trace assertion** — the same probe function
+- [x] **Positive control for the trace assertion** — the same probe function
       name must be asserted **present** in the trace of the cold happy-path run
       (criterion 6), and the trace must additionally show the probe file being
       **executed**, not merely written and `chmod`ed. Without this the negative
@@ -162,11 +176,11 @@ Validation Results for any exclusion claimed.
       reasons. The exec half also gives the retained cold-path probe its only
       real verification — see criterion 5 for why the `chmod -x` cases cannot
       supply it.
-- [ ] **The `noexec` diagnostic survives on the cold path**: with an empty
+- [x] **The `noexec` diagnostic survives on the cold path**: with an empty
       cache dir made non-executable (`chmod -x`), a cold invocation exits
       non-zero and its combined output contains the substring
       `no writable, exec-capable cache directory` (`bin/accelerator:196`).
-- [ ] **The exec-vs-write coverage limitation is recorded.** Both `chmod -x`
+- [x] **The exec-vs-write coverage limitation is recorded.** Both `chmod -x`
       criteria create their failure by removing a directory's execute bit,
       which also blocks creating files inside it — so an implementation
       retaining only the *write* half of the probe would produce the same exit
@@ -177,21 +191,21 @@ Validation Results for any exclusion claimed.
       an attached disk image on darwin) would close it completely and is
       **explicitly out of scope here** — raise it as a follow-up if the
       cold-path probe ever regresses.
-- [ ] **Cold happy path after the split** — pins the always-run `ensure_dir`
+- [x] **Cold happy path after the split** — pins the always-run `ensure_dir`
       half: with `ACCELERATOR_CACHE_DIR` set to a path that does not yet exist,
       a cold invocation creates the directory and `bin/accelerator version`
       exits 0 with the expected output. This is the run that carries the
       positive control (criterion 3).
-- [ ] **Diagnostic preserved when a warmed cache dir becomes non-executable**:
+- [x] **Diagnostic preserved when a warmed cache dir becomes non-executable**:
       given a *warmed* cache dir subsequently made non-executable, the
       invocation exits non-zero with the same `no writable, exec-capable cache
       directory` substring. Note this is an end-state guard, not proof of
       routing — today's bootstrap produces the same result by probing before
       the branch, so the criterion cannot by itself demonstrate the
       warm-to-cold fall-through. The routing claim is carried by criterion 3.
-- [ ] `bin/accelerator` passes the bash-3.2 gate — `scripts/lint-bashisms.sh`
+- [x] `bin/accelerator` passes the bash-3.2 gate — `scripts/lint-bashisms.sh`
       plus the standard shfmt/ShellCheck checks report no findings.
-- [ ] **The warm-path saving clears its gate.** Take the median of 20 warm
+- [x] **The warm-path saving clears its gate.** Take the median of 20 warm
       `bin/accelerator version` invocations, on one darwin-arm64 host in a
       single session with no build running, using the same method for both
       figures (a bash loop over 20 runs taking the median, matching how the
@@ -209,14 +223,14 @@ Validation Results for any exclusion claimed.
       (darwin and linux) for the new cases, not only locally — these are the
       most environment-sensitive criteria in the suite. Which lanes were
       observed is recorded in Validation Results.
-- [ ] **The 0169 hand-off note is present and still accurate.** Confirm the
+- [x] **The 0169 hand-off note is present and still accurate.** Confirm the
       dated note in 0169's Dependencies still holds after the rebase and after
       the measurement lands — in particular that the quoted residual and its
       consequence for 0169's `≤ 1.1 × B` gate match the measured after-median.
       Update the figure if it moved; do not change 0169's threshold.
 - [x] The shim double-hash decision is recorded with its rationale — discharged
       during review-1; see the Validation Results entry and Open Questions.
-- [ ] `mise run` is green end to end.
+- [x] `mise run` is green end to end.
 
 ## Open Questions
 
@@ -252,9 +266,16 @@ once, in Validation Results.
   exec probe alone leaves the warm bootstrap at roughly 41 ms, while 0169
   requires a warm `accelerator vcs guard` at ≤ 1.1 × the 35.1 ms shell guard
   (≈ 38.6 ms) and pays a sub-binary exec and verify on top. The residual is the
-  verify shim's staging block — **~11.7 ms for the second `sha256_file` alone,
-  or ~23 ms if staging were skipped entirely**; neither is addressable without
-  weakening a tested trust boundary (see Validation Results). So 0169 must
+  verify shim's staging block — **measured at ~3.5 ms per `sha256_file` call
+  and ~7 ms for both on a host where `/sbin/sha256sum` resolves, or ~12 ms and
+  ~24 ms where only the Perl `shasum` fallback exists**; neither is addressable
+  without weakening a tested trust boundary (see Validation Results). The
+  ~11.7 ms / ~23 ms figures this item originally quoted describe the *fallback*
+  backend, not the one the code uses on the measuring host. The measurement also
+  moved the headline: the warm bootstrap lands at **~30 ms**, not ~41 ms, so the
+  shortfall against 0169's gate is smaller than assumed — but 0169 additionally
+  pays the launcher-side probe (0189), which this item does not remove. So 0169
+  must
   either relax its threshold or accept the cost with a stated rationale. A
   dated hand-off note in 0169's Dependencies carries this, so the obligation
   does not die with this task.
@@ -299,7 +320,9 @@ genuinely startable once the rebase baseline exists.
   source digest, and the lock directory is acquired only on the cold path. Note
   the staging `if`'s **condition** (`:255-256`) is still evaluated on every
   invocation and contains the second `sha256_file` — that reads, it does not
-  write, so the invariant stands while the ~11.7 ms cost remains. If the warm
+  write, so the invariant stands while its cost remains (**measured ~3.5 ms on
+  a host resolving `/sbin/sha256sum`, ~12 ms on the Perl `shasum` fallback**;
+  the ~11.7 ms originally quoted here is the fallback figure). If the warm
   path proves not to be write-free on some configuration, that is a finding to
   raise, **not work to absorb here** — the staging block is out of scope.
 - The latency gate assumes 0182's `bin/accelerator` changes leave warm-path
@@ -378,30 +401,238 @@ challenge:
 
 ## Validation Results
 
+All behavioural criteria are discharged by named cases in
+`tests/integration/entrypoint/test_accelerator_entrypoint.py`, so each traces to
+a permanent guard rather than a one-off observation.
+
 - **Warm-path exec-probe-free check** (non-writable populated cache dir) —
-  _pending_.
-- **Direct probe-absence check** (`bash -x`, `PS4='+${FUNCNAME[0]}:'`, probe
-  function name absent from the warm trace) — _pending_.
-- **Positive control** (probe function name present in the cold trace, and the
-  probe file observed being executed) — _pending_.
-- **`noexec` cold-path check** — _pending_.
-- **Exec-vs-write coverage limitation recorded** — _pending_.
-- **Cold happy-path (`ensure_dir`) check** — _pending_.
-- **Diagnostic preserved on a warmed-then-non-executable cache** — _pending_.
-- **Lanes observed green** (darwin, linux) — _pending_.
-- **Lane exclusions**, each with the privilege-check command and output that
-  justified it — _pending_ (none expected).
-- **Warm-path median, before** (re-measured post-0182) — _pending_; **after** —
-  _pending_; gate `after ≤ 0.5 × before` — _pending_; delta (recorded, not
-  gating) — _pending_; host and OS version — _pending_; launcher provenance
-  (release asset, locally staged, or pre-cached) and confirmation both medians
-  used the same post-0182 binary — _pending_.
-- **0169 hand-off note** — appended 2026-07-31; **re-confirmation after rebase
-  and measurement** — _pending_.
+  `test_warm_path_survives_a_non_writable_cache_dir`. Asserts stdout
+  **equality** against a direct `launcher_bin version` run rather than a literal
+  version string; see the criterion-1 amendment below.
+- **Direct probe-absence check** — `test_warm_path_does_not_enter_the_probe`.
+  `ensure_dir` and `verify_launcher` present in the warm trace,
+  `probe_exec_capable` absent. The `verify_launcher` assertion bounds the trace
+  from the far end, so a truncated trace cannot satisfy the negative assertion.
+- **Positive control** — `test_cold_path_enters_and_executes_the_probe`.
+  Asserts the probe file is executed as its own command word **exactly once**
+  (`^\++probe_exec_capable:/\S*\.accelerator-probe-\d+$`). The `:/` anchor is
+  load-bearing: the function's own `probe=/…` assignment is traced too, and an
+  unanchored pattern matches it, passing on an implementation that never execs.
+  Manually confirmed on 2026-08-03 that the assignment line is present in the
+  same trace and **not** matched, and that `+main:require_exec_capable_cache`
+  appears twice while the probe runs once — so the idempotence flag is
+  exercised, not merely present.
+- **`noexec` cold-path check** — `test_cold_path_keeps_the_noexec_diagnostic`,
+  which additionally asserts the new `is not writable` cause clause.
+- **Exec-vs-write coverage limitation recorded** — both `noexec` criteria create
+  their failure by clearing a directory's **search** bit, which blocks name
+  resolution and so fails the probe's *write* step; its exec branch is never
+  evaluated, and no directory-permission combination can produce
+  exec-without-write. The exec half is covered instead by the positive control's
+  execution assertion. Both cases are lane-deterministic: `ensure_dir`'s
+  `[[ -d ]]` guard means `mkdir` never runs on an existing directory, so no
+  BSD/GNU `mkdir -p` difference is reachable. A genuine `mount -o noexec`
+  filesystem would close the gap and stays out of scope.
+- **Cold happy-path (`ensure_dir`) check** —
+  `test_cold_happy_path_creates_a_missing_cache_dir`.
+- **Diagnostic preserved on a warmed-then-non-executable cache** —
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic`. Note this is a
+  **code-path duplicate** of the `noexec` cold-path case: clearing the search
+  bit makes the staged shim unresolvable either way, so the populated cache has
+  no observable effect. The genuinely distinct warmed-then-unusable scenario is
+  the `0o555` case below.
+- **Beyond the criteria** —
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast` (the cold-branch
+  gate and its anti-hang property, the only cover for either) and
+  `test_uncreatable_cache_dir_is_a_named_error` (the retained
+  `resolve_cache_dir` failure, pinned by its `could not be created` cause).
+- **The two probe call sites, and which case guards which.** The **staging
+  gate** sits inside the shim-staging `if` body, the first required write into
+  `cache_dir` on every path, so it covers every write. Two writes sit outside
+  that invariant, both benign: `fail_integrity`'s append to
+  `.accelerator-unverified.log` (best-effort, failure paths only) and the
+  dev-override block's append (guarded by `|| true`, and it `exec`s
+  immediately). The **cold-branch gate** covers the verification-failed residual
+  where staging was skipped, and prevents a ~30 s `acquire_lock` spin.
+  Confirmed by mutation after the change (2026-08-03): deleting the staging gate
+  reds `test_cold_path_keeps_the_noexec_diagnostic`,
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and
+  `test_readonly_root_without_override_is_a_named_error` while
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast` still passes;
+  deleting the cold-branch gate reds only the latter, via its timeout. That
+  mutation is the only demonstration the cold-branch gate is guarded at all,
+  since its case passes before the change too.
+- **Red step, recorded per case** (2026-08-03, 5 failed / 3 passed, exactly as
+  planned). Red before the change:
+  `test_warm_path_survives_a_non_writable_cache_dir` (today's fatal probe fails
+  its write under `0o555`); `test_warm_path_does_not_enter_the_probe` and
+  `test_cold_path_enters_and_executes_the_probe` (the new function names did not
+  exist); `test_uncreatable_cache_dir_is_a_named_error` and
+  `test_cold_path_keeps_the_noexec_diagnostic` (the cause clauses did not
+  exist — the latter's exit and leading substring already passed). Green before
+  and after, as preservation guards:
+  `test_cold_happy_path_creates_a_missing_cache_dir`,
+  `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast`.
+- **Lanes observed green** (darwin, linux) — darwin observed locally
+  (2026-08-03): `test:integration:entrypoint` 54 passed,
+  `test:integration:skill-invocation` 128 passed, `mise run check` green.
+  **Linux lane pending CI.** The harness pins `BASH = "/bin/bash"`, which is
+  3.2.57 on darwin and 5.2 on `ubuntu-latest`, so the two trace cases are
+  covered on **both interpreters** by the standard CI run with no extra work.
+- **Lane exclusions** — **none**. `.github/workflows/main.yml` contains no
+  `container:` key; `test-integration` is a plain `runs-on: ${{ matrix.os }}`
+  matrix over `ubuntu-latest`/`macos-latest`, so both lanes run unprivileged and
+  the root guard will not fire. The single `docker` reference belongs to the
+  visual-regression job, which never reaches this suite. If a root lane is ever
+  introduced, the escape to add is a registered `unprivileged` pytest marker, so
+  the exclusion stays explicit and greppable rather than a silent skip.
+- **Warm-path median** — measured 2026-08-03 on darwin-arm64 (Apple M4 Max,
+  Mac16,5; macOS 26.3, build 25D125), 50 interleaved samples per variant in one
+  process, order alternated:
+
+  | Variant | min | median | p90 | median − harness floor |
+  | --- | --- | --- | --- | --- |
+  | before | 119.02 | **125.35** | 234.15 | 123.75 |
+  | after | 27.18 | **29.92** | 32.44 | 28.32 |
+
+  All figures in ms. **Gate `after ≤ 0.5 × before`: PASS** — 29.92 against a
+  62.68 ceiling, a ratio of **0.239**. Delta **95.43 ms** (recorded, not
+  gating). Instrument floors: `/usr/bin/true` **1.60 ms** (within a millisecond
+  or two of a bare fork+exec, so the harness is not measuring itself) and a
+  trivial bash script **6.10 ms**. Landing is materially better than the ~41 ms
+  expectation.
+
+  **Launcher provenance**: both variants shared one pre-cached
+  `bin/accelerator-launcher-1.24.0-pre.21-darwin-arm64` (7,999,792 bytes, inode
+  177376217) — a genuine signed release asset for the current `plugin.json`
+  version, published post-0182. Both variants resolve the same plugin root from
+  their own location (the before copy lives at `bin/.tmp-accelerator-before`,
+  covered by the existing `bin/.tmp-*` ignore rule), so the cached launcher path
+  is identical by construction. `ls -li` confirmed one inode across the run.
+
+- **Measured composition against the budget** (after-median 29.92 ms; marginal
+  costs over the relevant baseline, darwin-arm64, 2026-08-03):
+
+  | Term | ms |
+  | --- | --- |
+  | harness floor + bash interpreter startup | 6.10 |
+  | two `sha256_file` calls (`sha256sum` + `awk` each) | ~7.1 |
+  | staged shim exec + minisign verify of the 7.6 MB launcher | ~6.8 |
+  | launcher exec (`version`) | ~2.4 |
+  | two `uname` substitutions, `sed` over `plugin.json`, two `cd -P`/`pwd -P` subshells, the `resolve_cache_dir` substitution | ~4.6 |
+  | **explained total** | **~27.0** |
+  | unexplained remainder | ~2.9 (≈10%) |
+
+  The remainder is under the ~25% threshold, so no per-line `bash -x`
+  attribution was needed. Note the shim exec plus minisign is ~6.8 ms, not the
+  2.3 ms the Context table quotes for minisign alone — the shim's own startup
+  and its read of the 7.6 MB launcher dominate that term, and it is now
+  comparable to the two hashes.
+
+- **Resolved sha256 backend** — `command -v sha256sum` resolves to
+  **`/sbin/sha256sum`** on this host, an Apple-signed Mach-O universal binary,
+  so `sha256_file` never reaches its `shasum` fallback. Measured: one
+  `$(sha256sum f | awk …)` substitution costs **3.55 ms** marginal over a
+  `bash -c` baseline; `sha256sum` alone is 3.43 ms against a 1.41 ms fork+exec
+  floor, so actual hashing is well under a millisecond and the rest is process
+  startup. The Perl `shasum -a 256` fallback costs **11.99 ms** per call. **This
+  is a single-host observation, not a darwin fact** — `/sbin/sha256sum` is a
+  comparatively recent macOS addition, so an older macOS or a minimal image may
+  resolve only `shasum`. The two-hash residual is therefore **~7 ms or ~24 ms
+  depending on the host**, and the ~11.7 ms figure previously quoted throughout
+  this item describes the *fallback*, not the backend the code actually uses
+  here. 0169 is handed the range and the backend, not a point estimate.
+  Recording `command -v sha256sum` on both CI lanes costs nothing and says
+  whether the fallback is reachable in CI at all — still to be done there.
+
+- **Re-derived probe attribution** (the Context table's methodology was not
+  recorded, and its "re-exec of a pre-existing probe file | 10.6 ms" row is
+  seven times this harness's fork+exec floor). Measured directly on the same
+  harness, 2026-08-03:
+
+  | Operation | ms |
+  | --- | --- |
+  | bare fork+exec (`/usr/bin/true`) | 1.41 |
+  | re-exec of a *pre-existing* probe file | 3.72 |
+  | write + `chmod` + exec + `rm` in `/tmp` | 107.15 |
+  | write + `chmod` + exec + `rm` in the repo's `bin/` | 131.97 |
+
+  So the first-exec penalty is ~103 ms in `/tmp` and ~128 ms in the working
+  copy — the ~25 ms difference is worth knowing but was not chased. **Host
+  security-agent status**: no third-party EndpointSecurity or anti-malware agent
+  is installed (`systemextensionsctl list` shows only a Karabiner driver
+  extension; no CrowdStrike/SentinelOne/Defender/Jamf/Santa processes). Only
+  Apple's own `xprotectd` runs, with SIP enabled and Gatekeeper assessments
+  enabled. The penalty is therefore attributable to **stock macOS**, not to a
+  scanning agent — which means the ratio gate should transfer to other macOS
+  hosts and the extrapolation to the launcher-side probe (0189) holds.
+
+- **Deviations from the acceptance criteria, each deliberate**:
+  - **PS4 (criterion 2)**: the criterion mandates `PS4='+${FUNCNAME[0]}:'`,
+    which is broken under the bootstrap's `set -u` on bash 3.2 — it emits
+    `FUNCNAME[0]: unbound variable` per top-level command and leaves PS4
+    literally unexpanded, and an unbound expansion aborts a non-interactive
+    bash 5 outright. Implemented as `'+${FUNCNAME[0]:-main}:'`, defaulted inside
+    `run_bootstrap` when `xtrace` is set, which also labels the top-level frame
+    usefully.
+  - **Criterion 1's version assertion**: the harness's default launcher prints
+    nothing and the real one prints `CARGO_PKG_VERSION`, not the fixture's
+    `9.9.9-test`, so "the version the harness fixture builds, asserted exactly"
+    was unachievable as literally worded. Implemented against the real launcher,
+    asserting stdout **equality** with a direct `launcher_bin version` run —
+    which also pins the vergen commit and build stamps.
+  - **Criterion 3's positive control** rides on its own traced cold run rather
+    than on criterion 6's, because criterion 6's run uses the real launcher and
+    is not traced.
+  - **Criterion 9's method**: 50 interleaved samples from a single Python
+    process using `perf_counter`, two instrument floors and order alternation,
+    rather than a bash loop over 20. A per-call `python3` clock read would put a
+    whole interpreter startup *inside* the measured interval — comparable to the
+    ~30 ms being measured; batching either side of a working-copy swap would
+    alias jj snapshot and file-watcher drift onto the difference; and a fixed
+    within-pair order would bias whichever variant is always second. **The
+    Context table's figures are therefore not method-comparable to these
+    medians.**
+  - **`_restricted`'s mode check**: the plan's single
+    `not os.access(path, os.W_OK)` assertion is wrong for the two `0o666` cases,
+    which keep the owner write bit and clear only the search bit — it fired on
+    correctly-restricted directories. Implemented as a loop over both owner
+    bits, checking `W_OK` only when the mode clears `0o200` and `X_OK` only when
+    it clears `0o100`, which covers both shapes (`0o555` drops write, `0o666`
+    drops search).
+  - **The staging comment's `465KB`**: the plan's correction was itself wrong.
+    465,568 bytes is the **linux-x64** shim; the four vendored shims measure
+    486,672 / 496,896 / 426,400 / 465,568 bytes for darwin-arm64, darwin-x64,
+    linux-arm64 and linux-x64 respectively. The original `475KB` was already
+    right for the shipped darwin-arm64 shim (486,672 B = 475.3 KiB), so the
+    comment reads `~475KB` — approximate, because the figure is per-triple.
+- **One reordering worth knowing**: because the staging gate sits inside the
+  staging body, a cold invocation that is going to fail with the cache-dir
+  diagnostic now spends ~7 ms hashing first, where previously
+  `resolve_cache_dir` failed before any hashing.
+- **Follow-ups raised** (2026-08-03): **0189** (the launcher runs the same
+  write-chmod-exec probe on every external-subcommand dispatch, so this saving
+  does not reach `accelerator vcs guard`; necessary but not sufficient for 0169,
+  whose threshold decision must not be deferred pending it), **0190**
+  (`acquire_lock` cannot distinguish contention from an unusable directory, and
+  its dead-owner reclaim arm can spin unbounded — the cold-branch gate masks the
+  one instance reachable today), and **0191** (batch the two shim hashes into
+  one invocation, ~2.5 ms, deliberately not absorbed here). Deliberately **not**
+  raised: a faster `sha256_file` backend — the native `sha256sum` is already in
+  use here, actual hashing is sub-millisecond, `openssl dgst` is slower, and
+  dropping the two `awk` forks alone saves ~0.4 ms. Reopen if a lane resolves
+  the Perl fallback.
+- **0169 hand-off note** — appended 2026-07-31; **re-confirmed 2026-08-03**
+  against the measured after-median, with its quoted residual corrected to the
+  backend-dependent range and the launcher-side probe (0189) handed over as the
+  dominant unaddressed cost. 0169's threshold and rationale left untouched.
 - **Shim double-hash decision** — **resolved 2026-07-31: keep both hashes and
   the staging block unchanged.** The source research (§12) framed this as an
   open trade-off worth ~23 ms via two distinct changes: dropping the second
-  hash at `bin/accelerator:256` (~11.7 ms, one hash of the 475 K shim), or
+  hash at `bin/accelerator:256` (quoted at ~11.7 ms, one hash of the 475 K
+  shim — **measured at ~3.5 ms** on a host resolving `/sbin/sha256sum`; the
+  quoted figure is the Perl `shasum` fallback's), or
   skipping staging entirely when `shim_source`'s directory and `cache_dir`
   resolve to the same path (~23 ms, the default configuration where both are
   `${plugin_root}/bin`). Neither is as cheap as it looked: the planted-stub

--- a/meta/work/0189-launcher-probes-the-cache-root-on-every-dispatch.md
+++ b/meta/work/0189-launcher-probes-the-cache-root-on-every-dispatch.md
@@ -1,0 +1,110 @@
+---
+type: work-item
+id: "0189"
+title: "The launcher probes the cache root on every external-subcommand dispatch"
+date: "2026-08-03T00:00:00+00:00"
+author: Toby Clemson
+producer: implement-plan
+status: draft
+kind: task
+priority: high
+parent: "work-item:0136"
+relates_to: ["work-item:0186", "work-item:0169", "work-item:0164"]
+tags: [cli, launcher, performance, bootstrap]
+last_updated: "2026-08-03T00:00:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0189: The launcher probes the cache root on every external-subcommand dispatch
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+0186 removed the write-chmod-exec probe from the shell bootstrap's warm path.
+The launcher still runs the identical probe, in Rust, on **every** dispatch to
+an external sub-binary — so the saving does not reach `accelerator vcs guard`
+or any other dispatched subcommand. Apply the same `ensure_dir` / lazy-probe
+split on the Rust side.
+
+## Context
+
+`cache_root::resolve`
+(`cli/launcher/src/launch/outbound/resolve/cache_root.rs`)
+calls `probe_writable_and_executable`, which `create_dir_all`s, writes
+`.accelerator-probe-<pid>`, `chmod`s it to `0o755`, runs it and removes it.
+`LazyProductionResolver::resolve` (`cli/launcher/src/main.rs`) calls it
+*before* constructing `FetchVerifyCacheResolver`, so it runs ahead of the
+sub-binary cache-hit test rather than behind it.
+
+Built-ins (`version`, `config`) never reach the resolver — which is why today's
+SessionStart hook escapes the cost, and why 0186's `version`-based measurement
+cannot see it.
+
+Measured on darwin-arm64 (macOS 26.3, Apple M4 Max, 2026-08-03) as part of
+0186's closeout: the write-chmod-exec-rm cycle costs **131.97 ms** in the repo's
+own `bin/` and **107.15 ms** in `/tmp`, against a **3.72 ms** re-exec of the
+same file left in place and a **1.41 ms** bare fork+exec floor. Nearly all of it
+is macOS's first-exec assessment of a freshly written file. No third-party
+EndpointSecurity or anti-malware agent is installed on the measuring host — only
+Apple's own `xprotectd`, with SIP and Gatekeeper assessments enabled — so the
+penalty is attributable to stock macOS and should be expected on other macOS
+hosts rather than being an artefact of this machine.
+
+## Requirements
+
+- Split `probe_writable_and_executable` the way `bin/accelerator` was split: an
+  always-run directory-creation half, and a probe reached only when the
+  sub-binary is not already cached and verified.
+- Gate the probe on the cache miss inside `FetchVerifyCacheResolver::resolve`,
+  which is the first place that must write into the cache root, rather than in
+  `cache_root::resolve` which runs unconditionally.
+- Keep `ResolutionError::CacheRootUnavailable` firing on every path that cannot
+  use its cache root, with no new hang and no loss of the `noexec` diagnostic.
+  0186's shell side reports which of three causes it detected; the Rust side
+  should be at least as specific.
+
+## Acceptance Criteria
+
+- [ ] A warm dispatch to an already-cached, already-verified sub-binary writes
+      no probe file — asserted behaviourally against a cache root made
+      non-writable after warming, mirroring
+      `test_warm_path_survives_a_non_writable_cache_dir`.
+- [ ] A cold dispatch still probes, and a `noexec`-shaped cache root still
+      fails with `CacheRootUnavailable` naming the directory.
+- [ ] The probe runs at most once per process.
+- [ ] Warm dispatch latency is measured before and after on one darwin host in
+      one session, both figures recorded, with `after ≤ 0.5 × before` as the
+      gate — the same shape 0186 used.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- **Relates to**: 0186, which established the pattern, the diagnostic shape and
+  the measurement method.
+- **Necessary but not sufficient for 0169.** 0169's own hand-off note records
+  the bootstrap alone landing near 30 ms against a ≈38.6 ms gate, so the
+  threshold decision is 0169's regardless and **must not be deferred pending
+  this item**.
+- **Parent**: epic 0136.
+
+## Assumptions
+
+- `FetchVerifyCacheResolver::resolve` re-verifies the cached sub-binary's
+  signature on every dispatch, so a warm dispatch already proves the cache root
+  is exec-capable for real — the same argument that made the shell probe
+  redundant on the warm path.
+
+## References
+
+- `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` — the
+  shell-side change, its measurement method and its diagnostic shape
+- `meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md`
+- `cli/launcher/src/launch/outbound/resolve/cache_root.rs`
+- `cli/launcher/src/main.rs` — `LazyProductionResolver::resolve`
+- `docs/internals.md` — "Offline, mirrored and read-only installs", which
+  documents this as the limit on a read-only cache directory

--- a/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
+++ b/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
@@ -1,0 +1,94 @@
+---
+type: work-item
+id: "0190"
+title: "acquire_lock cannot classify an unusable lock directory"
+date: "2026-08-03T00:00:00+00:00"
+author: Toby Clemson
+producer: implement-plan
+status: draft
+kind: bug
+priority: medium
+parent: "work-item:0136"
+relates_to: ["work-item:0186", "work-item:0164"]
+tags: [bug, shell, bootstrap, bash-3.2]
+last_updated: "2026-08-03T00:00:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0190: acquire_lock cannot classify an unusable lock directory
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+`acquire_lock` in [`bin/accelerator`](../../bin/accelerator) treats every failed
+`mkdir "${lock_dir}"` as "someone else holds the lock". It has no notion of an
+`mkdir` that can never succeed, so an unusable lock directory is reported as a
+lock timeout after the full 300 × 0.1 s budget — and one arm has no bound at
+all.
+
+## Context
+
+Found while implementing 0186. That work added a probe gate at the top of the
+cold branch specifically to keep the one reachable instance of this from
+regressing: with an unwritable cache directory and a skipped staging step,
+control reached `acquire_lock`, `mkdir` could never succeed, no pid file
+existed, so the loop took the `else` arm and burned its whole budget before
+failing with the wrong diagnostic (measured at a reduced ceiling as
+`TIMEOUT after 31 iters, 3s`). The gate masks that instance; it does not fix the
+classification.
+
+There is a worse arm, which neither gate prevents. When the pid file names a
+dead process, the loop does `rm -f`/`rmdir` then `continue` — **with no `sleep`
+and no `waited` increment**. If the lock directory cannot be removed (created by
+another user, or the cache directory is writable but the lock directory is not),
+the loop spins **unbounded, with no timeout at all**. The probe gate does not
+help: the probe passes on a writable cache directory whose lock directory
+happens to be foreign.
+
+## Requirements
+
+- Classify the `mkdir` failure instead of assuming contention: after a failed
+  `mkdir`, `[[ -d "${lock_dir}" ]]` distinguishes `EEXIST` (a genuine
+  competitor) from a permission or I/O failure (unrecoverable — fail
+  immediately, naming the cause).
+- Give the dead-owner reclaim arm a bound: a failed `rmdir` must not loop
+  without advancing the budget.
+- Stay within the bash 3.2 floor.
+
+**Scope**: classifying `mkdir` and `rmdir` failures. **Not** re-wording the
+timeout message, and not redesigning the locking scheme.
+
+## Acceptance Criteria
+
+- [ ] A cold run against a cache directory whose lock directory cannot be
+      created fails within a second with a diagnostic naming the cause, not
+      after the timeout budget with a lock-timeout message.
+- [ ] A lock directory holding a dead owner's pid file that cannot be removed
+      terminates within the timeout budget rather than spinning unbounded —
+      pinned by a case with an explicit `timeout=`, so a regression shows as a
+      failure rather than a hung suite.
+- [ ] `test_stale_lock_is_reclaimed` and
+      `test_concurrent_cold_cache_slow_downloader_all_succeed` stay green: a
+      live owner still extends the budget and a dead owner is still reclaimed.
+- [ ] `scripts/lint-bashisms.sh`, shfmt and ShellCheck report no findings.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- **Relates to**: 0186, which masked the one reachable instance and recorded the
+  unbounded arm; 0164, which introduced the lock.
+- **Parent**: epic 0136.
+
+## References
+
+- `bin/accelerator` — `acquire_lock`, and the `rm -f`/`rmdir`/`continue` arm
+- `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` — Validation
+  Results, which records the measurement and the reachable instance
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py` —
+  `test_unverifiable_launcher_in_readonly_cache_fails_fast` guards the masked
+  instance

--- a/meta/work/0191-batch-the-two-shim-hashes-into-one-invocation.md
+++ b/meta/work/0191-batch-the-two-shim-hashes-into-one-invocation.md
@@ -1,0 +1,115 @@
+---
+type: work-item
+id: "0191"
+title: "Batch the bootstrap's two shim hashes into one sha256 invocation"
+date: "2026-08-03T00:00:00+00:00"
+author: Toby Clemson
+producer: implement-plan
+status: draft
+kind: task
+priority: low
+parent: "work-item:0136"
+relates_to: ["work-item:0186", "work-item:0169"]
+tags: [shell, performance, bootstrap, bash-3.2]
+last_updated: "2026-08-03T00:00:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0191: Batch the bootstrap's two shim hashes into one sha256 invocation
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Low
+**Author**: Toby Clemson
+
+## Summary
+
+The shim-staging condition in [`bin/accelerator`](../../bin/accelerator) calls
+`sha256_file` twice on every invocation — once for the source shim and once for
+the staged copy — each forking the backend plus an `awk`. Batching both into a
+single `sha256sum f1 f2` with no `awk` saves roughly 2.5 ms per warm call
+without weakening anything: both digests are still computed and compared.
+
+## Context
+
+Raised from 0186's closeout, which removed the exec probe and left this as the
+largest remaining warm-path term. 0186 deliberately did **not** absorb this: it
+needs a branch to preserve today's short-circuit, and ~2.5 ms is essentially the
+whole of 0169's ~2.4 ms shortfall, so it deserves its own before/after rather
+than riding along inside another change's measurement.
+
+Measured on darwin-arm64 (macOS 26.3, Apple M4 Max):
+
+| Shape | ms |
+| --- | --- |
+| two `$(sha256sum f \| awk …)` substitutions | 7.05 |
+| one `$(sha256sum f1 f2)`, no `awk` | 4.57 |
+| bash-interpreter baseline | 2.02 |
+
+Re-measured during 0186's closeout in a slightly different shape — one
+`sha256_file` call marginal over a `bash -c` baseline — at **3.55 ms**, so the
+two calls cost around 7 ms together, consistent with the table.
+
+**The saving is backend-dependent.** On this host `command -v sha256sum`
+resolves to `/sbin/sha256sum`, an Apple-signed Mach-O. Where only the Perl
+`shasum` fallback exists the per-call cost is ~12 ms rather than ~3.5 ms, so the
+two-hash residual swings roughly 3×. Confirm which backend each CI lane resolves
+before quoting a figure.
+
+The staged-shim hash currently runs **only when the staged shim is executable**
+(`[[ ! -x "${shim}" ]] ||` short-circuits), so a naive batch would hash a
+nonexistent file on a cold run. Apple's `/sbin/sha256sum` handles that
+gracefully — it prints the surviving digests, writes the error to stderr and
+exits 1 — but the parse must not silently mis-assign digests to paths when one
+input is missing.
+
+## Requirements
+
+- Compute both digests in one backend invocation, dropping the two `awk` forks.
+- Preserve the short-circuit: a cold run must not pay for hashing a file that
+  does not exist, and must not mis-parse the output when it does.
+- Preserve the planted-stub defence exactly — both digests still compared. The
+  three tests at
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+  (`test_planted_staged_shim_rehashed_then_succeeds`,
+  `test_planted_staged_shim_is_not_trusted`,
+  `test_planted_staged_shim_via_cache_dir_is_not_trusted`) stay green
+  unmodified.
+- Confirm the multi-file output format and the missing-file exit semantics on
+  **both** the Apple `/sbin/sha256sum` and the GNU coreutils backends, and on
+  the `shasum` fallback if the batched form is used there too.
+- Stay within the bash 3.2 floor.
+
+## Acceptance Criteria
+
+- [ ] The warm path forks the sha256 backend once, not twice, and forks no
+      `awk` — assertable from a `bash -x` trace using the seam 0186 added to
+      `run_bootstrap`.
+- [ ] The three planted-stub tests pass unmodified.
+- [ ] A cold run with no staged shim behaves as today and produces no spurious
+      diagnostic from the missing second input.
+- [ ] Warm-path median measured before and after in one session on one host,
+      both figures and the resolved backend recorded.
+- [ ] `scripts/lint-bashisms.sh`, shfmt and ShellCheck report no findings.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- **Relates to**: 0186 (measured the saving and declined to absorb it), 0169
+  (whose latency gate this most directly affects).
+- **Parent**: epic 0136.
+
+## Assumptions
+
+- Every supported backend prints one `<digest>  <path>` line per input in
+  argument order. Verified for Apple `/sbin/sha256sum`; unverified for GNU
+  coreutils and `shasum` at time of writing.
+
+## References
+
+- `bin/accelerator` — `sha256_file` and the shim-staging condition
+- `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` — Validation
+  Results, which carries the measurement and the backend range
+- `meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md` —
+  What We're NOT Doing

--- a/skills/integrations/jira/scripts/test-helpers/mock-jira-server.py
+++ b/skills/integrations/jira/scripts/test-helpers/mock-jira-server.py
@@ -138,10 +138,18 @@ def main():
     port = server.server_address[1]
     url = f"http://127.0.0.1:{port}"
 
+    # Registered before the url file is written, and the ordering is
+    # load-bearing: that file is the readiness signal start_mock blocks on, so
+    # a test can SIGTERM us the instant it appears. A case that makes no
+    # request at all (the --describe and --print-payload guards) does exactly
+    # that, and if SIGTERM lands while it still has its default disposition the
+    # process dies without running the finally below — leaving the captured-*
+    # files as the empty files mktemp created, which reads as `''` rather than
+    # `[]` at the assertion.
+    signal.signal(signal.SIGTERM, lambda *_: threading.Thread(target=server.shutdown, daemon=True).start())
+
     with open(args.url_file, "w") as f:
         f.write(url)
-
-    signal.signal(signal.SIGTERM, lambda *_: threading.Thread(target=server.shutdown, daemon=True).start())
 
     try:
         server.serve_forever()

--- a/skills/integrations/linear/scripts/test-helpers/mock-linear-server.py
+++ b/skills/integrations/linear/scripts/test-helpers/mock-linear-server.py
@@ -181,15 +181,23 @@ def main():
     port = server.server_address[1]
     url = f"http://127.0.0.1:{port}"
 
-    with open(args.url_file, "w") as f:
-        f.write(url)
-
+    # Registered before the url file is written, and the ordering is
+    # load-bearing: that file is the readiness signal start_mock blocks on, so
+    # a test can SIGTERM us the instant it appears. A case that makes no
+    # request at all (the --describe and --print-payload guards) does exactly
+    # that, and if SIGTERM lands while it still has its default disposition the
+    # process dies without running the finally below — leaving the captured-*
+    # files as the empty files mktemp created, which reads as `''` rather than
+    # `[]` at the assertion.
     signal.signal(
         signal.SIGTERM,
         lambda *_: threading.Thread(
             target=server.shutdown, daemon=True
         ).start(),
     )
+
+    with open(args.url_file, "w") as f:
+        f.write(url)
 
     try:
         server.serve_forever()

--- a/tests/integration/entrypoint/test_accelerator_entrypoint.py
+++ b/tests/integration/entrypoint/test_accelerator_entrypoint.py
@@ -1,7 +1,9 @@
 import concurrent.futures
+import contextlib
 import hashlib
 import os
 import platform
+import re
 import shutil
 import subprocess
 from collections.abc import Callable, Iterator
@@ -1103,3 +1105,236 @@ def test_a_record_is_always_one_line(
     log = cache_dir / ".accelerator-unverified.log"
     assert log.exists(), result.stderr
     assert len(log.read_text().splitlines()) == 1, log.read_text()
+
+
+# ── Exec probe: cold-path only ───────────────────────────────────────────────
+
+_PROBE_FN = "probe_exec_capable"
+_ENSURE_FN = "ensure_dir"
+
+
+@contextlib.contextmanager
+def _restricted(path: Path, mode: int) -> Iterator[None]:
+    """Apply a mode and always restore it: `tmp_path` teardown cannot remove an
+    unwritable directory, and an advisory-permission filesystem (a bind mount,
+    WSL drvfs, an inherited ACL) would silently void the case, so every bit the
+    mode clears is verified to have bitten. Both bits are checked because the
+    two failure shapes differ: 0o555 keeps search and drops write, 0o666 drops
+    search and keeps write.
+    """
+    path.chmod(mode)
+    try:
+        for owner_bit, probe, label in (
+            (0o200, os.W_OK, "write"),
+            (0o100, os.X_OK, "search"),
+        ):
+            assert mode & owner_bit or not os.access(path, probe), (
+                f"chmod {mode:#o} left {label} available on {path}; "
+                "permission bits appear advisory on this filesystem — "
+                "exclude it explicitly"
+            )
+        yield
+    finally:
+        path.chmod(0o755)
+
+
+def _traced(
+    harness: Harness,
+    downloader: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_bootstrap(
+        harness.root,
+        harness.server,
+        downloader,
+        xtrace=True,
+        extra_env=extra_env,
+        timeout=30,
+    )
+
+
+def _entered(trace: str, function: str) -> bool:
+    pattern = rf"^\++{re.escape(function)}:"
+    return re.search(pattern, trace, re.MULTILINE) is not None
+
+
+def _probe_execs(trace: str) -> int:
+    # The `:/` anchor is load-bearing: the function's own
+    # `probe=/…/.accelerator-probe-<pid>` assignment is traced too, and a looser
+    # pattern matches it — passing on an implementation that never execs.
+    # Counting rather than searching also pins the idempotence flag.
+    pattern = rf"^\++{re.escape(_PROBE_FN)}:/\S*\.accelerator-probe-\d+$"
+    return len(re.findall(pattern, trace, re.MULTILINE))
+
+
+def test_warm_path_survives_a_non_writable_cache_dir(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    launcher_bin: Path,
+) -> None:
+    # Equality against a direct launcher run proves the cached binary is the one
+    # the fixture built. It pins the vergen commit/build stamps too, so a
+    # relink between fixture setup and this call would fail it.
+    _require_unprivileged()
+    harness = make_harness(real_launcher=True)
+    root, server = harness.root, harness.server
+    warm = _run_bootstrap(root, server, downloader, args=("version",))
+    assert warm.returncode == 0, warm.stdout + warm.stderr
+    with _restricted(root / "bin", 0o555):
+        result = _run_bootstrap(root, server, downloader, args=("version",))
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    direct = subprocess.run(
+        [str(launcher_bin), "version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout == direct.stdout, output
+
+
+def test_warm_path_does_not_enter_the_probe(
+    make_harness: Callable[..., Harness], downloader: Path
+) -> None:
+    harness = make_harness()
+    warm = _run_bootstrap(harness.root, harness.server, downloader)
+    assert warm.returncode == 0, warm.stdout + warm.stderr
+    traced = _traced(harness, downloader)
+    assert traced.returncode == 0, traced.stdout + traced.stderr
+    trace = traced.stderr
+    # `verify_launcher` bounds the trace from the far end: `ensure_dir` alone
+    # only proves the run reached `resolve_cache_dir`, which is upstream of both
+    # gates, so a truncated trace would satisfy the negative assertion.
+    assert _entered(trace, _ENSURE_FN), trace
+    assert _entered(trace, "verify_launcher"), trace
+    assert not _entered(trace, _PROBE_FN), trace
+
+
+def test_cold_path_enters_and_executes_the_probe(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    harness = make_harness()
+    cache = tmp_path / "fresh-cache"
+    result = _traced(
+        harness, downloader, extra_env={"ACCELERATOR_CACHE_DIR": str(cache)}
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert cache.is_dir(), "the always-run ensure_dir half must create it"
+    assert _entered(result.stderr, _PROBE_FN), result.stderr
+    # Exactly one: a cold run reaches both gates, so a broken idempotence flag
+    # would probe twice.
+    assert _probe_execs(result.stderr) == 1, result.stderr
+    assert not list(cache.glob(".accelerator-probe-*")), "probe not cleaned up"
+
+
+def test_cold_happy_path_creates_a_missing_cache_dir(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    harness = make_harness(real_launcher=True)
+    cache = tmp_path / "absent" / "cache"
+    result = _run_bootstrap(
+        harness.root,
+        harness.server,
+        downloader,
+        args=("version",),
+        extra_env={"ACCELERATOR_CACHE_DIR": str(cache)},
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert cache.is_dir(), output
+    assert result.stdout.startswith("accelerator "), output
+
+
+def test_cold_path_keeps_the_noexec_diagnostic(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "noexec-cache"
+    cache.mkdir()
+    with _restricted(cache, 0o666):
+        result = _run_bootstrap(
+            harness.root,
+            harness.server,
+            downloader,
+            extra_env={"ACCELERATOR_CACHE_DIR": str(cache)},
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+    assert str(cache) in output, output
+    assert "is not writable" in output, output
+
+
+def test_warmed_then_non_executable_cache_keeps_the_diagnostic(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "warm-cache"
+    cache.mkdir()
+    env = {"ACCELERATOR_CACHE_DIR": str(cache)}
+    first = _run_bootstrap(
+        harness.root, harness.server, downloader, extra_env=env
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    with _restricted(cache, 0o666):
+        result = _run_bootstrap(
+            harness.root, harness.server, downloader, extra_env=env
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+
+
+def test_unverifiable_launcher_in_readonly_cache_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    tmp_path: Path,
+    host_platform: str,
+) -> None:
+    # 0o555, not 0o666: keeping the search bit means the cached artefacts still
+    # stat and the staged shim still hashes equal, so staging is skipped and
+    # verification is genuinely reached. `timeout` sits between the sub-second
+    # pass and the ~30s lock-timeout budget the gate prevents.
+    _require_unprivileged()
+    harness = make_harness()
+    cache = tmp_path / "readonly-cache"
+    cache.mkdir()
+    env = {"ACCELERATOR_CACHE_DIR": str(cache)}
+    first = _run_bootstrap(
+        harness.root, harness.server, downloader, extra_env=env
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    launcher = cache / f"accelerator-launcher-{_VERSION}-{host_platform}"
+    launcher.write_bytes(b"poisoned")
+    with _restricted(cache, 0o555):
+        result = _run_bootstrap(
+            harness.root, harness.server, downloader, extra_env=env, timeout=15
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+
+
+def test_uncreatable_cache_dir_is_a_named_error(
+    make_harness: Callable[..., Harness], downloader: Path, tmp_path: Path
+) -> None:
+    # The cause clause is what distinguishes this site from the two probe
+    # gates, which emit the same leading substring.
+    _require_unprivileged()
+    harness = make_harness()
+    parent = tmp_path / "readonly-parent"
+    parent.mkdir()
+    with _restricted(parent, 0o555):
+        result = _run_bootstrap(
+            harness.root,
+            harness.server,
+            downloader,
+            extra_env={"ACCELERATOR_CACHE_DIR": str(parent / "nested")},
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "no writable, exec-capable cache directory" in output, output
+    assert "could not be created" in output, output

--- a/tests/integration/entrypoint/test_accelerator_entrypoint.py
+++ b/tests/integration/entrypoint/test_accelerator_entrypoint.py
@@ -54,6 +54,19 @@ _dumped_env = dumped_env
 _dl_lines = download_log
 
 
+def _require_unprivileged() -> None:
+    """Hard-fail rather than skip under uid 0.
+
+    Root bypasses both the write permission and the execute bit, so these
+    assertions would hold whatever the code did; a skip would report green on a
+    lane that verified nothing.
+    """
+    assert os.getuid() != 0, (
+        "these cases assert on permission bits, which are advisory for uid 0; "
+        "run them unprivileged, or exclude them with a recorded privilege check"
+    )
+
+
 @pytest.fixture(scope="module")
 def host_platform() -> str:
     return _resolve_host_platform()
@@ -256,6 +269,7 @@ def test_readonly_root_with_override_runs_from_override(
     tmp_path: Path,
     host_platform: str,
 ) -> None:
+    _require_unprivileged()
     harness = make_harness()
     root, server = harness.root, harness.server
     bin_dir = root / "bin"
@@ -279,6 +293,7 @@ def test_readonly_root_with_override_runs_from_override(
 def test_readonly_root_without_override_is_a_named_error(
     make_harness: Callable[..., Harness], downloader: Path
 ) -> None:
+    _require_unprivileged()
     harness = make_harness()
     root, server = harness.root, harness.server
     bin_dir = root / "bin"
@@ -1066,6 +1081,7 @@ def test_a_record_is_always_one_line(
     # A cache dir carrying a newline reaches the staging diagnostic verbatim,
     # so the write-site sanitiser — not any input check — is what keeps the log
     # parseable.
+    _require_unprivileged()
     harness = make_harness()
     cache_dir = tmp_path / "cache\nwith-newline"
     cache_dir.mkdir()

--- a/tests/integration/support/installation.py
+++ b/tests/integration/support/installation.py
@@ -327,6 +327,7 @@ def run_bootstrap(
     downloader: Path,
     *,
     args: tuple[str, ...] = (),
+    xtrace: bool = False,
     extra_env: dict[str, str] | None = None,
     path: str | None = None,
     entry: Path | None = None,
@@ -339,6 +340,16 @@ def run_bootstrap(
     which defaults to the installation root's own copy. `cwd` defaults to an
     empty directory, since the launcher's `config` family reads project config
     from the working directory.
+
+    `xtrace` runs the bootstrap under `bash -x` for this call only, since the
+    trace lands on the same stderr other cases assert diagnostics on. It
+    defaults `PS4` alongside, because a bare `${FUNCNAME[0]}` is unbound at top
+    level under the bootstrap's `set -u`. `SHELLOPTS=xtrace` is not an
+    equivalent: it is exported into every bash descendant, and the probe's
+    `#!/bin/sh` is bash on macOS but dash on Linux, so the trace content would
+    differ by lane. A boolean rather than an argument list, because bash reads
+    the first non-option operand as the script and an arbitrary list could
+    demote the validated `entry` to `$1`.
     """
     env = {
         "PATH": path or os.environ["PATH"],
@@ -350,6 +361,9 @@ def run_bootstrap(
     }
     if extra_env:
         env.update(extra_env)
+    bash_flags = ("-x",) if xtrace else ()
+    if xtrace:
+        env.setdefault("PS4", "+${FUNCNAME[0]:-main}:")
     entry = entry or root / "bin/accelerator"
     with contextlib.ExitStack() as stack:
         if cwd is None:
@@ -357,7 +371,7 @@ def run_bootstrap(
         assert_hermetic(env, cwd / entry)
         try:
             return subprocess.run(
-                [BASH, str(entry), *args],
+                [BASH, *bash_flags, str(entry), *args],
                 capture_output=True,
                 text=True,
                 env=env,

--- a/tests/unit/tasks/test_bootstrap_coverage.py
+++ b/tests/unit/tasks/test_bootstrap_coverage.py
@@ -76,6 +76,18 @@ def test_bootstrap_exports_the_one_plugin_root_the_launcher_reads() -> None:
         )
 
 
+def test_the_cache_dir_helpers_keep_the_names_the_traces_assert_on() -> None:
+    # The entrypoint trace cases match these tokens in a `bash -x` trace. A
+    # rename would otherwise fail only after a cargo build and a full
+    # fetch-verify-cache round trip, reporting "probe not entered" rather than
+    # "the name moved" — and would silently void the warm-path negative
+    # assertion in the meantime.
+    for name in ("ensure_dir", "probe_exec_capable"):
+        assert name in _BOOTSTRAP_SRC.read_text(), (
+            f"{name} is asserted on by name in the entrypoint trace cases"
+        )
+
+
 def test_the_committed_vendored_shims_are_not_gitignored() -> None:
     # The staged-shim ignore pattern is digest-anchored; a `-*-*` form would
     # also match these four and block `git add` after a shim refresh.


### PR DESCRIPTION

# [0186] Probe the cache directory only on the bootstrap's cold path

## Summary

`bin/accelerator` wrote, `chmod +x`'ed, exec'ed and removed a probe file on **every** invocation — a capability check the warm path never needed, since a warm call proves the same capability for real by running the staged verify shim and the launcher out of that directory. On macOS the exec of a freshly written file pays a first-exec check that dominated the whole invocation. Splitting `probe_dir` into an always-run `ensure_dir` and a cold-path-only `probe_exec_capable` takes the warm median from **125.35 ms to 29.92 ms** on darwin-arm64. Every SessionStart hook and every skill's `!`-preprocessor site pays that cost, so it is the most-executed path in the plugin.

## Changes

- **`bin/accelerator` — the split.** `ensure_dir` keeps the `mkdir -p` (guarded by `[[ -d ]]`, so a warm call does not even fork `mkdir`) and stays reachable on every invocation via `resolve_cache_dir`. `probe_exec_capable` keeps the write-`chmod`-exec-`rm` and now returns **1** for a write failure and **2** for an exec failure, so the caller can report the cause it actually detected. Every exit path removes the probe file.
- **Two gates, not one.** `require_exec_capable_cache` sits behind a `probed` flag and is called from (a) the first statement of the shim-staging `if` **body**, which is the first required write into the cache directory on every path, and (b) the top of the cold branch, before `acquire_lock`. Both sit below the dev-launcher override, so the contributor path stops paying for a probe it never needed. A cold run reaching both probes exactly once.
- **One diagnostic, three causes.** `fail_no_cache_dir` gives `no writable, exec-capable cache directory` a single definition; each site supplies what it detected (`could not be created` / `is not writable` / `rejected an executable file — possibly a noexec mount`). It also fixes a pre-existing wart: the message named `${plugin_root}/bin` even when an `ACCELERATOR_CACHE_DIR` override was the thing that failed.
- **New supported configuration** — a cache directory populated once may afterwards be **read-only for warm bootstrap invocations**. Documented in `docs/internals.md` and `CHANGELOG.md` together with the limit that matters: dispatching a subcommand to a separate binary makes the *launcher* probe the same directory, and that probe writes.
- **Test harness gains a per-call `xtrace` seam** (`run_bootstrap(..., xtrace=True)`), defaulting `PS4` alongside it, so probe absence can be asserted by function name rather than by residue.
- **Eight new entrypoint cases plus three retrofits**, and a hard-failing `_require_unprivileged()` guard.
- **Three follow-ups raised** — 0189, 0190, 0191 — and 0169's hand-off note re-confirmed against the measured figures.

Production surface is small: `bin/accelerator` (+82/-…), `docs/internals.md`, `CHANGELOG.md`. Tests are +279 across three files. The remaining ~6,000 lines are `meta/` artefacts (research, plan, plan review, work items, validation report).

## Context

Work item [`0186`](../work/0186-remove-exec-probe-from-bootstrap-warm-path.md), under epic 0136, unblocked by 0182 and blocking [`0169`](../work/0169-vcs-subdomain-and-hooks-migration.md). Plan and its review are in `meta/plans/` and `meta/reviews/plans/`; the validation report is `meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md`.

### Why two call sites

A single gate in the staging body is not enough. In the residual case — launcher present and executable, signature present, staged shim present and matching (so staging is skipped), *verification fails*, directory unwritable — control reaches `acquire_lock`, whose `mkdir` can never succeed and whose loop treats a missing pid file as an imminent competitor. It then burns its full 300 × 0.1 s budget and reports a **lock timeout** instead of the real cause. That case fails instantly today, so the second gate prevents a regression rather than merely preserving a nicer message. It is measured at 27 ms with the gate in place.

Equally, a gate placed only in the cold branch would miss the `chmod -x` scenarios: `cp` fails first with `could not stage the verify shim into …`, losing the cache-dir substring entirely.

### Measured result

50 interleaved samples per variant in one Python process, order alternated, on darwin-arm64 (Apple M4 Max, macOS 26.3 build 25D125). Both variants shared one pre-cached signed release launcher, confirmed by inode across the run.

| Variant | min | median | p90 | median − harness floor |
| --- | --- | --- | --- | --- |
| before | 119.02 | **125.35** | 234.15 | 123.75 |
| after | 27.18 | **29.92** | 32.44 | 28.32 |

All ms. Gate `after ≤ 0.5 × before` passes at a ratio of **0.239** — materially better than the ~41 ms the plan expected. Instrument floors: 1.60 ms (`/usr/bin/true`) and 6.10 ms (a trivial bash script). The remaining ~30 ms is accounted for term by term in the work item's Validation Results, with ~10% unexplained (under the 25% threshold that would have triggered a per-line attribution).

### Two figures in circulation were wrong, and are corrected here

- **The retained double-hash residual is backend-dependent.** The ~11.7 ms per `sha256_file` call quoted in 0186 and 0169's hand-off note describes the **Perl `shasum` fallback**. On a host where `command -v sha256sum` resolves to Apple's `/sbin/sha256sum` — as it does on the measuring host — a call costs **~3.5 ms**, so the two-hash residual is **~7 ms or ~24 ms depending on the host**. 0169 is handed the range and the backend, not a point estimate. Corrected in 0186's Dependencies, Assumptions and Validation Results, not only in 0169's note.
- **The probe's first-exec penalty is re-derived rather than inherited.** The Context table's methodology was unrecorded and its "re-exec of a pre-existing probe file | 10.6 ms" row is seven times this harness's fork+exec floor. Measured directly: 1.41 ms bare fork+exec, 3.72 ms to re-exec a probe file left in place, 107.15 ms to write+`chmod`+exec+`rm` in `/tmp`, 131.97 ms in the repo's `bin/`. The host runs **no third-party EndpointSecurity or anti-malware agent** (only Apple's `xprotectd`, SIP and Gatekeeper on), so the penalty is stock macOS behaviour rather than a machine artefact — which means the ratio should transfer to other macOS hosts, and the extrapolation to the launcher-side probe (0189) holds.

## Testing

- [x] `mise run test:integration:entrypoint` — **54 passed**, including all eight new cases.
- [x] `mise run test:integration:skill-invocation` — **128 passed**. The `run_bootstrap` seam is shared with this suite; the `xtrace=False` default keeps it unaffected.
- [x] `uv run pytest tests/unit/tasks/test_bootstrap_coverage.py tests/unit/tasks/test_mise.py` — 33 passed, including the new name-pin assertion and the standing no-`build:cli:dev` guard.
- [x] `mise run check` — green end to end across all four components.
- [x] `mise run scripts:check` — shfmt, ShellCheck, bashisms and exec-bits clean over `bin/accelerator` (which `tasks/shared/sources.py:110` puts in shell-source scope despite being extensionless, and which is tab-indented because `.editorconfig`'s `[*.sh]` section does not match it).
- [x] `mise run build-system:check` — format, lint and types clean.
- [x] `mise run test:integration:config` — 58 passed; the corpus frontmatter validator accepts the amended items and the three new ones.
- [x] **Written test-first, with the red step recorded per case** — 5 failed / 3 passed before the change, exactly as predicted. Three of the eight are green before *and* after: they are preservation guards, which the record says explicitly rather than claiming a uniform red.
- [x] **Both gates confirmed by mutation after the change.** Deleting the staging gate reds `test_cold_path_keeps_the_noexec_diagnostic`, `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and `test_readonly_root_without_override_is_a_named_error`; deleting the cold-branch gate reds only `test_unverifiable_launcher_in_readonly_cache_fails_fast`, via its timeout. That mutation is the only demonstration the cold-branch gate is guarded at all, since its case passes before the change too.
- [x] **Manual**: a tampered cached launcher in an unwritable cache dir fails in **27 ms** with the cache-dir diagnostic, not after the ~30 s lock budget. Cold trace shows the probe entered and the probe file executed as its own command word exactly once, with `+main:require_exec_capable_cache` appearing twice — so the idempotence flag is exercised, not merely present. Warm trace shows `ensure_dir` and `verify_launcher` but no `probe_exec_capable`.
- [ ] **The linux lane.** Not observed — this branch has not had a CI run. See below.

## Notes for Reviewers

**The one genuinely outstanding item is the ubuntu lane, and 0186 stays `in-progress` until it is seen.** The harness pins `BASH = "/bin/bash"`, which is 3.2.57 on darwin and **5.2** on `ubuntu-latest`, so the two trace cases exercise both interpreters on every CI run with no extra wiring — but that also means a trace-format divergence surfaces in CI rather than locally. `.github/workflows/main.yml` has no `container:` key and `test-integration` is a plain `runs-on: ${{ matrix.os }}` matrix, so both lanes run unprivileged and `_require_unprivileged` should not fire; no lane exclusion is expected. The work item's own Drafting Notes call this observation "a genuine closure condition, not a formality", which is why the status is held rather than moved to `complete`. Worth also capturing `command -v sha256sum` on both lanes while CI runs — it costs nothing and tells 0169 whether the Perl fallback is reachable in CI at all.

**One of the three diagnostic causes ships untested, deliberately.** No directory-permission combination can produce exec-without-write: clearing a directory's search bit blocks name resolution, so the probe fails at its *write* step and the exec branch is never evaluated. The exec **half** is covered by the positive control's assertion that the probe file is executed as its own command word; the `rejected an executable file` **cause clause** is not covered by any automated case. Closing it needs a genuine `mount -o noexec` filesystem, which is explicitly out of scope. If you would rather have a cheap seam than an untested branch, say so — but note 0189 will face the identical gap on the launcher side, so it may be better solved once, there.

**The trace matcher's `:/` anchor is load-bearing and easy to "simplify" wrongly.** `probe_exec_capable`'s own `probe=/…/.accelerator-probe-<pid>` **assignment** is traced too. The unanchored form `…:\S*\.accelerator-probe-\S*$` matches **two** lines and therefore passes on an implementation that never execs anything; the anchored form matches exactly one. Verified against a real trace. Relatedly, `PS4` is `'+${FUNCNAME[0]:-main}:'` rather than the acceptance criterion's literal `'+${FUNCNAME[0]}:'` — a bare `${FUNCNAME[0]}` is unbound at top level under the bootstrap's `set -u`, which on bash 3.2 emits `FUNCNAME[0]: unbound variable` per command and leaves PS4 literally unexpanded, and aborts a non-interactive bash 5 outright. And trace depth is not stable (`resolve_cache_dir` runs inside `$( )`, so its lines carry `++`), which is why every matcher allows one *or more* leading `+`.

**`_require_unprivileged` asserts where the neighbouring idiom skips, and that is intentional.** `tests/integration/hooks/test_launcher_link_refresh.py:275-293` uses `skipif`. Root bypasses both the write permission and the execute bit, so a skip would report green on a lane that verified nothing. The asymmetry worth knowing when reading these: cases asserting **success** under a restrictive mode go silently green under uid 0; cases asserting **failure** red noisily but for the wrong reason. One guard covers both.

**Two deviations from the plan are corrections *to* the plan, both recorded in place.** `_restricted`'s mode check: the plan's single `not os.access(path, os.W_OK)` assertion is wrong for the two `0o666` cases, which keep the owner write bit and clear only search — it fired on correctly-restricted directories. Implemented as a loop over both owner bits, checking each probe only when the mode clears the corresponding bit. And the staging comment's byte figure: the plan instructed correcting `475KB` to `465KB`, but 465,568 B is the **linux-x64** shim — the four vendored shims measure 486,672 / 496,896 / 426,400 / 465,568 bytes, so `475KB` was already right for darwin-arm64 and the comment now reads `~475KB`.

**One reordering to be aware of.** Because the staging gate sits inside the staging body, a cold invocation destined to fail with the cache-dir diagnostic now spends ~7 ms hashing first, where `resolve_cache_dir` previously failed before any hashing. No test depends on the old ordering, and it only affects a path that is about to abort.

**The saving does not reach the paths that motivated the work item, and 0169 must not wait for it.** `cache_root::resolve` runs the identical write-`chmod`-exec probe on **every** external-subcommand dispatch, before the sub-binary cache-hit test — so a warm `accelerator vcs guard` still pays a first-exec penalty of the same shape (measured 131.97 ms in the repo's `bin/`). Built-ins like `version` never reach it, which is why this PR's measurement cannot see it. Raised as **0189**; **0190** covers `acquire_lock`'s inability to classify an unusable lock directory (one arm spins *unbounded* — `rm -f`/`rmdir` then `continue` with no `sleep` and no `waited` increment); **0191** covers batching the two shim hashes (~2.5 ms measured, essentially 0169's whole shortfall). 0169's hand-off note is re-confirmed with **its threshold and rationale untouched** — that decision remains 0169's own.

**Not done here, deliberately**: the shim staging block's two hashes stay (three tests assert the planted-stub defence they provide); no `launcher`/`launcher_sig` hoisting; no `sha256_file` backend change (the native backend is already in use and `openssl dgst` is slower); no new `test:integration:*` leaf; no pytest marker for the root guard until a root lane actually exists.
