### PR TITLE
Fix four load-sensitive test flakes

### DIFF
--- a/cli/visualiser/frontend/src/test/setup.ts
+++ b/cli/visualiser/frontend/src/test/setup.ts
@@ -1,5 +1,20 @@
 import "@testing-library/jest-dom";
+// Re-exported from @testing-library/dom, which is not a declared dependency —
+// importing it directly would be a phantom. Every spec reaches `screen` and
+// `waitFor` through this package for the same reason.
+import { configure } from "@testing-library/react";
 import { afterAll, vi } from "vitest";
+
+// `waitFor` and every `findBy*` built on it poll against their OWN budget,
+// which defaults to 1000ms — `testTimeout` in vite.config.ts does not govern
+// them. So the reasoning recorded there applies here and had to be repeated:
+// the number is a hang detector, not a latency budget. Vitest sizes its worker
+// pool to the CPU count and `mise run` schedules this suite alongside cargo
+// builds and the Python suites, so a mocked-promise render that settles in
+// ~50ms idle has been measured past 1s on a loaded CI runner — surfacing as a
+// findBy* that still sees "Loading…". A genuinely stuck query still fails,
+// 5s later, and well inside the 30s testTimeout so it reports as itself.
+configure({ asyncUtilTimeout: 5_000 });
 
 // Stub global EventSource as a safety net — prevents any test that
 // mounts a component using the production `useDocEvents` hook from

--- a/cli/visualiser/server/src/watcher.rs
+++ b/cli/visualiser/server/src/watcher.rs
@@ -469,6 +469,24 @@ impl TemplateChangeHandler {
     }
 }
 
+/// How long a test waits for an event it *expects* to arrive.
+///
+/// This is a hang detector, not a latency budget. Delivery runs the whole
+/// chain: FSEvents/inotify latency, then the debounce, then `rescan` plus
+/// `compute_clusters_with_backfill` over the entire snapshot. Cargo runs
+/// this module's tests concurrently — one `current_thread` runtime each —
+/// and `mise run` schedules the suite alongside cargo builds and the
+/// frontend and Python suites. A chain that settles in tens of
+/// milliseconds idle has been measured past 500ms on a loaded CI runner,
+/// surfacing as a spurious "timed out". A genuinely stuck watcher still
+/// fails, five seconds later, and reports as itself.
+///
+/// The "expected *no* event" waits deliberately do **not** use this: there
+/// the wait *is* the assertion, so a short quiet window keeps the suite
+/// fast without weakening it. Do not unify the two.
+#[cfg(test)]
+const EVENT_BUDGET: Duration = Duration::from_secs(5);
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -498,9 +516,10 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         std::fs::write(&probe, "b").unwrap();
 
-        tokio::time::timeout(Duration::from_millis(300), rx.recv())
-            .await
-            .is_ok()
+        // Same budget as the real waits, for a sharper reason: a `false`
+        // here silently skips the caller, so a slow-but-working runner
+        // read as "not firing" turns a whole test into a false green.
+        tokio::time::timeout(EVENT_BUDGET, rx.recv()).await.is_ok()
     }
 
     async fn setup(
@@ -581,7 +600,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out waiting for SSE event")
             .expect("channel closed");
@@ -686,13 +705,10 @@ mod tests {
             std::fs::write(&path, format!("---\ntitle: v{i}\n---\n")).unwrap();
         }
 
-        let event = tokio::time::timeout(
-            debounce + Duration::from_millis(500),
-            rx.recv(),
-        )
-        .await
-        .expect("timed out")
-        .expect("channel closed");
+        let event = tokio::time::timeout(debounce + EVENT_BUDGET, rx.recv())
+            .await
+            .expect("timed out")
+            .expect("channel closed");
         match event {
             SsePayload::DocChanged { action, .. } => {
                 assert_eq!(action, ActionKind::Edited);
@@ -741,7 +757,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -786,7 +802,7 @@ mod tests {
         )
         .unwrap();
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -858,7 +874,7 @@ mod tests {
 
         std::fs::remove_file(&path).unwrap();
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out waiting for deletion SSE event")
             .expect("channel closed");
@@ -916,29 +932,26 @@ mod tests {
 
         // 1. Create.
         std::fs::write(&chain_path, "---\ntitle: Chain v1\n---\n").unwrap();
-        let created =
-            tokio::time::timeout(Duration::from_millis(800), rx.recv())
-                .await
-                .expect("timed out waiting for created event")
-                .expect("channel closed");
+        let created = tokio::time::timeout(EVENT_BUDGET, rx.recv())
+            .await
+            .expect("timed out waiting for created event")
+            .expect("channel closed");
 
         // 2. Edit. Pause longer than debounce so the events do not coalesce.
         tokio::time::sleep(Duration::from_millis(150)).await;
         std::fs::write(&chain_path, "---\ntitle: Chain v2\n---\n").unwrap();
-        let edited =
-            tokio::time::timeout(Duration::from_millis(800), rx.recv())
-                .await
-                .expect("timed out waiting for edited event")
-                .expect("channel closed");
+        let edited = tokio::time::timeout(EVENT_BUDGET, rx.recv())
+            .await
+            .expect("timed out waiting for edited event")
+            .expect("channel closed");
 
         // 3. Delete.
         tokio::time::sleep(Duration::from_millis(150)).await;
         std::fs::remove_file(&chain_path).unwrap();
-        let deleted =
-            tokio::time::timeout(Duration::from_millis(800), rx.recv())
-                .await
-                .expect("timed out waiting for deleted event")
-                .expect("channel closed");
+        let deleted = tokio::time::timeout(EVENT_BUDGET, rx.recv())
+            .await
+            .expect("timed out waiting for deleted event")
+            .expect("channel closed");
 
         let (a0, t0) = match &created {
             SsePayload::DocChanged {
@@ -1119,7 +1132,7 @@ mod template_change_handler_tests {
         let canon = canonicalise_path_or_ancestor(&plugin).await;
         assert!(handler.try_handle(&canon));
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -1160,7 +1173,7 @@ mod template_change_handler_tests {
         let canon = canonicalise_path_or_ancestor(&plugin).await;
         assert!(handler.try_handle(&canon));
 
-        let event = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -1260,11 +1273,10 @@ mod template_change_handler_tests {
 
         let mut got: Vec<String> = Vec::new();
         for _ in 0..2 {
-            let event =
-                tokio::time::timeout(Duration::from_millis(500), rx.recv())
-                    .await
-                    .expect("timed out")
-                    .expect("channel closed");
+            let event = tokio::time::timeout(EVENT_BUDGET, rx.recv())
+                .await
+                .expect("timed out")
+                .expect("channel closed");
             if let SsePayload::TemplateChanged { template, .. } = event {
                 got.push(template);
             }

--- a/meta/prs/46-description.md
+++ b/meta/prs/46-description.md
@@ -1,0 +1,136 @@
+---
+type: pr-description
+id: "46"
+title: "Fix four load-sensitive test flakes"
+date: "2026-08-03T15:19:25+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/46"
+pr_number: 46
+tags: [testing, ci, flakiness, build-system, frontend, visualiser]
+revision: "05a35fdc7abf372e3830ae5f6b3af334c4406e69"
+repository: "accelerator"
+last_updated: "2026-08-03T15:19:25+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Fix four load-sensitive test flakes
+
+## Summary
+
+Four tests fail intermittently on CI and pass in isolation. All four fail for the same underlying reason — a budget or a check that is really measuring *how busy the machine is* — but each needs a different fix, so this is four independent commits. None of them is fixed by retrying, and all four have already cost real CI runs: two of the last twelve `main` runs failed on one of them, PR #42 was re-run for another, and two of them took out PR #43's `Run unit tests (macos-latest)` three times over.
+
+**Based on `main`, with `0186-closeout` (PR #43) stacked on top of this branch.** That ordering is deliberate and is itself part of the fix: #43 is a docs-only change that kept failing `Run unit tests (macos-latest)` on flakes it inherited from `main`, and while these fixes sat *above* it in the stack its CI could never see them. Content-independent of #43 — that branch touches three `meta/` documents and no code.
+
+**This PR replaces #44, which GitHub auto-closed as "merged".** Nothing was merged: #44's base was `0186-closeout`, so reordering the stack made its head an ancestor of its base, and GitHub marked it merged on push and refuses to reopen it. `main` never received these commits. #44's `mergeCommit` is just this branch's head, not a merge.
+
+## Changes
+
+### 1. The vendor-shim marker tests copied 46k files to read three
+
+`vendor_shim_marker_digest` reads `cli/verify/**`, the `minisign-verify` pin in `cli/Cargo.toml`, and `cli/Cargo.lock` — three inputs, about 12 KB. The three tests that feed it a mutated tree copied the whole of `cli/`: 46,391 files including the ~200 MB `cli/visualiser/frontend/node_modules`, with symlinks followed. Any concurrently-running frontend task can move a link target mid-walk, and `shutil.copytree` raises:
+
+```
+shutil.Error: [(... /node_modules/@tanstack/router-core/skills/.../SKILL.md,
+  "[Errno 2] No such file or directory: ...")]
+```
+
+Now they copy the three inputs. Each test still measures against a baseline digest taken over the **real** tree, so an input missed by the seeding shows up as a digest mismatch rather than a false pass — the tests check their own fixture.
+
+`tests/unit/tasks/test_build.py` drops from **11.3s to 0.1s**.
+
+### 2. The frontend watcher was confirmed by poll count, not elapsed time
+
+Accepting `dev up` required two consecutive `"active"` polls inside `frontend_active_timeout`. That measures the wrong thing in both directions:
+
+- On an idle machine the two polls land 100ms apart and prove almost nothing about staying-power — which is what the check exists to establish.
+- On a loaded runner, where one status call can take up to `probe_timeout` (5s in the integration driver), a perfectly healthy watcher may never land two *consecutive* polls inside the deadline, and the whole dev stack is torn down for it.
+
+An unreadable poll made it worse. `SupervisorUnreachableError` was folded into an empty status map, which took the `else` branch and reset the counter — so a transient timeout on a busy runner threw away already-confirmed progress. That is the CI failure.
+
+The check is now two distinct questions:
+
+1. **Is it up?** Poll until the watcher reports active, bounded by the deadline. An unreadable poll is retried, not counted against the watcher.
+2. **Did it stay up?** Sleep a fixed `frontend_settle` (0.5s) and re-read. This is wall-clock, so it means the same thing regardless of poll cadence.
+
+`None` now means *unknown* rather than *down*, at both steps. At the confirmation it is accepted: being unable to read the status is not evidence the watcher died, and `do_status` already reports a genuinely dead watcher as degraded, which is the safety net. Failing there would just move the flake one step later.
+
+A watcher that really does die in the settle window now reports `became active then stopped` instead of a misleading activation timeout.
+
+This also removes a latent crash. The sleep was `min(0.1, deadline - deps.clock.now())`, and the loop condition was evaluated *before* a status call that can outlast the deadline — so the remainder could go negative, and `sleep` rejects a negative duration.
+
+### 3. `waitFor` had a 1000ms budget that `testTimeout` does not govern
+
+`vite.config.ts` already raises `testTimeout` to 30s, with a comment recording that the number is a hang detector rather than a latency budget, because this suite is scheduled alongside cargo builds and the Python suites. But `waitFor` — and every `findBy*` built on it — polls against its **own** budget, which `testTimeout` does not govern and which still defaulted to 1000ms.
+
+So a mocked-promise render that settles in ~50ms idle can exceed it under load and fail with `Unable to find role="heading" and name "Foo Cluster"`, having only ever rendered `Loading…`. That is exactly the observed failure, in both affected specs.
+
+The existing reasoning is extended to the async utils: `configure({ asyncUtilTimeout: 5_000 })`, still well inside the 30s `testTimeout` so a genuinely stuck query reports as itself rather than being swallowed. `configure` is imported from `@testing-library/react` rather than `@testing-library/dom`, which is not a declared dependency — the same reason every spec reaches `screen` and `waitFor` through that package.
+
+### 4. The watcher tests waited sub-second for a full rescan
+
+Same shape as #3, one language over. Every `watcher.rs` test that expects a filesystem-driven SSE event waited 500ms for it — 800ms in the create/edit/delete chain. That is a latency budget wearing a hang detector's clothes, because delivery runs the whole chain: FSEvents/inotify latency, then the debounce, then `indexer.rescan()` plus `compute_clusters_with_backfill` over the entire snapshot plus `collect_linked_counts`. Cargo runs this module's tests concurrently — one `current_thread` runtime each — while `mise run` schedules the suite alongside cargo builds and the Python and frontend suites.
+
+Instrumented, that chain settles in **~18ms** idle, so 500ms already looked like 28× headroom. A loaded macOS runner still blew through it, failing `new_file_in_watched_dir_produces_doc_changed_event` with a bare `timed out: Elapsed(())`.
+
+The positive waits now route through a shared `EVENT_BUDGET` of 5s. The **expects-no-event** waits deliberately keep their short windows (200–400ms): there the wait *is* the assertion, so lengthening it would only slow the suite without strengthening it. The constant's comment says exactly that, so the two are not helpfully unified later.
+
+Raising the budget weakens no assertion in the affected test. Its `before`/`after` bracketing and the AC6 one-second tolerance both measure *broadcast → receipt*, because the payload's `timestamp` is captured at line 193, after all the rescan work and immediately before the broadcast. Extra fsevents latency lands outside both windows.
+
+One further change, for a sharper reason than budget. `watcher_fires_in_this_env` probes whether the platform watcher fires at all, and its budget was 300ms. A `false` return **silently skips its caller** — so a slow-but-working runner read as "not firing" turns the whole test into a false green rather than a failure. That probe now uses the same `EVENT_BUDGET`.
+
+## Context
+
+Flakes 1–3 were diagnosed while getting PR #42's checks green. #42 changes no file involved in any of those failures, so none of them is caused by it — its description records all three as deserving their own item. This is that item.
+
+Flake 4 was found while diagnosing why PR #43 kept failing `Run unit tests (macos-latest)`. That investigation turned up two things: the watcher flake below, which was unfixed anywhere, and the stack-ordering problem described in the Summary.
+
+Observed failures:
+
+| Test | Where |
+| --- | --- |
+| `test_dev_integration.py::test_restart_round_trip` | PR #42, `Run integration tests (macos-latest)` |
+| `LifecycleClusterView.test.tsx` — "Foo Cluster" | `main` run 30767051461, PR #43 runs 30825942165 + 30831408793, and locally |
+| `use-dev-activation.test.tsx` — "restores the LATEST non-/dev path" | locally, under full-suite load |
+| `watcher::tests::new_file_in_watched_dir_produces_doc_changed_event` | PR #43 run 30828047240 |
+
+## Testing
+
+- [x] `mise run check` — exit 0, including `types:frontend:check` and `lint:build-system:check`.
+- [x] `mise run test:unit:tasks` — exit 0, 625 passed (620 before; +5, all in the new `TestFrontendActivation`).
+- [x] `mise run test:integration:tasks` — exit 0, 65 passed.
+- [x] `mise run test:unit:frontend` — exit 0, **2536 passed**, 8.85s. No test got slower: nothing relies on an async util timing out, since the negative assertions use the synchronous `queryBy`.
+- [x] `mise run test:integration:dev` — exit 0, 17 passed, **three consecutive runs**.
+- [x] **The watcher change is covered by tests that did not exist.** The mechanism had none: `FakeSupervisor.start` flipped the status to active, so every case arrived at the loop with the answer already yes. Five cases now cover slow activation, transient unreachability while waiting, transient unreachability at the confirmation, never activating, and dying in the settle window.
+- [x] **Each new test is mutation-checked** — every mutation kills exactly the intended test, and every test is killed by at least one mutation:
+
+  | Mutation | Test killed |
+  | --- | --- |
+  | drop the settle confirmation | `test_a_watcher_that_dies_during_the_settle_window_fails` |
+  | an unreadable poll counts as a negative (the old behaviour) | `test_a_transiently_unreachable_supervisor_does_not_fail_it` |
+  | an unreadable settle poll counts as death | `test_an_unreadable_settle_poll_does_not_fail_the_watcher` |
+  | give up after the first non-active poll | `test_a_watcher_slow_to_report_active_is_accepted`, `test_a_transiently_unreachable_supervisor_does_not_fail_it` |
+
+- [x] **The `asyncUtilTimeout` change is control-tested.** A probe component resolving at 1500ms passes with the `configure` in place and fails with `Unable to find role="heading"` without it — the same signature as the CI failure. The probe was temporary and is not committed.
+- [x] `mise run cli:check` — exit 0 (workspace-wide rustfmt + clippy).
+- [x] `mise run test:unit:visualiser` — exit 0, 334 + 330 passed. The watcher tests run in 0.84s, unchanged: a raised timeout costs nothing unless it is exceeded.
+- [x] `mise run test:unit` — exit 0 with the whole group standing on `main` rather than on #43, confirming none of these fixes depended on that branch.
+- [x] **The watcher tests do not silently skip.** Verified `watcher_fires_in_this_env` returns true locally, so all 15 watcher tests genuinely execute rather than passing vacuously.
+- [x] **Watcher latency measured, not guessed.** Temporary instrumentation put delivery at 17–20ms across three full-suite runs.
+- [ ] **Repeated green CI runs.** By construction these are load-dependent, so the real evidence is the macOS jobs staying green over the next several runs rather than anything reproducible locally.
+
+## Notes for Reviewers
+
+**The watcher change trades a false negative for a narrow false positive, deliberately.** If the supervisor is unreadable at the confirmation poll, the start is now accepted. A watcher that died in that exact window would be reported as started. That is the right trade for a developer-facing dev task: the cost of the old behaviour was tearing down a healthy stack and failing CI, while the cost of the new one is `dev up` reporting success for a stack that `dev status` will immediately show as degraded. The alternative — failing on "could not read" — is precisely the bug being fixed.
+
+**`frontend_settle` sits outside the activation deadline on purpose.** Clamping it to the remaining deadline would silently skip the check for a watcher that became active just before the deadline, which is exactly the slow case it exists for. The cost is a bounded extra 0.5s per `up`.
+
+**The seeding helper in commit 1 is not self-validating in isolation** — it is validated by its callers, which compare against a digest of the real tree. If someone later adds an input to `vendor_shim_marker_digest` without adding it to `_seed_digest_inputs`, the three tests fail with a digest mismatch rather than a helpful message. That is a real (if loud) failure mode, and the helper's docstring says so.
+
+**Flake 4 could not be reproduced locally, and the fix is reasoned rather than demonstrated.** The watcher tests survive 12/12 runs under 12-way CPU load, but they also survived 12/12 at the *old* 500ms budget — this hardware has too much headroom, and loading it did not degrade delivery latency at all (~18ms idle, ~7–9ms under load; the variation is noise). The stretch that broke CI is specific to a 3–4 core shared macOS runner mid-way through a 240s job. So the evidence for #4 is the measured idle latency, the identical failure signature, and the precedent set by #3 in the same CI job — not a local reproduction. Worth weighing if you would rather cap that job's concurrency instead.
+
+**Not fixed here: the underlying parallelism.** All four failures ultimately trace to `mise run test` scheduling every suite at once on a 3-core runner. Raising budgets and shrinking fixtures treats the symptom. If macOS keeps flaking after this, the next move is capping concurrency for that job rather than raising numbers again — and after four separate budget fixes, that point is arguably already here.
+
+**A correction to PR #42's description.** It reports `mise run test:unit:tasks — 619 passed`. A clean re-measurement of that same commit collects **620**. I could not reconstruct where the 619 came from, and the discrepancy is one test either way; #42's committed description and posted body are left as they are rather than force-pushing over a review-in-progress for a ±1 prose count. The number to trust is 620 before this PR, 625 after.

--- a/tasks/shared/dev/lifecycle.py
+++ b/tasks/shared/dev/lifecycle.py
@@ -13,7 +13,7 @@ import json
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from tasks.shared.clock import Clock
 from tasks.shared.dev.circus import (
@@ -77,6 +77,9 @@ class DevDeps:
     pidfile_timeout: float = 10.0
     readiness_timeout: float = 30.0
     frontend_active_timeout: float = 15.0
+    # How long a watcher must stay active after first reporting active before
+    # the start is accepted. Wall-clock, not a poll count: see start_frontend.
+    frontend_settle: float = 0.5
     grace_quit: float = (
         5.0  # covers circus's own 2 s graceful_timeout + reaping
     )
@@ -124,6 +127,11 @@ class LaunchedArbiter:
     frontend_port: int
     frontend_url: str
     endpoint: str
+
+
+# Cadence for the frontend-activation poll. Only an upper bound on how often
+# the supervisor is asked; the deadline is what bounds the wait.
+_FRONTEND_POLL_INTERVAL = 0.1
 
 
 class _UpAbortError(Exception):
@@ -427,42 +435,79 @@ def start_frontend(launched: LaunchedArbiter, deps: DevDeps) -> None:
                 )
             ) from exc
         # send "start" only confirms acceptance; with respawn=false a frontend
-        # that starts then dies goes active->stopped silently. Require two
-        # consecutive "active" polls so a flapping watcher is treated as failed.
+        # that starts then dies goes active->stopped silently. So wait for the
+        # watcher to report active, then confirm it is *still* active after a
+        # settle interval.
+        #
+        # The confirmation is wall-clock rather than a second consecutive poll.
+        # Poll cadence tracks how loaded the machine is, so a poll-count rule
+        # measures the wrong thing in both directions: two polls 100ms apart on
+        # an idle machine prove almost nothing about staying-power, while on a
+        # loaded runner — where one status call can take up to probe_timeout —
+        # a healthy watcher may never land two consecutive polls inside the
+        # deadline and gets torn down for it.
         deadline = deps.clock.now() + deps.frontend_active_timeout
-        consecutive_active = 0
-        while deps.clock.now() < deadline:
-            statuses = _safe_status(sup)
-            if statuses.get("frontend") == "active":
-                consecutive_active += 1
-                if consecutive_active >= 2:
-                    break
-            else:
-                consecutive_active = 0
-            deps.clock.sleep(min(0.1, deadline - deps.clock.now()))
-        if consecutive_active < 2:
-            teardown(launched.state, deps, lock_held=True)
-            log_diagnostic(deps, "frontend watcher did not stay active")
-            raise _UpAbortError(
-                UpResult(
-                    "failed",
-                    message=(
-                        f"the frontend watcher did not become active; see "
-                        f"{deps.dev_dir}/frontend.log"
-                    ),
-                    artifact=f"{deps.dev_dir}/frontend.log",
-                )
-            )
+        if not _await_frontend_active(sup, deps, deadline):
+            _abort_frontend(launched, deps, "did not become active")
+        # The settle window sits outside the activation deadline on purpose:
+        # clamping it would silently skip the check for a watcher that became
+        # active just before the deadline — exactly the slow case it is for.
+        deps.clock.sleep(deps.frontend_settle)
+        if _frontend_status(sup) not in ("active", None):
+            _abort_frontend(launched, deps, "became active then stopped")
     finally:
         _maybe_close(sup)
     _record_watcher_pid(launched, deps, "frontend")
 
 
-def _safe_status(sup: Supervisor) -> dict[str, str]:
+def _frontend_status(sup: Supervisor) -> str | None:
+    """Return the watcher's status, or None when nothing could be read.
+
+    None means "unknown", not "not running": an unreachable supervisor and a
+    watcher absent from the status map are both cases where we have learned
+    nothing, and callers must not read either as evidence the watcher is down.
+    """
     try:
-        return sup.status()
+        return sup.status().get("frontend")
     except SupervisorUnreachableError:
-        return {}
+        return None
+
+
+def _await_frontend_active(
+    sup: Supervisor, deps: DevDeps, deadline: float
+) -> bool:
+    """Whether the watcher reported active before ``deadline``.
+
+    A transiently unreachable supervisor is retried rather than counted
+    against the watcher — on a loaded machine the status endpoint times out
+    from time to time, and a watcher that is up must not fail for that.
+    """
+    while True:
+        if _frontend_status(sup) == "active":
+            return True
+        remaining = deadline - deps.clock.now()
+        if remaining <= 0:
+            return False
+        # Checked positive before sleeping: a status call can outlast the
+        # deadline, and `sleep` rejects a negative duration.
+        deps.clock.sleep(min(_FRONTEND_POLL_INTERVAL, remaining))
+
+
+def _abort_frontend(
+    launched: LaunchedArbiter, deps: DevDeps, reason: str
+) -> NoReturn:
+    teardown(launched.state, deps, lock_held=True)
+    log_diagnostic(deps, f"frontend watcher {reason}")
+    raise _UpAbortError(
+        UpResult(
+            "failed",
+            message=(
+                f"the frontend watcher {reason}; see "
+                f"{deps.dev_dir}/frontend.log"
+            ),
+            artifact=f"{deps.dev_dir}/frontend.log",
+        )
+    )
 
 
 def _record_watcher_pid(

--- a/tests/unit/tasks/shared/dev/test_lifecycle.py
+++ b/tests/unit/tasks/shared/dev/test_lifecycle.py
@@ -22,7 +22,15 @@ from tests.unit.tasks.shared.doubles import FakeClock, FakeProcs
 
 class FakeWorld:
     def __init__(
-        self, procs, *, statuses=None, pids=None, reachable=True, quit_kills=()
+        self,
+        procs,
+        *,
+        statuses=None,
+        pids=None,
+        reachable=True,
+        quit_kills=(),
+        activate_on_start=True,
+        status_hook=None,
     ):
         self.procs = procs
         self.statuses = dict(statuses or {})
@@ -31,6 +39,13 @@ class FakeWorld:
         self.quit_kills = list(quit_kills)
         self.quit_called = 0
         self.started: list[str] = []
+        # A real `start` only confirms the arbiter accepted the command; the
+        # watcher may reach "active" later, or never. activate_on_start=False
+        # models that gap, and status_hook — run on every status() call, before
+        # the reachability check so it can toggle that too — scripts what
+        # happens next.
+        self.activate_on_start = activate_on_start
+        self.status_hook = status_hook
 
     def do_quit(self):
         self.quit_called += 1
@@ -46,6 +61,8 @@ class FakeSupervisor:
         self.world = world
 
     def status(self):
+        if self.world.status_hook:
+            self.world.status_hook(self.world)
         if not self.world.reachable:
             raise SupervisorUnreachableError("unreachable")
         return dict(self.world.statuses)
@@ -59,7 +76,8 @@ class FakeSupervisor:
         if not self.world.reachable:
             raise SupervisorUnreachableError("unreachable")
         self.world.started.append(name)
-        self.world.statuses[name] = "active"
+        if self.world.activate_on_start:
+            self.world.statuses[name] = "active"
 
     def quit(self):
         if not self.world.reachable:
@@ -395,6 +413,144 @@ class TestBringUp:
         assert result.kind == "failed"
         assert "server.log" in result.message
         assert not deps.state_path.exists()  # torn down
+
+
+# ─── bring_up: frontend activation ───────────────────────────
+
+
+def _after_start(action):
+    """Run ``action(world, poll_number)`` on each status poll after start.
+
+    Counting only post-start polls keeps a case independent of how many times
+    the earlier launch and readiness steps happen to ask for status.
+    """
+    polls = 0
+
+    def hook(world):
+        nonlocal polls
+        if "frontend" not in world.started:
+            return
+        polls += 1
+        action(world, polls)
+
+    return hook
+
+
+class TestFrontendActivation:
+    """Separating "is it up?" from "did it stay up?".
+
+    Neither question had a test: `FakeSupervisor.start` flipped the status to
+    active, so every case arrived at the poll loop with the answer already
+    yes. These are the cases the check has to tell apart on a loaded machine.
+    """
+
+    def _world(self, procs, **kwargs):
+        return FakeWorld(
+            procs,
+            statuses={"server": "active", "frontend": "stopped"},
+            pids={"server": [9001], "frontend": [9002]},
+            **kwargs,
+        )
+
+    def _deps(self, tmp_path, procs, world, **overrides):
+        deps = _orch_deps(tmp_path, procs=procs, world=world, **overrides)
+        return dataclasses_replace(
+            deps,
+            launcher=FakeLauncher(
+                procs,
+                pidfile=deps.pidfile,
+                server_info_path=deps.server_info_path,
+                state_path=deps.state_path,
+            ),
+        )
+
+    def test_a_watcher_slow_to_report_active_is_accepted(self, tmp_path):
+        procs = FakeProcs()
+
+        def activate_on_the_third_poll(world, poll):
+            if poll >= 3:
+                world.statuses["frontend"] = "active"
+
+        world = self._world(
+            procs,
+            activate_on_start=False,
+            status_hook=_after_start(activate_on_the_third_poll),
+        )
+
+        assert bring_up(self._deps(tmp_path, procs, world)).kind == "started"
+
+    def test_a_transiently_unreachable_supervisor_does_not_fail_it(
+        self, tmp_path
+    ):
+        # The CI failure this fixes. On a loaded runner the status endpoint
+        # times out from time to time; the watcher is up, the poll just could
+        # not read it. An unreadable poll must not count against the watcher —
+        # under the old rule it reset the consecutive-active counter, so a
+        # healthy frontend could be torn down for the machine being busy.
+        procs = FakeProcs()
+
+        def unreachable_for_two_polls(world, poll):
+            world.reachable = poll > 2
+
+        world = self._world(
+            procs, status_hook=_after_start(unreachable_for_two_polls)
+        )
+
+        assert bring_up(self._deps(tmp_path, procs, world)).kind == "started"
+
+    def test_a_watcher_that_never_activates_is_torn_down(self, tmp_path):
+        procs = FakeProcs()
+        world = self._world(procs, activate_on_start=False, quit_kills=[9000])
+        deps = self._deps(tmp_path, procs, world)
+
+        result = bring_up(deps)
+
+        assert result.kind == "failed"
+        assert "did not become active" in result.message
+        assert "/frontend.log" in result.message
+        assert not deps.state_path.exists()
+
+    def test_a_watcher_that_dies_during_the_settle_window_fails(self, tmp_path):
+        # Active on the first poll, gone by the confirmation poll: the
+        # respawn=false start-then-die the settle window exists to catch.
+        procs = FakeProcs()
+
+        def stop_after_the_first_poll(world, poll):
+            if poll >= 2:
+                world.statuses["frontend"] = "stopped"
+
+        world = self._world(
+            procs,
+            status_hook=_after_start(stop_after_the_first_poll),
+            quit_kills=[9000],
+        )
+        fc = FakeClock()
+        deps = self._deps(tmp_path, procs, world, clock=fc)
+
+        result = bring_up(deps)
+
+        assert result.kind == "failed"
+        assert "became active then stopped" in result.message
+        # The confirmation waited a fixed duration rather than a second poll.
+        assert deps.frontend_settle in fc.sleeps
+        assert not deps.state_path.exists()
+
+    def test_an_unreadable_settle_poll_does_not_fail_the_watcher(
+        self, tmp_path
+    ):
+        # "Could not read" is not evidence the watcher died, and failing here
+        # would reintroduce the same flake one step later. A watcher that did
+        # die is reported by do_status as degraded, which is the safety net.
+        procs = FakeProcs()
+
+        def unreachable_from_the_settle_poll(world, poll):
+            world.reachable = poll < 2
+
+        world = self._world(
+            procs, status_hook=_after_start(unreachable_from_the_settle_poll)
+        )
+
+        assert bring_up(self._deps(tmp_path, procs, world)).kind == "started"
 
 
 # ─── teardown / do_stop ──────────────────────────────────────

--- a/tests/unit/tasks/test_build.py
+++ b/tests/unit/tasks/test_build.py
@@ -190,6 +190,27 @@ class TestWriteDebugArchives:
 # ── vendor_shim_marker_digest() ───────────────────────────────────────
 
 
+def _seed_digest_inputs(tmp_path: Path) -> Path:
+    """Copy just the tree `vendor_shim_marker_digest` reads into `tmp_path`.
+
+    It reads `cli/verify/**`, the `minisign-verify` pin in `cli/Cargo.toml`
+    and `cli/Cargo.lock` — three inputs, ~12 KB. Copying the whole of `cli/`
+    instead walked 46k files including the ~200 MB
+    `cli/visualiser/frontend/node_modules`, following its symlinks, so the
+    copy raced any concurrently-running frontend task and raised
+    `shutil.Error` on a link whose target moved. That was the macOS CI flake.
+
+    Each caller asserts against a baseline digest taken over the *real* tree,
+    so an input missed here shows up as a mismatch rather than a false pass.
+    """
+    cli_dst = tmp_path / "cli"
+    cli_dst.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_REPO_ROOT / "cli" / "verify", cli_dst / "verify")
+    for name in ("Cargo.toml", "Cargo.lock"):
+        shutil.copy2(_REPO_ROOT / "cli" / name, cli_dst / name)
+    return cli_dst
+
+
 class TestVendorShimMarkerDigest:
     def test_matches_committed_marker(self):
         recorded = (
@@ -203,11 +224,7 @@ class TestVendorShimMarkerDigest:
         # Copy the cli tree, bump the accelerator-verify lock version, and
         # assert the digest is unchanged: a version bump is not shim drift.
         baseline = vendor_shim_marker_digest()
-        cli_src = _REPO_ROOT / "cli"
-        cli_dst = tmp_path / "cli"
-        shutil.copytree(
-            cli_src, cli_dst, ignore=shutil.ignore_patterns("target")
-        )
+        cli_dst = _seed_digest_inputs(tmp_path)
         lock = cli_dst / "Cargo.lock"
         lock.write_text(
             lock.read_text().replace(
@@ -220,12 +237,7 @@ class TestVendorShimMarkerDigest:
 
     def test_detects_a_minisign_verify_bump(self, tmp_path):
         baseline = vendor_shim_marker_digest()
-        cli_dst = tmp_path / "cli"
-        shutil.copytree(
-            _REPO_ROOT / "cli",
-            cli_dst,
-            ignore=shutil.ignore_patterns("target"),
-        )
+        cli_dst = _seed_digest_inputs(tmp_path)
         cargo = cli_dst / "Cargo.toml"
         cargo.write_text(
             cargo.read_text().replace(
@@ -239,12 +251,7 @@ class TestVendorShimMarkerDigest:
         # shim, so adding one under [dev-dependencies] (and to the lock block)
         # must not register as drift.
         baseline = vendor_shim_marker_digest()
-        cli_dst = tmp_path / "cli"
-        shutil.copytree(
-            _REPO_ROOT / "cli",
-            cli_dst,
-            ignore=shutil.ignore_patterns("target"),
-        )
+        cli_dst = _seed_digest_inputs(tmp_path)
         manifest = cli_dst / "verify" / "Cargo.toml"
         manifest.write_text(
             manifest.read_text().rstrip() + '\nfastrand = "2"\n'


### PR DESCRIPTION
# Fix four load-sensitive test flakes

## Summary

Four tests fail intermittently on CI and pass in isolation. All four fail for the same underlying reason — a budget or a check that is really measuring *how busy the machine is* — but each needs a different fix, so this is four independent commits. None of them is fixed by retrying, and all four have already cost real CI runs: two of the last twelve `main` runs failed on one of them, PR #42 was re-run for another, and two of them took out PR #43's `Run unit tests (macos-latest)` three times over.

**Based on `main`, with `0186-closeout` (PR #43) stacked on top of this branch.** That ordering is deliberate and is itself part of the fix: #43 is a docs-only change that kept failing `Run unit tests (macos-latest)` on flakes it inherited from `main`, and while these fixes sat *above* it in the stack its CI could never see them. Content-independent of #43 — that branch touches three `meta/` documents and no code.

## Changes

### 1. The vendor-shim marker tests copied 46k files to read three

`vendor_shim_marker_digest` reads `cli/verify/**`, the `minisign-verify` pin in `cli/Cargo.toml`, and `cli/Cargo.lock` — three inputs, about 12 KB. The three tests that feed it a mutated tree copied the whole of `cli/`: 46,391 files including the ~200 MB `cli/visualiser/frontend/node_modules`, with symlinks followed. Any concurrently-running frontend task can move a link target mid-walk, and `shutil.copytree` raises:

```
shutil.Error: [(... /node_modules/@tanstack/router-core/skills/.../SKILL.md,
  "[Errno 2] No such file or directory: ...")]
```

Now they copy the three inputs. Each test still measures against a baseline digest taken over the **real** tree, so an input missed by the seeding shows up as a digest mismatch rather than a false pass — the tests check their own fixture.

`tests/unit/tasks/test_build.py` drops from **11.3s to 0.1s**.

### 2. The frontend watcher was confirmed by poll count, not elapsed time

Accepting `dev up` required two consecutive `"active"` polls inside `frontend_active_timeout`. That measures the wrong thing in both directions:

- On an idle machine the two polls land 100ms apart and prove almost nothing about staying-power — which is what the check exists to establish.
- On a loaded runner, where one status call can take up to `probe_timeout` (5s in the integration driver), a perfectly healthy watcher may never land two *consecutive* polls inside the deadline, and the whole dev stack is torn down for it.

An unreadable poll made it worse. `SupervisorUnreachableError` was folded into an empty status map, which took the `else` branch and reset the counter — so a transient timeout on a busy runner threw away already-confirmed progress. That is the CI failure.

The check is now two distinct questions:

1. **Is it up?** Poll until the watcher reports active, bounded by the deadline. An unreadable poll is retried, not counted against the watcher.
2. **Did it stay up?** Sleep a fixed `frontend_settle` (0.5s) and re-read. This is wall-clock, so it means the same thing regardless of poll cadence.

`None` now means *unknown* rather than *down*, at both steps. At the confirmation it is accepted: being unable to read the status is not evidence the watcher died, and `do_status` already reports a genuinely dead watcher as degraded, which is the safety net. Failing there would just move the flake one step later.

A watcher that really does die in the settle window now reports `became active then stopped` instead of a misleading activation timeout.

This also removes a latent crash. The sleep was `min(0.1, deadline - deps.clock.now())`, and the loop condition was evaluated *before* a status call that can outlast the deadline — so the remainder could go negative, and `sleep` rejects a negative duration.

### 3. `waitFor` had a 1000ms budget that `testTimeout` does not govern

`vite.config.ts` already raises `testTimeout` to 30s, with a comment recording that the number is a hang detector rather than a latency budget, because this suite is scheduled alongside cargo builds and the Python suites. But `waitFor` — and every `findBy*` built on it — polls against its **own** budget, which `testTimeout` does not govern and which still defaulted to 1000ms.

So a mocked-promise render that settles in ~50ms idle can exceed it under load and fail with `Unable to find role="heading" and name "Foo Cluster"`, having only ever rendered `Loading…`. That is exactly the observed failure, in both affected specs.

The existing reasoning is extended to the async utils: `configure({ asyncUtilTimeout: 5_000 })`, still well inside the 30s `testTimeout` so a genuinely stuck query reports as itself rather than being swallowed. `configure` is imported from `@testing-library/react` rather than `@testing-library/dom`, which is not a declared dependency — the same reason every spec reaches `screen` and `waitFor` through that package.

### 4. The watcher tests waited sub-second for a full rescan

Same shape as #3, one language over. Every `watcher.rs` test that expects a filesystem-driven SSE event waited 500ms for it — 800ms in the create/edit/delete chain. That is a latency budget wearing a hang detector's clothes, because delivery runs the whole chain: FSEvents/inotify latency, then the debounce, then `indexer.rescan()` plus `compute_clusters_with_backfill` over the entire snapshot plus `collect_linked_counts`. Cargo runs this module's tests concurrently — one `current_thread` runtime each — while `mise run` schedules the suite alongside cargo builds and the Python and frontend suites.

Instrumented, that chain settles in **~18ms** idle, so 500ms already looked like 28× headroom. A loaded macOS runner still blew through it, failing `new_file_in_watched_dir_produces_doc_changed_event` with a bare `timed out: Elapsed(())`.

The positive waits now route through a shared `EVENT_BUDGET` of 5s. The **expects-no-event** waits deliberately keep their short windows (200–400ms): there the wait *is* the assertion, so lengthening it would only slow the suite without strengthening it. The constant's comment says exactly that, so the two are not helpfully unified later.

Raising the budget weakens no assertion in the affected test. Its `before`/`after` bracketing and the AC6 one-second tolerance both measure *broadcast → receipt*, because the payload's `timestamp` is captured at line 193, after all the rescan work and immediately before the broadcast. Extra fsevents latency lands outside both windows.

One further change, for a sharper reason than budget. `watcher_fires_in_this_env` probes whether the platform watcher fires at all, and its budget was 300ms. A `false` return **silently skips its caller** — so a slow-but-working runner read as "not firing" turns the whole test into a false green rather than a failure. That probe now uses the same `EVENT_BUDGET`.

## Context

Flakes 1–3 were diagnosed while getting PR #42's checks green. #42 changes no file involved in any of those failures, so none of them is caused by it — its description records all three as deserving their own item. This is that item.

Flake 4 was found while diagnosing why PR #43 kept failing `Run unit tests (macos-latest)`. That investigation turned up two things: the watcher flake below, which was unfixed anywhere, and the stack-ordering problem described in the Summary.

Observed failures:

| Test | Where |
| --- | --- |
| `test_dev_integration.py::test_restart_round_trip` | PR #42, `Run integration tests (macos-latest)` |
| `LifecycleClusterView.test.tsx` — "Foo Cluster" | `main` run 30767051461, PR #43 runs 30825942165 + 30831408793, and locally |
| `use-dev-activation.test.tsx` — "restores the LATEST non-/dev path" | locally, under full-suite load |
| `watcher::tests::new_file_in_watched_dir_produces_doc_changed_event` | PR #43 run 30828047240 |

## Testing

- [x] `mise run check` — exit 0, including `types:frontend:check` and `lint:build-system:check`.
- [x] `mise run test:unit:tasks` — exit 0, 625 passed (620 before; +5, all in the new `TestFrontendActivation`).
- [x] `mise run test:integration:tasks` — exit 0, 65 passed.
- [x] `mise run test:unit:frontend` — exit 0, **2536 passed**, 8.85s. No test got slower: nothing relies on an async util timing out, since the negative assertions use the synchronous `queryBy`.
- [x] `mise run test:integration:dev` — exit 0, 17 passed, **three consecutive runs**.
- [x] **The watcher change is covered by tests that did not exist.** The mechanism had none: `FakeSupervisor.start` flipped the status to active, so every case arrived at the loop with the answer already yes. Five cases now cover slow activation, transient unreachability while waiting, transient unreachability at the confirmation, never activating, and dying in the settle window.
- [x] **Each new test is mutation-checked** — every mutation kills exactly the intended test, and every test is killed by at least one mutation:

  | Mutation | Test killed |
  | --- | --- |
  | drop the settle confirmation | `test_a_watcher_that_dies_during_the_settle_window_fails` |
  | an unreadable poll counts as a negative (the old behaviour) | `test_a_transiently_unreachable_supervisor_does_not_fail_it` |
  | an unreadable settle poll counts as death | `test_an_unreadable_settle_poll_does_not_fail_the_watcher` |
  | give up after the first non-active poll | `test_a_watcher_slow_to_report_active_is_accepted`, `test_a_transiently_unreachable_supervisor_does_not_fail_it` |

- [x] **The `asyncUtilTimeout` change is control-tested.** A probe component resolving at 1500ms passes with the `configure` in place and fails with `Unable to find role="heading"` without it — the same signature as the CI failure. The probe was temporary and is not committed.
- [x] `mise run cli:check` — exit 0 (workspace-wide rustfmt + clippy).
- [x] `mise run test:unit:visualiser` — exit 0, 334 + 330 passed. The watcher tests run in 0.84s, unchanged: a raised timeout costs nothing unless it is exceeded.
- [x] `mise run test:unit` — exit 0 with the whole group standing on `main` rather than on #43, confirming none of these fixes depended on that branch.
- [x] **The watcher tests do not silently skip.** Verified `watcher_fires_in_this_env` returns true locally, so all 15 watcher tests genuinely execute rather than passing vacuously.
- [x] **Watcher latency measured, not guessed.** Temporary instrumentation put delivery at 17–20ms across three full-suite runs.
- [ ] **Repeated green CI runs.** By construction these are load-dependent, so the real evidence is the macOS jobs staying green over the next several runs rather than anything reproducible locally.

## Notes for Reviewers

**The watcher change trades a false negative for a narrow false positive, deliberately.** If the supervisor is unreadable at the confirmation poll, the start is now accepted. A watcher that died in that exact window would be reported as started. That is the right trade for a developer-facing dev task: the cost of the old behaviour was tearing down a healthy stack and failing CI, while the cost of the new one is `dev up` reporting success for a stack that `dev status` will immediately show as degraded. The alternative — failing on "could not read" — is precisely the bug being fixed.

**`frontend_settle` sits outside the activation deadline on purpose.** Clamping it to the remaining deadline would silently skip the check for a watcher that became active just before the deadline, which is exactly the slow case it exists for. The cost is a bounded extra 0.5s per `up`.

**The seeding helper in commit 1 is not self-validating in isolation** — it is validated by its callers, which compare against a digest of the real tree. If someone later adds an input to `vendor_shim_marker_digest` without adding it to `_seed_digest_inputs`, the three tests fail with a digest mismatch rather than a helpful message. That is a real (if loud) failure mode, and the helper's docstring says so.

**Flake 4 could not be reproduced locally, and the fix is reasoned rather than demonstrated.** The watcher tests survive 12/12 runs under 12-way CPU load, but they also survived 12/12 at the *old* 500ms budget — this hardware has too much headroom, and loading it did not degrade delivery latency at all (~18ms idle, ~7–9ms under load; the variation is noise). The stretch that broke CI is specific to a 3–4 core shared macOS runner mid-way through a 240s job. So the evidence for #4 is the measured idle latency, the identical failure signature, and the precedent set by #3 in the same CI job — not a local reproduction. Worth weighing if you would rather cap that job's concurrency instead.

**Not fixed here: the underlying parallelism.** All four failures ultimately trace to `mise run test` scheduling every suite at once on a 3-core runner. Raising budgets and shrinking fixtures treats the symptom. If macOS keeps flaking after this, the next move is capping concurrency for that job rather than raising numbers again — and after four separate budget fixes, that point is arguably already here.

**A correction to PR #42's description.** It reports `mise run test:unit:tasks — 619 passed`. A clean re-measurement of that same commit collects **620**. I could not reconstruct where the 619 came from, and the discrepancy is one test either way; #42's committed description and posted body are left as they are rather than force-pushing over a review-in-progress for a ±1 prose count. The number to trust is 620 before this PR, 625 after.
