### PR TITLE
[0186] Close out 0186 against both observed CI lanes

### DIFF
--- a/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/plans/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -5,7 +5,7 @@ title: "Remove the Exec Probe from the Bootstrap Warm Path Implementation Plan"
 date: "2026-08-02T22:01:31+00:00"
 author: "Toby Clemson"
 producer: create-plan
-status: ready
+status: done
 work_item_id: "work-item:0186"
 parent: "work-item:0186"
 derived_from:
@@ -14,7 +14,7 @@ relates_to: ["work-item:0169", "work-item:0182", "work-item:0164"]
 tags: [shell, performance, bootstrap, bash-3.2, testing]
 revision: "4a68344cd2614f3bdd07223c8aeaf64583c036f0"
 repository: "accelerator"
-last_updated: "2026-08-03T10:31:13+00:00"
+last_updated: "2026-08-03T15:00:23+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -896,10 +896,15 @@ negative assertion in the meantime.
       and the probe runs once, so the idempotence flag is exercised
 - [x] Warm trace shows `ensure_dir` and `verify_launcher` but no
       `probe_exec_capable`
-- [ ] Both interpreters are covered without extra work: the harness pins
+- [x] Both interpreters are covered without extra work: the harness pins
       `/bin/bash`, which is 3.2.57 on darwin and 5.2 on `ubuntu-latest`, so the
-      two trace cases run under both on every CI run. Confirm the ubuntu lane
-      green on them specifically rather than assuming (Phase 4 records it)
+      two trace cases run under both on every CI run. Confirmed on the ubuntu
+      lane specifically rather than assumed — run 30821400291 (2026-08-03),
+      `test_warm_path_does_not_enter_the_probe` and
+      `test_cold_path_enters_and_executes_the_probe` both PASSED there. The
+      lanes are also demonstrably running *different* interpreters:
+      `test_the_suite_runs_the_bootstrap_on_the_bash_floor` passes on
+      macos-latest and skips on ubuntu-latest
 
 ---
 
@@ -1353,9 +1358,11 @@ rationale** — that is 0169's own work.
       attributed
 - [x] The probe attribution is re-derived on this harness and the host's
       security-agent status recorded
-- [ ] Both CI lanes observed green on the new cases, and which were observed is
+- [x] Both CI lanes observed green on the new cases, and which were observed is
       recorded — including the ubuntu lane's bash 5.2 coverage of the trace
-      cases
+      cases. Run 30821400291 (2026-08-03): macos-latest 54 passed,
+      ubuntu-latest 53 passed / 1 skipped, all eight new cases green on both,
+      no lane exclusion needed
 - [x] Every _pending_ entry in Validation Results is resolved, each behavioural
       one naming the test function that discharges it
 - [x] The stale ~11.7 ms / ~23 ms figures are corrected in 0186's Dependencies,

--- a/meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md
+++ b/meta/validations/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path-validation.md
@@ -6,11 +6,11 @@ date: "2026-08-03T12:23:32+00:00"
 author: "Toby Clemson"
 producer: validate-plan
 status: complete
-result: "partial"
+result: "pass"
 parent: "work-item:0186"
 target: "plan:2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path"
 tags: [shell, performance, bootstrap, bash-3.2, testing]
-last_updated: "2026-08-03T12:23:32+00:00"
+last_updated: "2026-08-03T15:00:23+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -23,14 +23,16 @@ schema_version: 1
 ✓ Phase 2: Split the Probe and Relocate It Off the Warm Path — fully
 implemented (`rpzsskwo`)
 ✓ Phase 3: Documentation — fully implemented (`oqkknkry`)
-⚠️ Phase 4: Measurement and Closeout — implemented (`vwkmolqw`); one
-criterion outstanding by construction (see below)
+✓ Phase 4: Measurement and Closeout — fully implemented (`vwkmolqw`), with
+the cross-lane observation discharged by CI run 30821400291
 
-Every code, test and documentation change the plan specifies is present in the
-working tree and committed. `jj status` is clean. The single unresolved item is
-the cross-lane CI observation, which cannot be discharged locally: the change
-sits on an unnamed change with no bookmark and no pushed branch, so CI has not
-run against it at all.
+Every code, test and documentation change the plan specifies is present and
+committed, and every success criterion in the plan is now ticked. The
+cross-lane CI observation — the one item that could not be discharged locally
+when this report was first written — was confirmed on 2026-08-03.
+
+**Amended 2026-08-03** after the CI observation landed. The report below is
+otherwise as originally written; the result moves from `partial` to `pass`.
 
 ### Automated Verification Results
 
@@ -54,6 +56,32 @@ follow-ups
 Not re-run here: the bare `mise run` default task. Its constituent read-only
 gate (`mise run check`) and all three affected test suites are green, and the
 plan records it as observed green during Phase 4.
+
+**CI, run
+[30821400291](https://github.com/atomicinnovation/accelerator/actions/runs/30821400291)
+(2026-08-03, head `f0fdeeb2`) — all 16 jobs green:**
+
+✓ `Run integration tests (macos-latest)` — entrypoint suite 54 passed (139.29s)
+✓ `Run integration tests (ubuntu-latest)` — entrypoint suite 53 passed, 1
+skipped (72.76s); all eight new cases green
+✓ Both unit lanes, both E2E lanes, visual regression, and all seven `Check *`
+jobs
+
+The two trace cases are confirmed on both interpreters. The single ubuntu skip
+is `test_the_suite_runs_the_bootstrap_on_the_bash_floor`, which is darwin-only
+— and its passing on macos while skipping on ubuntu is itself the evidence the
+lanes run genuinely different bash versions, so the coverage claim is observed
+rather than inferred. `_require_unprivileged` did not fire on either lane, so
+no exclusion was needed, as predicted.
+
+An unrelated flake had to be fixed first: both mock HTTP servers installed
+their SIGTERM handler *after* writing the url file that `start_mock` treats as
+the readiness signal, so a test making no request at all (`--describe`,
+`--print-payload`) could kill the process while SIGTERM still had its default
+disposition — skipping the `finally` that writes the captured-urls file.
+Reproduced 10/10 with the window widened, 0/10 with the ordering reversed.
+Fixed in both `mock-jira-server.py` and `mock-linear-server.py`. Unrelated to
+this plan, but it blocked the observation.
 
 ### Code Review Findings
 
@@ -124,20 +152,22 @@ reasoning — none is silent.
   a direct launcher run, the positive control got its own traced cold run, and
   the measurement method became 50 interleaved single-process samples. All three
   were specified by the plan and are recorded as deviations in the work item.
-- **Work item status** — Phase 4 change 6 says "move `status` to `complete`";
-  it is `in-progress`, with an explicit note at the top of the item explaining
-  that the item's own Drafting Notes make the cross-lane observation "a genuine
-  closure condition, not a formality". This is the correct call, not a miss.
+- **Work item status** — Phase 4 change 6 says "move `status` to `complete`",
+  but `complete` is not in the schema's status vocabulary
+  (`draft | ready | in-progress | review | done | blocked | abandoned`), as
+  `scripts/validate-corpus-frontmatter.sh` reports. The item was correctly held
+  at `in-progress` pending the cross-lane observation, with a note at the top
+  explaining why; on 2026-08-03, once run 30821400291 discharged that
+  criterion, it moved to **`done`** — the terminal value the plan should have
+  named.
 
 #### Potential Issues
 
-- **The linux lane is entirely unobserved.** The two trace cases
-  (`test_warm_path_does_not_enter_the_probe`,
-  `test_cold_path_enters_and_executes_the_probe`) are the most
-  environment-sensitive in the suite, and the plan's own reasoning is that the
-  harness's pinned `/bin/bash` is 3.2.57 on darwin but 5.2 on `ubuntu-latest` —
-  so a trace-format divergence would surface only in CI. The change is not on a
-  bookmark and has not been pushed, so nothing has run there.
+- ~~**The linux lane is entirely unobserved.**~~ **Resolved 2026-08-03.** Both
+  trace cases pass on `ubuntu-latest` (bash 5.2) and `macos-latest`
+  (bash 3.2.57) in run 30821400291. No trace-format divergence exists between
+  the interpreters; the `PS4` `:-main` default and the `^\++` matchers behave
+  identically on both.
 - **The exec-vs-write coverage gap remains open**, as the plan intends. No
   directory-permission combination produces exec-without-write, so
   `probe_exec_capable`'s `return 2` branch — and the `rejected an executable
@@ -158,15 +188,18 @@ reasoning — none is silent.
 
 ### Manual Testing Required
 
-1. CI observation (the only genuinely blocking item):
-  - [ ] Push the change and confirm the `test-integration` matrix is green on
-        `ubuntu-latest`, specifically on `test_warm_path_does_not_enter_the_probe`
-        and `test_cold_path_enters_and_executes_the_probe` (bash 5.2 coverage of
-        the trace assertions)
-  - [ ] Confirm no lane exclusion was needed — `_require_unprivileged` should
-        not fire on either runner
+1. CI observation — **complete**:
+  - [x] `test-integration` green on `ubuntu-latest`, specifically on
+        `test_warm_path_does_not_enter_the_probe` and
+        `test_cold_path_enters_and_executes_the_probe` (bash 5.2 coverage of
+        the trace assertions) — run 30821400291, 2026-08-03
+  - [x] No lane exclusion needed — `_require_unprivileged` did not fire on
+        either runner
   - [ ] Record `command -v sha256sum` on both lanes, so 0169 learns whether the
-        Perl `shasum` fallback is reachable in CI at all
+        Perl `shasum` fallback is reachable in CI at all. **Not done** — it
+        needs a deliberate step in the workflow and nothing in this plan
+        required it; 0169 carries the backend as a range rather than a per-lane
+        fact.
 
 2. Optional, out of scope but worth noting if an opportunity arises:
   - [ ] Point `ACCELERATOR_CACHE_DIR` at a genuine `mount -o noexec` filesystem
@@ -175,15 +208,16 @@ reasoning — none is silent.
 
 ### Recommendations
 
-- **Push the branch and let CI discharge the last criterion**, then tick the
-  two remaining boxes (Phase 2 manual item 4, Phase 4 manual item 5), fill the
-  "Lanes observed green" entry in the work item's Validation Results, and move
-  0186 to `complete`. Nothing else stands between the change and closure.
-- **Leave the work item at `in-progress` until then.** The deliberate hold is
-  correct and the note explaining it should stay until CI replaces it with an
-  observation.
+- **The plan is complete and 0186 is closed.** All success criteria are ticked,
+  both lanes are observed, and PR #41 is green end to end. Nothing blocks merge.
 - **Consider whether the `return 2` cause clause deserves a cheap seam** rather
   than staying untested indefinitely — for example an injectable probe command
   in a test-only env var. Not required by this plan, and the trade-off (a new
   seam in a trust-root script) may well favour leaving it; worth a sentence in
   0189, which will face the same gap on the launcher side.
+- **Pick up `command -v sha256sum` on the CI lanes when 0169 needs it.** It is
+  the one recording step this work left undone, and it is 0169's input rather
+  than 0186's.
+- **`main` is currently red** on `Run unit tests (macos-latest)`, unrelated to
+  this work and predating it. Worth its own look — this branch is green on that
+  same job, so whatever it is does not reproduce here.

--- a/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
+++ b/meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md
@@ -5,7 +5,7 @@ title: "Remove the Exec Probe from the Bootstrap Warm Path"
 date: "2026-07-31T10:41:51+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: in-progress
+status: done
 kind: task
 priority: high
 parent: "work-item:0136"
@@ -21,7 +21,7 @@ relates_to:
     "work-item:0191",
   ]
 tags: [shell, performance, bootstrap]
-last_updated: "2026-08-03T00:00:00+00:00"
+last_updated: "2026-08-03T15:00:23+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -29,15 +29,17 @@ schema_version: 1
 # 0186: Remove the Exec Probe from the Bootstrap Warm Path
 
 **Kind**: Task
-**Status**: In Progress
+**Status**: Done
 **Priority**: High
 **Author**: Toby Clemson
 
-> **Implemented and measured 2026-08-03.** Every criterion is discharged except
-> the cross-lane observation, which needs a CI run this branch has not had yet.
-> This item's own Drafting Notes call that observation "a genuine closure
-> condition, not a formality", so the status stays short of `done` until the
-> linux lane is seen green on the new cases. Nothing else is outstanding.
+> **Done 2026-08-03.** Implemented, measured and observed green on both
+> shipped lanes. Warm `bin/accelerator version` drops from a 125.35 ms median
+> to 29.92 ms on darwin-arm64 — a ratio of 0.239 against the 0.5 gate. The
+> cross-lane observation this item's Drafting Notes call "a genuine closure
+> condition, not a formality" is discharged by CI run 30821400291, with all
+> eight new cases green on macos-latest and ubuntu-latest. Follow-ups 0189,
+> 0190 and 0191 carry the work this deliberately did not absorb.
 
 ## Summary
 
@@ -219,7 +221,7 @@ Validation Results for any exclusion claimed.
       probe cost is itself host-specific and a fast host could remove the whole
       probe yet miss a fixed 80 ms bar. Both medians, the delta, and the host
       and OS version go in Validation Results.
-- [ ] `test:integration:entrypoint` is observed green on **both shipped lanes**
+- [x] `test:integration:entrypoint` is observed green on **both shipped lanes**
       (darwin and linux) for the new cases, not only locally — these are the
       most environment-sensitive criteria in the suite. Which lanes were
       observed is recorded in Validation Results.
@@ -474,12 +476,30 @@ a permanent guard rather than a one-off observation.
   `test_cold_happy_path_creates_a_missing_cache_dir`,
   `test_warmed_then_non_executable_cache_keeps_the_diagnostic` and
   `test_unverifiable_launcher_in_readonly_cache_fails_fast`.
-- **Lanes observed green** (darwin, linux) — darwin observed locally
-  (2026-08-03): `test:integration:entrypoint` 54 passed,
+- **Lanes observed green** (darwin, linux) — **both observed**, CI run
+  [30821400291](https://github.com/atomicinnovation/accelerator/actions/runs/30821400291)
+  on 2026-08-03 (PR #41, head `f0fdeeb2`), all 16 jobs green:
+
+  | Lane | `test:integration:entrypoint` | Job |
+  | --- | --- | --- |
+  | macos-latest | 54 passed (139.29s) | 91711926312 |
+  | ubuntu-latest | 53 passed, 1 skipped (72.76s) | 91711926176 |
+
+  All eight new cases passed on **both** lanes. The one skip is
+  `test_the_suite_runs_the_bootstrap_on_the_bash_floor`, which is darwin-only —
+  and its passing on macos while skipping on ubuntu is itself the evidence that
+  the two lanes really do run different interpreters, so
+  `test_warm_path_does_not_enter_the_probe` and
+  `test_cold_path_enters_and_executes_the_probe` are genuinely covered on bash
+  3.2.57 **and** bash 5.2 rather than twice on the same one. The `PS4`
+  `:-main` default and the `^\++` trace matchers behave identically across
+  both. Also observed locally on darwin (2026-08-03):
   `test:integration:skill-invocation` 128 passed, `mise run check` green.
-  **Linux lane pending CI.** The harness pins `BASH = "/bin/bash"`, which is
-  3.2.57 on darwin and 5.2 on `ubuntu-latest`, so the two trace cases are
-  covered on **both interpreters** by the standard CI run with no extra work.
+
+  Not recorded, and worth capturing if the question ever becomes live:
+  `command -v sha256sum` on either lane. It costs nothing but needs a
+  deliberate step, so 0169 still has the backend as a range rather than a
+  per-lane fact.
 - **Lane exclusions** — **none**. `.github/workflows/main.yml` contains no
   `container:` key; `test-integration` is a plain `runs-on: ${{ matrix.os }}`
   matrix over `ubuntu-latest`/`macos-latest`, so both lanes run unprivileged and


### PR DESCRIPTION
## Summary

Closes out 0186 now that CI has observed the new entrypoint cases green on **both** shipped lanes. Documentation only — no production or test code changes; the behavioural work merged in #41.

## Changes

- **`meta/work/0186-…`** — the cross-lane acceptance criterion ticked, status → `done`, the in-progress holding note replaced with a closure note, and the "Lanes observed green" entry filled in per lane.
- **`meta/plans/2026-08-02-0186-…`** — the two remaining manual criteria ticked with the run recorded, `status: ready` → `done`. No unticked criteria remain in either document.
- **`meta/validations/2026-08-02-0186-…-validation.md`** — result `partial` → `pass`, with the CI results, the now-resolved linux-lane gap, and the mock-server flake that blocked the observation.

## The observation

CI run [30821400291](https://github.com/atomicinnovation/accelerator/actions/runs/30821400291), all 16 jobs green:

| Lane | `test:integration:entrypoint` |
| --- | --- |
| macos-latest | 54 passed (139.29s) |
| ubuntu-latest | 53 passed, 1 skipped (72.76s) |

All eight new cases passed on both. The single ubuntu skip is `test_the_suite_runs_the_bootstrap_on_the_bash_floor`, which is darwin-only — and **that asymmetry is itself the evidence** the lanes run genuinely different interpreters. So `test_warm_path_does_not_enter_the_probe` and `test_cold_path_enters_and_executes_the_probe` are confirmed on bash 3.2.57 *and* bash 5.2 rather than twice on the same one, which was the specific risk the plan flagged. `_require_unprivileged` did not fire on either lane, so no exclusion was needed.

## Notes for Reviewers

**The plan's own closeout step named a status that does not exist.** Phase 4 change 6 says "move `status` to `complete`", but the schema vocabulary is `draft | ready | in-progress | review | done | blocked | abandoned`. Writing `complete` was rejected by `scripts/validate-corpus-frontmatter.sh`; the item is `done`. Recorded as a plan deviation in the validation report. Worth knowing that step was drafted, reviewed and only caught by the validator.

**One recording step is deliberately left undone.** `command -v sha256sum` was not captured on either CI lane — it needs a dedicated workflow step and nothing in the plan required one. 0169 therefore still carries the hash backend as a range (~7 ms or ~24 ms for the two-hash residual) rather than a per-lane fact. Noted in the work item, the validation report and the commit message rather than dropped quietly.

**Unrelated, but worth a look:** `main` has been red on `Run unit tests (macos-latest)` since before this work. This branch is green on that same job, so whatever it is does not reproduce here.

## Testing

- [x] `scripts/validate-corpus-frontmatter.sh meta` — exit 0
- [x] `mise run test:integration:config` — 58 passed (the corpus validator is a by-name required suite there, and is *not* part of `mise run check`)
- [x] No code paths touched — the diff is three `meta/` documents
