### PR TITLE
[0188] Add a library-backed VCS adapter over gix and jj-lib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -359,103 +359,32 @@ jobs:
         with:
           workspaces: cli
 
-      # Everything needing a real git or jj happens BEFORE the shadow window.
-      # Compilation is one: cli/launcher carries a vergen-gitcl build dependency
-      # that shells out to git, and cargo may need git on a cold registry cache.
-      - name: Compile the suite and the reference artefact
-        run: |
-          cargo build --manifest-path cli/Cargo.toml \
-            -p vcs-adapters --bin vcs-adapters-fixture --bin vcs-adapters-fixture-stub
-          cargo nextest run --manifest-path cli/Cargo.toml \
-            -p corpus-adapters --features bash-parity \
-            -E 'binary(zero_spawn)' --no-run
-
-      # Fixture construction is the other: every shape is built by invoking the
-      # real CLIs. Building them inside the window would leave the suite an
-      # empty matrix, which would pass vacuously.
-      - name: Build the fixture matrix
-        run: |
-          MATRIX_DIR="$(mktemp -d -p "$RUNNER_TEMP")"
-          echo "MATRIX_DIR=$MATRIX_DIR" >> "$GITHUB_ENV"
-          cargo nextest run --manifest-path cli/Cargo.toml \
-            -p vcs-test-support -E 'binary(matrix)'
-
-      # The host-native ratio floor, so a contributor who stops printing a query
-      # result gets PR-level feedback instead of a red release pipeline.
-      - name: Assert the reference artefact links its dependency trees
-        run: mise run build:cli:fixture-size
-
-      # Shadow, run and restore live in ONE step with a trap, so the shell
-      # rather than the scheduler guarantees the restore: a job-level timeout
-      # cancels the job, and whether trailing if:always() steps run then is not
-      # a contract a system-binary restore should rest on.
-      - name: Shadow the real binaries and run the strong-form suite
+      # One task owns the whole sequence, so the ordering that makes this
+      # meaningful lives in the build system rather than in YAML: compile and
+      # build the fixture matrix while the real binaries are still reachable,
+      # shadow them, run the prebuilt suite, restore in a `finally`. The
+      # reference artefact's size floor rides in as a `depends`.
+      #
+      # mise is entered BEFORE the window and never inside it — cargo is invoked
+      # directly from the task — because mise could otherwise observe `jj` as
+      # missing mid-run and reinstall it, silently restoring the binary and
+      # making the assertion vacuous.
+      - name: Run the strong-form zero-spawn suite
         timeout-minutes: 10
-        run: |
-          set -uo pipefail
-          SHADOW_DIR="$RUNNER_TEMP/shadowed"
-          mkdir -p "$SHADOW_DIR"
+        env:
+          # The task refuses to shadow anything without this. /opt/homebrew/bin
+          # is user-writable, so an ungated task could leave a developer without
+          # git; the gate keeps the destructive path opt-in and CI-shaped.
+          ACCELERATOR_ZERO_SPAWN_SHADOW: "yes"
+        run: mise run test:integration:zero-spawn:strong
 
-          # Resolve targets at run time, taking EVERY PATH hit rather than the
-          # first: macOS provides git in two directories, and the same
-          # enumeration keeps this honest if a runner image changes.
-          targets=""
-          for binary in git jj; do
-            while IFS= read -r hit; do
-              [ -n "$hit" ] && targets="$targets $hit"
-            done <<EOF
-          $(command -v -a "$binary" 2>/dev/null || true)
-          EOF
-          done
-          for absolute in /usr/bin/git /usr/local/bin/git /usr/bin/jj; do
-            [ -x "$absolute" ] && targets="$targets $absolute"
-          done
-
-          restore() {
-            status=0
-            for target in $targets; do
-              stashed="$SHADOW_DIR/$(echo "$target" | tr / _)"
-              # Idempotent per path: tolerate a missing source, and report at
-              # the end rather than aborting on the first one.
-              if [ -e "$stashed" ]; then
-                sudo mv -f "$stashed" "$target" || status=1
-              fi
-              if [ ! -x "$target" ]; then
-                echo "still shadowed: $target" >&2
-                status=1
-              fi
-            done
-            return $status
-          }
-          trap restore EXIT
-
-          shadowed=""
-          for target in $targets; do
-            stashed="$SHADOW_DIR/$(echo "$target" | tr / _)"
-            if [ -e "$target" ]; then
-              sudo mv "$target" "$stashed" || {
-                echo "could not shadow $target" >&2
-                exit 1
-              }
-              shadowed="${shadowed:+$shadowed:}$target"
-            fi
-          done
-
-          # The step and the harness have an explicit contract rather than each
-          # assuming the other did the work. The harness hard-fails when the
-          # mode is strong and any listed path is still executable.
-          export ACCELERATOR_ZERO_SPAWN_MODE=strong
-          export ACCELERATOR_ZERO_SPAWN_SHADOWED="$shadowed"
-
-          # The prebuilt test binary directly, NOT through `mise run`: mise may
-          # observe jj as missing inside the window and reinstall it, silently
-          # restoring the binary and making the assertion vacuous.
-          cargo nextest run --manifest-path cli/Cargo.toml \
-            -p corpus-adapters --features bash-parity \
-            -E 'binary(zero_spawn)' --no-fail-fast
-
-      # Backstop for the trap above. actions/checkout's own post step runs git
-      # to strip the auth token, so an unrestored git breaks it.
+      # Backstop for the task's own restore, for the case where the task process
+      # died before its `finally` ran. actions/checkout's post step runs git to
+      # strip the auth token, so an unrestored git breaks it.
+      #
+      # Deliberately NOT `mise run`: mise would see the missing tool and
+      # reinstall it, turning the one check that can catch a failed restore into
+      # a check that quietly repairs it. Bare commands are the point here.
       - name: Assert the restore worked
         if: always()
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -320,6 +320,148 @@ jobs:
       - name: Run cargo-pup behavioural regression
         run: mise run test:integration:pup
 
+  check-zero-spawn:
+    name: Check zero-spawn
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Linux-only, and deliberately not folded into test-unit or
+    # test-integration: both are OS matrices, and a strong-form assertion on the
+    # macOS leg would fail under SIP. macOS degrades to PATH-only with the
+    # unshadowable paths recorded.
+    #
+    # The containment relies on GitHub-hosted runners being EPHEMERAL VMs, and
+    # on git at /usr/bin/git with jj under the mise install tree. A move to
+    # self-hosted, containerised or reusable runners turns a contained hazard
+    # into a persistently broken runner — see tasks/README.md.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Route the rust toolchain into the cached mise data dir
+        run: echo "RUSTUP_HOME=$HOME/.local/share/mise/rustup" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
+        with:
+          install: true
+          # cache: false on purpose. The jj shadow target sits inside the tree
+          # mise-action saves on its post step, which runs AFTER the restore, so
+          # a failed restore would persist a jj-less tool tree into the cache
+          # that every later run restores — self-perpetuating until someone
+          # bumped the prefix. This job installs one toolchain plus jj, so
+          # disabling its cache is cheap and removes the hazard outright.
+          cache: false
+          experimental: true
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          workspaces: cli
+
+      # Everything needing a real git or jj happens BEFORE the shadow window.
+      # Compilation is one: cli/launcher carries a vergen-gitcl build dependency
+      # that shells out to git, and cargo may need git on a cold registry cache.
+      - name: Compile the suite and the reference artefact
+        run: |
+          cargo build --manifest-path cli/Cargo.toml \
+            -p vcs-adapters --bin vcs-adapters-fixture --bin vcs-adapters-fixture-stub
+          cargo nextest run --manifest-path cli/Cargo.toml \
+            -p corpus-adapters --features bash-parity \
+            -E 'binary(zero_spawn)' --no-run
+
+      # Fixture construction is the other: every shape is built by invoking the
+      # real CLIs. Building them inside the window would leave the suite an
+      # empty matrix, which would pass vacuously.
+      - name: Build the fixture matrix
+        run: |
+          MATRIX_DIR="$(mktemp -d -p "$RUNNER_TEMP")"
+          echo "MATRIX_DIR=$MATRIX_DIR" >> "$GITHUB_ENV"
+          cargo nextest run --manifest-path cli/Cargo.toml \
+            -p vcs-test-support -E 'binary(matrix)'
+
+      # The host-native ratio floor, so a contributor who stops printing a query
+      # result gets PR-level feedback instead of a red release pipeline.
+      - name: Assert the reference artefact links its dependency trees
+        run: mise run build:cli:fixture-size
+
+      # Shadow, run and restore live in ONE step with a trap, so the shell
+      # rather than the scheduler guarantees the restore: a job-level timeout
+      # cancels the job, and whether trailing if:always() steps run then is not
+      # a contract a system-binary restore should rest on.
+      - name: Shadow the real binaries and run the strong-form suite
+        timeout-minutes: 10
+        run: |
+          set -uo pipefail
+          SHADOW_DIR="$RUNNER_TEMP/shadowed"
+          mkdir -p "$SHADOW_DIR"
+
+          # Resolve targets at run time, taking EVERY PATH hit rather than the
+          # first: macOS provides git in two directories, and the same
+          # enumeration keeps this honest if a runner image changes.
+          targets=""
+          for binary in git jj; do
+            while IFS= read -r hit; do
+              [ -n "$hit" ] && targets="$targets $hit"
+            done <<EOF
+          $(command -v -a "$binary" 2>/dev/null || true)
+          EOF
+          done
+          for absolute in /usr/bin/git /usr/local/bin/git /usr/bin/jj; do
+            [ -x "$absolute" ] && targets="$targets $absolute"
+          done
+
+          restore() {
+            status=0
+            for target in $targets; do
+              stashed="$SHADOW_DIR/$(echo "$target" | tr / _)"
+              # Idempotent per path: tolerate a missing source, and report at
+              # the end rather than aborting on the first one.
+              if [ -e "$stashed" ]; then
+                sudo mv -f "$stashed" "$target" || status=1
+              fi
+              if [ ! -x "$target" ]; then
+                echo "still shadowed: $target" >&2
+                status=1
+              fi
+            done
+            return $status
+          }
+          trap restore EXIT
+
+          shadowed=""
+          for target in $targets; do
+            stashed="$SHADOW_DIR/$(echo "$target" | tr / _)"
+            if [ -e "$target" ]; then
+              sudo mv "$target" "$stashed" || {
+                echo "could not shadow $target" >&2
+                exit 1
+              }
+              shadowed="${shadowed:+$shadowed:}$target"
+            fi
+          done
+
+          # The step and the harness have an explicit contract rather than each
+          # assuming the other did the work. The harness hard-fails when the
+          # mode is strong and any listed path is still executable.
+          export ACCELERATOR_ZERO_SPAWN_MODE=strong
+          export ACCELERATOR_ZERO_SPAWN_SHADOWED="$shadowed"
+
+          # The prebuilt test binary directly, NOT through `mise run`: mise may
+          # observe jj as missing inside the window and reinstall it, silently
+          # restoring the binary and making the assertion vacuous.
+          cargo nextest run --manifest-path cli/Cargo.toml \
+            -p corpus-adapters --features bash-parity \
+            -E 'binary(zero_spawn)' --no-fail-fast
+
+      # Backstop for the trap above. actions/checkout's own post step runs git
+      # to strip the auth token, so an unrestored git breaks it.
+      - name: Assert the restore worked
+        if: always()
+        run: |
+          git --version
+          jj --version
+
   check-visualiser-frontend:
     name: Check visualiser frontend
     runs-on: ubuntu-latest
@@ -353,6 +495,7 @@ jobs:
       - check-cli
       - check-supply-chain
       - check-architecture
+      - check-zero-spawn
     if: github.event_name == 'push'
     # Serialise all release pipelines onto one queue: prepare (pull + bump) and
     # finalise (commit + tag + push) are steps in this single job, so a queued

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,15 +325,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    # Linux-only, and deliberately not folded into test-unit or
-    # test-integration: both are OS matrices, and a strong-form assertion on the
-    # macOS leg would fail under SIP. macOS degrades to PATH-only with the
-    # unshadowable paths recorded.
+    # Its own job rather than a leg of test-unit/test-integration: those are OS
+    # matrices, and shadowing system binaries fails under SIP on macOS.
     #
-    # The containment relies on GitHub-hosted runners being EPHEMERAL VMs, and
-    # on git at /usr/bin/git with jj under the mise install tree. A move to
-    # self-hosted, containerised or reusable runners turns a contained hazard
-    # into a persistently broken runner — see tasks/README.md.
+    # Containment assumes EPHEMERAL runners. Moving to self-hosted,
+    # containerised or reusable ones turns a contained hazard into a
+    # persistently broken runner.
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -359,32 +356,20 @@ jobs:
         with:
           workspaces: cli
 
-      # One task owns the whole sequence, so the ordering that makes this
-      # meaningful lives in the build system rather than in YAML: compile and
-      # build the fixture matrix while the real binaries are still reachable,
-      # shadow them, run the prebuilt suite, restore in a `finally`. The
-      # reference artefact's size floor rides in as a `depends`.
-      #
-      # mise is entered BEFORE the window and never inside it — cargo is invoked
-      # directly from the task — because mise could otherwise observe `jj` as
-      # missing mid-run and reinstall it, silently restoring the binary and
-      # making the assertion vacuous.
+      # One task owns the ordering that makes this meaningful. mise is entered
+      # before the shadow window and never inside it, or it could see `jj`
+      # missing mid-run and reinstall it, making the assertion vacuous.
       - name: Run the strong-form zero-spawn suite
         timeout-minutes: 10
         env:
-          # The task refuses to shadow anything without this. /opt/homebrew/bin
-          # is user-writable, so an ungated task could leave a developer without
-          # git; the gate keeps the destructive path opt-in and CI-shaped.
+          # The task refuses to shadow anything without this.
           ACCELERATOR_ZERO_SPAWN_SHADOW: "yes"
         run: mise run test:integration:zero-spawn:strong
 
-      # Backstop for the task's own restore, for the case where the task process
-      # died before its `finally` ran. actions/checkout's post step runs git to
-      # strip the auth token, so an unrestored git breaks it.
-      #
-      # Deliberately NOT `mise run`: mise would see the missing tool and
-      # reinstall it, turning the one check that can catch a failed restore into
-      # a check that quietly repairs it. Bare commands are the point here.
+      # Backstop for the case where the task died before its `finally` ran.
+      # Deliberately NOT `mise run`: that would reinstall the missing tool,
+      # turning the one check that catches a failed restore into one that
+      # quietly repairs it.
       - name: Assert the restore worked
         if: always()
         run: |

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4349,6 +4349,8 @@ version = "1.24.0-pre.23"
 dependencies = [
  "gix",
  "jj-lib",
+ "pollster",
+ "prost",
  "tempfile",
  "tracing",
  "vcs",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -642,6 +642,7 @@ dependencies = [
  "time",
  "vcs",
  "vcs-adapters",
+ "vcs-test-support",
 ]
 
 [[package]]
@@ -4351,6 +4352,14 @@ dependencies = [
  "tempfile",
  "tracing",
  "vcs",
+ "vcs-test-support",
+]
+
+[[package]]
+name = "vcs-test-support"
+version = "1.24.0-pre.21"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -223,6 +223,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +354,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -398,6 +419,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -531,6 +558,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,10 +772,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "deranged"
@@ -782,6 +873,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -813,6 +905,18 @@ dependencies = [
  "serde",
  "serde-saphyr",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding_rs"
@@ -858,6 +962,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -949,6 +1073,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -972,10 +1097,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "futures-sink"
@@ -998,6 +1145,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1057,6 +1205,740 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.85.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.17.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.17.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.82.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
+dependencies = [
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "granit-parser"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1949,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1972,27 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1428,6 +2346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +2375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "interim"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ce9099a85f468663d3225bf87e85d0548968441e1db12248b996b24f0f5b5a"
+dependencies = [
+ "chrono",
+ "logos",
 ]
 
 [[package]]
@@ -1473,10 +2413,139 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jj-lib"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22e2ced34a1a51f0f449bfff2cbacda1c338b2611268b5684a80251e4c8bf71"
+dependencies = [
+ "async-trait",
+ "blake2",
+ "bstr",
+ "chrono",
+ "clru",
+ "digest 0.10.7",
+ "dunce",
+ "either",
+ "etcetera",
+ "futures",
+ "gix",
+ "gix-ignore",
+ "globset",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "interim",
+ "itertools 0.15.0",
+ "jj-lib-proc-macros",
+ "maplit",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "pollster",
+ "prost",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rayon",
+ "ref-cast",
+ "regex",
+ "rustix",
+ "same-file",
+ "serde",
+ "smallvec",
+ "strsim",
+ "tempfile",
+ "thiserror",
+ "toml_edit",
+ "tracing",
+ "winreg",
+]
+
+[[package]]
+name = "jj-lib-proc-macros"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21554e3755e5ecfec934d84ac64d0295d9c2f2b96f6a740a1ddb66addf4142e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "jobserver"
@@ -1529,6 +2598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,7 +2637,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "no_std_io2",
  "rle-decode-fast",
 ]
@@ -1592,10 +2670,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -1613,10 +2731,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1716,6 +2854,12 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -1821,6 +2965,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,10 +3019,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1924,6 +3125,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,7 +3239,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2029,6 +3262,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2056,12 +3299,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2203,6 +3486,15 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -2363,6 +3655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +3673,27 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
 ]
 
 [[package]]
@@ -2406,6 +3728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +3766,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2454,6 +3785,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "store"
@@ -2499,6 +3836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -2696,6 +4034,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,16 +4244,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2939,6 +4346,8 @@ version = "1.24.0-pre.23"
 name = "vcs-adapters"
 version = "1.24.0-pre.23"
 dependencies = [
+ "gix",
+ "jj-lib",
  "tempfile",
  "tracing",
  "vcs",
@@ -3351,6 +4760,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +4892,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "vcs-test-support"
-version = "1.24.0-pre.21"
+version = "1.24.0-pre.23"
 dependencies = [
  "tempfile",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,6 +78,20 @@ rustix = { version = "1", features = ["process", "fs"] }
 # additions stay visible.
 jj-lib = "=0.43.0"
 gix = { version = "~0.85.0", default-features = false }
+# prost and pollster are jj-lib's own, adopted as direct edges rather than new
+# crates: both are already in the lock through jj-lib, so this adds no
+# supply-chain surface and no licence. They exist to read the jj working-copy
+# commit id without a UserSettings, which the checkout state makes possible:
+# prost decodes jj_lib::protos::local_working_copy::Checkout (a public module,
+# so this is API rather than a private wire format), and pollster drives the
+# OpStore trait's async read methods, which jj-lib itself drives with pollster.
+#
+# Both are pinned to the major jj-lib requires, because the decoded type comes
+# FROM jj-lib: a prost major mismatch would put two prost graphs in the lock and
+# the generated code would stop matching the decoder. They move with jj-lib, so
+# a jj-lib bump is now a six-pin change — see tasks/README.md.
+prost = "0.14"
+pollster = "0.4"
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,32 @@ serde-saphyr = "=0.0.29"
 tempfile = "3"
 rand = "0.9"
 rustix = { version = "1", features = ["process", "fs"] }
+# jj-lib and gix are a matched pair, pinned asymmetrically on purpose.
+#
+# jj-lib is EXACT: it declares its API unstable, the library-backed VCS adapter
+# leans on its workspace-loader internals, and a patch release can shift its
+# MSRV or its own gix requirement. Adopting one is a deliberate act, not a
+# resolution outcome.
+#
+# gix is TILDE: ~0.85.0 permits 0.85.x only, which is the range jj-lib already
+# requires (^0.85.0), so patch agility costs nothing here and a RustSec fix is a
+# lock update rather than a pin edit. gix 0.86 exists and a caret on a 0.x crate
+# will not cross it, so requesting 0.86 would put two gix graphs in the lock.
+#
+# A jj-lib bump is a coordinated four-pin change: jj-lib, gix, the Rust
+# toolchain (jj-lib's MSRV moved 1.85 -> 1.88 -> 1.89 across eight releases) and
+# the mise jj CLI pin, which writes the format jj-lib reads.
+#
+# default-features = false because gix's `default` reaches `extras` ->
+# `credentials`, which pulls gix-credentials -- the one gix subsystem that
+# spawns `git credential-*` helper programs, against a module whose whole point
+# is reading git without a subprocess. Nothing is lost: jj-lib's own selection
+# still enables attributes, blob-diff, index, max-performance-safe, sha1 and
+# zlib-rs, and every gix call the adapter makes is available without the
+# `extras` set. Widening this list is how a consumer adds a capability, so the
+# additions stay visible.
+jj-lib = "=0.43.0"
+gix = { version = "~0.85.0", default-features = false }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 # resolver 3 so rust-version drives MSRV-aware dependency selection.
 [workspace]
 resolver = "3"
-members = ["launcher", "kernel", "verify", "document", "config", "config-adapters", "corpus", "corpus-adapters", "vcs", "vcs-adapters", "store", "visualiser/server"]
+members = ["launcher", "kernel", "verify", "document", "config", "config-adapters", "corpus", "corpus-adapters", "vcs", "vcs-adapters", "vcs-test-support", "store", "visualiser/server"]
 
 [workspace.package]
 version = "1.24.0-pre.23"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,44 +52,28 @@ serde-saphyr = "=0.0.29"
 tempfile = "3"
 rand = "0.9"
 rustix = { version = "1", features = ["process", "fs"] }
-# jj-lib and gix are a matched pair, pinned asymmetrically on purpose.
+# jj-lib and gix are a matched pair, pinned asymmetrically. jj-lib is EXACT
+# because it declares its API unstable and a patch can shift its MSRV or its own
+# gix requirement; gix is TILDE because ~0.85.0 is the range jj-lib already
+# requires, so a RustSec fix is a lock update rather than a pin edit. A caret on
+# a 0.x crate will not cross to the existing 0.86, which would put two gix
+# graphs in the lock.
 #
-# jj-lib is EXACT: it declares its API unstable, the library-backed VCS adapter
-# leans on its workspace-loader internals, and a patch release can shift its
-# MSRV or its own gix requirement. Adopting one is a deliberate act, not a
-# resolution outcome.
+# gix takes default-features = false because its `default` reaches `extras` ->
+# `credentials`, pulling gix-credentials — the one gix subsystem that spawns
+# helper programs. jj-lib's own selection still enables everything the adapter
+# calls. Widening this list is how a consumer adds a capability.
 #
-# gix is TILDE: ~0.85.0 permits 0.85.x only, which is the range jj-lib already
-# requires (^0.85.0), so patch agility costs nothing here and a RustSec fix is a
-# lock update rather than a pin edit. gix 0.86 exists and a caret on a 0.x crate
-# will not cross it, so requesting 0.86 would put two gix graphs in the lock.
-#
-# A jj-lib bump is a coordinated four-pin change: jj-lib, gix, the Rust
-# toolchain (jj-lib's MSRV moved 1.85 -> 1.88 -> 1.89 across eight releases) and
-# the mise jj CLI pin, which writes the format jj-lib reads.
-#
-# default-features = false because gix's `default` reaches `extras` ->
-# `credentials`, which pulls gix-credentials -- the one gix subsystem that
-# spawns `git credential-*` helper programs, against a module whose whole point
-# is reading git without a subprocess. Nothing is lost: jj-lib's own selection
-# still enables attributes, blob-diff, index, max-performance-safe, sha1 and
-# zlib-rs, and every gix call the adapter makes is available without the
-# `extras` set. Widening this list is how a consumer adds a capability, so the
-# additions stay visible.
+# A jj-lib bump moves all four of these plus the Rust toolchain and the mise jj
+# CLI pin, which writes the format jj-lib reads.
 jj-lib = "=0.43.0"
 gix = { version = "~0.85.0", default-features = false }
-# prost and pollster are jj-lib's own, adopted as direct edges rather than new
-# crates: both are already in the lock through jj-lib, so this adds no
-# supply-chain surface and no licence. They exist to read the jj working-copy
-# commit id without a UserSettings, which the checkout state makes possible:
-# prost decodes jj_lib::protos::local_working_copy::Checkout (a public module,
-# so this is API rather than a private wire format), and pollster drives the
-# OpStore trait's async read methods, which jj-lib itself drives with pollster.
-#
-# Both are pinned to the major jj-lib requires, because the decoded type comes
-# FROM jj-lib: a prost major mismatch would put two prost graphs in the lock and
-# the generated code would stop matching the decoder. They move with jj-lib, so
-# a jj-lib bump is now a six-pin change — see tasks/README.md.
+# prost and pollster are jj-lib's own, adopted as direct edges: both are already
+# in the lock through it, so this adds no packages. prost decodes
+# jj_lib::protos::local_working_copy::Checkout (a public module, so API rather
+# than a private wire format) and pollster drives the OpStore trait's async
+# reads. Pinned to the majors jj-lib requires, because the decoded type comes
+# from jj-lib: a major mismatch splits the graph and breaks the decode.
 prost = "0.14"
 pollster = "0.4"
 

--- a/cli/corpus-adapters/Cargo.toml
+++ b/cli/corpus-adapters/Cargo.toml
@@ -29,3 +29,9 @@ tempfile = { workspace = true }
 rand = { workspace = true }
 rustix = { workspace = true }
 serde_json = { workspace = true }
+
+# Test-only edge to the shared VCS harness. Under resolver 3 a dev-dependency's
+# features stay out of the normal build, which matters because the visualiser
+# server depends on this crate. The normal vcs-adapters edge above is untouched.
+[dev-dependencies]
+vcs-test-support = { path = "../vcs-test-support" }

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -15,8 +15,8 @@ use std::fmt::Write as _;
 use std::path::Path;
 use std::process::Command;
 
+use vcs_test_support::fixtures;
 use vcs_test_support::fixtures::Matrix;
-use vcs_test_support::hermetic::assert_git_is_recent_enough;
 use vcs_test_support::stubs::assert_shadowing_holds;
 use vcs_test_support::stubs::reference_artefact;
 use vcs_test_support::stubs::Mode;
@@ -51,22 +51,21 @@ fn query(
 #[test]
 fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
 {
-    assert_git_is_recent_enough()?;
-
     // Fail closed on a malformed contract too, or a dropped export silently
     // downgrades the run.
     let mode = Mode::from_environment()?;
     assert_shadowing_holds(mode)?;
 
-    let base = tempfile::Builder::new()
-        .prefix("vcs-zero-spawn-")
-        .tempdir()?;
-    let matrix = Matrix::build_in(base.path())?;
+    // Adopted rather than built when a root is handed over: building needs the
+    // real binaries, which the strong form has already moved out of reach.
+    let (_matrix_guard, root) = fixtures::matrix_root()?;
+    let matrix = Matrix::build_or_adopt(&root)?;
     let artefact = reference_artefact()?;
 
-    // Built before the stubs take effect: building it is what needs the real
-    // binaries, and a stubbed build would leave an empty matrix.
-    let stubs = Stubs::rooted_at(base.path())?;
+    let stub_base = tempfile::Builder::new()
+        .prefix("vcs-zero-spawn-")
+        .tempdir()?;
+    let stubs = Stubs::rooted_at(stub_base.path())?;
     assert!(
         !matrix.fixtures.is_empty(),
         "an empty matrix would pass every assertion below while proving nothing"

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -1,17 +1,13 @@
-//! The zero-spawn property, proven **across a crate boundary**.
+//! The zero-spawn property, proven across a crate boundary.
 //!
-//! `corpus-adapters` is the crate that will converge onto the library-backed
-//! probe, so the harness is exercised from here rather than from the crate that
-//! defines it — that is what retires the restructuring risk. Everything it uses
-//! comes from `vcs_test_support`'s public API: the fixture matrix, the stubs,
-//! the shadow list and the hermetic environment. All three parts, not one.
+//! Exercised from `corpus-adapters` — the crate that will converge onto the
+//! library-backed probe — through `vcs_test_support`'s public API only.
 //!
-//! The assertion is scoped to `git`/`jj` **specifically**, not "no subprocess at
-//! all": `SystemClock::try_new` spawns `date` unconditionally, so a blanket
-//! marker would trip on it.
+//! Scoped to `git`/`jj` specifically rather than "no subprocess at all", because
+//! `SystemClock::try_new` spawns `date` unconditionally.
 //!
-//! Two things are asserted together, because either alone is satisfiable by a
-//! broken adapter: no stub marker was written, **and** every value matches an
+//! Two things are asserted together, since either alone is satisfiable by a
+//! broken adapter: no stub marker was written, and every value matches an
 //! unrestricted run. An adapter degrading to `None` also writes no marker.
 #![cfg(feature = "bash-parity")]
 
@@ -57,8 +53,8 @@ fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
 {
     assert_git_is_recent_enough()?;
 
-    // Fail closed on a malformed contract, not just on an unshadowed path: a
-    // typo or a dropped export would otherwise silently downgrade the run.
+    // Fail closed on a malformed contract too, or a dropped export silently
+    // downgrades the run.
     let mode = Mode::from_environment()?;
     assert_shadowing_holds(mode)?;
 
@@ -68,9 +64,8 @@ fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
     let matrix = Matrix::build_in(base.path())?;
     let artefact = reference_artefact()?;
 
-    // The matrix must be built *before* the stubs take effect — building it is
-    // what needs the real binaries. A stubbed build would leave an empty matrix
-    // and the whole assertion would pass vacuously.
+    // Built before the stubs take effect: building it is what needs the real
+    // binaries, and a stubbed build would leave an empty matrix.
     let stubs = Stubs::rooted_at(base.path())?;
     assert!(
         !matrix.fixtures.is_empty(),
@@ -97,9 +92,8 @@ fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
          degraded rather than reading in-process:\n{mismatches}"
     );
 
-    // On a platform where the absolute paths could not be shadowed, record
-    // which — the property is proven in its strong form only where the mode
-    // says so.
+    // Record what stayed reachable, since the strong form is only proven where
+    // the mode says so.
     if mode == Mode::PathOnly {
         let reachable = vcs_test_support::stubs::unshadowed_paths()?;
         println!(

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -1,0 +1,111 @@
+//! The zero-spawn property, proven **across a crate boundary**.
+//!
+//! `corpus-adapters` is the crate that will converge onto the library-backed
+//! probe, so the harness is exercised from here rather than from the crate that
+//! defines it — that is what retires the restructuring risk. Everything it uses
+//! comes from `vcs_test_support`'s public API: the fixture matrix, the stubs,
+//! the shadow list and the hermetic environment. All three parts, not one.
+//!
+//! The assertion is scoped to `git`/`jj` **specifically**, not "no subprocess at
+//! all": `SystemClock::try_new` spawns `date` unconditionally, so a blanket
+//! marker would trip on it.
+//!
+//! Two things are asserted together, because either alone is satisfiable by a
+//! broken adapter: no stub marker was written, **and** every value matches an
+//! unrestricted run. An adapter degrading to `None` also writes no marker.
+#![cfg(feature = "bash-parity")]
+
+use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
+
+use vcs_test_support::fixtures::Matrix;
+use vcs_test_support::hermetic::assert_git_is_recent_enough;
+use vcs_test_support::stubs::assert_shadowing_holds;
+use vcs_test_support::stubs::reference_artefact;
+use vcs_test_support::stubs::Mode;
+use vcs_test_support::stubs::Stubs;
+
+type TestError = Box<dyn std::error::Error>;
+
+/// Runs every query against `start` through the reference artefact, optionally
+/// with the real binaries stubbed out.
+fn query(
+    binary: &Path,
+    start: &Path,
+    stubs: Option<&Stubs>,
+) -> Result<String, TestError> {
+    let mut command = Command::new(binary);
+    command.arg("all").arg(start);
+    if let Some(stubs) = stubs {
+        stubs.apply(&mut command);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "the reference artefact failed for {}: {}",
+            start.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+#[test]
+fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
+{
+    assert_git_is_recent_enough()?;
+
+    // Fail closed on a malformed contract, not just on an unshadowed path: a
+    // typo or a dropped export would otherwise silently downgrade the run.
+    let mode = Mode::from_environment()?;
+    assert_shadowing_holds(mode)?;
+
+    let base = tempfile::Builder::new()
+        .prefix("vcs-zero-spawn-")
+        .tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+    let artefact = reference_artefact()?;
+
+    // The matrix must be built *before* the stubs take effect — building it is
+    // what needs the real binaries. A stubbed build would leave an empty matrix
+    // and the whole assertion would pass vacuously.
+    let stubs = Stubs::rooted_at(base.path())?;
+    assert!(
+        !matrix.fixtures.is_empty(),
+        "an empty matrix would pass every assertion below while proving nothing"
+    );
+
+    let mut mismatches = String::new();
+    for fixture in &matrix.fixtures {
+        let unrestricted = query(&artefact, &fixture.start, None)?;
+        let stubbed = query(&artefact, &fixture.start, Some(&stubs))?;
+        if unrestricted != stubbed {
+            writeln!(mismatches, "  {} ({})", fixture.key, fixture.shape)?;
+        }
+    }
+
+    assert_eq!(
+        stubs.spawns()?,
+        None,
+        "a git or jj subprocess was spawned; the stub recorded it"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "values changed when the real binaries were removed, so the adapter \
+         degraded rather than reading in-process:\n{mismatches}"
+    );
+
+    // On a platform where the absolute paths could not be shadowed, record
+    // which — the property is proven in its strong form only where the mode
+    // says so.
+    if mode == Mode::PathOnly {
+        let reachable = vcs_test_support::stubs::unshadowed_paths()?;
+        println!(
+            "zero-spawn ran in path-only mode; still reachable by absolute \
+             path: {reachable:?}"
+        );
+    }
+    Ok(())
+}

--- a/cli/deny.toml
+++ b/cli/deny.toml
@@ -64,28 +64,18 @@ allow = [
 ]
 confidence-threshold = 0.8
 
-# uluru is gix-pack's LRU pack cache, enabled by gix-odb's default features and
-# reached from both gix and gix-odb, so it is not feature-gatable out of the
-# graph. MPL-2.0 is file-level weak copyleft: we ship no modifications, so §3.1
-# is satisfied trivially. The obligation that would bind is §3.2 — distributing
-# the Executable Form requires telling recipients how to obtain the Source Form.
+# uluru is gix-pack's LRU pack cache, enabled by gix-odb's default features, so
+# it cannot be feature-gated out. MPL-2.0 is file-level weak copyleft: we ship
+# no modifications, and §3.2's notice obligation does not bind because dead-code
+# elimination removes the whole gix/jj-lib closure from the only shipped binary
+# that reaches it. Re-check that when anything makes the visualiser reach
+# vcs-adapters: once the trees link, distributing the binary requires telling
+# recipients how to obtain the source, which the release upload set carries no
+# artefact for.
 #
-# Verified 2026-08-03 that §3.2 does not bind: uluru is in the normal closure of
-# exactly one shipped binary (accelerator-visualiser; neither accelerator nor
-# accelerator-verify has it at all), and dead-code elimination removes the whole
-# gix/jj-lib closure from it. Distinctive literals — "extensions.objectFormat"
-# from gix, "There is no Jujutsu repo" from jj-lib — are present in the linked
-# reference artefact and absent from the shipped binary, which carries zero
-# symbols from gix, gix-pack, gix-odb, jj_lib or uluru against 26,247 total.
-# Nothing in the visualiser's reachable call graph enters vcs-adapters at all:
-# CommandProbe's own "rev-parse" literal is absent too.
-#
-# RE-CHECK WHEN THE VISUALISER STARTS REACHING vcs_adapters::facts — 0185's
-# composition-root switch is the expected trigger. Once the trees link, §3.2
-# binds and a third-party attribution artefact has to join the release upload
-# set, which _release_uploads() does not carry today.
-#
-# Adopted for the library-backed VCS adapter (work item 0188).
+# Verify with: an unstripped --release accelerator-visualiser carries neither
+# the `extensions.objectFormat` (gix) nor the `There is no Jujutsu repo`
+# (jj-lib) literal, both of which the linked reference artefact does carry.
 [[licenses.exceptions]]
 crate = "uluru"
 allow = ["MPL-2.0"]
@@ -100,14 +90,12 @@ allow-wildcard-paths = true
 # infra-out-of-domain ban: the YAML crate is reachable only through the
 # document wrapper, so a direct domain import violates.
 #
-# gix-credentials and curl-sys are the VCS-adapter additions: the first spawns
-# `git credential-*` helper programs, the second is the other transport stack
-# gix can be built against. Both are verified absent from the resolved graph —
-# gix-credentials only because the gix pin sets default-features = false, so
-# this ban is what keeps a later feature widening from reintroducing it
-# silently. gix-transport and gix-protocol are deliberately NOT banned: they
-# ARE in the graph via jj-lib's defaults and are kept inert by gix's network
-# client features being off, which the feature-graph test asserts instead.
+# gix-credentials spawns `git credential-*` helper programs and is absent only
+# because the gix pin sets default-features = false, so this ban is what stops a
+# later feature widening reintroducing it. curl-sys is the other transport stack
+# gix can be built against. gix-transport and gix-protocol are deliberately NOT
+# banned: they ARE in the graph via jj-lib's defaults, and are kept inert by
+# gix's network client features being off, which the feature-graph test asserts.
 deny = [
     { crate = "native-tls" },
     { crate = "openssl" },

--- a/cli/deny.toml
+++ b/cli/deny.toml
@@ -25,9 +25,20 @@ unmaintained = "all"
 yanked = "deny"
 # hickory-proto 0.25 DNS-parsing DoS advisories with no upgrade path yet
 # (reqwest 0.12 pins hickory-resolver 0.25). Remove when reqwest adopts 0.26.
+#
+# Every entry carries a `review-by: YYYY-MM-DD` in its reason, asserted by
+# tests/integration/deny/test_advisory_ignores.py — cargo-deny enforces no
+# expiry of its own, so an ignore added under release pressure would otherwise
+# outlive its justification silently. A lapsed date is a prompt to re-check the
+# upstream state and re-date or remove, not a reason to bump it blindly.
+#
+# The break-glass in tasks/README.md is scoped to unmaintained/yanked/notice
+# advisories only. A vulnerability-class advisory takes the escalation path —
+# upgrade, patch or vendor — never an ignore, because this closure reaches the
+# publicly distributed signed accelerator-visualiser binary.
 ignore = [
-    "RUSTSEC-2026-0118",
-    "RUSTSEC-2026-0119",
+    { id = "RUSTSEC-2026-0118", reason = "hickory-proto 0.25 DNS-parsing DoS; no upgrade path until reqwest adopts hickory-resolver 0.26. review-by: 2026-11-03" },
+    { id = "RUSTSEC-2026-0119", reason = "hickory-proto 0.25 DNS-parsing DoS; no upgrade path until reqwest adopts hickory-resolver 0.26. review-by: 2026-11-03" },
 ]
 
 [licenses]
@@ -53,6 +64,18 @@ allow = [
 ]
 confidence-threshold = 0.8
 
+# uluru is gix-pack's LRU object cache (reached from both gix and gix-odb) and
+# is not feature-gatable out of the graph. MPL-2.0 is file-level weak copyleft:
+# we ship no modifications, so §3.1 is satisfied trivially. The obligation that
+# binds is §3.2 — distributing the Executable Form requires telling recipients
+# how to obtain the Source Form — and this crate reaches the published
+# accelerator-visualiser binary, so it is discharged by the third-party licence
+# file staged into the release payload, not by the absence of modifications.
+# Adopted for the library-backed VCS adapter (work item 0188).
+[[licenses.exceptions]]
+crate = "uluru"
+allow = ["MPL-2.0"]
+
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
@@ -62,11 +85,22 @@ allow-wildcard-paths = true
 # musl-static build. This covers the TLS vector only. serde-saphyr is the
 # infra-out-of-domain ban: the YAML crate is reachable only through the
 # document wrapper, so a direct domain import violates.
+#
+# gix-credentials and curl-sys are the VCS-adapter additions: the first spawns
+# `git credential-*` helper programs, the second is the other transport stack
+# gix can be built against. Both are verified absent from the resolved graph —
+# gix-credentials only because the gix pin sets default-features = false, so
+# this ban is what keeps a later feature widening from reintroducing it
+# silently. gix-transport and gix-protocol are deliberately NOT banned: they
+# ARE in the graph via jj-lib's defaults and are kept inert by gix's network
+# client features being off, which the feature-graph test asserts instead.
 deny = [
     { crate = "native-tls" },
     { crate = "openssl" },
     { crate = "openssl-sys" },
     { crate = "serde-saphyr", wrappers = ["document"] },
+    { crate = "gix-credentials" },
+    { crate = "curl-sys" },
 ]
 
 [sources]

--- a/cli/deny.toml
+++ b/cli/deny.toml
@@ -64,13 +64,27 @@ allow = [
 ]
 confidence-threshold = 0.8
 
-# uluru is gix-pack's LRU object cache (reached from both gix and gix-odb) and
-# is not feature-gatable out of the graph. MPL-2.0 is file-level weak copyleft:
-# we ship no modifications, so §3.1 is satisfied trivially. The obligation that
-# binds is §3.2 — distributing the Executable Form requires telling recipients
-# how to obtain the Source Form — and this crate reaches the published
-# accelerator-visualiser binary, so it is discharged by the third-party licence
-# file staged into the release payload, not by the absence of modifications.
+# uluru is gix-pack's LRU pack cache, enabled by gix-odb's default features and
+# reached from both gix and gix-odb, so it is not feature-gatable out of the
+# graph. MPL-2.0 is file-level weak copyleft: we ship no modifications, so §3.1
+# is satisfied trivially. The obligation that would bind is §3.2 — distributing
+# the Executable Form requires telling recipients how to obtain the Source Form.
+#
+# Verified 2026-08-03 that §3.2 does not bind: uluru is in the normal closure of
+# exactly one shipped binary (accelerator-visualiser; neither accelerator nor
+# accelerator-verify has it at all), and dead-code elimination removes the whole
+# gix/jj-lib closure from it. Distinctive literals — "extensions.objectFormat"
+# from gix, "There is no Jujutsu repo" from jj-lib — are present in the linked
+# reference artefact and absent from the shipped binary, which carries zero
+# symbols from gix, gix-pack, gix-odb, jj_lib or uluru against 26,247 total.
+# Nothing in the visualiser's reachable call graph enters vcs-adapters at all:
+# CommandProbe's own "rev-parse" literal is absent too.
+#
+# RE-CHECK WHEN THE VISUALISER STARTS REACHING vcs_adapters::facts — 0185's
+# composition-root switch is the expected trigger. Once the trees link, §3.2
+# binds and a third-party attribution artefact has to join the release upload
+# set, which _release_uploads() does not carry today.
+#
 # Adopted for the library-backed VCS adapter (work item 0188).
 [[licenses.exceptions]]
 crate = "uluru"

--- a/cli/pup.ron
+++ b/cli/pup.ron
@@ -87,19 +87,16 @@
                 ),
             ],
         )),
-        // The library-backed adapter reads git and jj in-process. A permit list
-        // alone cannot express this because std::process sits inside the
-        // permitted std, so the rule pairs a permit list with an explicit deny:
-        // the deny wins on overlap. Note the permit list rejects grouped
+        // A permit list alone cannot express this, because std::process sits
+        // inside the permitted std, so the rule pairs one with an explicit
+        // deny; the deny wins on overlap. The permit list rejects grouped
         // imports (cargo-pup resolves `use a::{b, c}` to an empty module name),
-        // so this module writes one single-item `use` per import.
+        // so that module writes one single-item `use` per import.
         //
-        // Scoped to the module, not the crate: the sibling
-        // vcs_adapters::subprocess spawns by design. Two things this does NOT
-        // deliver: an inline fully-qualified std::process::Command::new() with
-        // no `use` is unaffected, and `^crate(::|$)` reaches
-        // crate::subprocess, which spawns. The zero-spawn property itself is
-        // established by the harness.
+        // Scoped to the module because the sibling subprocess module spawns by
+        // design. This does not stop an inline fully-qualified
+        // std::process::Command::new(), nor reaching crate::subprocess through
+        // the permitted `^crate`; the harness is what establishes zero-spawn.
         Module((
             name: "vcs_adapters_library_reads_in_process",
             matches: Module("^vcs_adapters::library($|::)"),

--- a/cli/pup.ron
+++ b/cli/pup.ron
@@ -87,15 +87,6 @@
                 ),
             ],
         )),
-        // The config command's inbound hexagon must not reach the composition
-        // root's adapter crate (`config_adapters`) nor a sibling launcher
-        // module (`crate::launch`), so the injected-ports seam cannot erode.
-        // Expressed as a `denied` list rather than `allowed_only`: cargo-pup
-        // resolves a grouped `use config::{a, b}` to an empty module name,
-        // which an `allowed_only` rule would reject as unpermitted — false-
-        // positiving every legitimate grouped import the codebase uses. A
-        // `denied` list is unaffected by that resolution and states the seam
-        // prohibition directly.
         // The library-backed adapter reads git and jj in-process. A permit list
         // alone cannot express this because std::process sits inside the
         // permitted std, so the rule pairs a permit list with an explicit deny:
@@ -103,11 +94,12 @@
         // imports (cargo-pup resolves `use a::{b, c}` to an empty module name),
         // so this module writes one single-item `use` per import.
         //
-        // Scoped to the module, not the crate: the retained CommandProbe
-        // spawns by design. Two things this does NOT deliver: an inline
-        // fully-qualified std::process::Command::new() with no `use` is
-        // unaffected, and `^crate(::|$)` reaches crate::CommandProbe. The
-        // zero-spawn property itself is established by the harness.
+        // Scoped to the module, not the crate: the sibling
+        // vcs_adapters::subprocess spawns by design. Two things this does NOT
+        // deliver: an inline fully-qualified std::process::Command::new() with
+        // no `use` is unaffected, and `^crate(::|$)` reaches
+        // crate::subprocess, which spawns. The zero-spawn property itself is
+        // established by the harness.
         Module((
             name: "vcs_adapters_library_reads_in_process",
             matches: Module("^vcs_adapters::library($|::)"),
@@ -130,6 +122,15 @@
                 ),
             ],
         )),
+        // The config command's inbound hexagon must not reach the composition
+        // root's adapter crate (`config_adapters`) nor a sibling launcher
+        // module (`crate::launch`), so the injected-ports seam cannot erode.
+        // Expressed as a `denied` list rather than `allowed_only`: cargo-pup
+        // resolves a grouped `use config::{a, b}` to an empty module name,
+        // which an `allowed_only` rule would reject as unpermitted — false-
+        // positiving every legitimate grouped import the codebase uses. A
+        // `denied` list is unaffected by that resolution and states the seam
+        // prohibition directly.
         Module((
             name: "config_command_may_not_import_adapters_or_launch",
             matches: Module("^accelerator::config_command($|::)"),

--- a/cli/pup.ron
+++ b/cli/pup.ron
@@ -96,6 +96,38 @@
         // positiving every legitimate grouped import the codebase uses. A
         // `denied` list is unaffected by that resolution and states the seam
         // prohibition directly.
+        // The library-backed adapter reads git and jj in-process. A permit list
+        // alone cannot express this because std::process sits inside the
+        // permitted std, so the rule pairs a permit list with an explicit deny:
+        // the deny wins on overlap. Note the permit list rejects grouped
+        // imports (cargo-pup resolves `use a::{b, c}` to an empty module name),
+        // so this module writes one single-item `use` per import.
+        //
+        // Scoped to the module, not the crate: the retained CommandProbe
+        // spawns by design. Two things this does NOT deliver: an inline
+        // fully-qualified std::process::Command::new() with no `use` is
+        // unaffected, and `^crate(::|$)` reaches crate::CommandProbe. The
+        // zero-spawn property itself is established by the harness.
+        Module((
+            name: "vcs_adapters_library_reads_in_process",
+            matches: Module("^vcs_adapters::library($|::)"),
+            rules: [
+                RestrictImports(
+                    allowed_only: Some([
+                        "^(std|core|alloc)(::|$)",
+                        "^gix(::|$)",
+                        "^jj_lib(::|$)",
+                        "^tracing(::|$)",
+                        "^vcs(::|$)",
+                        "^crate(::|$)",
+                    ]),
+                    denied: Some([
+                        "^std::process(::|$)",
+                    ]),
+                    severity: Error,
+                ),
+            ],
+        )),
         Module((
             name: "config_command_may_not_import_adapters_or_launch",
             matches: Module("^accelerator::config_command($|::)"),

--- a/cli/pup.ron
+++ b/cli/pup.ron
@@ -117,6 +117,8 @@
                         "^(std|core|alloc)(::|$)",
                         "^gix(::|$)",
                         "^jj_lib(::|$)",
+                        "^pollster(::|$)",
+                        "^prost(::|$)",
                         "^tracing(::|$)",
                         "^vcs(::|$)",
                         "^crate(::|$)",

--- a/cli/vcs-adapters/Cargo.toml
+++ b/cli/vcs-adapters/Cargo.toml
@@ -24,6 +24,14 @@ bash-parity = []
 name = "vcs-adapters-fixture"
 path = "tests/fixtures/vcs_adapters_fixture.rs"
 
+# The stubbed twin, giving the size floor a denominator. A second [[bin]] rather
+# than a `stub` feature: the crate must gain no [features] entry beyond
+# bash-parity, and CI's --all-features would turn a fixture feature on
+# workspace-wide.
+[[bin]]
+name = "vcs-adapters-fixture-stub"
+path = "tests/fixtures/vcs_adapters_fixture_stub.rs"
+
 [dependencies]
 vcs = { path = "../vcs" }
 gix = { workspace = true }

--- a/cli/vcs-adapters/Cargo.toml
+++ b/cli/vcs-adapters/Cargo.toml
@@ -15,6 +15,15 @@ workspace = true
 # run. CI enables it (tasks/test/cli.py).
 bash-parity = []
 
+# Composition-root demonstration and black-box test entry point — not a shipped
+# artifact. Lives under tests/fixtures/ so it stays off the crate's normal build
+# surface. The scrub-invariant runs drive both the poisoned and the clean arm
+# through this binary, so a difference is behavioural rather than two
+# serialisation routes disagreeing.
+[[bin]]
+name = "vcs-adapters-fixture"
+path = "tests/fixtures/vcs_adapters_fixture.rs"
+
 [dependencies]
 vcs = { path = "../vcs" }
 gix = { workspace = true }
@@ -23,3 +32,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+vcs-test-support = { path = "../vcs-test-support" }

--- a/cli/vcs-adapters/Cargo.toml
+++ b/cli/vcs-adapters/Cargo.toml
@@ -36,6 +36,8 @@ path = "tests/fixtures/vcs_adapters_fixture_stub.rs"
 vcs = { path = "../vcs" }
 gix = { workspace = true }
 jj-lib = { workspace = true }
+pollster = { workspace = true }
+prost = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/cli/vcs-adapters/Cargo.toml
+++ b/cli/vcs-adapters/Cargo.toml
@@ -17,6 +17,8 @@ bash-parity = []
 
 [dependencies]
 vcs = { path = "../vcs" }
+gix = { workspace = true }
+jj-lib = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/cli/vcs-adapters/src/lib.rs
+++ b/cli/vcs-adapters/src/lib.rs
@@ -1,215 +1,34 @@
-//! The outbound VCS probes: an ancestor marker-walk for the repository root,
-//! and a subprocess probe for the working-copy revision.
+//! The outbound VCS adapters, and the composition root that picks one.
 //!
-//! The probe subprocess runs with a scrubbed environment and colour disabled,
-//! so ambient user config cannot redirect the root or inject ANSI into a
-//! revision. Every way the probe can fail to answer — an absent binary, a
-//! non-zero exit, empty output, or a run that outlives its time cap — resolves
-//! to `None` and is warn-logged, so a real failure leaves a trace instead of
-//! reading like a legitimately revision-less repository.
+//! Two implementations of the same two ports live here, side by side and
+//! deliberately in separate files:
+//!
+//! - [`subprocess`] runs the `jj`/`git` binaries in a child process, bounded by
+//!   a time cap and a scrubbed environment. It is what [`facts`] uses.
+//! - [`library`] reads both idioms in the calling process through `gix` and
+//!   `jj-lib`, and additionally carries the taxonomy queries the subprocess pair
+//!   has no equivalent for. It ships unwired: nothing here routes a caller to
+//!   it yet.
+//!
+//! Keeping them apart is what lets [`library`] carry a cargo-pup rule denying
+//! `std::process` while [`subprocess`] spawns by design — one module could not
+//! be both. This crate root holds no adapter code of its own, so the file layout
+//! now says the same thing `pup.ron` does, and retiring the subprocess pair is a
+//! file deletion.
+//!
+//! What both agree on — the ancestor walk and the marker reading — lives in a
+//! third, private module that each delegates *to*, so removing either adapter
+//! does not strand it.
 
 pub mod library;
 mod markers;
+pub mod subprocess;
 
-use std::fs;
-use std::io::Read as _;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::path::Path;
 
-use tracing::warn;
-use vcs::{RepoFacts, RepoRoot, VcsKind, VcsProbe};
+use vcs::RepoFacts;
 
-use crate::markers::{carries_any_marker, marker_kind, walk_up};
-
-/// Headroom for a legitimately slow or lock-contended repository, while still
-/// bounding metadata derivation.
-const DEFAULT_CAP: Duration = Duration::from_secs(10);
-
-const POLL_INTERVAL: Duration = Duration::from_millis(10);
-
-/// Finds the repository root by walking ancestors for the first `.jj` or
-/// `.git` marker, testing for *existence* so a `.git` file — a worktree or
-/// submodule — counts alongside a `.git` directory.
-///
-/// The filesystem root itself is never tested, matching the bash walk.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct MarkerWalkRoot;
-
-impl RepoRoot for MarkerWalkRoot {
-    fn discover(&self, start: &Path) -> Option<PathBuf> {
-        walk_up(start, carries_any_marker)
-    }
-
-    fn repository_root(&self, working_copy_root: &Path) -> PathBuf {
-        jj_repository_root(working_copy_root)
-            .unwrap_or_else(|| working_copy_root.to_path_buf())
-    }
-}
-
-/// Resolves a jj secondary workspace's working-copy root to the repository whose
-/// store it shares. A secondary workspace's `.jj/repo` is a file pointing at the
-/// shared `<repo>/.jj/repo` store, so the repository is the store's grandparent;
-/// the primary workspace's `.jj/repo` is that store directory. `None` when this
-/// is not a jj workspace or the pointer cannot be resolved.
-fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
-    let marker = working_copy_root.join(".jj").join("repo");
-    let metadata = fs::symlink_metadata(&marker).ok()?;
-    if !metadata.is_file() {
-        return None;
-    }
-    let pointer = fs::read_to_string(&marker).ok()?;
-    let store =
-        fs::canonicalize(working_copy_root.join(".jj").join(pointer.trim()))
-            .ok()?;
-    Some(store.parent()?.parent()?.to_path_buf())
-}
-
-/// Reads the repository's idiom from its markers and its revision by running
-/// the matching VCS binary.
-#[derive(Debug, Clone, Copy)]
-pub struct CommandProbe {
-    cap: Duration,
-}
-
-impl CommandProbe {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self { cap: DEFAULT_CAP }
-    }
-
-    /// A probe bounded by `cap` rather than the default.
-    #[must_use]
-    pub const fn with_cap(cap: Duration) -> Self {
-        Self { cap }
-    }
-}
-
-impl Default for CommandProbe {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl VcsProbe for CommandProbe {
-    fn kind(&self, root: &Path) -> VcsKind {
-        marker_kind(root)
-    }
-
-    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {
-        let mut command = match kind {
-            VcsKind::Jj => {
-                let mut command = Command::new("jj");
-                command.args([
-                    "--color=never",
-                    "--no-pager",
-                    "log",
-                    "-r",
-                    "@",
-                    "--no-graph",
-                    "-T",
-                    "commit_id",
-                ]);
-                command
-            }
-            VcsKind::Git => {
-                let mut command = Command::new("git");
-                command.args(["-c", "color.ui=false", "rev-parse", "HEAD"]);
-                command
-            }
-            VcsKind::None => return None,
-        };
-
-        command.current_dir(root);
-        scrub_environment(&mut command);
-        capped_stdout(command, self.cap, kind.as_str())
-    }
-}
-
-/// Denies the subprocess the ambient config that could redirect it at another
-/// repository or dress its output up in ANSI.
-fn scrub_environment(command: &mut Command) {
-    for key in [
-        "GIT_DIR",
-        "GIT_WORK_TREE",
-        "GIT_INDEX_FILE",
-        "GIT_COMMON_DIR",
-        "GIT_CONFIG",
-        "GIT_CONFIG_COUNT",
-        "JJ_CONFIG",
-    ] {
-        command.env_remove(key);
-    }
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
-    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
-    command.env("GIT_CONFIG_SYSTEM", "/dev/null");
-}
-
-/// Runs `command` and returns its trimmed stdout, or `None` — warn-logged —
-/// when it cannot be spawned, exits non-zero, outlives `cap`, or says nothing.
-fn capped_stdout(
-    mut command: Command,
-    cap: Duration,
-    vcs: &str,
-) -> Option<String> {
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = match command.spawn() {
-        Ok(child) => child,
-        Err(error) => {
-            warn!(vcs, %error, "could not run the revision probe");
-            return None;
-        }
-    };
-
-    let deadline = Instant::now() + cap;
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {}
-            Err(error) => {
-                warn!(vcs, %error, "could not await the revision probe");
-                return None;
-            }
-        }
-
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            warn!(
-                vcs,
-                cap = ?cap,
-                "the revision probe outlived its time cap and was killed"
-            );
-            return None;
-        }
-
-        std::thread::sleep(POLL_INTERVAL);
-    };
-
-    if !status.success() {
-        warn!(vcs, %status, "the revision probe exited non-zero");
-        return None;
-    }
-
-    let mut stdout = String::new();
-    if let Some(mut pipe) = child.stdout.take() {
-        if let Err(error) = pipe.read_to_string(&mut stdout) {
-            warn!(vcs, %error, "could not read the revision probe's output");
-            return None;
-        }
-    }
-
-    let revision = stdout.trim();
-    if revision.is_empty() {
-        warn!(vcs, "the revision probe reported no revision");
-        return None;
-    }
-    Some(revision.to_owned())
-}
+use crate::subprocess::{CommandProbe, MarkerWalkRoot};
 
 /// The facts for the repository containing `start`, probed against the real
 /// filesystem and the real VCS binaries.
@@ -220,10 +39,7 @@ pub fn facts(start: &Path) -> Option<RepoFacts> {
 
 #[cfg(test)]
 mod tests {
-    use std::process::Command;
-    use std::time::Duration;
-
-    use super::{capped_stdout, facts, scrub_environment};
+    use super::facts;
 
     #[test]
     fn a_tree_with_no_marker_has_no_facts(
@@ -239,76 +55,5 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    fn a_probe_that_outlives_its_cap_reports_no_revision() {
-        let mut command = Command::new("sleep");
-        command.arg("30");
-
-        let started = std::time::Instant::now();
-        let revision =
-            capped_stdout(command, Duration::from_millis(100), "test");
-
-        assert_eq!(revision, None);
-        assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "the probe should have been killed at its cap, not waited out"
-        );
-    }
-
-    #[test]
-    fn a_probe_that_cannot_be_spawned_reports_no_revision() {
-        let command = Command::new("accelerator-no-such-binary");
-        assert_eq!(
-            capped_stdout(command, Duration::from_secs(1), "test"),
-            None
-        );
-    }
-
-    #[test]
-    fn a_probe_that_exits_non_zero_reports_no_revision() {
-        let command = Command::new("false");
-        assert_eq!(
-            capped_stdout(command, Duration::from_secs(1), "test"),
-            None
-        );
-    }
-
-    #[test]
-    fn a_probe_that_says_nothing_reports_no_revision() {
-        let command = Command::new("true");
-        assert_eq!(
-            capped_stdout(command, Duration::from_secs(1), "test"),
-            None
-        );
-    }
-
-    #[test]
-    fn stdout_is_trimmed() {
-        let mut command = Command::new("printf");
-        command.arg("abc123\n");
-        assert_eq!(
-            capped_stdout(command, Duration::from_secs(1), "test").as_deref(),
-            Some("abc123")
-        );
-    }
-
-    #[test]
-    fn the_scrubbed_environment_drops_the_redirecting_variables() {
-        let mut command = Command::new("sh");
-        command
-            .args([
-                "-c",
-                "if [ -n \"$GIT_DIR\" ]; then printf carried; \
-                 else printf unset; fi",
-            ])
-            .env("GIT_DIR", "/somewhere/else/.git");
-        scrub_environment(&mut command);
-
-        assert_eq!(
-            capped_stdout(command, Duration::from_secs(1), "test").as_deref(),
-            Some("unset")
-        );
     }
 }

--- a/cli/vcs-adapters/src/lib.rs
+++ b/cli/vcs-adapters/src/lib.rs
@@ -1,24 +1,13 @@
 //! The outbound VCS adapters, and the composition root that picks one.
 //!
-//! Two implementations of the same two ports live here, side by side and
-//! deliberately in separate files:
-//!
-//! - [`subprocess`] runs the `jj`/`git` binaries in a child process, bounded by
-//!   a time cap and a scrubbed environment. It is what [`facts`] uses.
-//! - [`library`] reads both idioms in the calling process through `gix` and
-//!   `jj-lib`, and additionally carries the taxonomy queries the subprocess pair
-//!   has no equivalent for. It ships unwired: nothing here routes a caller to
-//!   it yet.
-//!
-//! Keeping them apart is what lets [`library`] carry a cargo-pup rule denying
-//! `std::process` while [`subprocess`] spawns by design — one module could not
-//! be both. This crate root holds no adapter code of its own, so the file layout
-//! now says the same thing `pup.ron` does, and retiring the subprocess pair is a
-//! file deletion.
+//! [`subprocess`] runs the `jj`/`git` binaries in a child process and is what
+//! [`facts`] uses. [`library`] reads both idioms in the calling process and
+//! additionally carries the taxonomy queries the subprocess pair has no
+//! equivalent for. Keeping them apart is what lets [`library`] carry an import
+//! rule denying `std::process` while [`subprocess`] spawns by design.
 //!
 //! What both agree on — the ancestor walk and the marker reading — lives in a
-//! third, private module that each delegates *to*, so removing either adapter
-//! does not strand it.
+//! third, private module that each delegates *to*.
 
 pub mod library;
 mod markers;
@@ -30,8 +19,7 @@ use vcs::RepoFacts;
 
 use crate::subprocess::{CommandProbe, MarkerWalkRoot};
 
-/// The facts for the repository containing `start`, probed against the real
-/// filesystem and the real VCS binaries.
+/// The facts for the repository containing `start`.
 #[must_use]
 pub fn facts(start: &Path) -> Option<RepoFacts> {
     vcs::facts(start, &MarkerWalkRoot, &CommandProbe::new())
@@ -44,8 +32,7 @@ mod tests {
     #[test]
     fn a_tree_with_no_marker_has_no_facts(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // The marker walk needs no VCS binary, so this stays outside the
-        // `bash-parity` detection fixtures and runs on a bare machine.
+        // The marker walk needs no VCS binary, so this runs on a bare machine.
         let loose = tempfile::Builder::new().prefix("vcs-loose-").tempdir()?;
 
         assert_eq!(

--- a/cli/vcs-adapters/src/lib.rs
+++ b/cli/vcs-adapters/src/lib.rs
@@ -8,6 +8,9 @@
 //! to `None` and is warn-logged, so a real failure leaves a trace instead of
 //! reading like a legitimately revision-less repository.
 
+pub mod library;
+mod markers;
+
 use std::fs;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
@@ -16,6 +19,8 @@ use std::time::{Duration, Instant};
 
 use tracing::warn;
 use vcs::{RepoFacts, RepoRoot, VcsKind, VcsProbe};
+
+use crate::markers::{carries_any_marker, marker_kind, walk_up};
 
 /// Headroom for a legitimately slow or lock-contended repository, while still
 /// bounding metadata derivation.
@@ -33,14 +38,7 @@ pub struct MarkerWalkRoot;
 
 impl RepoRoot for MarkerWalkRoot {
     fn discover(&self, start: &Path) -> Option<PathBuf> {
-        let mut dir = start;
-        while dir.parent().is_some() {
-            if dir.join(".jj").exists() || dir.join(".git").exists() {
-                return Some(dir.to_path_buf());
-            }
-            dir = dir.parent()?;
-        }
-        None
+        walk_up(start, carries_any_marker)
     }
 
     fn repository_root(&self, working_copy_root: &Path) -> PathBuf {
@@ -95,13 +93,7 @@ impl Default for CommandProbe {
 
 impl VcsProbe for CommandProbe {
     fn kind(&self, root: &Path) -> VcsKind {
-        if root.join(".jj").exists() {
-            VcsKind::Jj
-        } else if root.join(".git").exists() {
-            VcsKind::Git
-        } else {
-            VcsKind::None
-        }
+        marker_kind(root)
     }
 
     fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -38,14 +38,27 @@
 //! list rejects — so every import here is single-item, and must stay that way.
 
 use std::fmt;
+use std::fs;
+use std::future::Future;
 use std::path::absolute;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
+use jj_lib::backend::CommitId;
+use jj_lib::object_id::ObjectId;
+use jj_lib::op_store::OpStore as _;
+use jj_lib::op_store::OpStoreError;
+use jj_lib::op_store::OperationId;
+use jj_lib::op_store::RootOperationData;
+use jj_lib::protos::local_working_copy::Checkout as CheckoutProto;
+use jj_lib::ref_name::WorkspaceName;
+use jj_lib::ref_name::WorkspaceNameBuf;
+use jj_lib::simple_op_store::SimpleOpStore;
 use jj_lib::workspace::DefaultWorkspaceLoaderFactory;
 use jj_lib::workspace::WorkspaceLoadError;
 use jj_lib::workspace::WorkspaceLoaderFactory as _;
+use prost::Message as _;
 use tracing::warn;
 use vcs::RepoRoot;
 use vcs::VcsKind;
@@ -88,6 +101,19 @@ pub enum Error {
     /// either with no room for a root above it, or failing the
     /// `<root>/.jj/repo` post-condition.
     JjStoreLayout { store: PathBuf },
+    /// The workspace uses a working-copy backend whose on-disk layout this
+    /// module does not know how to read.
+    JjWorkingCopyBackend { backend: String },
+    /// A jj workspace's checkout state could not be read or decoded, so the
+    /// operation and workspace name it records are unavailable.
+    JjCheckout {
+        path: PathBuf,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// A jj operation or view could not be read out of the operation store.
+    JjOpStore {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 impl fmt::Display for Error {
@@ -120,6 +146,22 @@ impl fmt::Display for Error {
                     store.display()
                 )
             }
+            Self::JjWorkingCopyBackend { backend } => {
+                write!(
+                    formatter,
+                    "unsupported jj working copy backend {backend:?}"
+                )
+            }
+            Self::JjCheckout { path, .. } => {
+                write!(
+                    formatter,
+                    "could not read the jj checkout state at {}",
+                    path.display()
+                )
+            }
+            Self::JjOpStore { .. } => {
+                write!(formatter, "could not read the jj operation store")
+            }
         }
     }
 }
@@ -129,10 +171,13 @@ impl std::error::Error for Error {
         match self {
             Self::Absolutise { source, .. }
             | Self::Canonicalise { source, .. } => Some(source),
-            Self::Git { source, .. } | Self::Jj { source, .. } => {
-                Some(source.as_ref())
+            Self::Git { source, .. }
+            | Self::Jj { source, .. }
+            | Self::JjCheckout { source, .. }
+            | Self::JjOpStore { source } => Some(source.as_ref()),
+            Self::JjStoreLayout { .. } | Self::JjWorkingCopyBackend { .. } => {
+                None
             }
-            Self::JjStoreLayout { .. } => None,
         }
     }
 }
@@ -389,14 +434,16 @@ impl VcsProbe for InProcessProbe {
     fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {
         match kind {
             VcsKind::Git => git_revision(root),
-            VcsKind::Jj => {
-                warn!(
-                    vcs = "jj",
-                    "jj-lib 0.43 exposes no read-only, settings-free route to \
-                     the working-copy commit id, so no revision is reported"
-                );
-                None
-            }
+            VcsKind::Jj => match jj_revision(root) {
+                Ok(revision) => revision,
+                Err(error) => {
+                    warn!(
+                        vcs = "jj",
+                        %error, "could not read the working-copy commit id"
+                    );
+                    None
+                }
+            },
             VcsKind::None => None,
         }
     }
@@ -454,6 +501,118 @@ fn git_revision(root: &Path) -> Option<String> {
             None
         }
     }
+}
+
+/// The full working-copy revision of a jj workspace, read without constructing
+/// any settings and without writing anything.
+///
+/// The chain is the one jj itself walks. The workspace's `checkout` file records
+/// the operation the working copy is at and the workspace's own name; that
+/// operation's view maps every workspace name to its working-copy commit. Both
+/// links are public API: `jj_lib::protos` is a public module, so the decoded
+/// `Checkout` is a published schema rather than a private wire format, and
+/// `View::wc_commit_ids` is a public field. `SimpleOpStore::load` takes a path
+/// only — this is what makes the whole route settings-free, and it is why this
+/// crate needs no jj settings type anywhere.
+///
+/// Deliberately not routed through the higher-level repository loader: that one
+/// requires a settings value whose defaults live in the jj CLI rather than in
+/// jj-lib, and the working-copy loader it reaches writes to the store.
+///
+/// The name lookup is load-bearing rather than incidental. A repository with
+/// several workspaces has one view entry per workspace and they hold different
+/// commits, so taking the sole entry would answer for the wrong workspace as
+/// soon as anyone runs `jj workspace add`.
+///
+/// This reports the commit as of the **last recorded operation**. It does not
+/// snapshot, which is the one place it diverges from asking the `jj` binary:
+/// `jj log` snapshots the working copy first and so reports a newly created
+/// commit — and mutates the repository — when files have changed since the last
+/// jj command. A probe that must work on a read-only filesystem cannot do that.
+fn jj_revision(root: &Path) -> Result<Option<String>, Error> {
+    let Some(loader) = load_jj_workspace(root)? else {
+        return Ok(None);
+    };
+
+    // The on-disk layout below belongs to the local working-copy backend. Assert
+    // it before reading, so an unfamiliar backend is a named failure rather than
+    // a missing-file error attributed to the wrong cause.
+    let backend =
+        loader.get_working_copy_type().map_err(|error| Error::Jj {
+            path: root.to_path_buf(),
+            source: Box::new(error),
+        })?;
+    if backend != LOCAL_WORKING_COPY {
+        return Err(Error::JjWorkingCopyBackend { backend });
+    }
+
+    let state = loader.workspace_root().join(".jj").join("working_copy");
+    let checkout = read_checkout(&state)?;
+
+    // Only the root operation would consult this, and the checkout file gives a
+    // concrete operation id, so it is never read. The width matches the git
+    // backend's ids.
+    let root_data = RootOperationData {
+        root_commit_id: CommitId::from_bytes(&[0; 20]),
+    };
+    let store =
+        SimpleOpStore::load(&loader.repo_path().join("op_store"), root_data);
+
+    let operation = block_on_jj(store.read_operation(&checkout.operation))?;
+    let view = block_on_jj(store.read_view(&operation.view_id))?;
+
+    Ok(view
+        .wc_commit_ids
+        .get(&checkout.workspace)
+        .map(ObjectId::hex))
+}
+
+/// The working copy type this module's path knowledge is valid for.
+const LOCAL_WORKING_COPY: &str = "local";
+
+/// The two fields of the workspace's checkout state this module needs.
+struct Checkout {
+    operation: OperationId,
+    workspace: WorkspaceNameBuf,
+}
+
+/// Decodes `<state>/checkout` into the operation and workspace name it records.
+///
+/// The empty-name fallback mirrors jj's own back-compatibility branch for
+/// working copies written before the field existed.
+fn read_checkout(state: &Path) -> Result<Checkout, Error> {
+    let path = state.join("checkout");
+    let bytes = fs::read(&path).map_err(|source| Error::JjCheckout {
+        path: path.clone(),
+        source: Box::new(source),
+    })?;
+    let proto =
+        CheckoutProto::decode(&*bytes).map_err(|source| Error::JjCheckout {
+            path,
+            source: Box::new(source),
+        })?;
+
+    let workspace = if proto.workspace_name.is_empty() {
+        WorkspaceName::DEFAULT.to_owned()
+    } else {
+        proto.workspace_name.into()
+    };
+    Ok(Checkout {
+        operation: OperationId::new(proto.operation_id),
+        workspace,
+    })
+}
+
+/// Drives one of the `OpStore` trait's async reads to completion.
+///
+/// The trait is async and jj-lib drives it with `pollster` itself; there is no
+/// runtime in this process and these reads are plain file reads.
+fn block_on_jj<T>(
+    read: impl Future<Output = Result<T, OpStoreError>>,
+) -> Result<T, Error> {
+    pollster::block_on(read).map_err(|source| Error::JjOpStore {
+        source: Box::new(source),
+    })
 }
 
 /// Whether the head could not be peeled because nothing has been committed yet,

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -1,41 +1,24 @@
-//! The library-backed probe: git through `gix`, jj through `jj-lib`, both read
-//! in the calling process rather than by spawning the VCS binaries.
+//! Reads git through `gix` and jj through `jj-lib`, in-process.
 //!
-//! Two mechanisms live here and must not be confused. `RepoRoot::discover` is
-//! the marker walk followed by nothing else, because the checkout boundary is
-//! the start path or its nearest marked ancestor and never an ancestor above
-//! it. `gix::discover` deliberately *does* walk past that boundary and is used
-//! only where following a recorded link out of the checkout is the answer being
-//! asked for. A ceiling cannot enforce the boundary rule — `ceiling_dirs`
-//! computes its height as `strip_prefix(ceiling).components().count()` and
-//! discards height 0, so a ceiling at the boundary is silently ignored.
+//! Three walks, and using the wrong one is the mistake to avoid. The combined
+//! `.jj`-or-`.git` marker walk answers `RepoRoot::discover` only. A `.jj`-only
+//! walk answers the jj queries, because `DefaultWorkspaceLoaderFactory::create`
+//! performs no walk of its own and the combined boundary makes it report absence
+//! on a git checkout nested inside a jj workspace, where `jj workspace root`
+//! reports a root. `gix::discover` performs the third.
 //!
-//! Every path returned from this module is canonicalised, at the single choke
-//! point below. The sources disagree otherwise: `repo_path()` arrives already
-//! canonicalised from jj-lib while `workspace_root()` is whatever was passed
-//! in, and a linked worktree's `workdir()` is reconstructed from the absolute
-//! path git recorded at `git worktree add` time.
+//! `gix_discover::upwards::Options::ceiling_dirs` cannot confine a walk to the
+//! boundary: it derives the ceiling height from
+//! `strip_prefix(ceiling).components().count()`, discards height 0, and tests
+//! `current_height > max_height` before incrementing.
 //!
-//! Three walks live here, and using the wrong one is the mistake this module
-//! is shaped to prevent. The combined `.jj`-or-`.git` boundary walk answers
-//! `RepoRoot::discover` only. A **`.jj`-only** walk answers the jj queries,
-//! because `DefaultWorkspaceLoaderFactory::create` performs no walk of its own
-//! and feeding it the combined boundary makes it report absence on a git
-//! checkout nested inside a jj workspace — where `jj workspace root` reports a
-//! root. `gix::discover` performs the third, for the git queries.
+//! Every returned path goes through `canonicalise`/`canonical`. `repo_path()`
+//! arrives canonicalised from jj-lib while `workspace_root()` is whatever was
+//! passed in, and a linked worktree's `workdir()` is reconstructed from the path
+//! git recorded at `git worktree add` time.
 //!
-//! Queries distinguish failure from absence: `Ok(None)` is "no repository of
-//! this kind here", `Err` is "a repository is here and the pinned library could
-//! not answer". Collapsing the two would be a real regression against the
-//! subprocess probe, which runs its parse in a child process with a time cap
-//! and a scrubbed environment; this module parses repository-controlled data in
-//! the caller's address space with no time bound and no crash isolation. Only
-//! the not-found-shaped variant of each library error maps to `Ok(None)`.
-//!
-//! A cargo-pup rule (`vcs_adapters_library_reads_in_process`) restricts this
-//! module's imports to a permit list and denies `std::process`. cargo-pup
-//! resolves a grouped `use a::{b, c}` to an empty module name, which the permit
-//! list rejects — so every import here is single-item, and must stay that way.
+//! The cargo-pup import rule resolves a grouped `use a::{b, c}` to an empty
+//! module name and rejects it, so every import here is single-item.
 
 use std::fmt;
 use std::fs;
@@ -70,47 +53,34 @@ use crate::markers::marker_kind;
 use crate::markers::walk_up;
 
 /// A repository is here and the pinned library could not answer.
-///
-/// Deliberately not `kernel::Error`: `kernel` is not a dependency of this
-/// crate, and taking one to carry an error type would couple the adapter to the
-/// launcher's error vocabulary for no gain.
 #[derive(Debug)]
 pub enum Error {
-    /// A path could not be made absolute, so the three walks would disagree.
     Absolutise {
         path: PathBuf,
         source: std::io::Error,
     },
-    /// A path could not be canonicalised, so it cannot be compared with the
-    /// others this module returns.
     Canonicalise {
         path: PathBuf,
         source: std::io::Error,
     },
-    /// A git repository was found but could not be read.
     Git {
         path: PathBuf,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    /// A jj workspace was found but could not be read.
     Jj {
         path: PathBuf,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    /// A jj store resolved to something that is not a repository layout —
-    /// either with no room for a root above it, or failing the
-    /// `<root>/.jj/repo` post-condition.
-    JjStoreLayout { store: PathBuf },
-    /// The workspace uses a working-copy backend whose on-disk layout this
-    /// module does not know how to read.
-    JjWorkingCopyBackend { backend: String },
-    /// A jj workspace's checkout state could not be read or decoded, so the
-    /// operation and workspace name it records are unavailable.
+    JjStoreLayout {
+        store: PathBuf,
+    },
+    JjWorkingCopyBackend {
+        backend: String,
+    },
     JjCheckout {
         path: PathBuf,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
-    /// A jj operation or view could not be read out of the operation store.
     JjOpStore {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -185,16 +155,10 @@ impl std::error::Error for Error {
 /// Whether a checkout is a linked worktree, and where its git directories are.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorktreeFacts {
-    /// The `--git-dir` vs `--git-common-dir` comparison, canonicalised. `kind()`
-    /// is not used for this: it is a single mutually-exclusive enum, so it
-    /// cannot represent a checkout that is both a submodule and a linked
-    /// worktree, which git reports as a worktree.
     pub linked: bool,
     pub git_dir: PathBuf,
     pub common_dir: PathBuf,
-    /// `None` for a bare repository. Carries no oracle for the bare and
-    /// submodule shapes, where the shell's `dirname <common-dir>` formula does
-    /// not name a worktree root at all.
+    /// `None` for a bare repository.
     pub main_worktree_root: Option<PathBuf>,
 }
 
@@ -215,16 +179,9 @@ pub struct JjRepositoryFacts {
 /// The git repository root and the jj workspace root, each resolved by its own
 /// walk so neither is truncated by the other's marker.
 ///
-/// Infallible as a whole, with a `Result` per side. A whole-struct `Result`
-/// could not say "the git side failed but the jj side answered": a one-sided
-/// failure would either propagate as `Err` and discard a valid answer, or
-/// flatten to `None` and reinstate the absence/failure conflation on the single
-/// field that separates a colocated checkout from a nested one. A repository
-/// whose git side the pinned library cannot parse must never be observable as
-/// "jj only".
-///
-/// Callers comparing the two sides for equality must treat any `Err` as "not
-/// comparable", never as inequality.
+/// A `Result` per side rather than one for the struct, so a git-side failure
+/// cannot be observed as "jj only". Compare the sides only when both are `Ok`;
+/// an `Err` means "not comparable", not "unequal".
 #[derive(Debug)]
 pub struct DualRoots {
     pub git: Result<Option<PathBuf>, Error>,
@@ -232,9 +189,6 @@ pub struct DualRoots {
 }
 
 /// Reads a repository's root, idiom and revision in-process.
-///
-/// Ships unwired: `crate::facts` still composes the subprocess pair, and no
-/// feature flag or config switch routes a caller here.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InProcessProbe;
 
@@ -268,8 +222,7 @@ impl InProcessProbe {
         };
 
         let git_dir = canonicalise(repository.git_dir())?;
-        // The raw value carries `../..` for a linked worktree, where the oracle
-        // reports the resolved path; they are equal only after this.
+        // Raw, this carries `../..` for a linked worktree.
         let common_dir = canonicalise(repository.common_dir())?;
 
         let main = repository.main_repo().map_err(|error| Error::Git {
@@ -289,38 +242,27 @@ impl InProcessProbe {
 
     /// The superproject's working directory, when `start` is inside a submodule.
     ///
-    /// gix exposes no API for this direction — `main_repo()` on a submodule
-    /// returns the submodule, and `submodules()` resolves superproject to
-    /// children — so it is derived from the `git_dir()` path shape.
+    /// Derived from the `git_dir()` path shape: gix has no API for this
+    /// direction, and `main_repo()` on a submodule returns the submodule.
     ///
     /// # Errors
     ///
-    /// When a candidate superproject directory exists but cannot be opened,
-    /// which must not be mistaken for "this candidate is not a repository" and
-    /// silently scanned past.
+    /// When a candidate superproject exists but cannot be opened.
     pub fn superproject(&self, start: &Path) -> Result<Option<PathBuf>, Error> {
         let start = absolutise(start)?;
         let Some(repository) = discover_git(&start)? else {
             return Ok(None);
         };
 
-        // A linked worktree *of* a submodule carries `modules` in its git dir,
-        // and git reports **no** superproject for it. `kind()` cannot express
-        // that: it is a single mutually-exclusive enum and reports `Submodule`
-        // for exactly that shape, which is why the gate is the oracle's own
-        // discriminator — the git-dir vs common-dir comparison — and not
-        // `kind()`. Gating on `kind() == Submodule` instead both admits this
-        // shape wrongly and rejects a submodule inside a linked worktree, whose
-        // git dir sits under `worktrees/<id>/modules/` and which git *does*
-        // give a superproject.
+        // Gating on `kind() == Submodule` is wrong in both directions: it
+        // admits a linked worktree *of* a submodule, for which git reports no
+        // superproject, and rejects a submodule inside a linked worktree, for
+        // which git reports one. The dirs comparison is git's own discriminator.
         let git_dir = canonicalise(repository.git_dir())?;
         if git_dir != canonicalise(repository.common_dir())? {
             return Ok(None);
         }
 
-        // Canonicalisation belongs to the probe rather than to the scan, so the
-        // scan stays pure path logic and its unit tests can drive it over paths
-        // that need not exist.
         superproject_of(&git_dir, |candidate| {
             let Some(found) = open_git(candidate)? else {
                 return Ok(None);
@@ -354,9 +296,7 @@ impl InProcessProbe {
     /// # Errors
     ///
     /// When the workspace cannot be loaded, or its store does not resolve to a
-    /// jj repository layout — the case a `.jj/repo` pointer aimed at an
-    /// arbitrary existing directory produces, which would otherwise yield a
-    /// real-looking but wrong repository root.
+    /// jj repository layout.
     pub fn jj_repository(
         &self,
         start: &Path,
@@ -369,8 +309,6 @@ impl InProcessProbe {
             return Ok(None);
         };
 
-        // jj-lib canonicalises repo_path() itself but returns workspace_root()
-        // as passed in, so both sides need it before comparison.
         let store = canonicalise(loader.repo_path())?;
         let own_store = canonicalise(&root.join(".jj").join("repo"))?;
         let role = if store == own_store {
@@ -382,8 +320,8 @@ impl InProcessProbe {
         let Some(main_root) = store.parent().and_then(Path::parent) else {
             return Err(Error::JjStoreLayout { store });
         };
-        // The shell oracle carries this post-condition explicitly, so a future
-        // jj layout change cannot silently produce a wrong-but-non-empty root.
+        // Without this, a `.jj/repo` pointing at any existing directory yields
+        // a real-looking but wrong root two levels up.
         if !main_root.join(".jj").join("repo").is_dir() {
             return Err(Error::JjStoreLayout { store });
         }
@@ -449,13 +387,11 @@ impl VcsProbe for InProcessProbe {
     }
 }
 
-/// The repository a jj working copy belongs to, resolved through the loader so
-/// the `.jj/repo`-file-means-secondary rule has one implementation.
+/// The repository a jj working copy belongs to.
 ///
 /// The store is always `<repository>/.jj/repo`, so the repository is its
-/// grandparent — for a secondary workspace that is the main repository, and for
-/// a main workspace it is the workspace itself. `None` when this is not a jj
-/// workspace at all, which is the one absence that does not log.
+/// grandparent: the main repository for a secondary workspace, the workspace
+/// itself otherwise.
 fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
     let loader = match DefaultWorkspaceLoaderFactory.create(working_copy_root) {
         Ok(loader) => loader,
@@ -477,9 +413,8 @@ fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
     Some(canonical(repository))
 }
 
-/// The full working-copy revision of a git checkout. `None` — unlogged — for a
-/// repository with no commits yet, since that is a legitimate absence rather
-/// than a probe that could not answer.
+/// The full working-copy revision of a git checkout. `None`, unlogged, for a
+/// repository with no commits yet.
 fn git_revision(root: &Path) -> Option<String> {
     let repository = match gix::discover(root) {
         Ok(repository) => repository,
@@ -506,37 +441,26 @@ fn git_revision(root: &Path) -> Option<String> {
 /// The full working-copy revision of a jj workspace, read without constructing
 /// any settings and without writing anything.
 ///
-/// The chain is the one jj itself walks. The workspace's `checkout` file records
-/// the operation the working copy is at and the workspace's own name; that
-/// operation's view maps every workspace name to its working-copy commit. Both
-/// links are public API: `jj_lib::protos` is a public module, so the decoded
-/// `Checkout` is a published schema rather than a private wire format, and
-/// `View::wc_commit_ids` is a public field. `SimpleOpStore::load` takes a path
-/// only — this is what makes the whole route settings-free, and it is why this
-/// crate needs no jj settings type anywhere.
+/// The workspace's `checkout` file records the operation the working copy is at
+/// and the workspace's own name; that operation's view maps every workspace name
+/// to its working-copy commit. `SimpleOpStore::load` takes a path only, which is
+/// what keeps the route settings-free — the higher-level repository loader needs
+/// a settings value, and the working-copy loader it reaches writes to the store.
 ///
-/// Deliberately not routed through the higher-level repository loader: that one
-/// requires a settings value whose defaults live in the jj CLI rather than in
-/// jj-lib, and the working-copy loader it reaches writes to the store.
+/// Indexing by name is load-bearing: a repository with several workspaces holds
+/// a different commit per workspace, so taking the sole view entry would answer
+/// for the wrong one.
 ///
-/// The name lookup is load-bearing rather than incidental. A repository with
-/// several workspaces has one view entry per workspace and they hold different
-/// commits, so taking the sole entry would answer for the wrong workspace as
-/// soon as anyone runs `jj workspace add`.
-///
-/// This reports the commit as of the **last recorded operation**. It does not
-/// snapshot, which is the one place it diverges from asking the `jj` binary:
-/// `jj log` snapshots the working copy first and so reports a newly created
-/// commit — and mutates the repository — when files have changed since the last
-/// jj command. A probe that must work on a read-only filesystem cannot do that.
+/// Reports the commit as of the last recorded operation, and does not snapshot.
+/// Asking the `jj` binary does snapshot, so it reports — and writes — a new
+/// commit when files changed since the last jj command.
 fn jj_revision(root: &Path) -> Result<Option<String>, Error> {
     let Some(loader) = load_jj_workspace(root)? else {
         return Ok(None);
     };
 
-    // The on-disk layout below belongs to the local working-copy backend. Assert
-    // it before reading, so an unfamiliar backend is a named failure rather than
-    // a missing-file error attributed to the wrong cause.
+    // The paths below belong to the local backend, so an unfamiliar one has to
+    // fail by name rather than as a missing file.
     let backend =
         loader.get_working_copy_type().map_err(|error| Error::Jj {
             path: root.to_path_buf(),
@@ -549,9 +473,8 @@ fn jj_revision(root: &Path) -> Result<Option<String>, Error> {
     let state = loader.workspace_root().join(".jj").join("working_copy");
     let checkout = read_checkout(&state)?;
 
-    // Only the root operation would consult this, and the checkout file gives a
-    // concrete operation id, so it is never read. The width matches the git
-    // backend's ids.
+    // Only the root operation consults this, and the checkout file gives a
+    // concrete id, so it is never read.
     let root_data = RootOperationData {
         root_commit_id: CommitId::from_bytes(&[0; 20]),
     };
@@ -567,10 +490,8 @@ fn jj_revision(root: &Path) -> Result<Option<String>, Error> {
         .map(ObjectId::hex))
 }
 
-/// The working copy type this module's path knowledge is valid for.
 const LOCAL_WORKING_COPY: &str = "local";
 
-/// The two fields of the workspace's checkout state this module needs.
 struct Checkout {
     operation: OperationId,
     workspace: WorkspaceNameBuf,
@@ -578,8 +499,8 @@ struct Checkout {
 
 /// Decodes `<state>/checkout` into the operation and workspace name it records.
 ///
-/// The empty-name fallback mirrors jj's own back-compatibility branch for
-/// working copies written before the field existed.
+/// The empty-name fallback mirrors jj's own, for working copies written before
+/// the field existed.
 fn read_checkout(state: &Path) -> Result<Checkout, Error> {
     let path = state.join("checkout");
     let bytes = fs::read(&path).map_err(|source| Error::JjCheckout {
@@ -603,10 +524,8 @@ fn read_checkout(state: &Path) -> Result<Checkout, Error> {
     })
 }
 
-/// Drives one of the `OpStore` trait's async reads to completion.
-///
-/// The trait is async and jj-lib drives it with `pollster` itself; there is no
-/// runtime in this process and these reads are plain file reads.
+/// Drives one of the `OpStore` trait's async reads to completion. There is no
+/// runtime in this process, and these are plain file reads.
 fn block_on_jj<T>(
     read: impl Future<Output = Result<T, OpStoreError>>,
 ) -> Result<T, Error> {
@@ -615,8 +534,8 @@ fn block_on_jj<T>(
     })
 }
 
-/// Whether the head could not be peeled because nothing has been committed yet,
-/// as opposed to the repository being unreadable.
+/// Whether the head could not be peeled because nothing is committed yet, as
+/// opposed to the repository being unreadable.
 const fn is_unborn_head(error: &gix::reference::head_commit::Error) -> bool {
     matches!(
         error,
@@ -628,22 +547,15 @@ const fn is_unborn_head(error: &gix::reference::head_commit::Error) -> bool {
 
 /// The superproject working directory implied by a submodule's git directory.
 ///
-/// The rule is: scan the `modules` components from the **innermost outward**
-/// and take the first whose parent opens as a repository. Two shapes
-/// discriminate it. At submodule depth 2 the git dir is
-/// `<super>/.git/modules/mid/modules/leaf`, and the innermost `modules` anchors
-/// on the `mid` submodule — taking the outermost would name the wrong
-/// repository. A submodule added at a path that itself contains `modules`
-/// gives `<super>/.git/modules/modules/foo`, where the innermost candidate is
-/// not a repository at all and the scan must continue outward; a bare
-/// `rposition` stops there and reports absence.
+/// Scans the `modules` components innermost outward, taking the first whose
+/// parent opens as a repository. Both directions matter: at depth 2
+/// (`<super>/.git/modules/mid/modules/leaf`) the innermost anchors on `mid`,
+/// while a submodule added under a path containing `modules`
+/// (`<super>/.git/modules/modules/foo`) has an innermost candidate that is not a
+/// repository, so a bare `rposition` reports absence.
 ///
-/// `opens` is injected and **fallible** so the unit tests can drive the
-/// derivation over known paths without building the matrix's most expensive
-/// fixtures. It must not collapse to a bool: "this candidate is not a
-/// repository" and "this candidate is a repository the pinned library could not
-/// open" have to stay distinct, or a corrupt superproject makes the scan
-/// continue outward and return a plausible wrong path.
+/// `opens` is fallible so an unopenable candidate short-circuits instead of the
+/// scan continuing outward and returning a plausible wrong path.
 fn superproject_of(
     git_dir: &Path,
     opens: impl Fn(&Path) -> Result<Option<PathBuf>, Error>,
@@ -698,9 +610,8 @@ fn open_git(path: &Path) -> Result<Option<gix::Repository>, Error> {
     }
 }
 
-/// Loads the jj workspace rooted at `root`. `Ok(None)` only for the two
-/// not-found-shaped variants; every other failure is `Err`, because a `.jj`
-/// directory that cannot be read is not the same as no jj repository here.
+/// Loads the jj workspace rooted at `root`. Only the not-found variants are
+/// `Ok(None)`: a `.jj` that cannot be read is not the same as no jj here.
 fn load_jj_workspace(
     root: &Path,
 ) -> Result<Option<Box<dyn jj_lib::workspace::WorkspaceLoader>>, Error> {
@@ -719,11 +630,9 @@ fn load_jj_workspace(
 
 /// Makes `start` absolute before any walk.
 ///
-/// The three walks disagree otherwise: `gix::discover` absolutises against the
-/// process cwd internally, whereas `walk_up` is purely lexical — for a relative
-/// `"sub"`, `Path::new("sub").parent()` is `Some("")` and that parent is
-/// `None`, so it tests one directory and stops. Given a relative start, a
-/// colocated checkout would report a git root and no jj root: the wrong arm.
+/// The walks disagree otherwise: `gix::discover` absolutises against the process
+/// cwd internally, while `walk_up` is lexical and stops after one directory for a
+/// relative path, since `Path::new("sub").parent()` is `Some("")`.
 fn absolutise(start: &Path) -> Result<PathBuf, Error> {
     absolute(start).map_err(|source| Error::Absolutise {
         path: start.to_path_buf(),
@@ -731,7 +640,6 @@ fn absolutise(start: &Path) -> Result<PathBuf, Error> {
     })
 }
 
-/// The fallible form of the canonicalisation choke point.
 fn canonicalise(path: &Path) -> Result<PathBuf, Error> {
     path.canonicalize().map_err(|source| Error::Canonicalise {
         path: path.to_path_buf(),
@@ -739,11 +647,8 @@ fn canonicalise(path: &Path) -> Result<PathBuf, Error> {
     })
 }
 
-/// The single choke point every path leaving this module passes through.
-///
-/// Falls back to the uncanonicalised path rather than dropping the answer: the
-/// callers return `Option`/`PathBuf` and cannot carry the distinction, and the
-/// paths reaching here have just been read off the filesystem.
+/// Falls back to the uncanonicalised path, because the callers returning
+/// `Option`/`PathBuf` cannot carry the distinction.
 fn canonical(path: &Path) -> PathBuf {
     match path.canonicalize() {
         Ok(canonical) => canonical,
@@ -765,8 +670,8 @@ mod tests {
     use super::superproject_of;
     use super::Error;
 
-    /// A total probe over a known set of repository git-dirs, so the derivation
-    /// is exercised without building the matrix's most expensive fixtures.
+    /// A total probe over known git-dirs, so the derivation is exercised
+    /// without building real submodule fixtures.
     fn opens(
         repositories: &'static [(&'static str, &'static str)],
     ) -> impl Fn(&Path) -> Result<Option<PathBuf>, Error> {
@@ -789,8 +694,8 @@ mod tests {
 
     #[test]
     fn a_depth_two_submodule_anchors_on_the_nearest_modules() {
-        // Taking the *outermost* `modules` would name /tmp/super, which is the
-        // superproject of `mid` rather than of `leaf`.
+        // The outermost `modules` would name /tmp/super, the superproject of
+        // `mid` rather than of `leaf`.
         let found = superproject_of(
             Path::new("/tmp/super/.git/modules/mid/modules/leaf"),
             opens(&[
@@ -803,10 +708,8 @@ mod tests {
 
     #[test]
     fn the_scan_continues_outward_past_a_candidate_that_is_not_a_repository() {
-        // A submodule added at a path that itself contains `modules` gives
-        // `.git/modules/modules/foo`. The innermost candidate,
-        // `/tmp/supm/.git/modules`, is a plain directory — a bare rposition
-        // stops there and reports absence.
+        // `/tmp/supm/.git/modules` is a plain directory, where a bare
+        // rposition would stop and report absence.
         let found = superproject_of(
             Path::new("/tmp/supm/.git/modules/modules/foo"),
             opens(&[("/tmp/supm/.git", "/tmp/supm")]),
@@ -822,10 +725,8 @@ mod tests {
 
     #[test]
     fn an_unopenable_candidate_short_circuits_rather_than_scanning_past() {
-        // The reason the probe is fallible. With a bool return, "not a
-        // repository" and "a repository the pinned library could not open" are
-        // indistinguishable, so a corrupt superproject would let the scan
-        // continue outward and return a plausible wrong path.
+        // Why the probe is fallible: with a bool, a corrupt superproject is
+        // indistinguishable from "not a repository" and the scan continues.
         let found = superproject_of(
             Path::new("/tmp/super/.git/modules/mid/modules/leaf"),
             |candidate| {

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -16,11 +16,30 @@
 //! in, and a linked worktree's `workdir()` is reconstructed from the absolute
 //! path git recorded at `git worktree add` time.
 //!
+//! Three walks live here, and using the wrong one is the mistake this module
+//! is shaped to prevent. The combined `.jj`-or-`.git` boundary walk answers
+//! `RepoRoot::discover` only. A **`.jj`-only** walk answers the jj queries,
+//! because `DefaultWorkspaceLoaderFactory::create` performs no walk of its own
+//! and feeding it the combined boundary makes it report absence on a git
+//! checkout nested inside a jj workspace — where `jj workspace root` reports a
+//! root. `gix::discover` performs the third, for the git queries.
+//!
+//! Queries distinguish failure from absence: `Ok(None)` is "no repository of
+//! this kind here", `Err` is "a repository is here and the pinned library could
+//! not answer". Collapsing the two would be a real regression against the
+//! subprocess probe, which runs its parse in a child process with a time cap
+//! and a scrubbed environment; this module parses repository-controlled data in
+//! the caller's address space with no time bound and no crash isolation. Only
+//! the not-found-shaped variant of each library error maps to `Ok(None)`.
+//!
 //! A cargo-pup rule (`vcs_adapters_library_reads_in_process`) restricts this
 //! module's imports to a permit list and denies `std::process`. cargo-pup
 //! resolves a grouped `use a::{b, c}` to an empty module name, which the permit
 //! list rejects — so every import here is single-item, and must stay that way.
 
+use std::fmt;
+use std::path::absolute;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -33,8 +52,139 @@ use vcs::VcsKind;
 use vcs::VcsProbe;
 
 use crate::markers::carries_any_marker;
+use crate::markers::carries_jj_marker;
 use crate::markers::marker_kind;
 use crate::markers::walk_up;
+
+/// A repository is here and the pinned library could not answer.
+///
+/// Deliberately not `kernel::Error`: `kernel` is not a dependency of this
+/// crate, and taking one to carry an error type would couple the adapter to the
+/// launcher's error vocabulary for no gain.
+#[derive(Debug)]
+pub enum Error {
+    /// A path could not be made absolute, so the three walks would disagree.
+    Absolutise {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// A path could not be canonicalised, so it cannot be compared with the
+    /// others this module returns.
+    Canonicalise {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// A git repository was found but could not be read.
+    Git {
+        path: PathBuf,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// A jj workspace was found but could not be read.
+    Jj {
+        path: PathBuf,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    /// A jj store resolved to something that is not a repository layout —
+    /// either with no room for a root above it, or failing the
+    /// `<root>/.jj/repo` post-condition.
+    JjStoreLayout { store: PathBuf },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Absolutise { path, .. } => {
+                write!(formatter, "could not absolutise {}", path.display())
+            }
+            Self::Canonicalise { path, .. } => {
+                write!(formatter, "could not canonicalise {}", path.display())
+            }
+            Self::Git { path, .. } => {
+                write!(
+                    formatter,
+                    "could not read the git repository at {}",
+                    path.display()
+                )
+            }
+            Self::Jj { path, .. } => {
+                write!(
+                    formatter,
+                    "could not read the jj workspace at {}",
+                    path.display()
+                )
+            }
+            Self::JjStoreLayout { store } => {
+                write!(
+                    formatter,
+                    "{} is not a jj repository store",
+                    store.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Absolutise { source, .. }
+            | Self::Canonicalise { source, .. } => Some(source),
+            Self::Git { source, .. } | Self::Jj { source, .. } => {
+                Some(source.as_ref())
+            }
+            Self::JjStoreLayout { .. } => None,
+        }
+    }
+}
+
+/// Whether a checkout is a linked worktree, and where its git directories are.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeFacts {
+    /// The `--git-dir` vs `--git-common-dir` comparison, canonicalised. `kind()`
+    /// is not used for this: it is a single mutually-exclusive enum, so it
+    /// cannot represent a checkout that is both a submodule and a linked
+    /// worktree, which git reports as a worktree.
+    pub linked: bool,
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+    /// `None` for a bare repository. Carries no oracle for the bare and
+    /// submodule shapes, where the shell's `dirname <common-dir>` formula does
+    /// not name a worktree root at all.
+    pub main_worktree_root: Option<PathBuf>,
+}
+
+/// Whether a jj workspace owns its repository store or shares another's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JjWorkspaceRole {
+    Main,
+    Secondary,
+}
+
+/// Which jj repository a workspace belongs to, and in what role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JjRepositoryFacts {
+    pub role: JjWorkspaceRole,
+    pub main_root: PathBuf,
+}
+
+/// The git repository root and the jj workspace root, each resolved by its own
+/// walk so neither is truncated by the other's marker.
+///
+/// Infallible as a whole, with a `Result` per side. A whole-struct `Result`
+/// could not say "the git side failed but the jj side answered": a one-sided
+/// failure would either propagate as `Err` and discard a valid answer, or
+/// flatten to `None` and reinstate the absence/failure conflation on the single
+/// field that separates a colocated checkout from a nested one. A repository
+/// whose git side the pinned library cannot parse must never be observable as
+/// "jj only".
+///
+/// Callers comparing the two sides for equality must treat any `Err` as "not
+/// comparable", never as inequality.
+#[derive(Debug)]
+pub struct DualRoots {
+    pub git: Result<Option<PathBuf>, Error>,
+    pub jj: Result<Option<PathBuf>, Error>,
+}
 
 /// Reads a repository's root, idiom and revision in-process.
 ///
@@ -42,6 +192,183 @@ use crate::markers::walk_up;
 /// feature flag or config switch routes a caller here.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InProcessProbe;
+
+impl InProcessProbe {
+    /// Whether the repository containing `start` is bare.
+    ///
+    /// A bare repository carries neither marker, so it is unreachable from the
+    /// boundary walk and needs this entry point of its own.
+    ///
+    /// # Errors
+    ///
+    /// When a repository is present but cannot be opened or configured.
+    pub fn is_bare(&self, start: &Path) -> Result<Option<bool>, Error> {
+        let start = absolutise(start)?;
+        Ok(discover_git(&start)?.map(|repository| repository.is_bare()))
+    }
+
+    /// Whether the checkout containing `start` is a linked worktree, and where
+    /// its git directories are.
+    ///
+    /// # Errors
+    ///
+    /// When a repository is present but its directories cannot be read.
+    pub fn worktree(
+        &self,
+        start: &Path,
+    ) -> Result<Option<WorktreeFacts>, Error> {
+        let start = absolutise(start)?;
+        let Some(repository) = discover_git(&start)? else {
+            return Ok(None);
+        };
+
+        let git_dir = canonicalise(repository.git_dir())?;
+        // The raw value carries `../..` for a linked worktree, where the oracle
+        // reports the resolved path; they are equal only after this.
+        let common_dir = canonicalise(repository.common_dir())?;
+
+        let main = repository.main_repo().map_err(|error| Error::Git {
+            path: git_dir.clone(),
+            source: Box::new(error),
+        })?;
+        let main_worktree_root =
+            main.workdir().map(canonicalise).transpose()?;
+
+        Ok(Some(WorktreeFacts {
+            linked: git_dir != common_dir,
+            git_dir,
+            common_dir,
+            main_worktree_root,
+        }))
+    }
+
+    /// The superproject's working directory, when `start` is inside a submodule.
+    ///
+    /// gix exposes no API for this direction — `main_repo()` on a submodule
+    /// returns the submodule, and `submodules()` resolves superproject to
+    /// children — so it is derived from the `git_dir()` path shape.
+    ///
+    /// # Errors
+    ///
+    /// When a candidate superproject directory exists but cannot be opened,
+    /// which must not be mistaken for "this candidate is not a repository" and
+    /// silently scanned past.
+    pub fn superproject(&self, start: &Path) -> Result<Option<PathBuf>, Error> {
+        let start = absolutise(start)?;
+        let Some(repository) = discover_git(&start)? else {
+            return Ok(None);
+        };
+
+        // A linked worktree *of* a submodule carries `modules` in its git dir,
+        // and git reports **no** superproject for it. `kind()` cannot express
+        // that: it is a single mutually-exclusive enum and reports `Submodule`
+        // for exactly that shape, which is why the gate is the oracle's own
+        // discriminator — the git-dir vs common-dir comparison — and not
+        // `kind()`. Gating on `kind() == Submodule` instead both admits this
+        // shape wrongly and rejects a submodule inside a linked worktree, whose
+        // git dir sits under `worktrees/<id>/modules/` and which git *does*
+        // give a superproject.
+        let git_dir = canonicalise(repository.git_dir())?;
+        if git_dir != canonicalise(repository.common_dir())? {
+            return Ok(None);
+        }
+
+        // Canonicalisation belongs to the probe rather than to the scan, so the
+        // scan stays pure path logic and its unit tests can drive it over paths
+        // that need not exist.
+        superproject_of(&git_dir, |candidate| {
+            let Some(found) = open_git(candidate)? else {
+                return Ok(None);
+            };
+            found.workdir().map(canonicalise).transpose()
+        })
+    }
+
+    /// The jj workspace root containing `start`.
+    ///
+    /// # Errors
+    ///
+    /// When a `.jj` directory is present but the workspace cannot be loaded.
+    pub fn jj_workspace_root(
+        &self,
+        start: &Path,
+    ) -> Result<Option<PathBuf>, Error> {
+        let start = absolutise(start)?;
+        let Some(root) = walk_up(&start, carries_jj_marker) else {
+            return Ok(None);
+        };
+        let Some(loader) = load_jj_workspace(&root)? else {
+            return Ok(None);
+        };
+        Ok(Some(canonicalise(loader.workspace_root())?))
+    }
+
+    /// Whether the jj workspace containing `start` owns its store or shares
+    /// another's, and where that repository is.
+    ///
+    /// # Errors
+    ///
+    /// When the workspace cannot be loaded, or its store does not resolve to a
+    /// jj repository layout — the case a `.jj/repo` pointer aimed at an
+    /// arbitrary existing directory produces, which would otherwise yield a
+    /// real-looking but wrong repository root.
+    pub fn jj_repository(
+        &self,
+        start: &Path,
+    ) -> Result<Option<JjRepositoryFacts>, Error> {
+        let start = absolutise(start)?;
+        let Some(root) = walk_up(&start, carries_jj_marker) else {
+            return Ok(None);
+        };
+        let Some(loader) = load_jj_workspace(&root)? else {
+            return Ok(None);
+        };
+
+        // jj-lib canonicalises repo_path() itself but returns workspace_root()
+        // as passed in, so both sides need it before comparison.
+        let store = canonicalise(loader.repo_path())?;
+        let own_store = canonicalise(&root.join(".jj").join("repo"))?;
+        let role = if store == own_store {
+            JjWorkspaceRole::Main
+        } else {
+            JjWorkspaceRole::Secondary
+        };
+
+        let Some(main_root) = store.parent().and_then(Path::parent) else {
+            return Err(Error::JjStoreLayout { store });
+        };
+        // The shell oracle carries this post-condition explicitly, so a future
+        // jj layout change cannot silently produce a wrong-but-non-empty root.
+        if !main_root.join(".jj").join("repo").is_dir() {
+            return Err(Error::JjStoreLayout { store });
+        }
+
+        Ok(Some(JjRepositoryFacts {
+            role,
+            main_root: main_root.to_path_buf(),
+        }))
+    }
+
+    /// The git repository root and the jj workspace root, resolved
+    /// independently.
+    pub fn dual_roots(&self, start: &Path) -> DualRoots {
+        DualRoots {
+            git: git_root(start),
+            jj: self.jj_workspace_root(start),
+        }
+    }
+}
+
+/// The git working-copy root containing `start`, by gix's own walk so it is not
+/// truncated by a `.jj` marker. `Ok(None)` for a bare repository, which has no
+/// working copy.
+fn git_root(start: &Path) -> Result<Option<PathBuf>, Error> {
+    let start = absolutise(start)?;
+    let Some(repository) = discover_git(&start)? else {
+        return Ok(None);
+    };
+    repository.workdir().map(canonicalise).transpose()
+}
 
 impl RepoRoot for InProcessProbe {
     fn discover(&self, start: &Path) -> Option<PathBuf> {
@@ -140,6 +467,119 @@ const fn is_unborn_head(error: &gix::reference::head_commit::Error) -> bool {
     )
 }
 
+/// The superproject working directory implied by a submodule's git directory.
+///
+/// The rule is: scan the `modules` components from the **innermost outward**
+/// and take the first whose parent opens as a repository. Two shapes
+/// discriminate it. At submodule depth 2 the git dir is
+/// `<super>/.git/modules/mid/modules/leaf`, and the innermost `modules` anchors
+/// on the `mid` submodule — taking the outermost would name the wrong
+/// repository. A submodule added at a path that itself contains `modules`
+/// gives `<super>/.git/modules/modules/foo`, where the innermost candidate is
+/// not a repository at all and the scan must continue outward; a bare
+/// `rposition` stops there and reports absence.
+///
+/// `opens` is injected and **fallible** so the unit tests can drive the
+/// derivation over known paths without building the matrix's most expensive
+/// fixtures. It must not collapse to a bool: "this candidate is not a
+/// repository" and "this candidate is a repository the pinned library could not
+/// open" have to stay distinct, or a corrupt superproject makes the scan
+/// continue outward and return a plausible wrong path.
+fn superproject_of(
+    git_dir: &Path,
+    opens: impl Fn(&Path) -> Result<Option<PathBuf>, Error>,
+) -> Result<Option<PathBuf>, Error> {
+    let components: Vec<_> = git_dir.components().collect();
+    let anchors = components
+        .iter()
+        .enumerate()
+        .filter(|(_, component)| {
+            matches!(component, Component::Normal(name) if *name == "modules")
+        })
+        .map(|(index, _)| index);
+
+    for anchor in anchors.collect::<Vec<_>>().into_iter().rev() {
+        let candidate: PathBuf = components[..anchor].iter().collect();
+        if let Some(workdir) = opens(&candidate)? {
+            return Ok(Some(workdir));
+        }
+    }
+    Ok(None)
+}
+
+/// Opens the repository containing `start`, walking upward. `Ok(None)` only
+/// when no repository was found at all.
+fn discover_git(start: &Path) -> Result<Option<gix::Repository>, Error> {
+    match gix::discover(start) {
+        Ok(repository) => Ok(Some(repository)),
+        Err(gix::discover::Error::Discover(
+            gix::discover::upwards::Error::NoGitRepository { .. }
+            | gix::discover::upwards::Error::NoGitRepositoryWithinCeiling {
+                ..
+            }
+            | gix::discover::upwards::Error::NoGitRepositoryWithinFs { .. },
+        )) => Ok(None),
+        Err(error) => Err(Error::Git {
+            path: start.to_path_buf(),
+            source: Box::new(error),
+        }),
+    }
+}
+
+/// Opens a repository at exactly `path`, performing no walk. `Ok(None)` only
+/// when the path is not a repository.
+fn open_git(path: &Path) -> Result<Option<gix::Repository>, Error> {
+    match gix::open(path) {
+        Ok(repository) => Ok(Some(repository)),
+        Err(gix::open::Error::NotARepository { .. }) => Ok(None),
+        Err(error) => Err(Error::Git {
+            path: path.to_path_buf(),
+            source: Box::new(error),
+        }),
+    }
+}
+
+/// Loads the jj workspace rooted at `root`. `Ok(None)` only for the two
+/// not-found-shaped variants; every other failure is `Err`, because a `.jj`
+/// directory that cannot be read is not the same as no jj repository here.
+fn load_jj_workspace(
+    root: &Path,
+) -> Result<Option<Box<dyn jj_lib::workspace::WorkspaceLoader>>, Error> {
+    match DefaultWorkspaceLoaderFactory.create(root) {
+        Ok(loader) => Ok(Some(loader)),
+        Err(
+            WorkspaceLoadError::NoWorkspaceHere(_)
+            | WorkspaceLoadError::RepoDoesNotExist(_),
+        ) => Ok(None),
+        Err(error) => Err(Error::Jj {
+            path: root.to_path_buf(),
+            source: Box::new(error),
+        }),
+    }
+}
+
+/// Makes `start` absolute before any walk.
+///
+/// The three walks disagree otherwise: `gix::discover` absolutises against the
+/// process cwd internally, whereas `walk_up` is purely lexical — for a relative
+/// `"sub"`, `Path::new("sub").parent()` is `Some("")` and that parent is
+/// `None`, so it tests one directory and stops. Given a relative start, a
+/// colocated checkout would report a git root and no jj root: the wrong arm.
+fn absolutise(start: &Path) -> Result<PathBuf, Error> {
+    absolute(start).map_err(|source| Error::Absolutise {
+        path: start.to_path_buf(),
+        source,
+    })
+}
+
+/// The fallible form of the canonicalisation choke point.
+fn canonicalise(path: &Path) -> Result<PathBuf, Error> {
+    path.canonicalize().map_err(|source| Error::Canonicalise {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
 /// The single choke point every path leaving this module passes through.
 ///
 /// Falls back to the uncanonicalised path rather than dropping the answer: the
@@ -155,5 +595,92 @@ fn canonical(path: &Path) -> PathBuf {
             );
             path.to_path_buf()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::path::PathBuf;
+
+    use super::superproject_of;
+    use super::Error;
+
+    /// A total probe over a known set of repository git-dirs, so the derivation
+    /// is exercised without building the matrix's most expensive fixtures.
+    fn opens(
+        repositories: &'static [(&'static str, &'static str)],
+    ) -> impl Fn(&Path) -> Result<Option<PathBuf>, Error> {
+        move |candidate| {
+            Ok(repositories.iter().find_map(|(git_dir, workdir)| {
+                (candidate == Path::new(git_dir))
+                    .then(|| PathBuf::from(workdir))
+            }))
+        }
+    }
+
+    #[test]
+    fn a_depth_one_submodule_anchors_on_the_superproject() {
+        let found = superproject_of(
+            Path::new("/tmp/super/.git/modules/mid"),
+            opens(&[("/tmp/super/.git", "/tmp/super")]),
+        );
+        assert_eq!(found.ok().flatten(), Some(PathBuf::from("/tmp/super")));
+    }
+
+    #[test]
+    fn a_depth_two_submodule_anchors_on_the_nearest_modules() {
+        // Taking the *outermost* `modules` would name /tmp/super, which is the
+        // superproject of `mid` rather than of `leaf`.
+        let found = superproject_of(
+            Path::new("/tmp/super/.git/modules/mid/modules/leaf"),
+            opens(&[
+                ("/tmp/super/.git", "/tmp/super"),
+                ("/tmp/super/.git/modules/mid", "/tmp/super/mid"),
+            ]),
+        );
+        assert_eq!(found.ok().flatten(), Some(PathBuf::from("/tmp/super/mid")));
+    }
+
+    #[test]
+    fn the_scan_continues_outward_past_a_candidate_that_is_not_a_repository() {
+        // A submodule added at a path that itself contains `modules` gives
+        // `.git/modules/modules/foo`. The innermost candidate,
+        // `/tmp/supm/.git/modules`, is a plain directory — a bare rposition
+        // stops there and reports absence.
+        let found = superproject_of(
+            Path::new("/tmp/supm/.git/modules/modules/foo"),
+            opens(&[("/tmp/supm/.git", "/tmp/supm")]),
+        );
+        assert_eq!(found.ok().flatten(), Some(PathBuf::from("/tmp/supm")));
+    }
+
+    #[test]
+    fn a_git_dir_with_no_modules_component_has_no_superproject() {
+        let found = superproject_of(Path::new("/tmp/plain/.git"), opens(&[]));
+        assert_eq!(found.ok().flatten(), None);
+    }
+
+    #[test]
+    fn an_unopenable_candidate_short_circuits_rather_than_scanning_past() {
+        // The reason the probe is fallible. With a bool return, "not a
+        // repository" and "a repository the pinned library could not open" are
+        // indistinguishable, so a corrupt superproject would let the scan
+        // continue outward and return a plausible wrong path.
+        let found = superproject_of(
+            Path::new("/tmp/super/.git/modules/mid/modules/leaf"),
+            |candidate| {
+                if candidate == Path::new("/tmp/super/.git/modules/mid") {
+                    return Err(Error::JjStoreLayout {
+                        store: candidate.to_path_buf(),
+                    });
+                }
+                Ok(Some(PathBuf::from("/tmp/super")))
+            },
+        );
+        assert!(
+            found.is_err(),
+            "an unopenable candidate must not be scanned past"
+        );
     }
 }

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -1,0 +1,159 @@
+//! The library-backed probe: git through `gix`, jj through `jj-lib`, both read
+//! in the calling process rather than by spawning the VCS binaries.
+//!
+//! Two mechanisms live here and must not be confused. `RepoRoot::discover` is
+//! the marker walk followed by nothing else, because the checkout boundary is
+//! the start path or its nearest marked ancestor and never an ancestor above
+//! it. `gix::discover` deliberately *does* walk past that boundary and is used
+//! only where following a recorded link out of the checkout is the answer being
+//! asked for. A ceiling cannot enforce the boundary rule — `ceiling_dirs`
+//! computes its height as `strip_prefix(ceiling).components().count()` and
+//! discards height 0, so a ceiling at the boundary is silently ignored.
+//!
+//! Every path returned from this module is canonicalised, at the single choke
+//! point below. The sources disagree otherwise: `repo_path()` arrives already
+//! canonicalised from jj-lib while `workspace_root()` is whatever was passed
+//! in, and a linked worktree's `workdir()` is reconstructed from the absolute
+//! path git recorded at `git worktree add` time.
+//!
+//! A cargo-pup rule (`vcs_adapters_library_reads_in_process`) restricts this
+//! module's imports to a permit list and denies `std::process`. cargo-pup
+//! resolves a grouped `use a::{b, c}` to an empty module name, which the permit
+//! list rejects — so every import here is single-item, and must stay that way.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use jj_lib::workspace::DefaultWorkspaceLoaderFactory;
+use jj_lib::workspace::WorkspaceLoadError;
+use jj_lib::workspace::WorkspaceLoaderFactory as _;
+use tracing::warn;
+use vcs::RepoRoot;
+use vcs::VcsKind;
+use vcs::VcsProbe;
+
+use crate::markers::carries_any_marker;
+use crate::markers::marker_kind;
+use crate::markers::walk_up;
+
+/// Reads a repository's root, idiom and revision in-process.
+///
+/// Ships unwired: `crate::facts` still composes the subprocess pair, and no
+/// feature flag or config switch routes a caller here.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InProcessProbe;
+
+impl RepoRoot for InProcessProbe {
+    fn discover(&self, start: &Path) -> Option<PathBuf> {
+        walk_up(start, carries_any_marker).map(|root| canonical(&root))
+    }
+
+    fn repository_root(&self, working_copy_root: &Path) -> PathBuf {
+        jj_repository_root(working_copy_root)
+            .unwrap_or_else(|| canonical(working_copy_root))
+    }
+}
+
+impl VcsProbe for InProcessProbe {
+    fn kind(&self, root: &Path) -> VcsKind {
+        marker_kind(root)
+    }
+
+    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {
+        match kind {
+            VcsKind::Git => git_revision(root),
+            VcsKind::Jj => {
+                warn!(
+                    vcs = "jj",
+                    "jj-lib 0.43 exposes no read-only, settings-free route to \
+                     the working-copy commit id, so no revision is reported"
+                );
+                None
+            }
+            VcsKind::None => None,
+        }
+    }
+}
+
+/// The repository a jj working copy belongs to, resolved through the loader so
+/// the `.jj/repo`-file-means-secondary rule has one implementation.
+///
+/// The store is always `<repository>/.jj/repo`, so the repository is its
+/// grandparent — for a secondary workspace that is the main repository, and for
+/// a main workspace it is the workspace itself. `None` when this is not a jj
+/// workspace at all, which is the one absence that does not log.
+fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
+    let loader = match DefaultWorkspaceLoaderFactory.create(working_copy_root) {
+        Ok(loader) => loader,
+        Err(WorkspaceLoadError::NoWorkspaceHere(_)) => return None,
+        Err(error) => {
+            warn!(%error, "could not load the jj workspace");
+            return None;
+        }
+    };
+
+    let store = loader.repo_path();
+    let Some(repository) = store.parent().and_then(Path::parent) else {
+        warn!(
+            store = %store.display(),
+            "the jj store has no repository root above it"
+        );
+        return None;
+    };
+    Some(canonical(repository))
+}
+
+/// The full working-copy revision of a git checkout. `None` — unlogged — for a
+/// repository with no commits yet, since that is a legitimate absence rather
+/// than a probe that could not answer.
+fn git_revision(root: &Path) -> Option<String> {
+    let repository = match gix::discover(root) {
+        Ok(repository) => repository,
+        Err(error) => {
+            warn!(
+                vcs = "git",
+                %error, "could not open the repository for its revision"
+            );
+            return None;
+        }
+    };
+
+    let head = repository.head_commit();
+    match head {
+        Ok(commit) => Some(commit.id().to_string()),
+        Err(error) if is_unborn_head(&error) => None,
+        Err(error) => {
+            warn!(vcs = "git", %error, "could not read the head commit");
+            None
+        }
+    }
+}
+
+/// Whether the head could not be peeled because nothing has been committed yet,
+/// as opposed to the repository being unreadable.
+const fn is_unborn_head(error: &gix::reference::head_commit::Error) -> bool {
+    matches!(
+        error,
+        gix::reference::head_commit::Error::Head(
+            gix::reference::find::existing::Error::NotFound { .. }
+        )
+    )
+}
+
+/// The single choke point every path leaving this module passes through.
+///
+/// Falls back to the uncanonicalised path rather than dropping the answer: the
+/// callers return `Option`/`PathBuf` and cannot carry the distinction, and the
+/// paths reaching here have just been read off the filesystem.
+fn canonical(path: &Path) -> PathBuf {
+    match path.canonicalize() {
+        Ok(canonical) => canonical,
+        Err(error) => {
+            warn!(
+                path = %path.display(),
+                %error, "could not canonicalise the path"
+            );
+            path.to_path_buf()
+        }
+    }
+}

--- a/cli/vcs-adapters/src/markers.rs
+++ b/cli/vcs-adapters/src/markers.rs
@@ -1,18 +1,13 @@
-//! The ancestor walk and the marker reading both probes share.
-//!
-//! These are the pieces the subprocess probes and the library-backed probe
-//! agree on, so they live apart from either: the subprocess pair delegates to
-//! them rather than the other way round, and outlives its deletion.
+//! The ancestor walk and marker reading both adapters share. Each delegates to
+//! these rather than to the other, so retiring either strands nothing.
 
 use std::path::Path;
 use std::path::PathBuf;
 
 use vcs::VcsKind;
 
-/// The nearest ancestor of `start`, `start` itself included, that
-/// `marks_a_repository` accepts.
-///
-/// The filesystem root itself is never tested, matching the bash walk.
+/// The nearest ancestor of `start`, `start` included, that
+/// `marks_a_repository` accepts. The filesystem root is never tested.
 pub fn walk_up(
     start: &Path,
     marks_a_repository: impl Fn(&Path) -> bool,
@@ -27,25 +22,23 @@ pub fn walk_up(
     None
 }
 
-/// Whether `dir` is a checkout boundary — a `.jj` or `.git` marker of any
-/// shape, tested for *existence* so a `.git` file counts alongside a directory.
+/// Whether `dir` carries a `.jj` or `.git` marker of any shape.
 pub fn carries_any_marker(dir: &Path) -> bool {
     dir.join(".jj").exists() || dir.join(".git").exists()
 }
 
 /// Whether `dir` is a jj workspace root.
 ///
-/// The jj queries need this in place of the combined boundary test: jj-lib's
-/// loader performs no walk of its own, so feeding it a boundary found by the
-/// `.git`-inclusive walk makes it report absence on a git checkout nested
-/// inside a jj workspace — where `jj workspace root` reports a root.
+/// The jj queries need this rather than the combined test: jj-lib's loader does
+/// not walk, so a boundary found by the `.git`-inclusive walk makes it report
+/// absence on a git checkout nested inside a jj workspace.
 pub fn carries_jj_marker(dir: &Path) -> bool {
     dir.join(".jj").exists()
 }
 
-/// The idiom the markers at `root` call for. `Jj` wins in a colocated
-/// checkout, because git's index lags the jj working-copy commit and a
-/// git-shaped probe would read live edits as clean.
+/// The idiom the markers at `root` call for. `Jj` wins in a colocated checkout,
+/// because git's index lags the jj working-copy commit and a git-shaped probe
+/// would read live edits as clean.
 pub fn marker_kind(root: &Path) -> VcsKind {
     if root.join(".jj").exists() {
         VcsKind::Jj

--- a/cli/vcs-adapters/src/markers.rs
+++ b/cli/vcs-adapters/src/markers.rs
@@ -33,6 +33,16 @@ pub fn carries_any_marker(dir: &Path) -> bool {
     dir.join(".jj").exists() || dir.join(".git").exists()
 }
 
+/// Whether `dir` is a jj workspace root.
+///
+/// The jj queries need this in place of the combined boundary test: jj-lib's
+/// loader performs no walk of its own, so feeding it a boundary found by the
+/// `.git`-inclusive walk makes it report absence on a git checkout nested
+/// inside a jj workspace — where `jj workspace root` reports a root.
+pub fn carries_jj_marker(dir: &Path) -> bool {
+    dir.join(".jj").exists()
+}
+
 /// The idiom the markers at `root` call for. `Jj` wins in a colocated
 /// checkout, because git's index lags the jj working-copy commit and a
 /// git-shaped probe would read live edits as clean.

--- a/cli/vcs-adapters/src/markers.rs
+++ b/cli/vcs-adapters/src/markers.rs
@@ -1,0 +1,47 @@
+//! The ancestor walk and the marker reading both probes share.
+//!
+//! These are the pieces the subprocess probes and the library-backed probe
+//! agree on, so they live apart from either: the subprocess pair delegates to
+//! them rather than the other way round, and outlives its deletion.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use vcs::VcsKind;
+
+/// The nearest ancestor of `start`, `start` itself included, that
+/// `marks_a_repository` accepts.
+///
+/// The filesystem root itself is never tested, matching the bash walk.
+pub fn walk_up(
+    start: &Path,
+    marks_a_repository: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let mut dir = start;
+    while dir.parent().is_some() {
+        if marks_a_repository(dir) {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+/// Whether `dir` is a checkout boundary — a `.jj` or `.git` marker of any
+/// shape, tested for *existence* so a `.git` file counts alongside a directory.
+pub fn carries_any_marker(dir: &Path) -> bool {
+    dir.join(".jj").exists() || dir.join(".git").exists()
+}
+
+/// The idiom the markers at `root` call for. `Jj` wins in a colocated
+/// checkout, because git's index lags the jj working-copy commit and a
+/// git-shaped probe would read live edits as clean.
+pub fn marker_kind(root: &Path) -> VcsKind {
+    if root.join(".jj").exists() {
+        VcsKind::Jj
+    } else if root.join(".git").exists() {
+        VcsKind::Git
+    } else {
+        VcsKind::None
+    }
+}

--- a/cli/vcs-adapters/src/subprocess.rs
+++ b/cli/vcs-adapters/src/subprocess.rs
@@ -1,25 +1,13 @@
-//! The subprocess-backed probes: an ancestor marker-walk for the repository
-//! root, and the VCS binaries themselves for the working-copy revision.
+//! The subprocess-backed probes: a marker walk for the root, and the VCS
+//! binaries themselves for the working-copy revision.
 //!
-//! The probe subprocess runs with a scrubbed environment and colour disabled,
-//! so ambient user config cannot redirect the root or inject ANSI into a
-//! revision. Every way the probe can fail to answer — an absent binary, a
-//! non-zero exit, empty output, or a run that outlives its time cap — resolves
-//! to `None` and is warn-logged, so a real failure leaves a trace instead of
-//! reading like a legitimately revision-less repository.
+//! The subprocess runs with a scrubbed environment and colour disabled, so
+//! ambient config cannot redirect the root or inject ANSI into a revision. Every
+//! way it can fail to answer resolves to `None` and is warn-logged, so a real
+//! failure does not read like a revision-less repository.
 //!
-//! This is the pair [`crate::library`] replaces. The two differ in more than
-//! mechanism: this one parses in a child process with a time cap, a
-//! kill-on-timeout and a scrubbed environment, which is containment the
-//! in-process reader cannot offer. Whether an equivalent bound is needed before
-//! the composition root switches over is a decision the switch owns.
-//!
-//! Spawning lives here and only here, and this module is deliberately unruled
-//! where [`crate::library`] carries a cargo-pup rule denying `std::process`.
-//! That rule is module-scoped, so it did not need this extraction to work — what
-//! the extraction buys is that the boundary is now visible in the file layout
-//! rather than only in `pup.ron`, and that retiring this pair is a file
-//! deletion.
+//! Spawning lives here and only here; [`crate::library`] carries an import rule
+//! denying `std::process`.
 
 use std::fs;
 use std::io::Read as _;
@@ -32,17 +20,13 @@ use vcs::{RepoRoot, VcsKind, VcsProbe};
 
 use crate::markers::{carries_any_marker, marker_kind, walk_up};
 
-/// Headroom for a legitimately slow or lock-contended repository, while still
-/// bounding metadata derivation.
+/// Headroom for a lock-contended repository, while still bounding derivation.
 const DEFAULT_CAP: Duration = Duration::from_secs(10);
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-/// Finds the repository root by walking ancestors for the first `.jj` or
-/// `.git` marker, testing for *existence* so a `.git` file — a worktree or
-/// submodule — counts alongside a `.git` directory.
-///
-/// The filesystem root itself is never tested, matching the bash walk.
+/// Finds the repository root by walking ancestors for the first `.jj` or `.git`
+/// marker, testing existence so a `.git` *file* counts alongside a directory.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MarkerWalkRoot;
 
@@ -57,16 +41,11 @@ impl RepoRoot for MarkerWalkRoot {
     }
 }
 
-/// Resolves a jj secondary workspace's working-copy root to the repository whose
-/// store it shares. A secondary workspace's `.jj/repo` is a file pointing at the
-/// shared `<repo>/.jj/repo` store, so the repository is the store's grandparent;
-/// the primary workspace's `.jj/repo` is that store directory. `None` when this
-/// is not a jj workspace or the pointer cannot be resolved.
+/// Resolves a jj secondary workspace to the repository whose store it shares.
 ///
-/// This reads the pointer by hand. [`crate::library`] resolves the same fact
-/// through jj-lib's workspace loader instead, so the file-versus-directory rule
-/// has one implementation per adapter rather than one shared one — the loader
-/// route needs the library this module deliberately does not depend on.
+/// A secondary workspace's `.jj/repo` is a *file* pointing at the shared
+/// `<repo>/.jj/repo`, so the repository is the store's grandparent; a primary
+/// workspace's `.jj/repo` is that store directory.
 fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
     let marker = working_copy_root.join(".jj").join("repo");
     let metadata = fs::symlink_metadata(&marker).ok()?;
@@ -142,7 +121,7 @@ impl VcsProbe for CommandProbe {
 }
 
 /// Denies the subprocess the ambient config that could redirect it at another
-/// repository or dress its output up in ANSI.
+/// repository.
 fn scrub_environment(command: &mut Command) {
     for key in [
         "GIT_DIR",

--- a/cli/vcs-adapters/src/subprocess.rs
+++ b/cli/vcs-adapters/src/subprocess.rs
@@ -1,0 +1,306 @@
+//! The subprocess-backed probes: an ancestor marker-walk for the repository
+//! root, and the VCS binaries themselves for the working-copy revision.
+//!
+//! The probe subprocess runs with a scrubbed environment and colour disabled,
+//! so ambient user config cannot redirect the root or inject ANSI into a
+//! revision. Every way the probe can fail to answer — an absent binary, a
+//! non-zero exit, empty output, or a run that outlives its time cap — resolves
+//! to `None` and is warn-logged, so a real failure leaves a trace instead of
+//! reading like a legitimately revision-less repository.
+//!
+//! This is the pair [`crate::library`] replaces. The two differ in more than
+//! mechanism: this one parses in a child process with a time cap, a
+//! kill-on-timeout and a scrubbed environment, which is containment the
+//! in-process reader cannot offer. Whether an equivalent bound is needed before
+//! the composition root switches over is a decision the switch owns.
+//!
+//! Spawning lives here and only here, and this module is deliberately unruled
+//! where [`crate::library`] carries a cargo-pup rule denying `std::process`.
+//! That rule is module-scoped, so it did not need this extraction to work — what
+//! the extraction buys is that the boundary is now visible in the file layout
+//! rather than only in `pup.ron`, and that retiring this pair is a file
+//! deletion.
+
+use std::fs;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tracing::warn;
+use vcs::{RepoRoot, VcsKind, VcsProbe};
+
+use crate::markers::{carries_any_marker, marker_kind, walk_up};
+
+/// Headroom for a legitimately slow or lock-contended repository, while still
+/// bounding metadata derivation.
+const DEFAULT_CAP: Duration = Duration::from_secs(10);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Finds the repository root by walking ancestors for the first `.jj` or
+/// `.git` marker, testing for *existence* so a `.git` file — a worktree or
+/// submodule — counts alongside a `.git` directory.
+///
+/// The filesystem root itself is never tested, matching the bash walk.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MarkerWalkRoot;
+
+impl RepoRoot for MarkerWalkRoot {
+    fn discover(&self, start: &Path) -> Option<PathBuf> {
+        walk_up(start, carries_any_marker)
+    }
+
+    fn repository_root(&self, working_copy_root: &Path) -> PathBuf {
+        jj_repository_root(working_copy_root)
+            .unwrap_or_else(|| working_copy_root.to_path_buf())
+    }
+}
+
+/// Resolves a jj secondary workspace's working-copy root to the repository whose
+/// store it shares. A secondary workspace's `.jj/repo` is a file pointing at the
+/// shared `<repo>/.jj/repo` store, so the repository is the store's grandparent;
+/// the primary workspace's `.jj/repo` is that store directory. `None` when this
+/// is not a jj workspace or the pointer cannot be resolved.
+///
+/// This reads the pointer by hand. [`crate::library`] resolves the same fact
+/// through jj-lib's workspace loader instead, so the file-versus-directory rule
+/// has one implementation per adapter rather than one shared one — the loader
+/// route needs the library this module deliberately does not depend on.
+fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
+    let marker = working_copy_root.join(".jj").join("repo");
+    let metadata = fs::symlink_metadata(&marker).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let pointer = fs::read_to_string(&marker).ok()?;
+    let store =
+        fs::canonicalize(working_copy_root.join(".jj").join(pointer.trim()))
+            .ok()?;
+    Some(store.parent()?.parent()?.to_path_buf())
+}
+
+/// Reads the repository's idiom from its markers and its revision by running
+/// the matching VCS binary.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandProbe {
+    cap: Duration,
+}
+
+impl CommandProbe {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { cap: DEFAULT_CAP }
+    }
+
+    /// A probe bounded by `cap` rather than the default.
+    #[must_use]
+    pub const fn with_cap(cap: Duration) -> Self {
+        Self { cap }
+    }
+}
+
+impl Default for CommandProbe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VcsProbe for CommandProbe {
+    fn kind(&self, root: &Path) -> VcsKind {
+        marker_kind(root)
+    }
+
+    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {
+        let mut command = match kind {
+            VcsKind::Jj => {
+                let mut command = Command::new("jj");
+                command.args([
+                    "--color=never",
+                    "--no-pager",
+                    "log",
+                    "-r",
+                    "@",
+                    "--no-graph",
+                    "-T",
+                    "commit_id",
+                ]);
+                command
+            }
+            VcsKind::Git => {
+                let mut command = Command::new("git");
+                command.args(["-c", "color.ui=false", "rev-parse", "HEAD"]);
+                command
+            }
+            VcsKind::None => return None,
+        };
+
+        command.current_dir(root);
+        scrub_environment(&mut command);
+        capped_stdout(command, self.cap, kind.as_str())
+    }
+}
+
+/// Denies the subprocess the ambient config that could redirect it at another
+/// repository or dress its output up in ANSI.
+fn scrub_environment(command: &mut Command) {
+    for key in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_CONFIG",
+        "GIT_CONFIG_COUNT",
+        "JJ_CONFIG",
+    ] {
+        command.env_remove(key);
+    }
+    command.env("GIT_CONFIG_NOSYSTEM", "1");
+    command.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    command.env("GIT_CONFIG_SYSTEM", "/dev/null");
+}
+
+/// Runs `command` and returns its trimmed stdout, or `None` — warn-logged —
+/// when it cannot be spawned, exits non-zero, outlives `cap`, or says nothing.
+fn capped_stdout(
+    mut command: Command,
+    cap: Duration,
+    vcs: &str,
+) -> Option<String> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            warn!(vcs, %error, "could not run the revision probe");
+            return None;
+        }
+    };
+
+    let deadline = Instant::now() + cap;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {}
+            Err(error) => {
+                warn!(vcs, %error, "could not await the revision probe");
+                return None;
+            }
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            warn!(
+                vcs,
+                cap = ?cap,
+                "the revision probe outlived its time cap and was killed"
+            );
+            return None;
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    };
+
+    if !status.success() {
+        warn!(vcs, %status, "the revision probe exited non-zero");
+        return None;
+    }
+
+    let mut stdout = String::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        if let Err(error) = pipe.read_to_string(&mut stdout) {
+            warn!(vcs, %error, "could not read the revision probe's output");
+            return None;
+        }
+    }
+
+    let revision = stdout.trim();
+    if revision.is_empty() {
+        warn!(vcs, "the revision probe reported no revision");
+        return None;
+    }
+    Some(revision.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+    use std::time::Duration;
+
+    use super::{capped_stdout, scrub_environment};
+
+    #[test]
+    fn a_probe_that_outlives_its_cap_reports_no_revision() {
+        let mut command = Command::new("sleep");
+        command.arg("30");
+
+        let started = std::time::Instant::now();
+        let revision =
+            capped_stdout(command, Duration::from_millis(100), "test");
+
+        assert_eq!(revision, None);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the probe should have been killed at its cap, not waited out"
+        );
+    }
+
+    #[test]
+    fn a_probe_that_cannot_be_spawned_reports_no_revision() {
+        let command = Command::new("accelerator-no-such-binary");
+        assert_eq!(
+            capped_stdout(command, Duration::from_secs(1), "test"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_probe_that_exits_non_zero_reports_no_revision() {
+        let command = Command::new("false");
+        assert_eq!(
+            capped_stdout(command, Duration::from_secs(1), "test"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_probe_that_says_nothing_reports_no_revision() {
+        let command = Command::new("true");
+        assert_eq!(
+            capped_stdout(command, Duration::from_secs(1), "test"),
+            None
+        );
+    }
+
+    #[test]
+    fn stdout_is_trimmed() {
+        let mut command = Command::new("printf");
+        command.arg("abc123\n");
+        assert_eq!(
+            capped_stdout(command, Duration::from_secs(1), "test").as_deref(),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn the_scrubbed_environment_drops_the_redirecting_variables() {
+        let mut command = Command::new("sh");
+        command
+            .args([
+                "-c",
+                "if [ -n \"$GIT_DIR\" ]; then printf carried; \
+                 else printf unset; fi",
+            ])
+            .env("GIT_DIR", "/somewhere/else/.git");
+        scrub_environment(&mut command);
+
+        assert_eq!(
+            capped_stdout(command, Duration::from_secs(1), "test").as_deref(),
+            Some("unset")
+        );
+    }
+}

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -18,8 +18,8 @@ use vcs::RepoRoot;
 use vcs::VcsKind;
 use vcs::VcsProbe;
 use vcs_adapters::library::InProcessProbe;
-use vcs_adapters::CommandProbe;
-use vcs_adapters::MarkerWalkRoot;
+use vcs_adapters::subprocess::CommandProbe;
+use vcs_adapters::subprocess::MarkerWalkRoot;
 
 type TestError = Box<dyn std::error::Error>;
 

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -13,8 +13,13 @@ use std::path::Path;
 use std::process::Command;
 
 use tempfile::TempDir;
+use vcs::RepoFacts;
+use vcs::RepoRoot;
 use vcs::VcsKind;
-use vcs_adapters::facts;
+use vcs::VcsProbe;
+use vcs_adapters::library::InProcessProbe;
+use vcs_adapters::CommandProbe;
+use vcs_adapters::MarkerWalkRoot;
 
 type TestError = Box<dyn std::error::Error>;
 
@@ -81,8 +86,79 @@ fn git_repo_with_a_commit(label: &str) -> Result<TempDir, TestError> {
 
 /// The probes ask for the *full* working-copy id — 40 hex digits from both jj
 /// (`commit_id`) and git (`rev-parse HEAD`) — so a short or decorated id fails.
+///
+/// Note this rejects a **sha256** repository's 64-hex id. That is deliberate
+/// here: no fixture in this suite uses one. Any wider revision validation has to
+/// accept both widths or record sha256 as unsupported — a decision the
+/// composition-root switch inherits, since it is what exposes users to it.
 fn is_full_revision_id(revision: &str) -> bool {
     revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// The facts for `start`, composed from an injected pair rather than the
+/// hard-wired composition root, so every case below runs against both
+/// implementations.
+fn facts_via(
+    start: &Path,
+    root: &dyn RepoRoot,
+    probe: &dyn VcsProbe,
+) -> Option<RepoFacts> {
+    vcs::facts(start, root, probe)
+}
+
+/// The retained subprocess pair — the values this suite has always pinned.
+fn facts(start: &Path) -> Option<RepoFacts> {
+    facts_via(start, &MarkerWalkRoot, &CommandProbe::new())
+}
+
+/// The library-backed pair.
+fn library_facts(start: &Path) -> Option<RepoFacts> {
+    facts_via(start, &InProcessProbe, &InProcessProbe)
+}
+
+/// Asserts the two implementations agree, **per `VcsKind`**.
+///
+/// Full `RepoFacts` equality for `VcsKind::Git`. For `VcsKind::Jj` only
+/// `root`/`name`/`kind`: jj-lib 0.43 exposes no read-only, settings-free route
+/// to the working-copy commit id, so the library-backed `revision` is `None` by
+/// design while the subprocess probe returns a 40-hex id. Narrowing wholesale
+/// would also discard achievable protection on the git revision path, which this
+/// suite already pins.
+///
+/// Agreement between two implementations is not on its own an oracle, which is
+/// why every case below also keeps its fixed expected values. This dual
+/// comparison is transitional: it collapses to the library-backed pair alone
+/// when the subprocess probe is deleted.
+fn assert_implementations_agree(start: &Path) {
+    let subprocess = facts(start);
+    let in_process = library_facts(start);
+
+    let (Some(subprocess), Some(in_process)) = (&subprocess, &in_process)
+    else {
+        assert_eq!(
+            subprocess.is_some(),
+            in_process.is_some(),
+            "the two implementations disagreed about whether a repository              exists at {}",
+            start.display()
+        );
+        return;
+    };
+
+    assert_eq!(subprocess.root, in_process.root, "root disagreed");
+    assert_eq!(subprocess.name, in_process.name, "name disagreed");
+    assert_eq!(subprocess.kind, in_process.kind, "kind disagreed");
+    match subprocess.kind {
+        VcsKind::Git | VcsKind::None => {
+            assert_eq!(
+                subprocess.revision, in_process.revision,
+                "git revision disagreed"
+            );
+        }
+        VcsKind::Jj => assert_eq!(
+            in_process.revision, None,
+            "the jj revision mechanism is out of scope and must report absence"
+        ),
+    }
 }
 
 #[test]
@@ -107,6 +183,7 @@ fn a_git_repository_reports_its_root_name_and_revision() -> Result<(), TestError
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
+    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -121,6 +198,7 @@ fn the_walk_finds_the_root_from_a_nested_directory() -> Result<(), TestError> {
     let derived = facts(&nested).ok_or("expected the walk to find the root")?;
 
     assert_eq!(derived.root, root);
+    assert_implementations_agree(&nested);
     Ok(())
 }
 
@@ -138,6 +216,7 @@ fn a_git_repository_with_no_commits_has_no_revision() -> Result<(), TestError> {
         derived.revision, None,
         "a commitless repo must report no revision, not an empty one"
     );
+    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -165,6 +244,7 @@ fn a_colocated_repository_is_driven_as_jj() -> Result<(), TestError> {
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
+    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -205,6 +285,7 @@ fn a_secondary_jj_workspace_roots_at_its_own_marker() -> Result<(), TestError> {
         "a workspace's name is the repository it shares a store with, not the \
          ephemeral workspace directory"
     );
+    assert_implementations_agree(&secondary);
     Ok(())
 }
 
@@ -244,6 +325,7 @@ fn a_worktree_whose_git_marker_is_a_file_is_recognised() -> Result<(), TestError
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
+    assert_implementations_agree(&worktree);
     Ok(())
 }
 
@@ -273,5 +355,6 @@ fn a_bare_repository_has_no_facts() -> Result<(), TestError> {
         None,
         "a bare repository must resolve to no facts, not an empty root"
     );
+    assert_implementations_agree(&bare);
     Ok(())
 }

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -325,10 +325,9 @@ fn a_worktree_whose_git_marker_is_a_file_is_recognised() -> Result<(), TestError
 fn a_bare_repository_has_no_facts() -> Result<(), TestError> {
     require("git")?;
 
-    // A bare repo keeps HEAD/objects/refs at its top level and has no `.git`
-    // marker at all, so the marker walk finds nothing. This is the shape the
-    // bash helpers fall through on, and the reason `facts` is an Option rather
-    // than a fabricated empty root.
+    // A bare repo keeps HEAD/objects/refs at its top level with no `.git`
+    // marker, so the marker walk finds nothing — the reason `facts` is an
+    // Option rather than a fabricated empty root.
     let bare = tempdir("bare")?;
     let bare = bare.path().canonicalize()?;
     run(

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -116,14 +116,20 @@ fn library_facts(start: &Path) -> Option<RepoFacts> {
     facts_via(start, &InProcessProbe, &InProcessProbe)
 }
 
-/// Asserts the two implementations agree, **per `VcsKind`**.
+/// Asserts the two implementations produce identical `RepoFacts`, for every
+/// `VcsKind`.
 ///
-/// Full `RepoFacts` equality for `VcsKind::Git`. For `VcsKind::Jj` only
-/// `root`/`name`/`kind`: jj-lib 0.43 exposes no read-only, settings-free route
-/// to the working-copy commit id, so the library-backed `revision` is `None` by
-/// design while the subprocess probe returns a 40-hex id. Narrowing wholesale
-/// would also discard achievable protection on the git revision path, which this
-/// suite already pins.
+/// Full equality on both idioms: the library-backed probe reads the jj
+/// working-copy commit id out of the checkout state and the operation store, so
+/// there is no field either implementation cannot answer.
+///
+/// The one shape where the two can legitimately differ is out of reach here.
+/// Asking the `jj` binary snapshots the working copy first, so with
+/// unsnapshotted changes present it reports — and records — a *new* commit,
+/// while the in-process route reports the last recorded one. Every fixture in
+/// this suite is built and then read without an intervening edit, so the
+/// recorded operation is current and both agree. `library.rs` pins the
+/// divergence itself.
 ///
 /// Agreement between two implementations is not on its own an oracle, which is
 /// why every case below also keeps its fixed expected values. This dual
@@ -144,21 +150,7 @@ fn assert_implementations_agree(start: &Path) {
         return;
     };
 
-    assert_eq!(subprocess.root, in_process.root, "root disagreed");
-    assert_eq!(subprocess.name, in_process.name, "name disagreed");
-    assert_eq!(subprocess.kind, in_process.kind, "kind disagreed");
-    match subprocess.kind {
-        VcsKind::Git | VcsKind::None => {
-            assert_eq!(
-                subprocess.revision, in_process.revision,
-                "git revision disagreed"
-            );
-        }
-        VcsKind::Jj => assert_eq!(
-            in_process.revision, None,
-            "the jj revision mechanism is out of scope and must report absence"
-        ),
-    }
+    assert_eq!(subprocess, in_process, "the two implementations disagreed");
 }
 
 #[test]

--- a/cli/vcs-adapters/tests/fixtures/vcs_adapters_fixture.rs
+++ b/cli/vcs-adapters/tests/fixtures/vcs_adapters_fixture.rs
@@ -1,0 +1,180 @@
+//! Composition root for the library-backed probe: calls every query and both
+//! port methods against a start directory and **prints each result**.
+//!
+//! Printing is load-bearing twice over. Without a caller that consumes them,
+//! dead-code elimination would let the musl and size checks pass while linking
+//! almost none of `gix`/`jj-lib`. And the scrub-invariant runs compare a
+//! poisoned child against a clean one on captured stdout — both arms through
+//! this same binary, so a difference is a behavioural difference rather than
+//! two serialisation routes disagreeing.
+//!
+//! Usage: `vcs-adapters-fixture <mode> <start-dir>`, where mode is `all` or
+//! `only <query>`.
+#![allow(
+    clippy::exit,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::restriction
+)]
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use vcs::RepoRoot;
+use vcs::VcsProbe;
+use vcs_adapters::library::DualRoots;
+use vcs_adapters::library::InProcessProbe;
+use vcs_adapters::library::JjRepositoryFacts;
+use vcs_adapters::library::JjWorkspaceRole;
+use vcs_adapters::library::WorktreeFacts;
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let (queries, start): (Vec<&str>, &str) = match arguments.as_slice() {
+        [mode, start] if mode == "all" => (ALL.to_vec(), start),
+        [mode, start] if mode == "control" => (vec!["control"], start),
+        [mode, query, start] if mode == "only" => (vec![query.as_str()], start),
+        _ => {
+            eprintln!("usage: vcs-adapters-fixture (all|only <query>) <dir>");
+            return ExitCode::from(2);
+        }
+    };
+
+    let start = Path::new(start);
+    for query in queries {
+        if let Err(message) = report(query, start) {
+            eprintln!("{message}");
+            return ExitCode::from(1);
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+const ALL: [&str; 8] = [
+    "is_bare",
+    "worktree",
+    "superproject",
+    "jj_workspace_root",
+    "jj_repository",
+    "dual_roots",
+    "discover",
+    "kind_and_revision",
+];
+
+fn report(query: &str, start: &Path) -> Result<(), String> {
+    let probe = InProcessProbe;
+    match query {
+        "is_bare" => print(query, &optional(probe.is_bare(start))),
+        "worktree" => {
+            let facts = probe
+                .worktree(start)
+                .map(|found| found.map(|facts| worktree(&facts)));
+            print(query, &optional(facts));
+        }
+        "superproject" => {
+            let root = probe
+                .superproject(start)
+                .map(|found| found.map(|path| render(&path)));
+            print(query, &optional(root));
+        }
+        "jj_workspace_root" => {
+            let root = probe
+                .jj_workspace_root(start)
+                .map(|found| found.map(|path| render(&path)));
+            print(query, &optional(root));
+        }
+        "jj_repository" => {
+            let facts = probe
+                .jj_repository(start)
+                .map(|found| found.map(|facts| repository(&facts)));
+            print(query, &optional(facts));
+        }
+        "dual_roots" => print(query, &dual(&probe.dual_roots(start))),
+        // The non-vacuity control for the scrub invariant, run *inside* the
+        // poisoned child so the poison it reports is the one the queries above
+        // ran under. Unlike plain `discover`, this entry point reads the
+        // environment, so under a live poison it resolves the poison target.
+        "control" => {
+            let found = gix::discover_with_environment_overrides(start)
+                .ok()
+                .and_then(|repository| {
+                    repository.git_dir().canonicalize().ok()
+                });
+            print(query, &show(found.as_deref()));
+        }
+        "discover" => print(query, &show(probe.discover(start).as_deref())),
+        "kind_and_revision" => {
+            let root = probe.discover(start);
+            let rendered = root.map_or_else(
+                || "absent".to_owned(),
+                |root| {
+                    let kind = probe.kind(&root);
+                    let revision = probe.revision(&root, kind);
+                    format!(
+                        "{} {}",
+                        kind.as_str(),
+                        revision.unwrap_or_else(|| "none".to_owned())
+                    )
+                },
+            );
+            print(query, &rendered);
+        }
+        other => return Err(format!("unknown query: {other}")),
+    }
+    Ok(())
+}
+
+fn print(query: &str, rendered: &str) {
+    println!("{query}\t{rendered}");
+}
+
+/// Renders `Ok(None)` and `Err` differently, because collapsing them is exactly
+/// the conflation the query signatures exist to prevent.
+fn optional<T: std::fmt::Display>(
+    value: Result<Option<T>, vcs_adapters::library::Error>,
+) -> String {
+    match value {
+        Ok(Some(inner)) => inner.to_string(),
+        Ok(None) => "absent".to_owned(),
+        Err(error) => format!("error: {error}"),
+    }
+}
+
+fn render(path: &Path) -> String {
+    path.display().to_string()
+}
+
+fn worktree(facts: &WorktreeFacts) -> String {
+    format!(
+        "linked={} git_dir={} common_dir={} main={}",
+        facts.linked,
+        facts.git_dir.display(),
+        facts.common_dir.display(),
+        show(facts.main_worktree_root.as_deref())
+    )
+}
+
+fn repository(facts: &JjRepositoryFacts) -> String {
+    let role = match facts.role {
+        JjWorkspaceRole::Main => "main",
+        JjWorkspaceRole::Secondary => "secondary",
+    };
+    format!("role={role} main_root={}", facts.main_root.display())
+}
+
+fn dual(roots: &DualRoots) -> String {
+    let render =
+        |side: &Result<Option<PathBuf>, vcs_adapters::library::Error>| {
+            match side {
+                Ok(Some(path)) => path.display().to_string(),
+                Ok(None) => "absent".to_owned(),
+                Err(error) => format!("error: {error}"),
+            }
+        };
+    format!("git={} jj={}", render(&roots.git), render(&roots.jj))
+}
+
+fn show(path: Option<&Path>) -> String {
+    path.map_or_else(|| "absent".to_owned(), |path| path.display().to_string())
+}

--- a/cli/vcs-adapters/tests/fixtures/vcs_adapters_fixture_stub.rs
+++ b/cli/vcs-adapters/tests/fixtures/vcs_adapters_fixture_stub.rs
@@ -1,0 +1,48 @@
+//! The stubbed twin of `vcs_adapters_fixture`: the same command surface and the
+//! same printing, with every query replaced by a constant.
+//!
+//! It exists to give the size floor a denominator. Built alongside the linked
+//! artefact from a crate that declares `gix` and `jj-lib` either way, the delta
+//! between the two is what dead-code elimination removed — so a linked build
+//! that stopped calling the queries would collapse toward this size and the
+//! floor would catch it.
+//!
+//! A second `[[bin]]` rather than a `stub` feature on `vcs-adapters`: the crate
+//! must gain no `[features]` entry beyond `bash-parity`, and CI's
+//! `--all-features` would otherwise turn a fixture feature on workspace-wide.
+#![allow(
+    clippy::exit,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::restriction
+)]
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let queries: Vec<&str> = match arguments.as_slice() {
+        [mode, _start] if mode == "all" => ALL.to_vec(),
+        [mode, query, _start] if mode == "only" => vec![query.as_str()],
+        _ => {
+            eprintln!("usage: vcs-adapters-fixture-stub (all|only <q>) <dir>");
+            return ExitCode::from(2);
+        }
+    };
+
+    for query in queries {
+        println!("{query}\tabsent");
+    }
+    ExitCode::SUCCESS
+}
+
+const ALL: [&str; 8] = [
+    "is_bare",
+    "worktree",
+    "superproject",
+    "jj_workspace_root",
+    "jj_repository",
+    "dual_roots",
+    "discover",
+    "kind_and_revision",
+];

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -212,10 +212,14 @@ fn the_walk_finds_the_boundary_from_a_nested_directory() -> Result<(), TestError
 
 // --- Parity with the subprocess pair ---
 
-/// Asserts the two implementations agree on everything the library-backed probe
-/// claims to answer. `revision` is compared for `VcsKind::Git` only: jj-lib
-/// 0.43 exposes no read-only, settings-free route to the working-copy commit
-/// id, so the jj half is `None` by design and is asserted as such.
+/// Asserts the two implementations agree on every port method, both idioms
+/// included.
+///
+/// `revision` is compared unconditionally. The fixtures are built and then read
+/// with no intervening edit, so the jj working copy's recorded operation is
+/// current and the snapshot the `jj` binary takes is a no-op; the one shape
+/// where the two legitimately differ is pinned separately by
+/// `an_unsnapshotted_edit_is_the_one_documented_divergence`.
 fn assert_parity(root: &Path) {
     let kind = InProcessProbe.kind(root);
     assert_eq!(kind, CommandProbe::new().kind(root), "kind disagreed");
@@ -224,26 +228,11 @@ fn assert_parity(root: &Path) {
         MarkerWalkRoot.repository_root(root),
         "repository_root disagreed"
     );
-
-    let subprocess = CommandProbe::new().revision(root, kind);
-    let in_process = InProcessProbe.revision(root, kind);
-    match kind {
-        VcsKind::Git => {
-            assert_eq!(in_process, subprocess, "git revision disagreed");
-        }
-        VcsKind::Jj => {
-            assert_eq!(
-                in_process, None,
-                "the jj revision mechanism is descoped and must report absence"
-            );
-            assert!(
-                subprocess.is_some(),
-                "the subprocess probe should still answer, or this fixture \
-                 proves nothing about the descope"
-            );
-        }
-        VcsKind::None => assert_eq!(in_process, subprocess),
-    }
+    assert_eq!(
+        InProcessProbe.revision(root, kind),
+        CommandProbe::new().revision(root, kind),
+        "revision disagreed"
+    );
 }
 
 #[test]
@@ -331,4 +320,197 @@ fn a_main_workspace_resolves_to_itself() -> Result<(), TestError> {
     assert_eq!(InProcessProbe.repository_root(&root), root);
     assert_parity(&root);
     Ok(())
+}
+
+// --- The jj revision route ---
+//
+// Read from the workspace's checkout state plus the operation store, with no jj
+// settings value and no write. These pin the properties that route rests on;
+// `assert_parity` above already pins agreement with the `jj` binary.
+
+/// The commit id the `jj` binary reports for `@`.
+fn jj_revision_oracle(root: &Path) -> Result<String, TestError> {
+    let output = Command::new("jj")
+        .args(["log", "-r", "@", "--no-graph", "-T", "commit_id"])
+        .current_dir(root)
+        .output()?;
+    assert!(output.status.success(), "the jj oracle failed: {output:?}");
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
+}
+
+#[test]
+fn a_pure_jj_workspace_reports_its_working_copy_commit() -> Result<(), TestError>
+{
+    require("jj")?;
+    let dir = tempdir("revision-pure-jj")?;
+    let root = path_of(&dir)?;
+    run("jj", &["git", "init", "--no-colocate"], &root)?;
+    fs::write(root.join("file"), "content")?;
+    run("jj", &["commit", "-m", "one"], &root)?;
+
+    // The point of a --no-colocate fixture: there is no git HEAD to fall back
+    // to, so this can only have come from the jj side.
+    assert!(!root.join(".git").exists(), "the fixture must be pure jj");
+    assert_eq!(
+        InProcessProbe.revision(&root, VcsKind::Jj),
+        Some(jj_revision_oracle(&root)?),
+    );
+    Ok(())
+}
+
+#[test]
+fn each_workspace_reports_its_own_commit_not_its_neighbour_s(
+) -> Result<(), TestError> {
+    require("jj")?;
+    require("git")?;
+    let main = colocated_repo("revision-ws-main")?;
+    let main = path_of(&main)?;
+    let secondary_root = tempdir("revision-ws-secondary")?;
+    let secondary = path_of(&secondary_root)?.join("workspace");
+    run(
+        "jj",
+        &[
+            "workspace",
+            "add",
+            "--name",
+            "inner",
+            secondary.to_str().ok_or("non-UTF-8 workspace path")?,
+        ],
+        &main,
+    )?;
+
+    let main_revision = InProcessProbe.revision(&main, VcsKind::Jj);
+    let secondary_revision = InProcessProbe.revision(&secondary, VcsKind::Jj);
+
+    assert_eq!(main_revision, Some(jj_revision_oracle(&main)?));
+    assert_eq!(secondary_revision, Some(jj_revision_oracle(&secondary)?));
+    // The load-bearing assertion: the route looks the commit up by the
+    // workspace's own name, so two workspaces sharing one operation store get
+    // different answers. Taking the view's sole entry would pass every
+    // single-workspace test and answer for the wrong workspace here.
+    assert_ne!(
+        main_revision, secondary_revision,
+        "two workspaces of one repository must not report the same commit"
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unreadable_checkout_state_reports_absence_rather_than_a_wrong_commit(
+) -> Result<(), TestError> {
+    require("jj")?;
+    let dir = tempdir("revision-broken-checkout")?;
+    let root = path_of(&dir)?;
+    run("jj", &["git", "init", "--no-colocate"], &root)?;
+    fs::write(root.join("file"), "content")?;
+    run("jj", &["commit", "-m", "one"], &root)?;
+
+    let checkout = root.join(".jj/working_copy/checkout");
+    assert!(
+        InProcessProbe.revision(&root, VcsKind::Jj).is_some(),
+        "the fixture must answer before it is broken, or this proves nothing"
+    );
+    fs::write(&checkout, b"not a protobuf")?;
+
+    // The port method's signature carries no error channel, so a failure is
+    // warn-logged and reported as absence — the same contract the subprocess
+    // probe has always had. What must not happen is a panic or a stale answer.
+    assert_eq!(InProcessProbe.revision(&root, VcsKind::Jj), None);
+    Ok(())
+}
+
+#[test]
+fn reading_the_revision_writes_nothing() -> Result<(), TestError> {
+    require("jj")?;
+    let dir = tempdir("revision-readonly")?;
+    let root = path_of(&dir)?;
+    run("jj", &["git", "init", "--no-colocate"], &root)?;
+    fs::write(root.join("file"), "content")?;
+    run("jj", &["commit", "-m", "one"], &root)?;
+
+    // The probe has to be usable on a read-only filesystem, and one jj store
+    // loader in this area does create directories on load. Fingerprint the whole
+    // .jj tree rather than spot-checking, so a create, delete or modify anywhere
+    // is caught.
+    let before = fingerprint(&root.join(".jj"))?;
+    assert!(InProcessProbe.revision(&root, VcsKind::Jj).is_some());
+    assert_eq!(
+        before,
+        fingerprint(&root.join(".jj"))?,
+        "the probe wrote to .jj"
+    );
+    Ok(())
+}
+
+#[test]
+fn an_unsnapshotted_edit_is_the_one_documented_divergence(
+) -> Result<(), TestError> {
+    require("jj")?;
+    let dir = tempdir("revision-snapshot")?;
+    let root = path_of(&dir)?;
+    run("jj", &["git", "init", "--no-colocate"], &root)?;
+    fs::write(root.join("file"), "content")?;
+    run("jj", &["commit", "-m", "one"], &root)?;
+
+    let recorded = InProcessProbe.revision(&root, VcsKind::Jj);
+    assert_eq!(
+        recorded,
+        Some(jj_revision_oracle(&root)?),
+        "in sync to begin"
+    );
+
+    // Change the tree without running any jj command, so the recorded operation
+    // is now behind the working copy.
+    fs::write(root.join("untracked"), "edited outside jj")?;
+
+    // The in-process route still reports the last recorded commit: it does not
+    // snapshot, because a probe that must work on a read-only filesystem cannot.
+    assert_eq!(
+        InProcessProbe.revision(&root, VcsKind::Jj),
+        recorded,
+        "the in-process route must not snapshot"
+    );
+
+    // The subprocess probe snapshots first, so it reports a *different* commit —
+    // and creates it. This is the divergence, and it is also a write side effect
+    // on the user's repository that the in-process route removes.
+    let snapshotted = CommandProbe::new().revision(&root, VcsKind::Jj);
+    assert!(snapshotted.is_some());
+    assert_ne!(
+        snapshotted, recorded,
+        "asking the jj binary snapshots, so it should report a new commit here"
+    );
+
+    // Having snapshotted, the recorded state has moved, and the two agree again.
+    assert_eq!(
+        InProcessProbe.revision(&root, VcsKind::Jj),
+        snapshotted,
+        "after the binary snapshots, the recorded commit is the new one"
+    );
+    Ok(())
+}
+
+/// Sorted `path:len` for every file under `dir`, so a create, delete or resize
+/// anywhere shows up. Lengths rather than mtimes: mtime granularity varies by
+/// filesystem, and a rewrite that preserves length is not a shape jj produces.
+fn fingerprint(dir: &Path) -> Result<Vec<String>, TestError> {
+    let mut entries = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(next) = stack.pop() {
+        for entry in fs::read_dir(&next)? {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
+                stack.push(path);
+            } else {
+                entries.push(format!(
+                    "{}:{}",
+                    path.display(),
+                    entry.metadata()?.len()
+                ));
+            }
+        }
+    }
+    entries.sort();
+    Ok(entries)
 }

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -1,0 +1,334 @@
+//! The library-backed probe against real repository shapes, alongside the
+//! subprocess pair it will eventually replace.
+//!
+//! Two properties are under test. The boundary rule: `RepoRoot::discover`
+//! reports the start path's nearest marked ancestor and never one above it,
+//! paired with the negative assertion that an unbounded `gix::discover` on the
+//! same fixture *does* escape — without which the containment claim could hold
+//! vacuously. And parity: `kind`, `repository_root` and the git half of
+//! `revision` agree with `CommandProbe`, so the swap 0185 makes is behaviour-
+//! preserving on the shapes pinned here.
+//!
+//! These need real `jj` and `git` binaries and hard-fail when one is absent —
+//! Rust's harness has no skip primitive, so an early return would register as a
+//! green PASS.
+#![cfg(feature = "bash-parity")]
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+use vcs::RepoRoot;
+use vcs::VcsKind;
+use vcs::VcsProbe;
+use vcs_adapters::library::InProcessProbe;
+use vcs_adapters::CommandProbe;
+use vcs_adapters::MarkerWalkRoot;
+
+type TestError = Box<dyn std::error::Error>;
+
+fn require(binary: &str) -> Result<(), TestError> {
+    let found = Command::new(binary)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if found {
+        return Ok(());
+    }
+    Err(format!("`{binary}` is required by the library fixtures").into())
+}
+
+fn tempdir(label: &str) -> Result<TempDir, TestError> {
+    Ok(tempfile::Builder::new()
+        .prefix(&format!("vcs-library-{label}-"))
+        .tempdir()?)
+}
+
+fn run(binary: &str, args: &[&str], dir: &Path) -> Result<(), TestError> {
+    let output = Command::new(binary)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|error| format!("could not run {binary}: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "{binary} {} failed in {}: {}",
+            args.join(" "),
+            dir.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Identity is passed per-invocation so the fixture does not depend on the
+/// developer's global git config, and so a hostname with no domain cannot make
+/// git refuse the commit.
+fn git_repo_with_a_commit(label: &str) -> Result<TempDir, TestError> {
+    let dir = tempdir(label)?;
+    run("git", &["init", "--quiet"], dir.path())?;
+    run(
+        "git",
+        &[
+            "-c",
+            "user.email=fixture@example.com",
+            "-c",
+            "user.name=Fixture",
+            "commit",
+            "--allow-empty",
+            "--quiet",
+            "-m",
+            "root",
+        ],
+        dir.path(),
+    )?;
+    Ok(dir)
+}
+
+fn colocated_repo(label: &str) -> Result<TempDir, TestError> {
+    let dir = git_repo_with_a_commit(label)?;
+    run("jj", &["git", "init", "--colocate"], dir.path())?;
+    Ok(dir)
+}
+
+fn path_of(dir: &TempDir) -> Result<PathBuf, TestError> {
+    Ok(dir.path().canonicalize()?)
+}
+
+// --- The boundary rule ---
+
+#[test]
+fn the_boundary_is_the_nearest_marker_not_an_ancestor() -> Result<(), TestError>
+{
+    require("jj")?;
+    require("git")?;
+
+    // A jj secondary workspace planted inside an unrelated git repository: the
+    // inner directory carries `.jj` only, so anything walking for `.git` alone
+    // sails past it into the outer repository.
+    let main = colocated_repo("nested-main")?;
+    let main = path_of(&main)?;
+    let outer = git_repo_with_a_commit("nested-outer")?;
+    let outer = path_of(&outer)?;
+    let inner = outer.join("sub");
+    run(
+        "jj",
+        &[
+            "workspace",
+            "add",
+            inner.to_str().ok_or("non-UTF-8 workspace path")?,
+        ],
+        &main,
+    )?;
+
+    assert!(inner.join(".jj").exists(), "expected a .jj marker");
+    assert!(
+        !inner.join(".git").exists(),
+        "the inner workspace must carry .jj only, or the fixture proves nothing"
+    );
+
+    assert_eq!(
+        InProcessProbe.discover(&inner),
+        Some(inner.clone()),
+        "discover must report the boundary, not the enclosing git repository"
+    );
+
+    // The paired negative: gix's own walk escapes the boundary on this very
+    // fixture, so the containment above is the adapter's doing and not an
+    // accident of the shape.
+    let escaped = gix::discover(&inner)?;
+    let escaped = escaped
+        .workdir()
+        .ok_or("expected the escaped repository to have a workdir")?
+        .canonicalize()?;
+    assert_eq!(
+        escaped, outer,
+        "the control must escape, or the containment assertion is vacuous"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn a_colocated_checkout_roots_at_its_own_markers() -> Result<(), TestError> {
+    require("jj")?;
+    require("git")?;
+    let root = colocated_repo("colocated")?;
+    let root = path_of(&root)?;
+
+    assert_eq!(InProcessProbe.discover(&root), Some(root.clone()));
+    Ok(())
+}
+
+#[test]
+fn a_worktree_whose_git_marker_is_a_file_roots_at_itself(
+) -> Result<(), TestError> {
+    require("git")?;
+    let primary = git_repo_with_a_commit("worktree-primary")?;
+    let primary = path_of(&primary)?;
+    let worktree_root = tempdir("worktree")?;
+    let worktree = path_of(&worktree_root)?.join("checkout");
+    run(
+        "git",
+        &[
+            "worktree",
+            "add",
+            worktree.to_str().ok_or("non-UTF-8 worktree path")?,
+        ],
+        &primary,
+    )?;
+
+    assert!(
+        worktree.join(".git").is_file(),
+        "a worktree's .git should be a file, not a directory"
+    );
+    assert_eq!(InProcessProbe.discover(&worktree), Some(worktree));
+    Ok(())
+}
+
+#[test]
+fn a_tree_with_no_marker_has_no_boundary() -> Result<(), TestError> {
+    let loose = tempdir("loose")?;
+    let loose = path_of(&loose)?;
+    assert_eq!(InProcessProbe.discover(&loose), None);
+    Ok(())
+}
+
+#[test]
+fn the_walk_finds_the_boundary_from_a_nested_directory() -> Result<(), TestError>
+{
+    require("git")?;
+    let root = git_repo_with_a_commit("nested-dir")?;
+    let root = path_of(&root)?;
+    let nested = root.join("meta/work");
+    fs::create_dir_all(&nested)?;
+
+    assert_eq!(InProcessProbe.discover(&nested), Some(root));
+    Ok(())
+}
+
+// --- Parity with the subprocess pair ---
+
+/// Asserts the two implementations agree on everything the library-backed probe
+/// claims to answer. `revision` is compared for `VcsKind::Git` only: jj-lib
+/// 0.43 exposes no read-only, settings-free route to the working-copy commit
+/// id, so the jj half is `None` by design and is asserted as such.
+fn assert_parity(root: &Path) {
+    let kind = InProcessProbe.kind(root);
+    assert_eq!(kind, CommandProbe::new().kind(root), "kind disagreed");
+    assert_eq!(
+        InProcessProbe.repository_root(root),
+        MarkerWalkRoot.repository_root(root),
+        "repository_root disagreed"
+    );
+
+    let subprocess = CommandProbe::new().revision(root, kind);
+    let in_process = InProcessProbe.revision(root, kind);
+    match kind {
+        VcsKind::Git => {
+            assert_eq!(in_process, subprocess, "git revision disagreed");
+        }
+        VcsKind::Jj => {
+            assert_eq!(
+                in_process, None,
+                "the jj revision mechanism is descoped and must report absence"
+            );
+            assert!(
+                subprocess.is_some(),
+                "the subprocess probe should still answer, or this fixture \
+                 proves nothing about the descope"
+            );
+        }
+        VcsKind::None => assert_eq!(in_process, subprocess),
+    }
+}
+
+#[test]
+fn a_plain_git_repository_agrees_with_the_subprocess_pair(
+) -> Result<(), TestError> {
+    require("git")?;
+    let root = git_repo_with_a_commit("parity-git")?;
+    let root = path_of(&root)?;
+
+    assert_eq!(InProcessProbe.kind(&root), VcsKind::Git);
+    assert_parity(&root);
+    Ok(())
+}
+
+#[test]
+fn a_commitless_repository_agrees_and_reports_no_revision(
+) -> Result<(), TestError> {
+    require("git")?;
+    let root = tempdir("parity-commitless")?;
+    let root = path_of(&root)?;
+    run("git", &["init", "--quiet"], &root)?;
+
+    assert_eq!(
+        InProcessProbe.revision(&root, VcsKind::Git),
+        None,
+        "a commitless repository has no revision, and that is not a failure"
+    );
+    assert_parity(&root);
+    Ok(())
+}
+
+#[test]
+fn a_colocated_repository_agrees_and_is_driven_as_jj() -> Result<(), TestError>
+{
+    require("jj")?;
+    require("git")?;
+    let root = colocated_repo("parity-colocated")?;
+    let root = path_of(&root)?;
+
+    assert_eq!(
+        InProcessProbe.kind(&root),
+        VcsKind::Jj,
+        "jj must win over git in a colocated checkout"
+    );
+    assert_parity(&root);
+    Ok(())
+}
+
+#[test]
+fn a_secondary_workspace_resolves_to_the_repository_it_shares(
+) -> Result<(), TestError> {
+    require("jj")?;
+    require("git")?;
+    let main = colocated_repo("parity-main")?;
+    let main = path_of(&main)?;
+    let secondary_root = tempdir("parity-secondary")?;
+    let secondary = path_of(&secondary_root)?.join("workspace");
+    run(
+        "jj",
+        &[
+            "workspace",
+            "add",
+            secondary.to_str().ok_or("non-UTF-8 workspace path")?,
+        ],
+        &main,
+    )?;
+
+    assert_eq!(
+        InProcessProbe.repository_root(&secondary),
+        main,
+        "a secondary workspace resolves through the loader to its main \
+         repository, not to its own working copy"
+    );
+    assert_parity(&secondary);
+    Ok(())
+}
+
+#[test]
+fn a_main_workspace_resolves_to_itself() -> Result<(), TestError> {
+    require("jj")?;
+    require("git")?;
+    let root = colocated_repo("parity-main-workspace")?;
+    let root = path_of(&root)?;
+
+    assert_eq!(InProcessProbe.repository_root(&root), root);
+    assert_parity(&root);
+    Ok(())
+}

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -1,15 +1,13 @@
 //! The library-backed probe against real repository shapes, alongside the
-//! subprocess pair it will eventually replace.
+//! subprocess pair.
 //!
-//! Two properties are under test. The boundary rule: `RepoRoot::discover`
-//! reports the start path's nearest marked ancestor and never one above it,
-//! paired with the negative assertion that an unbounded `gix::discover` on the
-//! same fixture *does* escape — without which the containment claim could hold
-//! vacuously. And parity: `kind`, `repository_root` and the git half of
-//! `revision` agree with `CommandProbe`, so the swap 0185 makes is behaviour-
-//! preserving on the shapes pinned here.
+//! Two properties. The boundary rule: `RepoRoot::discover` reports the start
+//! path's nearest marked ancestor and never one above it, paired with the
+//! negative assertion that an unbounded `gix::discover` on the same fixture
+//! *does* escape — without which the containment claim holds vacuously. And
+//! parity with `CommandProbe` on every port method.
 //!
-//! These need real `jj` and `git` binaries and hard-fail when one is absent —
+//! These need real `jj` and `git` binaries and hard-fail when one is absent:
 //! Rust's harness has no skip primitive, so an early return would register as a
 //! green PASS.
 #![cfg(feature = "bash-parity")]
@@ -106,8 +104,7 @@ fn the_boundary_is_the_nearest_marker_not_an_ancestor() -> Result<(), TestError>
     require("jj")?;
     require("git")?;
 
-    // A jj secondary workspace planted inside an unrelated git repository: the
-    // inner directory carries `.jj` only, so anything walking for `.git` alone
+    // The inner directory carries `.jj` only, so anything walking for `.git`
     // sails past it into the outer repository.
     let main = colocated_repo("nested-main")?;
     let main = path_of(&main)?;
@@ -136,9 +133,8 @@ fn the_boundary_is_the_nearest_marker_not_an_ancestor() -> Result<(), TestError>
         "discover must report the boundary, not the enclosing git repository"
     );
 
-    // The paired negative: gix's own walk escapes the boundary on this very
-    // fixture, so the containment above is the adapter's doing and not an
-    // accident of the shape.
+    // The paired negative: gix's own walk escapes on this very fixture, so the
+    // containment above is not an accident of the shape.
     let escaped = gix::discover(&inner)?;
     let escaped = escaped
         .workdir()
@@ -323,10 +319,6 @@ fn a_main_workspace_resolves_to_itself() -> Result<(), TestError> {
 }
 
 // --- The jj revision route ---
-//
-// Read from the workspace's checkout state plus the operation store, with no jj
-// settings value and no write. These pin the properties that route rests on;
-// `assert_parity` above already pins agreement with the `jj` binary.
 
 /// The commit id the `jj` binary reports for `@`.
 fn jj_revision_oracle(root: &Path) -> Result<String, TestError> {
@@ -348,8 +340,7 @@ fn a_pure_jj_workspace_reports_its_working_copy_commit() -> Result<(), TestError
     fs::write(root.join("file"), "content")?;
     run("jj", &["commit", "-m", "one"], &root)?;
 
-    // The point of a --no-colocate fixture: there is no git HEAD to fall back
-    // to, so this can only have come from the jj side.
+    // No git HEAD to fall back to, so this can only have come from the jj side.
     assert!(!root.join(".git").exists(), "the fixture must be pure jj");
     assert_eq!(
         InProcessProbe.revision(&root, VcsKind::Jj),
@@ -384,9 +375,7 @@ fn each_workspace_reports_its_own_commit_not_its_neighbour_s(
 
     assert_eq!(main_revision, Some(jj_revision_oracle(&main)?));
     assert_eq!(secondary_revision, Some(jj_revision_oracle(&secondary)?));
-    // The load-bearing assertion: the route looks the commit up by the
-    // workspace's own name, so two workspaces sharing one operation store get
-    // different answers. Taking the view's sole entry would pass every
+    // The load-bearing one: taking the view's sole entry would pass every
     // single-workspace test and answer for the wrong workspace here.
     assert_ne!(
         main_revision, secondary_revision,
@@ -412,9 +401,8 @@ fn an_unreadable_checkout_state_reports_absence_rather_than_a_wrong_commit(
     );
     fs::write(&checkout, b"not a protobuf")?;
 
-    // The port method's signature carries no error channel, so a failure is
-    // warn-logged and reported as absence — the same contract the subprocess
-    // probe has always had. What must not happen is a panic or a stale answer.
+    // The port carries no error channel, so a failure is warn-logged absence.
+    // What must not happen is a panic or a stale answer.
     assert_eq!(InProcessProbe.revision(&root, VcsKind::Jj), None);
     Ok(())
 }
@@ -428,10 +416,8 @@ fn reading_the_revision_writes_nothing() -> Result<(), TestError> {
     fs::write(root.join("file"), "content")?;
     run("jj", &["commit", "-m", "one"], &root)?;
 
-    // The probe has to be usable on a read-only filesystem, and one jj store
-    // loader in this area does create directories on load. Fingerprint the whole
-    // .jj tree rather than spot-checking, so a create, delete or modify anywhere
-    // is caught.
+    // One jj store loader in this area does create directories on load, so
+    // fingerprint the whole tree rather than spot-checking.
     let before = fingerprint(&root.join(".jj"))?;
     assert!(InProcessProbe.revision(&root, VcsKind::Jj).is_some());
     assert_eq!(
@@ -459,21 +445,18 @@ fn an_unsnapshotted_edit_is_the_one_documented_divergence(
         "in sync to begin"
     );
 
-    // Change the tree without running any jj command, so the recorded operation
-    // is now behind the working copy.
+    // No jj command, so the recorded operation falls behind the working copy.
     fs::write(root.join("untracked"), "edited outside jj")?;
 
-    // The in-process route still reports the last recorded commit: it does not
-    // snapshot, because a probe that must work on a read-only filesystem cannot.
+    // Still the last recorded commit: this route does not snapshot.
     assert_eq!(
         InProcessProbe.revision(&root, VcsKind::Jj),
         recorded,
         "the in-process route must not snapshot"
     );
 
-    // The subprocess probe snapshots first, so it reports a *different* commit —
-    // and creates it. This is the divergence, and it is also a write side effect
-    // on the user's repository that the in-process route removes.
+    // The subprocess probe snapshots first, so it reports a different commit —
+    // and creates it. That write is what the in-process route removes.
     let snapshotted = CommandProbe::new().revision(&root, VcsKind::Jj);
     assert!(snapshotted.is_some());
     assert_ne!(
@@ -481,7 +464,7 @@ fn an_unsnapshotted_edit_is_the_one_documented_divergence(
         "asking the jj binary snapshots, so it should report a new commit here"
     );
 
-    // Having snapshotted, the recorded state has moved, and the two agree again.
+    // The recorded state has now moved, and the two agree again.
     assert_eq!(
         InProcessProbe.revision(&root, VcsKind::Jj),
         snapshotted,

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -24,8 +24,8 @@ use vcs::RepoRoot;
 use vcs::VcsKind;
 use vcs::VcsProbe;
 use vcs_adapters::library::InProcessProbe;
-use vcs_adapters::CommandProbe;
-use vcs_adapters::MarkerWalkRoot;
+use vcs_adapters::subprocess::CommandProbe;
+use vcs_adapters::subprocess::MarkerWalkRoot;
 
 type TestError = Box<dyn std::error::Error>;
 

--- a/cli/vcs-adapters/tests/queries.rs
+++ b/cli/vcs-adapters/tests/queries.rs
@@ -1,16 +1,14 @@
-//! The six taxonomy queries against every (fixture, start directory) pair.
+//! The six taxonomy queries against every (fixture, start directory) pair,
+//! compared against values measured from the live `git`/`jj` CLIs.
 //!
-//! Every expected value below is traceable to a cell in the oracle mapping
-//! recorded in the plan, and was re-measured against the live `git`/`jj` CLIs
-//! when this suite was written. Values are compared as rendered strings so a
-//! failure names the cell rather than dumping a nested `Debug`.
+//! Values are compared as rendered strings so a failure names the cell rather
+//! than dumping a nested `Debug`.
 //!
-//! One test over the whole table rather than one test per pair: nextest is
+//! One test over the whole table rather than one per pair: nextest is
 //! process-per-test with no sharing, so a test per pair would rebuild the
-//! ~34-fixture matrix 34 times — each build driving dozens of `git`/`jj`
-//! subprocesses, on both legs of the OS matrix, against a suite with a
-//! documented flake history under parallel CI load. Every mismatch is collected
-//! and reported together, so per-cell traceability is kept.
+//! ~34-fixture matrix 34 times, each build driving dozens of `git`/`jj`
+//! subprocesses. Every mismatch is collected and reported together, so per-cell
+//! traceability is kept.
 #![cfg(feature = "bash-parity")]
 
 use std::fmt::Write as _;

--- a/cli/vcs-adapters/tests/queries.rs
+++ b/cli/vcs-adapters/tests/queries.rs
@@ -21,7 +21,6 @@ use vcs_adapters::library::JjRepositoryFacts;
 use vcs_adapters::library::JjWorkspaceRole;
 use vcs_adapters::library::WorktreeFacts;
 use vcs_test_support::fixtures::Matrix;
-use vcs_test_support::hermetic::assert_git_is_recent_enough;
 
 type TestError = Box<dyn std::error::Error>;
 
@@ -399,7 +398,6 @@ fn dual_cell(roots: &DualRoots) -> String {
 
 #[test]
 fn every_query_matches_the_recorded_oracle_mapping() -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-queries-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
     let probe = InProcessProbe;
@@ -465,7 +463,6 @@ fn every_query_matches_the_recorded_oracle_mapping() -> Result<(), TestError> {
 #[test]
 fn a_relative_start_resolves_the_same_as_an_absolute_one(
 ) -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-relative-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
     let probe = InProcessProbe;
@@ -511,7 +508,6 @@ fn a_relative_start_resolves_the_same_as_an_absolute_one(
 
 #[test]
 fn failure_and_absence_are_distinguishable() -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-errors-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
     let probe = InProcessProbe;
@@ -560,7 +556,6 @@ fn failure_and_absence_are_distinguishable() -> Result<(), TestError> {
 #[test]
 fn an_unsupported_object_format_fails_rather_than_misreads(
 ) -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-formats-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
     let probe = InProcessProbe;
@@ -585,7 +580,6 @@ fn an_unsupported_object_format_fails_rather_than_misreads(
 #[test]
 fn a_one_sided_failure_leaves_the_other_side_readable() -> Result<(), TestError>
 {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-onesided-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
 

--- a/cli/vcs-adapters/tests/queries.rs
+++ b/cli/vcs-adapters/tests/queries.rs
@@ -1,0 +1,635 @@
+//! The six taxonomy queries against every (fixture, start directory) pair.
+//!
+//! Every expected value below is traceable to a cell in the oracle mapping
+//! recorded in the plan, and was re-measured against the live `git`/`jj` CLIs
+//! when this suite was written. Values are compared as rendered strings so a
+//! failure names the cell rather than dumping a nested `Debug`.
+//!
+//! One test over the whole table rather than one test per pair: nextest is
+//! process-per-test with no sharing, so a test per pair would rebuild the
+//! ~34-fixture matrix 34 times — each build driving dozens of `git`/`jj`
+//! subprocesses, on both legs of the OS matrix, against a suite with a
+//! documented flake history under parallel CI load. Every mismatch is collected
+//! and reported together, so per-cell traceability is kept.
+#![cfg(feature = "bash-parity")]
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use vcs_adapters::library::DualRoots;
+use vcs_adapters::library::Error;
+use vcs_adapters::library::InProcessProbe;
+use vcs_adapters::library::JjRepositoryFacts;
+use vcs_adapters::library::JjWorkspaceRole;
+use vcs_adapters::library::WorktreeFacts;
+use vcs_test_support::fixtures::Matrix;
+use vcs_test_support::hermetic::assert_git_is_recent_enough;
+
+type TestError = Box<dyn std::error::Error>;
+
+/// The expected rendering of all six queries for one pair. `$B` stands for the
+/// matrix base directory.
+struct Cells {
+    key: &'static str,
+    is_bare: &'static str,
+    worktree: &'static str,
+    superproject: &'static str,
+    jj_workspace_root: &'static str,
+    jj_repository: &'static str,
+    dual_roots: &'static str,
+}
+
+const EXPECTED: &[Cells] = &[
+    Cells {
+        key: "PG-r",
+        is_bare: "false",
+        worktree: "linked=false git=$B/PG/.git common=$B/PG/.git main=$B/PG",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/PG jj=absent",
+    },
+    Cells {
+        key: "PG-s",
+        is_bare: "false",
+        worktree: "linked=false git=$B/PG/.git common=$B/PG/.git main=$B/PG",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/PG jj=absent",
+    },
+    Cells {
+        key: "WT-l",
+        is_bare: "false",
+        worktree: "linked=true git=$B/main/.git/worktrees/WT common=$B/main/.git main=$B/main",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/WT jj=absent",
+    },
+    Cells {
+        key: "WT-m",
+        is_bare: "false",
+        worktree: "linked=false git=$B/main/.git common=$B/main/.git main=$B/main",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/main jj=absent",
+    },
+    Cells {
+        key: "BARE",
+        is_bare: "true",
+        worktree: "linked=false git=$B/bare common=$B/bare main=absent",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=absent jj=absent",
+    },
+    Cells {
+        key: "NONE",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=absent jj=absent",
+    },
+    Cells {
+        key: "CR",
+        is_bare: "false",
+        worktree: "linked=false git=$B/CR/.git common=$B/CR/.git main=$B/CR",
+        superproject: "absent",
+        jj_workspace_root: "$B/CR",
+        jj_repository: "main $B/CR",
+        dual_roots: "git=$B/CR jj=$B/CR",
+    },
+    Cells {
+        key: "CG",
+        is_bare: "false",
+        worktree: "linked=true git=$B/gitparent-cg/.git/worktrees/CG common=$B/gitparent-cg/.git main=$B/gitparent-cg",
+        superproject: "absent",
+        jj_workspace_root: "$B/CG",
+        jj_repository: "secondary $B/jjparent",
+        dual_roots: "git=$B/CG jj=$B/CG",
+    },
+    Cells {
+        key: "JS-r",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/JS",
+        jj_repository: "secondary $B/jjmain-colocated",
+        dual_roots: "git=absent jj=$B/JS",
+    },
+    Cells {
+        key: "JS-s",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/JS",
+        jj_repository: "secondary $B/jjmain-colocated",
+        dual_roots: "git=absent jj=$B/JS",
+    },
+    Cells {
+        key: "PJ",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/PJ/a/b/c",
+        jj_repository: "main $B/PJ/a/b/c",
+        dual_roots: "git=absent jj=$B/PJ/a/b/c",
+    },
+    Cells {
+        key: "PJS",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/PJS",
+        jj_repository: "secondary $B/PJ/a/b/c",
+        dual_roots: "git=absent jj=$B/PJS",
+    },
+    Cells {
+        key: "JS-in",
+        is_bare: "false",
+        worktree: "linked=false git=$B/JSIN/.git common=$B/JSIN/.git main=$B/JSIN",
+        superproject: "absent",
+        jj_workspace_root: "$B/JSIN/workspaces/inner",
+        jj_repository: "secondary $B/JSIN",
+        dual_roots: "git=$B/JSIN jj=$B/JSIN/workspaces/inner",
+    },
+    Cells {
+        key: "NJG-i",
+        is_bare: "false",
+        worktree: "linked=false git=$B/NJG/.git common=$B/NJG/.git main=$B/NJG",
+        superproject: "absent",
+        jj_workspace_root: "$B/NJG/sub",
+        jj_repository: "secondary $B/jjmain-colocated",
+        dual_roots: "git=$B/NJG jj=$B/NJG/sub",
+    },
+    Cells {
+        key: "NJG-o",
+        is_bare: "false",
+        worktree: "linked=false git=$B/NJG/.git common=$B/NJG/.git main=$B/NJG",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/NJG jj=absent",
+    },
+    Cells {
+        key: "NGJ-i",
+        is_bare: "false",
+        worktree: "linked=true git=$B/gitparent-ngj/.git/worktrees/sub common=$B/gitparent-ngj/.git main=$B/gitparent-ngj",
+        superproject: "absent",
+        jj_workspace_root: "$B/NGJ",
+        jj_repository: "main $B/NGJ",
+        dual_roots: "git=$B/NGJ/sub jj=$B/NGJ",
+    },
+    Cells {
+        key: "NGJ-o",
+        is_bare: "false",
+        worktree: "linked=false git=$B/NGJ/.git common=$B/NGJ/.git main=$B/NGJ",
+        superproject: "absent",
+        jj_workspace_root: "$B/NGJ",
+        jj_repository: "main $B/NGJ",
+        dual_roots: "git=$B/NGJ jj=$B/NGJ",
+    },
+    Cells {
+        key: "NGPJ-i",
+        is_bare: "false",
+        worktree: "linked=true git=$B/gitparent-ngpj/.git/worktrees/sub common=$B/gitparent-ngpj/.git main=$B/gitparent-ngpj",
+        superproject: "absent",
+        jj_workspace_root: "$B/NGPJ",
+        jj_repository: "main $B/NGPJ",
+        dual_roots: "git=$B/NGPJ/sub jj=$B/NGPJ",
+    },
+    Cells {
+        key: "NGPJ-o",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/NGPJ",
+        jj_repository: "main $B/NGPJ",
+        dual_roots: "git=absent jj=$B/NGPJ",
+    },
+    Cells {
+        key: "PJG-i",
+        is_bare: "false",
+        worktree: "linked=false git=$B/PJG/.git common=$B/PJG/.git main=$B/PJG",
+        superproject: "absent",
+        jj_workspace_root: "$B/PJG/sub",
+        jj_repository: "secondary $B/jjmain-pure",
+        dual_roots: "git=$B/PJG jj=$B/PJG/sub",
+    },
+    Cells {
+        key: "PJG-o",
+        is_bare: "false",
+        worktree: "linked=false git=$B/PJG/.git common=$B/PJG/.git main=$B/PJG",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/PJG jj=absent",
+    },
+    Cells {
+        key: "SM-1",
+        is_bare: "false",
+        worktree: "linked=false git=$B/super/.git/modules/mid common=$B/super/.git/modules/mid main=$B/super/mid",
+        superproject: "$B/super",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/super/mid jj=absent",
+    },
+    Cells {
+        key: "SM-2",
+        is_bare: "false",
+        worktree: "linked=false git=$B/super/.git/modules/mid/modules/leaf common=$B/super/.git/modules/mid/modules/leaf main=$B/super/mid/leaf",
+        superproject: "$B/super/mid",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/super/mid/leaf jj=absent",
+    },
+    Cells {
+        key: "SM-s",
+        is_bare: "false",
+        worktree: "linked=false git=$B/super/.git common=$B/super/.git main=$B/super",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/super jj=absent",
+    },
+    Cells {
+        key: "SO",
+        is_bare: "false",
+        worktree: "linked=false git=$B/old/inner/.git common=$B/old/inner/.git main=$B/old/inner",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/old/inner jj=absent",
+    },
+    Cells {
+        key: "SM-m",
+        is_bare: "false",
+        worktree: "linked=false git=$B/supm/.git/modules/modules/foo common=$B/supm/.git/modules/modules/foo main=$B/supm/modules/foo",
+        superproject: "$B/supm",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/supm/modules/foo jj=absent",
+    },
+    Cells {
+        key: "SM-w",
+        is_bare: "false",
+        worktree: "linked=true git=$B/supw/.git/modules/mid/worktrees/smw common=$B/supw/.git/modules/mid main=absent",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/smw jj=absent",
+    },
+    Cells {
+        key: "SM-wt",
+        is_bare: "false",
+        worktree: "linked=false git=$B/supwt/.git/worktrees/supwt-wt/modules/sub common=$B/supwt/.git/worktrees/supwt-wt/modules/sub main=$B/supwt-wt/sub",
+        superproject: "$B/supwt-wt",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/supwt-wt/sub jj=absent",
+    },
+    Cells {
+        key: "RF",
+        is_bare: "false",
+        worktree: "linked=false git=$B/RF/.git common=$B/RF/.git main=$B/RF",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/RF jj=absent",
+    },
+    Cells {
+        key: "S256",
+        is_bare: "error",
+        worktree: "error",
+        superproject: "error",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=error jj=absent",
+    },
+    Cells {
+        key: "HOSTILE",
+        is_bare: "false",
+        worktree: "linked=false git=$B/HOSTILE/.git common=$B/HOSTILE/.git main=$B/HOSTILE",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=$B/HOSTILE jj=absent",
+    },
+    Cells {
+        key: "D1",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "error",
+        jj_repository: "error",
+        dual_roots: "git=absent jj=error",
+    },
+    Cells {
+        key: "D2",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "absent",
+        jj_repository: "absent",
+        dual_roots: "git=absent jj=absent",
+    },
+    Cells {
+        key: "D3",
+        is_bare: "absent",
+        worktree: "absent",
+        superproject: "absent",
+        jj_workspace_root: "$B/D3",
+        jj_repository: "error",
+        dual_roots: "git=absent jj=$B/D3",
+    },
+];
+
+fn simple<T: std::fmt::Display>(value: &Result<Option<T>, Error>) -> String {
+    match value {
+        Ok(Some(inner)) => inner.to_string(),
+        Ok(None) => "absent".to_owned(),
+        Err(_) => "error".to_owned(),
+    }
+}
+
+fn path_cell(value: &Result<Option<std::path::PathBuf>, Error>) -> String {
+    match value {
+        Ok(Some(path)) => path.display().to_string(),
+        Ok(None) => "absent".to_owned(),
+        Err(_) => "error".to_owned(),
+    }
+}
+
+fn worktree_cell(value: &Result<Option<WorktreeFacts>, Error>) -> String {
+    match value {
+        Ok(Some(facts)) => format!(
+            "linked={} git={} common={} main={}",
+            facts.linked,
+            facts.git_dir.display(),
+            facts.common_dir.display(),
+            facts.main_worktree_root.as_ref().map_or_else(
+                || "absent".to_owned(),
+                |path| path.display().to_string()
+            )
+        ),
+        Ok(None) => "absent".to_owned(),
+        Err(_) => "error".to_owned(),
+    }
+}
+
+fn repository_cell(value: &Result<Option<JjRepositoryFacts>, Error>) -> String {
+    match value {
+        Ok(Some(facts)) => {
+            let role = match facts.role {
+                JjWorkspaceRole::Main => "main",
+                JjWorkspaceRole::Secondary => "secondary",
+            };
+            format!("{role} {}", facts.main_root.display())
+        }
+        Ok(None) => "absent".to_owned(),
+        Err(_) => "error".to_owned(),
+    }
+}
+
+fn dual_cell(roots: &DualRoots) -> String {
+    format!("git={} jj={}", path_cell(&roots.git), path_cell(&roots.jj))
+}
+
+#[test]
+fn every_query_matches_the_recorded_oracle_mapping() -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-queries-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+    let probe = InProcessProbe;
+    let root = matrix.base.display().to_string();
+
+    let mut failures = String::new();
+    for cells in EXPECTED {
+        let start = matrix.start(cells.key)?;
+        let mut check = |query: &str, actual: &str, expected: &str| {
+            let expected = expected.replace("$B", &root);
+            if actual != expected {
+                let _ = writeln!(
+                    failures,
+                    "  {}/{query}\n    expected {expected}\n    actual   {actual}",
+                    cells.key
+                );
+            }
+        };
+
+        check("is_bare", &simple(&probe.is_bare(start)), cells.is_bare);
+        check(
+            "worktree",
+            &worktree_cell(&probe.worktree(start)),
+            cells.worktree,
+        );
+        check(
+            "superproject",
+            &path_cell(&probe.superproject(start)),
+            cells.superproject,
+        );
+        check(
+            "jj_workspace_root",
+            &path_cell(&probe.jj_workspace_root(start)),
+            cells.jj_workspace_root,
+        );
+        check(
+            "jj_repository",
+            &repository_cell(&probe.jj_repository(start)),
+            cells.jj_repository,
+        );
+        check(
+            "dual_roots",
+            &dual_cell(&probe.dual_roots(start)),
+            cells.dual_roots,
+        );
+    }
+
+    assert!(failures.is_empty(), "query mismatches:\n{failures}");
+    assert_eq!(
+        EXPECTED.len(),
+        matrix.fixtures.len(),
+        "the matrix and the expectation table have drifted apart"
+    );
+    Ok(())
+}
+
+/// The relative-start precondition, one test per walk.
+///
+/// `gix::discover` absolutises against the process cwd internally while the
+/// marker walk is purely lexical, so without the choke point a relative start
+/// makes a colocated checkout report a git root and no jj root — the wrong arm.
+/// The matrix cannot catch this, because every fixture path is absolute.
+#[test]
+fn a_relative_start_resolves_the_same_as_an_absolute_one(
+) -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-relative-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+    let probe = InProcessProbe;
+
+    // A colocated checkout is the discriminating shape: both walks must find it.
+    let absolute = matrix.start("CR")?;
+    let parent = absolute.parent().ok_or("CR has no parent")?;
+    let name = absolute.file_name().ok_or("CR has no final component")?;
+
+    let previous = std::env::current_dir()?;
+    std::env::set_current_dir(parent)?;
+    let relative = Path::new(name);
+
+    let roots = probe.dual_roots(relative);
+    let git_root = path_cell(&roots.git);
+    let jj_root = path_cell(&roots.jj);
+    let bareness = simple(&probe.is_bare(relative));
+    let facts = worktree_cell(&probe.worktree(relative));
+    std::env::set_current_dir(previous)?;
+
+    let expected = absolute.display().to_string();
+    assert_eq!(
+        git_root, expected,
+        "the gix walk disagreed on a relative start"
+    );
+    assert_eq!(
+        jj_root, expected,
+        "the .jj-only walk disagreed on a relative start"
+    );
+    assert_eq!(bareness, "false");
+    assert!(
+        facts.starts_with("linked=false"),
+        "worktree disagreed on a relative start: {facts}"
+    );
+    Ok(())
+}
+
+// --- The error channel, asserted specifically ---
+//
+// The table above renders every failure as the single token `error`, which
+// proves a cell is not `Ok` but not *which* failure it is. These pin the
+// distinctions the `Result<Option<T>, _>` signature exists to carry.
+
+#[test]
+fn failure_and_absence_are_distinguishable() -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-errors-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+    let probe = InProcessProbe;
+
+    // D3 is the load-bearing degenerate: its `.jj/repo` points at an existing
+    // directory that is not a store, so `jj workspace root` *succeeds*. Only
+    // the `<main_root>/.jj/repo` post-condition separates a real answer from a
+    // plausible wrong one — without it this reports Secondary with a bogus
+    // root, which would become RepoFacts.name and stamp artifacts with the
+    // wrong repository.
+    let wrong_store = matrix.start("D3")?;
+    assert!(
+        matches!(probe.jj_workspace_root(wrong_store), Ok(Some(_))),
+        "D3's workspace root should resolve, matching `jj workspace root`"
+    );
+    assert!(
+        probe.jj_repository(wrong_store).is_err(),
+        "D3's store post-condition must fail rather than yield a wrong root"
+    );
+
+    // A tree with no repository at all is absence, not failure — the other half
+    // of the distinction, without which the assertions above are vacuous.
+    let loose = matrix.start("NONE")?;
+    assert!(matches!(probe.jj_workspace_root(loose), Ok(None)));
+    assert!(matches!(probe.jj_repository(loose), Ok(None)));
+    assert!(matches!(probe.is_bare(loose), Ok(None)));
+    assert!(matches!(probe.worktree(loose), Ok(None)));
+
+    // D1's `.jj/repo` points at a *deleted* directory. Both CLIs report plain
+    // absence, but a `.jj` tree that cannot be read is not the same as no jj
+    // repository here, so this is `Err` — a deliberate divergence from the
+    // oracle, and the one the partition rule requires.
+    let deleted_store = matrix.start("D1")?;
+    assert!(
+        probe.jj_workspace_root(deleted_store).is_err(),
+        "a broken .jj/repo pointer must not read as `no VCS here`"
+    );
+
+    // D2's git side genuinely finds no repository, so it is absence.
+    let broken_worktree = matrix.start("D2")?;
+    assert!(matches!(probe.worktree(broken_worktree), Ok(None)));
+    assert!(matches!(probe.jj_workspace_root(broken_worktree), Ok(None)));
+    Ok(())
+}
+
+#[test]
+fn an_unsupported_object_format_fails_rather_than_misreads(
+) -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-formats-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+    let probe = InProcessProbe;
+
+    // gix 0.85 rejects extensions.objectFormat = sha256. Erroring is the
+    // correct outcome under the partition rule — a repository IS here and the
+    // pinned library cannot answer — and is why the queries carry an error
+    // channel at all. Collapsing it to `Ok(None)` would report "no repository"
+    // for a perfectly valid checkout.
+    let sha256 = matrix.start("S256")?;
+    assert!(probe.is_bare(sha256).is_err());
+    assert!(probe.worktree(sha256).is_err());
+    assert!(probe.dual_roots(sha256).git.is_err());
+
+    // The reftable backend, by contrast, reads normally.
+    let reftable = matrix.start("RF")?;
+    assert!(matches!(probe.is_bare(reftable), Ok(Some(false))));
+    assert!(matches!(probe.worktree(reftable), Ok(Some(_))));
+    Ok(())
+}
+
+#[test]
+fn a_one_sided_failure_leaves_the_other_side_readable() -> Result<(), TestError>
+{
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-onesided-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+
+    // The whole reason dual_roots carries a Result per side: a repository whose
+    // git side the pinned library cannot parse must never be observable as
+    // "jj only", which is what a whole-struct Result flattened to None would do
+    // on the single field that separates colocated from nested.
+    let roots = InProcessProbe.dual_roots(matrix.start("S256")?);
+    assert!(roots.git.is_err(), "the git side should report its failure");
+    assert!(
+        matches!(roots.jj, Ok(None)),
+        "the jj side should still answer"
+    );
+    Ok(())
+}
+
+/// The declared pins agree by construction — `test_vcs_pin_lockstep.py` asserts
+/// that. What nothing else checks is that the `jj` **binary** building these
+/// fixtures matches the `jj-lib` the queries read them with. This session's
+/// planning hit exactly that skew (a Homebrew jj 0.42 against a jj-lib 0.43
+/// design), and it surfaces as an apparently wrong answer in a 34-row
+/// expected-value table rather than as a version mismatch.
+#[test]
+fn the_jj_binary_matches_the_resolved_library() -> Result<(), TestError> {
+    // The resolved version, not the declared requirement: the tilde range
+    // deliberately permits a patch to float, and the lock is what says which
+    // one is actually linked.
+    let lock = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../Cargo.lock"),
+    )?;
+    let resolved = lock
+        .split("[[package]]")
+        .find_map(|entry| {
+            entry.contains("name = \"jj-lib\"").then(|| {
+                entry
+                    .lines()
+                    .find_map(|line| line.strip_prefix("version = "))
+                    .map(|value| value.trim_matches('"').to_owned())
+            })?
+        })
+        .ok_or("jj-lib is not in cli/Cargo.lock")?;
+
+    vcs_test_support::hermetic::assert_jj_matches(&resolved)?;
+    Ok(())
+}

--- a/cli/vcs-adapters/tests/scrub.rs
+++ b/cli/vcs-adapters/tests/scrub.rs
@@ -1,27 +1,22 @@
-//! The scrub invariant: every query answers identically whether or not the
-//! ambient git and jj environment is poisoned.
+//! Every query answers identically whether or not the ambient git and jj
+//! environment is poisoned.
 //!
-//! This is a property to **verify**, not to implement. `gix::discover`/
-//! `gix::open` do not consult the environment, and jj-lib's workspace loader is
-//! pure filesystem reads, so no scrub is written — but the claim is only worth
-//! anything if it is checked, and checked against a poison that would really
-//! change the answer.
+//! A property to verify rather than implement: `gix::discover`/`gix::open` do
+//! not consult the environment and jj-lib's loader is pure filesystem reads, so
+//! nothing scrubs — but the claim is only worth checking against a poison that
+//! would really change the answer.
 //!
 //! Poison means *another fixture's real `.git`*, not an empty or nonexistent
-//! path, which both git and the libraries ignore. The variable set is
-//! everything `scrub_environment` touches, **plus** the object-directory and
-//! `GIT_CONFIG_COUNT` families: `gix::open`'s default permissions do consult the
-//! environment for object directories and for system/global config discovery,
-//! and `is_bare()` reads `core.bare` *through* that config, so verifying two
-//! variables and generalising to "uniformly immune" would be broader than the
-//! evidence.
+//! path, which both git and the libraries ignore. The variable set covers the
+//! object-directory and `GIT_CONFIG_COUNT` families as well, because
+//! `gix::open`'s default permissions do consult the environment for object
+//! directories and for config discovery, and `is_bare()` reads `core.bare`
+//! through that config.
 //!
-//! Both arms run through the same child binary. Comparing an in-process value
-//! against a child's rendered output would compare two serialisation routes —
-//! producing false failures across the matrix, and the more dangerous false
-//! pass where both arms render absence identically for different reasons. A
-//! child is needed at all because libtest runs each test on a spawned thread,
-//! so in-process `set_var` is racy by construction.
+//! Both arms run through the same child binary: comparing an in-process value
+//! against a child's rendered output would compare two serialisation routes. A
+//! child is needed at all because libtest runs each test on a spawned thread, so
+//! in-process `set_var` is racy by construction.
 #![cfg(feature = "bash-parity")]
 
 use std::fmt::Write as _;

--- a/cli/vcs-adapters/tests/scrub.rs
+++ b/cli/vcs-adapters/tests/scrub.rs
@@ -25,7 +25,6 @@ use std::path::Path;
 use std::process::Command;
 
 use vcs_test_support::fixtures::Matrix;
-use vcs_test_support::hermetic::assert_git_is_recent_enough;
 
 type TestError = Box<dyn std::error::Error>;
 
@@ -85,7 +84,6 @@ impl Poison {
 
 #[test]
 fn every_query_is_unmoved_by_a_poisoned_environment() -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new().prefix("vcs-scrub-").tempdir()?;
     let matrix = Matrix::build_in(base.path())?;
 
@@ -125,7 +123,6 @@ fn every_query_is_unmoved_by_a_poisoned_environment() -> Result<(), TestError> {
 
 #[test]
 fn the_poison_is_live() -> Result<(), TestError> {
-    assert_git_is_recent_enough()?;
     let base = tempfile::Builder::new()
         .prefix("vcs-scrub-control-")
         .tempdir()?;

--- a/cli/vcs-adapters/tests/scrub.rs
+++ b/cli/vcs-adapters/tests/scrub.rs
@@ -1,0 +1,166 @@
+//! The scrub invariant: every query answers identically whether or not the
+//! ambient git and jj environment is poisoned.
+//!
+//! This is a property to **verify**, not to implement. `gix::discover`/
+//! `gix::open` do not consult the environment, and jj-lib's workspace loader is
+//! pure filesystem reads, so no scrub is written — but the claim is only worth
+//! anything if it is checked, and checked against a poison that would really
+//! change the answer.
+//!
+//! Poison means *another fixture's real `.git`*, not an empty or nonexistent
+//! path, which both git and the libraries ignore. The variable set is
+//! everything `scrub_environment` touches, **plus** the object-directory and
+//! `GIT_CONFIG_COUNT` families: `gix::open`'s default permissions do consult the
+//! environment for object directories and for system/global config discovery,
+//! and `is_bare()` reads `core.bare` *through* that config, so verifying two
+//! variables and generalising to "uniformly immune" would be broader than the
+//! evidence.
+//!
+//! Both arms run through the same child binary. Comparing an in-process value
+//! against a child's rendered output would compare two serialisation routes —
+//! producing false failures across the matrix, and the more dangerous false
+//! pass where both arms render absence identically for different reasons. A
+//! child is needed at all because libtest runs each test on a spawned thread,
+//! so in-process `set_var` is racy by construction.
+#![cfg(feature = "bash-parity")]
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use vcs_test_support::fixtures::Matrix;
+use vcs_test_support::hermetic::assert_git_is_recent_enough;
+
+type TestError = Box<dyn std::error::Error>;
+
+const FIXTURE: &str = env!("CARGO_BIN_EXE_vcs-adapters-fixture");
+
+fn run(start: &Path, poison: Option<&Poison>) -> Result<String, TestError> {
+    let mut command = Command::new(FIXTURE);
+    command.arg("all").arg(start);
+    if let Some(poison) = poison {
+        poison.apply(&mut command);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "fixture binary failed for {}: {}",
+            start.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Every variable the subprocess probe scrubs or forces, plus the two families
+/// `gix::open`'s default permissions actually consult.
+struct Poison {
+    git_dir: String,
+    global_config: String,
+}
+
+impl Poison {
+    fn apply(&self, command: &mut Command) {
+        for key in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_COMMON_DIR",
+            "GIT_OBJECT_DIRECTORY",
+        ] {
+            command.env(key, &self.git_dir);
+        }
+        command.env("GIT_INDEX_FILE", format!("{}/index", self.git_dir));
+        command.env(
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            format!("{}/objects", self.git_dir),
+        );
+        command.env("GIT_CONFIG", &self.global_config);
+        command.env("GIT_CONFIG_GLOBAL", &self.global_config);
+        command.env("GIT_CONFIG_SYSTEM", &self.global_config);
+        command.env("JJ_CONFIG", &self.global_config);
+        command.env("GIT_CONFIG_NOSYSTEM", "0");
+        // The three-part override family, which git honours as a config source.
+        command.env("GIT_CONFIG_COUNT", "1");
+        command.env("GIT_CONFIG_KEY_0", "core.bare");
+        command.env("GIT_CONFIG_VALUE_0", "true");
+    }
+}
+
+#[test]
+fn every_query_is_unmoved_by_a_poisoned_environment() -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-scrub-").tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+
+    // The poison is a *real* repository's git dir, and the global config it
+    // names asserts a divergent `core.bare` — the Phase-2 empty-config
+    // environment would otherwise mask exactly the config influence this
+    // invariant is meant to exclude.
+    let poison_repo = matrix.start("PG-r")?.join(".git");
+    let poison_config = matrix.base.join("poison.gitconfig");
+    fs::write(&poison_config, "[core]\n\tbare = true\n")?;
+    let poison = Poison {
+        git_dir: poison_repo.display().to_string(),
+        global_config: poison_config.display().to_string(),
+    };
+
+    let mut differences = String::new();
+    for fixture in &matrix.fixtures {
+        let clean = run(&fixture.start, None)?;
+        let poisoned = run(&fixture.start, Some(&poison))?;
+        if clean != poisoned {
+            writeln!(
+                differences,
+                "  {}\n    clean:    {}\n    poisoned: {}",
+                fixture.key,
+                clean.replace('\n', " | "),
+                poisoned.replace('\n', " | ")
+            )?;
+        }
+    }
+
+    assert!(
+        differences.is_empty(),
+        "the environment moved these answers:\n{differences}"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_poison_is_live() -> Result<(), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new()
+        .prefix("vcs-scrub-control-")
+        .tempdir()?;
+    let matrix = Matrix::build_in(base.path())?;
+
+    let poison_repo = matrix.start("PG-r")?.join(".git");
+    let poison_config = matrix.base.join("poison.gitconfig");
+    fs::write(&poison_config, "[core]\n\tbare = true\n")?;
+    let poison = Poison {
+        git_dir: poison_repo.display().to_string(),
+        global_config: poison_config.display().to_string(),
+    };
+
+    // `discover_with_environment_overrides` is the ready-made control: same
+    // library, same fixture, same poison — but it *does* read the environment.
+    // Without it the invariant above could hold because nothing was poisoned.
+    let start = matrix.start("NGJ-o")?;
+    let mut command = Command::new(FIXTURE);
+    command.arg("control").arg(start);
+    poison.apply(&mut command);
+    let output = command.output()?;
+    let reported = String::from_utf8(output.stdout)?;
+
+    let expected = poison_repo.canonicalize()?;
+    assert!(
+        reported.contains(&expected.display().to_string()),
+        "the control should have resolved the poison target {}, but reported \
+         {reported} — if it did not, the poisoning is not live and the \
+         invariant test above proves nothing",
+        expected.display()
+    );
+    Ok(())
+}

--- a/cli/vcs-test-support/Cargo.toml
+++ b/cli/vcs-test-support/Cargo.toml
@@ -17,6 +17,3 @@ workspace = true
 # separate crate rather than a feature.
 [dependencies]
 tempfile = { workspace = true }
-
-[dev-dependencies]
-tempfile = { workspace = true }

--- a/cli/vcs-test-support/Cargo.toml
+++ b/cli/vcs-test-support/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vcs-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+# Deliberately no edge to vcs-adapters. The fixtures, the hermetic environment
+# and the stubs need only tempfile and the real git/jj binaries, and taking that
+# edge would create a dev-dependency cycle (vcs-adapters tests ->
+# vcs-test-support -> vcs-adapters) that also forces vcs-adapters to be compiled
+# with bash-parity on via a *normal* edge — weakening the whole reason this is a
+# separate crate rather than a feature.
+[dependencies]
+tempfile = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/cli/vcs-test-support/src/fixtures.rs
+++ b/cli/vcs-test-support/src/fixtures.rs
@@ -1,14 +1,11 @@
-//! The checkout fixture matrix.
-//!
-//! Every shape the taxonomy queries must tell apart, built with the real `git`
-//! and `jj` binaries — that is what `bash-parity` means — beneath a
-//! caller-supplied root.
+//! The checkout fixture matrix: every shape the taxonomy queries must tell
+//! apart, built with the real `git` and `jj` binaries beneath a caller-supplied
+//! root.
 //!
 //! The root is supplied rather than owned. A builder holding a
-//! `tempfile::TempDir` deletes the tree on drop, which is right for an
-//! in-process test and wrong for a CI job that builds the matrix in one step
-//! and consumes it in another. Callers that want the guard create the `TempDir`
-//! themselves and pass its path.
+//! `tempfile::TempDir` deletes the tree on drop, which is right in-process and
+//! wrong for a CI job that builds the matrix in one step and consumes it in
+//! another.
 
 use std::fmt::Write as _;
 use std::fs;
@@ -147,8 +144,7 @@ fn add_git_shapes(
     );
     builder.add("WT-m", "linked git worktree, main", &worktree_main);
 
-    // A bare repository carries neither marker, so the boundary walk cannot
-    // reach it and query 1 needs its own entry point.
+    // Carries neither marker, so the boundary walk cannot reach it.
     let bare_repo = base.join("bare");
     fs::create_dir_all(&bare_repo)?;
     env.git(&["init", "--bare", "--quiet", "."], &bare_repo)?;
@@ -158,13 +154,11 @@ fn add_git_shapes(
     fs::create_dir_all(&loose)?;
     builder.add("NONE", "no repository", &loose.canonicalize()?);
 
-    // CR: a real `jj git init --colocate` main repository. It classifies as
-    // `main`, not `colocated`, because the shell's colocated arm additionally
-    // requires jj_secondary && git_worktree.
+    // Classifies as `main`, not `colocated`: that arm also wants a jj secondary
+    // workspace and a git linked worktree.
     builder.add("CR", "colocated, real", &colocated(base, "CR", env)?);
 
-    // CG: the only shape that classifies as `colocated` — one path that is
-    // simultaneously a jj secondary workspace and a git linked worktree.
+    // The only shape classifying as `colocated`: one path that is both.
     let grafted = grafted_colocated(
         base,
         "CG",
@@ -208,10 +202,8 @@ fn add_jj_shapes(
         &pure_secondary.canonicalize()?,
     );
 
-    // JS-in: a jj secondary workspace *inside* its own colocated main — this
-    // repo's own `workspaces/<name>` layout, and the shape where dual roots
-    // differ while the classification is `jj-secondary`, because the jj and git
-    // main roots are equal.
+    // Dual roots differ here while the classification is `jj-secondary`,
+    // because the jj and git main roots are equal. This repo's own layout.
     let host = colocated(base, "JSIN", env)?;
     let inner = host.join("workspaces/inner");
     // jj 0.43 does not create intermediate directories.
@@ -235,8 +227,8 @@ fn add_nested_shapes(
     env: &Hermetic,
     parents: &Parents,
 ) -> Result<(), Error> {
-    // The inner directory is a jj secondary workspace of a colocated main and
-    // carries `.jj` only, so a `.git`-inclusive walk sails past it.
+    // The inner directory carries `.jj` only, so a `.git`-inclusive walk sails
+    // past it.
     let jj_in_git = git_repo(base, "NJG", env)?;
     let jj_in_git_inner = jj_in_git.join("sub");
     env.jj(
@@ -250,8 +242,8 @@ fn add_nested_shapes(
     );
     builder.add("NJG-o", "nested-jj-in-git, outer", &jj_in_git);
 
-    // The two shapes where only the `.jj`-only walk agrees with the oracle:
-    // the boundary walk yields `sub`, and the loader reports no repo there.
+    // Only the `.jj`-only walk agrees here: the boundary walk yields `sub`, and
+    // the loader reports no repo there.
     let git_in_jj = colocated(base, "NGJ", env)?;
     let git_in_jj_inner = git_in_jj.join("sub");
     env.git(
@@ -312,8 +304,8 @@ fn add_submodule_shapes(
         &top,
     )?;
     builder.add("SM-1", "git submodule", &top.join("mid").canonicalize()?);
-    // Depth 2 is what proves the derivation takes the *nearest* `modules`
-    // component: taking the outermost names the superproject, not `mid`.
+    // Proves the derivation takes the *nearest* `modules`: the outermost names
+    // the superproject, not `mid`.
     builder.add(
         "SM-2",
         "git submodule, depth 2",
@@ -321,10 +313,8 @@ fn add_submodule_shapes(
     );
     builder.add("SM-s", "git submodule, superproject root", &top);
 
-    // An old-form submodule is a nested `.git` *directory*. It reports
-    // Kind::Common and git reports no superproject for it — the two agree, so a
-    // Kind::Submodule-only implementation would miss it with no oracle
-    // disagreement to reveal the omission.
+    // A nested `.git` *directory*. Reports Kind::Common and no superproject, so
+    // a Kind::Submodule-only implementation misses it silently.
     let outer = git_repo(base, "old", env)?;
     let nested = outer.join("inner");
     fs::create_dir_all(&nested)?;
@@ -335,9 +325,8 @@ fn add_submodule_shapes(
     )?;
     builder.add("SO", "old-form submodule", &nested.canonicalize()?);
 
-    // A submodule whose own path contains a `modules` segment, giving
-    // `<super>/.git/modules/modules/foo`. The innermost candidate's parent is
-    // not a repository, so a bare rposition stops there and reports absence.
+    // Gives `<super>/.git/modules/modules/foo`, where the innermost candidate's
+    // parent is not a repository and a bare rposition reports absence.
     let path_clash = git_repo(base, "supm", env)?;
     add_submodule(env, &path_clash, seed, "modules/foo")?;
     builder.add(
@@ -346,8 +335,7 @@ fn add_submodule_shapes(
         &path_clash.join("modules/foo").canonicalize()?,
     );
 
-    // A linked worktree *of* a submodule: the dirs differ so it is a worktree,
-    // and git reports **no** superproject for it.
+    // The dirs differ, so it is a worktree, and git reports no superproject.
     let with_worktree = git_repo(base, "supw", env)?;
     add_submodule(env, &with_worktree, seed, "mid")?;
     let submodule_worktree = base.join("smw");
@@ -361,9 +349,8 @@ fn add_submodule_shapes(
         &submodule_worktree.canonicalize()?,
     );
 
-    // A submodule initialised inside a linked worktree of the superproject.
-    // Git puts its git dir under `worktrees/<id>/modules/`, not under the
-    // common dir's `modules/`, and reports the *worktree* as the superproject.
+    // Git puts the git dir under `worktrees/<id>/modules/`, not the common
+    // dir's, and reports the *worktree* as the superproject.
     let host = git_repo(base, "supwt", env)?;
     let host_worktree = base.join("supwt-wt");
     env.git(&["worktree", "add", "-q", path_arg(&host_worktree)?], &host)?;
@@ -402,7 +389,6 @@ fn add_degenerate_shapes(
     builder: &mut Builder,
     base: &Path,
 ) -> Result<(), Error> {
-    // D1 and D2 report plain absence from both CLIs.
     let deleted_store = base.join("D1");
     fs::create_dir_all(deleted_store.join(".jj"))?;
     let gone = base.join("D1-store-gone");
@@ -427,9 +413,8 @@ fn add_degenerate_shapes(
         &broken_worktree.canonicalize()?,
     );
 
-    // D3 is the load-bearing degenerate: `jj workspace root` **succeeds**, so
-    // only the `<main_root>/.jj/repo` post-condition separates a real answer
-    // from a plausible wrong one.
+    // `jj workspace root` succeeds here, so only the `<main_root>/.jj/repo`
+    // post-condition separates a real answer from a plausible wrong one.
     let wrong_store = base.join("D3");
     fs::create_dir_all(wrong_store.join(".jj"))?;
     let not_a_store = base.join("D3-not-a-store");

--- a/cli/vcs-test-support/src/fixtures.rs
+++ b/cli/vcs-test-support/src/fixtures.rs
@@ -7,24 +7,53 @@
 //! wrong for a CI job that builds the matrix in one step and consumes it in
 //! another.
 
+use std::env;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
+use tempfile::TempDir;
+
+use crate::hermetic::assert_git_is_recent_enough;
 use crate::hermetic::assert_no_repository_ancestor;
 use crate::hermetic::Hermetic;
 use crate::Error;
+
+/// Names the root of a matrix built by an earlier step, for a caller that
+/// cannot build one itself.
+pub const MATRIX_ROOT_VARIABLE: &str = "ACCELERATOR_ZERO_SPAWN_MATRIX";
+
+/// Written beside the fixtures so a later process can adopt them.
+const MANIFEST: &str = "fixtures.tsv";
 
 /// One (fixture, start directory) pair from the matrix.
 #[derive(Debug, Clone)]
 pub struct Fixture {
     /// The key used in the recorded oracle mapping.
-    pub key: &'static str,
+    pub key: String,
     /// A one-line description of the shape, for failure messages.
-    pub shape: &'static str,
+    pub shape: String,
     /// The directory queries are invoked from. Canonicalised.
     pub start: PathBuf,
+}
+
+/// Where the matrix should live: a caller-supplied root when one is named,
+/// otherwise a temp directory the returned guard owns.
+///
+/// # Errors
+///
+/// When the temp directory cannot be created.
+pub fn matrix_root() -> Result<(Option<TempDir>, PathBuf), Error> {
+    match env::var(MATRIX_ROOT_VARIABLE) {
+        Ok(root) if !root.is_empty() => Ok((None, PathBuf::from(root))),
+        _ => {
+            let guard =
+                tempfile::Builder::new().prefix("vcs-matrix-").tempdir()?;
+            let path = guard.path().to_path_buf();
+            Ok((Some(guard), path))
+        }
+    }
 }
 
 /// Accumulates fixtures so each family builder can stay readable.
@@ -32,10 +61,10 @@ pub struct Fixture {
 struct Builder(Vec<Fixture>);
 
 impl Builder {
-    fn add(&mut self, key: &'static str, shape: &'static str, start: &Path) {
+    fn add(&mut self, key: &str, shape: &str, start: &Path) {
         self.0.push(Fixture {
-            key,
-            shape,
+            key: key.to_owned(),
+            shape: shape.to_owned(),
             start: start.to_path_buf(),
         });
     }
@@ -68,12 +97,75 @@ pub struct Matrix {
 }
 
 impl Matrix {
+    /// Adopts a matrix already built beneath `base`, or builds one there.
+    ///
+    /// Adoption needs neither `git` nor `jj`, which is what lets a CI job build
+    /// the matrix while both are still reachable and consume it after they have
+    /// been moved out of reach.
+    ///
+    /// # Errors
+    ///
+    /// When the manifest is unreadable or malformed, or a builder fails.
+    pub fn build_or_adopt(base: &Path) -> Result<Self, Error> {
+        if base.join(MANIFEST).is_file() {
+            return Self::adopt(base);
+        }
+        let built = Self::build_in(base)?;
+        built.persist()?;
+        Ok(built)
+    }
+
+    fn persist(&self) -> Result<(), Error> {
+        let mut manifest = String::new();
+        for fixture in &self.fixtures {
+            writeln!(
+                manifest,
+                "{}\t{}\t{}",
+                fixture.key,
+                fixture.shape,
+                fixture.start.display()
+            )
+            .map_err(|error| Error::message(error.to_string()))?;
+        }
+        fs::write(self.base.join(MANIFEST), manifest)?;
+        Ok(())
+    }
+
+    fn adopt(base: &Path) -> Result<Self, Error> {
+        let base = base.canonicalize()?;
+        let manifest = fs::read_to_string(base.join(MANIFEST))?;
+        let mut fixtures = Vec::new();
+        for line in manifest.lines() {
+            let mut fields = line.split('\t');
+            let (Some(key), Some(shape), Some(start), None) =
+                (fields.next(), fields.next(), fields.next(), fields.next())
+            else {
+                return Err(Error::message(format!(
+                    "malformed fixture manifest line: {line}"
+                )));
+            };
+            fixtures.push(Fixture {
+                key: key.to_owned(),
+                shape: shape.to_owned(),
+                start: PathBuf::from(start),
+            });
+        }
+        if fixtures.is_empty() {
+            return Err(Error::message(format!(
+                "the fixture manifest at {} is empty",
+                base.display()
+            )));
+        }
+        Ok(Self { base, fixtures })
+    }
+
     /// Builds every fixture beneath `base`.
     ///
     /// # Errors
     ///
     /// When `base` lies inside a repository, or any builder fails.
     pub fn build_in(base: &Path) -> Result<Self, Error> {
+        assert_git_is_recent_enough()?;
         assert_no_repository_ancestor(base)?;
         let base = base.canonicalize()?;
         let env = Hermetic::rooted_at(&base)?;

--- a/cli/vcs-test-support/src/fixtures.rs
+++ b/cli/vcs-test-support/src/fixtures.rs
@@ -1,0 +1,612 @@
+//! The checkout fixture matrix.
+//!
+//! Every shape the taxonomy queries must tell apart, built with the real `git`
+//! and `jj` binaries — that is what `bash-parity` means — beneath a
+//! caller-supplied root.
+//!
+//! The root is supplied rather than owned. A builder holding a
+//! `tempfile::TempDir` deletes the tree on drop, which is right for an
+//! in-process test and wrong for a CI job that builds the matrix in one step
+//! and consumes it in another. Callers that want the guard create the `TempDir`
+//! themselves and pass its path.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::hermetic::assert_no_repository_ancestor;
+use crate::hermetic::Hermetic;
+use crate::Error;
+
+/// One (fixture, start directory) pair from the matrix.
+#[derive(Debug, Clone)]
+pub struct Fixture {
+    /// The key used in the recorded oracle mapping.
+    pub key: &'static str,
+    /// A one-line description of the shape, for failure messages.
+    pub shape: &'static str,
+    /// The directory queries are invoked from. Canonicalised.
+    pub start: PathBuf,
+}
+
+/// Accumulates fixtures so each family builder can stay readable.
+#[derive(Debug, Default)]
+struct Builder(Vec<Fixture>);
+
+impl Builder {
+    fn add(&mut self, key: &'static str, shape: &'static str, start: &Path) {
+        self.0.push(Fixture {
+            key,
+            shape,
+            start: start.to_path_buf(),
+        });
+    }
+}
+
+/// The repositories more than one fixture hangs off.
+///
+/// Named per fixture rather than shared. Collapsing them produces two
+/// impossible identities: one jj main cannot be both colocated and
+/// `--no-colocate`, and one git parent cannot host two linked worktrees both
+/// keyed `sub` — git derives the id from the basename and de-duplicates the
+/// second to `sub1`, which would also make `worktrees()` count 3 rather than
+/// the recorded 1.
+#[derive(Debug)]
+struct Parents {
+    jj_main_colocated: PathBuf,
+    jj_main_pure: PathBuf,
+    jj_graft_source: PathBuf,
+    git_for_graft: PathBuf,
+    git_for_nested: PathBuf,
+    git_for_nested_pure: PathBuf,
+    submodule_seed: PathBuf,
+}
+
+/// The built matrix, keyed by the oracle mapping's fixture keys.
+#[derive(Debug)]
+pub struct Matrix {
+    pub base: PathBuf,
+    pub fixtures: Vec<Fixture>,
+}
+
+impl Matrix {
+    /// Builds every fixture beneath `base`.
+    ///
+    /// # Errors
+    ///
+    /// When `base` lies inside a repository, or any builder fails.
+    pub fn build_in(base: &Path) -> Result<Self, Error> {
+        assert_no_repository_ancestor(base)?;
+        let base = base.canonicalize()?;
+        let env = Hermetic::rooted_at(&base)?;
+        let parents = build_parents(&base, &env)?;
+
+        let mut builder = Builder::default();
+        add_git_shapes(&mut builder, &base, &env, &parents)?;
+        add_jj_shapes(&mut builder, &base, &env, &parents)?;
+        add_nested_shapes(&mut builder, &base, &env, &parents)?;
+        add_submodule_shapes(&mut builder, &base, &env, &parents)?;
+        add_format_shapes(&mut builder, &base, &env)?;
+        add_degenerate_shapes(&mut builder, &base)?;
+
+        Ok(Self {
+            base,
+            fixtures: builder.0,
+        })
+    }
+
+    /// The start directory recorded for `key`.
+    ///
+    /// # Errors
+    ///
+    /// When no fixture carries that key.
+    pub fn start(&self, key: &str) -> Result<&Path, Error> {
+        self.fixtures
+            .iter()
+            .find(|fixture| fixture.key == key)
+            .map(|fixture| fixture.start.as_path())
+            .ok_or_else(|| Error::message(format!("no fixture keyed {key}")))
+    }
+}
+
+fn build_parents(base: &Path, env: &Hermetic) -> Result<Parents, Error> {
+    Ok(Parents {
+        jj_main_colocated: colocated(base, "jjmain-colocated", env)?,
+        jj_main_pure: pure_jj(&base.join("jjmain-pure"), env)?,
+        jj_graft_source: colocated(base, "jjparent", env)?,
+        git_for_graft: git_repo(base, "gitparent-cg", env)?,
+        git_for_nested: git_repo(base, "gitparent-ngj", env)?,
+        git_for_nested_pure: git_repo(base, "gitparent-ngpj", env)?,
+        submodule_seed: git_repo(base, "seed", env)?,
+    })
+}
+
+/// Plain git, the linked worktree from both ends, bare, and no repository.
+fn add_git_shapes(
+    builder: &mut Builder,
+    base: &Path,
+    env: &Hermetic,
+    parents: &Parents,
+) -> Result<(), Error> {
+    let plain = git_repo(base, "PG", env)?;
+    fs::create_dir_all(plain.join("deep/er"))?;
+    builder.add("PG-r", "plain git", &plain);
+    builder.add("PG-s", "plain git, subdirectory", &plain.join("deep/er"));
+
+    let worktree_main = git_repo(base, "main", env)?;
+    let worktree_linked = base.join("WT");
+    env.git(
+        &["worktree", "add", "-q", path_arg(&worktree_linked)?],
+        &worktree_main,
+    )?;
+    builder.add(
+        "WT-l",
+        "linked git worktree, linked",
+        &worktree_linked.canonicalize()?,
+    );
+    builder.add("WT-m", "linked git worktree, main", &worktree_main);
+
+    // A bare repository carries neither marker, so the boundary walk cannot
+    // reach it and query 1 needs its own entry point.
+    let bare_repo = base.join("bare");
+    fs::create_dir_all(&bare_repo)?;
+    env.git(&["init", "--bare", "--quiet", "."], &bare_repo)?;
+    builder.add("BARE", "bare repository", &bare_repo.canonicalize()?);
+
+    let loose = base.join("none");
+    fs::create_dir_all(&loose)?;
+    builder.add("NONE", "no repository", &loose.canonicalize()?);
+
+    // CR: a real `jj git init --colocate` main repository. It classifies as
+    // `main`, not `colocated`, because the shell's colocated arm additionally
+    // requires jj_secondary && git_worktree.
+    builder.add("CR", "colocated, real", &colocated(base, "CR", env)?);
+
+    // CG: the only shape that classifies as `colocated` — one path that is
+    // simultaneously a jj secondary workspace and a git linked worktree.
+    let grafted = grafted_colocated(
+        base,
+        "CG",
+        &parents.git_for_graft,
+        &parents.jj_graft_source,
+        env,
+    )?;
+    builder.add("CG", "colocated, hand-grafted", &grafted);
+    Ok(())
+}
+
+/// The jj workspace shapes, colocated and pure.
+fn add_jj_shapes(
+    builder: &mut Builder,
+    base: &Path,
+    env: &Hermetic,
+    parents: &Parents,
+) -> Result<(), Error> {
+    let secondary = base.join("JS");
+    env.jj(
+        &["workspace", "add", path_arg(&secondary)?],
+        &parents.jj_main_colocated,
+    )?;
+    let secondary = secondary.canonicalize()?;
+    fs::create_dir_all(secondary.join("deep/er"))?;
+    builder.add("JS-r", "jj secondary workspace", &secondary);
+    builder.add(
+        "JS-s",
+        "jj secondary workspace, subdirectory",
+        &secondary.join("deep/er"),
+    );
+
+    let pure = pure_jj(&base.join("PJ/a/b/c"), env)?;
+    builder.add("PJ", "pure jj", &pure);
+
+    let pure_secondary = base.join("PJS");
+    env.jj(&["workspace", "add", path_arg(&pure_secondary)?], &pure)?;
+    builder.add(
+        "PJS",
+        "secondary of a pure-jj main",
+        &pure_secondary.canonicalize()?,
+    );
+
+    // JS-in: a jj secondary workspace *inside* its own colocated main — this
+    // repo's own `workspaces/<name>` layout, and the shape where dual roots
+    // differ while the classification is `jj-secondary`, because the jj and git
+    // main roots are equal.
+    let host = colocated(base, "JSIN", env)?;
+    let inner = host.join("workspaces/inner");
+    // jj 0.43 does not create intermediate directories.
+    fs::create_dir_all(host.join("workspaces"))?;
+    env.jj(
+        &["workspace", "add", "--name", "inner", path_arg(&inner)?],
+        &host,
+    )?;
+    builder.add(
+        "JS-in",
+        "jj secondary inside its own colocated main",
+        &inner.canonicalize()?,
+    );
+    Ok(())
+}
+
+/// The four nesting shapes, from both ends.
+fn add_nested_shapes(
+    builder: &mut Builder,
+    base: &Path,
+    env: &Hermetic,
+    parents: &Parents,
+) -> Result<(), Error> {
+    // The inner directory is a jj secondary workspace of a colocated main and
+    // carries `.jj` only, so a `.git`-inclusive walk sails past it.
+    let jj_in_git = git_repo(base, "NJG", env)?;
+    let jj_in_git_inner = jj_in_git.join("sub");
+    env.jj(
+        &["workspace", "add", path_arg(&jj_in_git_inner)?],
+        &parents.jj_main_colocated,
+    )?;
+    builder.add(
+        "NJG-i",
+        "nested-jj-in-git, inner",
+        &jj_in_git_inner.canonicalize()?,
+    );
+    builder.add("NJG-o", "nested-jj-in-git, outer", &jj_in_git);
+
+    // The two shapes where only the `.jj`-only walk agrees with the oracle:
+    // the boundary walk yields `sub`, and the loader reports no repo there.
+    let git_in_jj = colocated(base, "NGJ", env)?;
+    let git_in_jj_inner = git_in_jj.join("sub");
+    env.git(
+        &["worktree", "add", "-q", path_arg(&git_in_jj_inner)?],
+        &parents.git_for_nested,
+    )?;
+    builder.add(
+        "NGJ-i",
+        "nested-git-in-jj, inner",
+        &git_in_jj_inner.canonicalize()?,
+    );
+    builder.add("NGJ-o", "nested-git-in-jj, outer", &git_in_jj);
+
+    let git_in_pure = pure_jj(&base.join("NGPJ"), env)?;
+    let git_in_pure_inner = git_in_pure.join("sub");
+    env.git(
+        &["worktree", "add", "-q", path_arg(&git_in_pure_inner)?],
+        &parents.git_for_nested_pure,
+    )?;
+    builder.add(
+        "NGPJ-i",
+        "nested-git-in-pure-jj, inner",
+        &git_in_pure_inner.canonicalize()?,
+    );
+    builder.add("NGPJ-o", "nested-git-in-pure-jj, outer", &git_in_pure);
+
+    let pure_in_git = git_repo(base, "PJG", env)?;
+    let pure_in_git_inner = pure_in_git.join("sub");
+    env.jj(
+        &["workspace", "add", path_arg(&pure_in_git_inner)?],
+        &parents.jj_main_pure,
+    )?;
+    builder.add(
+        "PJG-i",
+        "pure-jj-in-git, inner",
+        &pure_in_git_inner.canonicalize()?,
+    );
+    builder.add("PJG-o", "pure-jj-in-git, outer", &pure_in_git);
+    Ok(())
+}
+
+/// Every submodule shape, including the three that discriminate the
+/// superproject derivation.
+fn add_submodule_shapes(
+    builder: &mut Builder,
+    base: &Path,
+    env: &Hermetic,
+    parents: &Parents,
+) -> Result<(), Error> {
+    let seed = &parents.submodule_seed;
+
+    let middle = git_repo(base, "midsrc", env)?;
+    add_submodule(env, &middle, seed, "leaf")?;
+    let top = git_repo(base, "super", env)?;
+    add_submodule(env, &top, &middle, "mid")?;
+    env.git(
+        &["submodule", "update", "--init", "--recursive", "--quiet"],
+        &top,
+    )?;
+    builder.add("SM-1", "git submodule", &top.join("mid").canonicalize()?);
+    // Depth 2 is what proves the derivation takes the *nearest* `modules`
+    // component: taking the outermost names the superproject, not `mid`.
+    builder.add(
+        "SM-2",
+        "git submodule, depth 2",
+        &top.join("mid/leaf").canonicalize()?,
+    );
+    builder.add("SM-s", "git submodule, superproject root", &top);
+
+    // An old-form submodule is a nested `.git` *directory*. It reports
+    // Kind::Common and git reports no superproject for it — the two agree, so a
+    // Kind::Submodule-only implementation would miss it with no oracle
+    // disagreement to reveal the omission.
+    let outer = git_repo(base, "old", env)?;
+    let nested = outer.join("inner");
+    fs::create_dir_all(&nested)?;
+    env.git(&["init", "--quiet"], &nested)?;
+    env.git(
+        &["commit", "--allow-empty", "--quiet", "-m", "root"],
+        &nested,
+    )?;
+    builder.add("SO", "old-form submodule", &nested.canonicalize()?);
+
+    // A submodule whose own path contains a `modules` segment, giving
+    // `<super>/.git/modules/modules/foo`. The innermost candidate's parent is
+    // not a repository, so a bare rposition stops there and reports absence.
+    let path_clash = git_repo(base, "supm", env)?;
+    add_submodule(env, &path_clash, seed, "modules/foo")?;
+    builder.add(
+        "SM-m",
+        "submodule at a path containing `modules`",
+        &path_clash.join("modules/foo").canonicalize()?,
+    );
+
+    // A linked worktree *of* a submodule: the dirs differ so it is a worktree,
+    // and git reports **no** superproject for it.
+    let with_worktree = git_repo(base, "supw", env)?;
+    add_submodule(env, &with_worktree, seed, "mid")?;
+    let submodule_worktree = base.join("smw");
+    env.git(
+        &["worktree", "add", "-q", path_arg(&submodule_worktree)?],
+        &with_worktree.join("mid"),
+    )?;
+    builder.add(
+        "SM-w",
+        "linked worktree of a submodule",
+        &submodule_worktree.canonicalize()?,
+    );
+
+    // A submodule initialised inside a linked worktree of the superproject.
+    // Git puts its git dir under `worktrees/<id>/modules/`, not under the
+    // common dir's `modules/`, and reports the *worktree* as the superproject.
+    let host = git_repo(base, "supwt", env)?;
+    let host_worktree = base.join("supwt-wt");
+    env.git(&["worktree", "add", "-q", path_arg(&host_worktree)?], &host)?;
+    add_submodule(env, &host_worktree, seed, "sub")?;
+    builder.add(
+        "SM-wt",
+        "submodule inside a linked worktree",
+        &host_worktree.join("sub").canonicalize()?,
+    );
+    Ok(())
+}
+
+/// The object-format and ref-backend variants, plus the hostile configuration.
+fn add_format_shapes(
+    builder: &mut Builder,
+    base: &Path,
+    env: &Hermetic,
+) -> Result<(), Error> {
+    builder.add(
+        "RF",
+        "reftable ref backend",
+        &formatted(base, "RF", "ref-format", "reftable", env)?,
+    );
+    // A sha256 repository's HEAD is 64 hex characters, not 40.
+    builder.add(
+        "S256",
+        "sha256 object format",
+        &formatted(base, "S256", "object-format", "sha256", env)?,
+    );
+    builder.add("HOSTILE", "adversarial configuration", &hostile(base, env)?);
+    Ok(())
+}
+
+/// The three degenerate shapes. Their expectations are **not** uniform.
+fn add_degenerate_shapes(
+    builder: &mut Builder,
+    base: &Path,
+) -> Result<(), Error> {
+    // D1 and D2 report plain absence from both CLIs.
+    let deleted_store = base.join("D1");
+    fs::create_dir_all(deleted_store.join(".jj"))?;
+    let gone = base.join("D1-store-gone");
+    fs::create_dir_all(&gone)?;
+    fs::write(deleted_store.join(".jj/repo"), path_arg(&gone)?)?;
+    fs::remove_dir_all(&gone)?;
+    builder.add(
+        "D1",
+        "`.jj/repo` -> a deleted directory",
+        &deleted_store.canonicalize()?,
+    );
+
+    let broken_worktree = base.join("D2");
+    fs::create_dir_all(&broken_worktree)?;
+    fs::write(
+        broken_worktree.join(".git"),
+        format!("gitdir: {}\n", base.join("D2-gitdir-gone").display()),
+    )?;
+    builder.add(
+        "D2",
+        "`.git` file -> a removed gitdir",
+        &broken_worktree.canonicalize()?,
+    );
+
+    // D3 is the load-bearing degenerate: `jj workspace root` **succeeds**, so
+    // only the `<main_root>/.jj/repo` post-condition separates a real answer
+    // from a plausible wrong one.
+    let wrong_store = base.join("D3");
+    fs::create_dir_all(wrong_store.join(".jj"))?;
+    let not_a_store = base.join("D3-not-a-store");
+    fs::create_dir_all(&not_a_store)?;
+    fs::write(wrong_store.join(".jj/repo"), path_arg(&not_a_store)?)?;
+    builder.add(
+        "D3",
+        "`.jj/repo` -> an existing non-store directory",
+        &wrong_store.canonicalize()?,
+    );
+    Ok(())
+}
+
+/// The pure-jj benchmark fixture, as a named reusable builder.
+///
+/// `jj git init` **colocates by default** at 0.43, so `--no-colocate` is
+/// mandatory and the absence of `.git` is asserted rather than assumed.
+///
+/// # Errors
+///
+/// When jj cannot build the workspace, or it comes out colocated after all.
+pub fn pure_jj(root: &Path, env: &Hermetic) -> Result<PathBuf, Error> {
+    fs::create_dir_all(root)?;
+    env.jj(&["git", "init", "--no-colocate"], root)?;
+    env.jj(&["describe", "-m", "root"], root)?;
+    env.jj(&["new"], root)?;
+
+    let root = root.canonicalize()?;
+    if root.join(".git").exists() {
+        return Err(Error::message(format!(
+            "{} was built with --no-colocate but carries a .git marker",
+            root.display()
+        )));
+    }
+    if !root.join(".jj").is_dir() {
+        return Err(Error::message(format!(
+            "{} has no .jj directory",
+            root.display()
+        )));
+    }
+    Ok(root)
+}
+
+/// A plain git repository with one commit, so `git worktree add` works later.
+fn git_repo(base: &Path, name: &str, env: &Hermetic) -> Result<PathBuf, Error> {
+    let root = base.join(name);
+    fs::create_dir_all(&root)?;
+    env.git(&["init", "--quiet"], &root)?;
+    env.git(&["commit", "--allow-empty", "--quiet", "-m", "root"], &root)?;
+    Ok(root.canonicalize()?)
+}
+
+fn add_submodule(
+    env: &Hermetic,
+    host: &Path,
+    source: &Path,
+    at: &str,
+) -> Result<(), Error> {
+    env.git(
+        &["submodule", "add", "--quiet", path_arg(source)?, at],
+        host,
+    )?;
+    env.git(&["commit", "--quiet", "-m", "add submodule"], host)?;
+    Ok(())
+}
+
+/// A git repository initialised with one format knob, then asserted to actually
+/// carry it — a silently ignored flag would restore the cross-runner drift the
+/// pinning exists to remove.
+fn formatted(
+    base: &Path,
+    name: &str,
+    knob: &str,
+    value: &str,
+    env: &Hermetic,
+) -> Result<PathBuf, Error> {
+    let root = base.join(name);
+    fs::create_dir_all(&root)?;
+    env.git(&["init", "--quiet", &format!("--{knob}={value}")], &root)?;
+    env.git(&["commit", "--allow-empty", "--quiet", "-m", "root"], &root)?;
+
+    let reported = env.git(&["rev-parse", &format!("--show-{knob}")], &root)?;
+    if reported != value {
+        return Err(Error::message(format!(
+            "{name} was initialised with --{knob}={value} but reports {reported}"
+        )));
+    }
+    Ok(root.canonicalize()?)
+}
+
+/// A real colocated repository: `git init` then `jj git init --colocate`.
+fn colocated(
+    base: &Path,
+    name: &str,
+    env: &Hermetic,
+) -> Result<PathBuf, Error> {
+    let root = git_repo(base, name, env)?;
+    env.jj(&["git", "init", "--colocate"], &root)?;
+    Ok(root)
+}
+
+/// The hand-grafted colocated shape: one path that is both a git linked
+/// worktree and a jj secondary workspace.
+///
+/// Both `git worktree add` and `jj workspace add` refuse an existing non-empty
+/// target, so the jj workspace is built elsewhere and its `.jj` grafted in. The
+/// grafted `.jj/repo`'s relative path no longer resolves, so it is rewritten
+/// absolute — with **no trailing newline**, because jj reads the file verbatim
+/// and a newline turns the target into a nonexistent path.
+fn grafted_colocated(
+    base: &Path,
+    name: &str,
+    git_parent: &Path,
+    jj_parent: &Path,
+    env: &Hermetic,
+) -> Result<PathBuf, Error> {
+    let target = base.join(name);
+    env.git(&["worktree", "add", "-q", path_arg(&target)?], git_parent)?;
+
+    let staging = base.join(format!("{name}-jj-staging"));
+    env.jj(&["workspace", "add", path_arg(&staging)?], jj_parent)?;
+    fs::rename(staging.join(".jj"), target.join(".jj"))?;
+    fs::remove_dir_all(&staging)?;
+    fs::write(
+        target.join(".jj/repo"),
+        path_arg(&jj_parent.join(".jj/repo"))?,
+    )?;
+
+    let target = target.canonicalize()?;
+    if !target.join(".jj/repo").is_file() {
+        return Err(Error::message(format!(
+            "{} should carry a .jj/repo *file*",
+            target.display()
+        )));
+    }
+    if !target.join(".git").exists() {
+        return Err(Error::message(format!(
+            "{} should carry a .git marker",
+            target.display()
+        )));
+    }
+    Ok(target)
+}
+
+/// A plain git repository whose own config points every hook-shaped knob at a
+/// marker-writing command.
+///
+/// None of these ran under the oracle's calls or this story's call set, so the
+/// fixture is a regression guard for the APIs that reach gix's filter, pager and
+/// external-diff machinery — not evidence about the queries here.
+fn hostile(base: &Path, env: &Hermetic) -> Result<PathBuf, Error> {
+    let root = git_repo(base, "HOSTILE", env)?;
+    let writer = format!(
+        "sh -c 'echo ran >> {}'",
+        base.join("hostile-marker").display()
+    );
+    let included = base.join("hostile-include");
+    fs::write(&included, format!("[alias]\n\tincluded = !{writer}\n"))?;
+
+    let config = root.join(".git/config");
+    let mut text = fs::read_to_string(&config)?;
+    write!(
+        text,
+        "[core]\n\tpager = {writer}\n\tfsmonitor = {writer}\n\
+         [diff]\n\texternal = {writer}\n\
+         [filter \"hostile\"]\n\tclean = {writer}\n\tsmudge = {writer}\n\
+         [alias]\n\thostile = !{writer}\n\
+         [include]\n\tpath = {}\n",
+        included.display()
+    )
+    .map_err(|error| Error::message(error.to_string()))?;
+    fs::write(&config, text)?;
+    Ok(root)
+}
+
+fn path_arg(path: &Path) -> Result<&str, Error> {
+    path.to_str().ok_or_else(|| {
+        Error::message(format!("non-UTF-8 path {}", path.display()))
+    })
+}

--- a/cli/vcs-test-support/src/hermetic.rs
+++ b/cli/vcs-test-support/src/hermetic.rs
@@ -1,0 +1,266 @@
+//! The empty-config environment the fixture matrix is built and measured in,
+//! and the preconditions that make its absence cells mean anything.
+//!
+//! The exact variables and value shapes here are the ones the recorded oracle
+//! mapping was measured with. They live in one place so the mapping and the
+//! shipped harness cannot drift apart per platform.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::Error;
+
+/// The lowest `git` the fixture matrix can be built with.
+///
+/// `git init --ref-format=reftable` landed in 2.45; the mapping itself was
+/// calibrated against 2.54.0. `git` is pinned nowhere in this repo, so a floor
+/// with a named diagnostic beats recording a version nobody reads.
+pub const MINIMUM_GIT: (u32, u32) = (2, 45);
+
+/// An isolated `HOME`, config and ceiling, applied to every `git` and `jj`
+/// invocation the fixtures make.
+#[derive(Debug, Clone)]
+pub struct Hermetic {
+    home: PathBuf,
+    config_home: PathBuf,
+    jj_config: PathBuf,
+    ceiling: PathBuf,
+}
+
+impl Hermetic {
+    /// Creates the isolated config tree beneath `base`.
+    ///
+    /// # Errors
+    ///
+    /// When the config tree cannot be written.
+    pub fn rooted_at(base: &Path) -> Result<Self, Error> {
+        let home = base.join("hermetic-home");
+        let config_home = base.join("hermetic-xdg");
+        let jj_config = base.join("hermetic-jj.toml");
+        fs::create_dir_all(&home)?;
+        fs::create_dir_all(&config_home)?;
+
+        // An identity is written rather than left empty: with HOME at a temp
+        // dir, GIT_CONFIG_GLOBAL at /dev/null and GIT_CONFIG_NOSYSTEM set, jj
+        // and git otherwise fall back to an auto-detected user@hostname and
+        // *refuse* the commit when the hostname carries no domain — the normal
+        // case on CI runners and in containers.
+        fs::write(
+            &jj_config,
+            "[user]\nname = \"Fixture\"\nemail = \"fixture@example.com\"\n",
+        )?;
+
+        Ok(Self {
+            home,
+            config_home,
+            jj_config,
+            ceiling: base.to_path_buf(),
+        })
+    }
+
+    /// Applies the isolated environment to `command`.
+    pub fn apply(&self, command: &mut Command) {
+        command.env("HOME", &self.home);
+        command.env("XDG_CONFIG_HOME", &self.config_home);
+        command.env("JJ_CONFIG", &self.jj_config);
+        command.env("GIT_CEILING_DIRECTORIES", &self.ceiling);
+        // A boolean, not a path. This is the only thing suppressing the
+        // *system* gitconfig, which lives at /etc/gitconfig on ubuntu and
+        // inside the Command Line Tools on macOS; pointing it at a temp dir
+        // would leave host config leaking in on one platform and not the other.
+        command.env("GIT_CONFIG_NOSYSTEM", "1");
+        command.env("GIT_CONFIG_GLOBAL", "/dev/null");
+        for key in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_COMMON_DIR",
+            "GIT_CONFIG",
+            "GIT_CONFIG_COUNT",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        ] {
+            command.env_remove(key);
+        }
+    }
+
+    /// Runs `git` in `dir` with the identity and isolation the fixtures need.
+    ///
+    /// `protocol.file.allow` and the identity are passed per invocation rather
+    /// than written into a config file, even one under the temp `HOME`.
+    ///
+    /// # Errors
+    ///
+    /// When git cannot be run or exits non-zero.
+    pub fn git<S: AsRef<OsStr>>(
+        &self,
+        args: &[S],
+        dir: &Path,
+    ) -> Result<String, Error> {
+        let mut command = Command::new("git");
+        command.args([
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+            "-c",
+            "protocol.file.allow=always",
+        ]);
+        command.args(args);
+        self.run(command, dir, "git")
+    }
+
+    /// Runs `jj` in `dir` with the identity and isolation the fixtures need.
+    ///
+    /// # Errors
+    ///
+    /// When jj cannot be run or exits non-zero.
+    pub fn jj<S: AsRef<OsStr>>(
+        &self,
+        args: &[S],
+        dir: &Path,
+    ) -> Result<String, Error> {
+        let mut command = Command::new("jj");
+        command.arg("--color=never");
+        command.arg("--no-pager");
+        command.args(args);
+        self.run(command, dir, "jj")
+    }
+
+    fn run(
+        &self,
+        mut command: Command,
+        dir: &Path,
+        binary: &str,
+    ) -> Result<String, Error> {
+        command.current_dir(dir);
+        self.apply(&mut command);
+        let output = command
+            .output()
+            .map_err(|error| Error::message(format!("{binary}: {error}")))?;
+        if !output.status.success() {
+            return Err(Error::message(format!(
+                "{binary} failed in {}: {}",
+                dir.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    }
+}
+
+/// Fails when any ancestor of `base` carries a `.git` or `.jj` marker.
+///
+/// Roughly a quarter of the oracle mapping's cells assert absence for the
+/// gix-backed queries, and `gix::discover` reads **no** environment — so
+/// `GIT_CEILING_DIRECTORIES`, which produced the oracle side's exit-128s, cannot
+/// fence the library side. On a host whose `TMPDIR` resolves inside a
+/// repository, those cells would silently resolve the enclosing repository
+/// instead, and the failure would read as a mass of confusing per-cell
+/// mismatches rather than one legible message.
+///
+/// # Errors
+///
+/// When a marked ancestor is found, naming it.
+pub fn assert_no_repository_ancestor(base: &Path) -> Result<(), Error> {
+    let mut dir = Some(base.canonicalize()?);
+    while let Some(current) = dir {
+        if current != base
+            && (current.join(".git").exists() || current.join(".jj").exists())
+        {
+            return Err(Error::message(format!(
+                "the fixture base {} lies inside the repository at {} — every \
+                 absence expectation in the matrix would silently resolve that \
+                 repository instead. Point TMPDIR outside any checkout.",
+                base.display(),
+                current.display()
+            )));
+        }
+        dir = current.parent().map(Path::to_path_buf);
+    }
+    Ok(())
+}
+
+/// Fails unless the installed `jj` CLI matches `jj_lib_version` at major.minor.
+///
+/// The pin-lockstep test compares two *declarations*; nothing else checks the
+/// binaries that write the repository formats the libraries read. This session's
+/// planning hit exactly that skew, and it would otherwise surface as an
+/// apparently wrong answer in a 24-row expected-value table.
+///
+/// Compared at major.minor because the tilde range deliberately permits the
+/// exact CLI pin to sit alongside a resolved patch of the library; an
+/// exact-equality assertion would fail the whole matrix on a skew the pins
+/// pre-authorise.
+///
+/// # Errors
+///
+/// When `jj` cannot be run, or its version's major.minor differs.
+pub fn assert_jj_matches(jj_lib_version: &str) -> Result<(), Error> {
+    let reported = tool_version("jj")?;
+    let expected = major_minor(jj_lib_version).ok_or_else(|| {
+        Error::message(format!("unparsable jj-lib version {jj_lib_version}"))
+    })?;
+    let found = major_minor(&reported).ok_or_else(|| {
+        Error::message(format!("unparsable jj --version output {reported}"))
+    })?;
+    if found != expected {
+        return Err(Error::message(format!(
+            "the installed jj CLI is {reported} but jj-lib is \
+             {jj_lib_version}: the CLI writes the format the library reads, so \
+             the fixture matrix would be measuring a skew. Run `mise install`."
+        )));
+    }
+    Ok(())
+}
+
+/// Fails unless the installed `git` meets [`MINIMUM_GIT`].
+///
+/// # Errors
+///
+/// When `git` cannot be run, or is older than the floor.
+pub fn assert_git_is_recent_enough() -> Result<(), Error> {
+    let reported = tool_version("git")?;
+    let found = major_minor(&reported).ok_or_else(|| {
+        Error::message(format!("unparsable git --version output {reported}"))
+    })?;
+    if found < MINIMUM_GIT {
+        return Err(Error::message(format!(
+            "git {reported} is below the {}.{} floor the fixture matrix needs \
+             (--ref-format=reftable landed in 2.45)",
+            MINIMUM_GIT.0, MINIMUM_GIT.1
+        )));
+    }
+    Ok(())
+}
+
+fn tool_version(binary: &str) -> Result<String, Error> {
+    let output = Command::new(binary)
+        .arg("--version")
+        .output()
+        .map_err(|error| Error::message(format!("{binary}: {error}")))?;
+    if !output.status.success() {
+        return Err(Error::message(format!(
+            "{binary} --version exited non-zero"
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn major_minor(text: &str) -> Option<(u32, u32)> {
+    let digits = text.split_whitespace().find_map(|word| {
+        let trimmed = word.trim_start_matches(|c: char| !c.is_ascii_digit());
+        trimmed.chars().next()?.is_ascii_digit().then_some(trimmed)
+    })?;
+    let mut parts = digits.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}

--- a/cli/vcs-test-support/src/hermetic.rs
+++ b/cli/vcs-test-support/src/hermetic.rs
@@ -1,9 +1,8 @@
 //! The empty-config environment the fixture matrix is built and measured in,
 //! and the preconditions that make its absence cells mean anything.
 //!
-//! The exact variables and value shapes here are the ones the recorded oracle
-//! mapping was measured with. They live in one place so the mapping and the
-//! shipped harness cannot drift apart per platform.
+//! The variables and value shapes live in one place so the recorded expectations
+//! and the shipped harness cannot drift apart per platform.
 
 use std::ffi::OsStr;
 use std::fs;
@@ -15,9 +14,8 @@ use crate::Error;
 
 /// The lowest `git` the fixture matrix can be built with.
 ///
-/// `git init --ref-format=reftable` landed in 2.45; the mapping itself was
-/// calibrated against 2.54.0. `git` is pinned nowhere in this repo, so a floor
-/// with a named diagnostic beats recording a version nobody reads.
+/// `git init --ref-format=reftable` landed in 2.45, and `git` is pinned nowhere
+/// in this repo, so a floor with a named diagnostic beats recording a version.
 pub const MINIMUM_GIT: (u32, u32) = (2, 45);
 
 /// An isolated `HOME`, config and ceiling, applied to every `git` and `jj`
@@ -43,11 +41,8 @@ impl Hermetic {
         fs::create_dir_all(&home)?;
         fs::create_dir_all(&config_home)?;
 
-        // An identity is written rather than left empty: with HOME at a temp
-        // dir, GIT_CONFIG_GLOBAL at /dev/null and GIT_CONFIG_NOSYSTEM set, jj
-        // and git otherwise fall back to an auto-detected user@hostname and
-        // *refuse* the commit when the hostname carries no domain — the normal
-        // case on CI runners and in containers.
+        // Without an identity, git and jj fall back to user@hostname and refuse
+        // the commit when the hostname carries no domain — the CI norm.
         fs::write(
             &jj_config,
             "[user]\nname = \"Fixture\"\nemail = \"fixture@example.com\"\n",
@@ -67,10 +62,8 @@ impl Hermetic {
         command.env("XDG_CONFIG_HOME", &self.config_home);
         command.env("JJ_CONFIG", &self.jj_config);
         command.env("GIT_CEILING_DIRECTORIES", &self.ceiling);
-        // A boolean, not a path. This is the only thing suppressing the
-        // *system* gitconfig, which lives at /etc/gitconfig on ubuntu and
-        // inside the Command Line Tools on macOS; pointing it at a temp dir
-        // would leave host config leaking in on one platform and not the other.
+        // A boolean, not a path: this is the only thing suppressing the
+        // *system* gitconfig, whose location differs per platform.
         command.env("GIT_CONFIG_NOSYSTEM", "1");
         command.env("GIT_CONFIG_GLOBAL", "/dev/null");
         for key in [
@@ -87,10 +80,8 @@ impl Hermetic {
         }
     }
 
-    /// Runs `git` in `dir` with the identity and isolation the fixtures need.
-    ///
-    /// `protocol.file.allow` and the identity are passed per invocation rather
-    /// than written into a config file, even one under the temp `HOME`.
+    /// Runs `git` in `dir` with the identity and isolation the fixtures need,
+    /// passed per invocation rather than written into any config file.
     ///
     /// # Errors
     ///
@@ -158,13 +149,9 @@ impl Hermetic {
 
 /// Fails when any ancestor of `base` carries a `.git` or `.jj` marker.
 ///
-/// Roughly a quarter of the oracle mapping's cells assert absence for the
-/// gix-backed queries, and `gix::discover` reads **no** environment — so
-/// `GIT_CEILING_DIRECTORIES`, which produced the oracle side's exit-128s, cannot
-/// fence the library side. On a host whose `TMPDIR` resolves inside a
-/// repository, those cells would silently resolve the enclosing repository
-/// instead, and the failure would read as a mass of confusing per-cell
-/// mismatches rather than one legible message.
+/// `gix::discover` reads no environment, so `GIT_CEILING_DIRECTORIES` cannot
+/// fence it. On a host whose `TMPDIR` sits inside a repository, every cell
+/// expecting absence would silently resolve the enclosing one.
 ///
 /// # Errors
 ///
@@ -191,14 +178,11 @@ pub fn assert_no_repository_ancestor(base: &Path) -> Result<(), Error> {
 /// Fails unless the installed `jj` CLI matches `jj_lib_version` at major.minor.
 ///
 /// The pin-lockstep test compares two *declarations*; nothing else checks the
-/// binaries that write the repository formats the libraries read. This session's
-/// planning hit exactly that skew, and it would otherwise surface as an
-/// apparently wrong answer in a 24-row expected-value table.
+/// binaries that write the formats the libraries read, and a skew there surfaces
+/// as an apparently wrong answer in the expected-value table.
 ///
-/// Compared at major.minor because the tilde range deliberately permits the
-/// exact CLI pin to sit alongside a resolved patch of the library; an
-/// exact-equality assertion would fail the whole matrix on a skew the pins
-/// pre-authorise.
+/// Major.minor, because the tilde range permits the exact CLI pin to sit
+/// alongside a resolved patch of the library.
 ///
 /// # Errors
 ///

--- a/cli/vcs-test-support/src/lib.rs
+++ b/cli/vcs-test-support/src/lib.rs
@@ -1,0 +1,43 @@
+//! The shared VCS test apparatus: the checkout fixture matrix, the hermetic
+//! environment it is built in, and (from the zero-spawn work) the marker
+//! stubs.
+//!
+//! Published as a crate rather than a feature on `vcs-adapters` for two
+//! reasons: it keeps that crate's `[features]` at exactly `bash-parity`, and it
+//! sidesteps CI's `--all-features` turning a fixture feature on workspace-wide.
+//! It is consumed from more than one crate, so the shadow list has one
+//! definition.
+
+pub mod fixtures;
+pub mod hermetic;
+pub mod stubs;
+
+use std::fmt;
+
+/// Anything that can go wrong building or describing a fixture.
+///
+/// A single opaque error on purpose: callers are test harnesses that report and
+/// abort, never branch on the cause.
+#[derive(Debug)]
+pub struct Error(String);
+
+impl Error {
+    #[must_use]
+    pub fn message(text: impl Into<String>) -> Self {
+        Self(text.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self(error.to_string())
+    }
+}

--- a/cli/vcs-test-support/src/lib.rs
+++ b/cli/vcs-test-support/src/lib.rs
@@ -1,12 +1,9 @@
 //! The shared VCS test apparatus: the checkout fixture matrix, the hermetic
-//! environment it is built in, and (from the zero-spawn work) the marker
-//! stubs.
+//! environment it is built in, and the marker stubs.
 //!
-//! Published as a crate rather than a feature on `vcs-adapters` for two
-//! reasons: it keeps that crate's `[features]` at exactly `bash-parity`, and it
-//! sidesteps CI's `--all-features` turning a fixture feature on workspace-wide.
-//! It is consumed from more than one crate, so the shadow list has one
-//! definition.
+//! A crate rather than a feature on `vcs-adapters`, so that crate's `[features]`
+//! stays at exactly `bash-parity` and CI's `--all-features` cannot turn a fixture
+//! feature on workspace-wide.
 
 pub mod fixtures;
 pub mod hermetic;
@@ -14,10 +11,8 @@ pub mod stubs;
 
 use std::fmt;
 
-/// Anything that can go wrong building or describing a fixture.
-///
-/// A single opaque error on purpose: callers are test harnesses that report and
-/// abort, never branch on the cause.
+/// A single opaque error: callers are test harnesses that report and abort,
+/// never branch on the cause.
 #[derive(Debug)]
 pub struct Error(String);
 

--- a/cli/vcs-test-support/src/stubs.rs
+++ b/cli/vcs-test-support/src/stubs.rs
@@ -2,19 +2,11 @@
 //! `PATH`, and a platform-aware report of the absolute paths `PATH` cannot
 //! reach.
 //!
-//! **This module never writes outside its own temp directories.** It resolves
-//! and *reports* absolute paths; it does not move, replace or chmod them, and
-//! it never invokes `sudo`. All privileged mutation lives in the CI workflow
-//! step, which is the only thing that can move a root-owned binary anyway — but
-//! the boundary is stated because `/opt/homebrew/bin` is user-writable, so an
-//! "attempt and record the failure" design would succeed there and could leave a
-//! developer's machine without `git` or `jj`. The suite is reachable from the
-//! bare `mise run` every contributor is told to run before pushing, so this is
-//! the difference between a test and a hazard.
-//!
-//! The in-repo precedent, `strip_binary_from_path`
-//! (`hooks/test-vcs-detect.sh`), is likewise purely non-destructive: it edits a
-//! `PATH` string and touches no file.
+//! **Never writes outside its own temp directories.** It resolves and *reports*
+//! absolute paths; it does not move, replace or chmod them, and never invokes
+//! `sudo`. `/opt/homebrew/bin` is user-writable, so an "attempt and record the
+//! failure" design would succeed there and could leave a developer without `git`
+//! or `jj`. All privileged mutation lives in the task that shadows them.
 
 use std::env;
 use std::fs;
@@ -39,13 +31,9 @@ pub enum Mode {
 }
 
 impl Mode {
-    /// Reads the mode the workflow step declared.
-    ///
-    /// **Fail-closed on malformed input**, not just on an unshadowed path: an
-    /// unrecognised value is an error rather than a silent downgrade to
-    /// `PathOnly`, and a non-empty shadow list without `strong` is an error too.
-    /// Otherwise a typo, a renamed variable or a step-ordering change that drops
-    /// the export silently weakens the one job that proves the property.
+    /// Reads the declared mode, failing closed on malformed input: an
+    /// unrecognised value, or a shadow list without `strong`, is an error rather
+    /// than a silent downgrade to `PathOnly`.
     ///
     /// # Errors
     ///
@@ -105,9 +93,8 @@ impl Stubs {
             make_executable(&stub)?;
         }
 
-        // Every directory that can resolve git or jj is dropped, not just the
-        // first: macOS commonly provides git in both /opt/homebrew/bin and
-        // /usr/bin, so stripping a single dirname leaves it resolvable.
+        // Every directory that resolves git or jj, not just the first: macOS
+        // commonly provides it in two.
         let existing = env::var("PATH").unwrap_or_default();
         let kept: Vec<&str> = existing
             .split(':')

--- a/cli/vcs-test-support/src/stubs.rs
+++ b/cli/vcs-test-support/src/stubs.rs
@@ -1,0 +1,298 @@
+//! The zero-spawn harness: marker-writing `git`/`jj` stubs on a synthetic
+//! `PATH`, and a platform-aware report of the absolute paths `PATH` cannot
+//! reach.
+//!
+//! **This module never writes outside its own temp directories.** It resolves
+//! and *reports* absolute paths; it does not move, replace or chmod them, and
+//! it never invokes `sudo`. All privileged mutation lives in the CI workflow
+//! step, which is the only thing that can move a root-owned binary anyway — but
+//! the boundary is stated because `/opt/homebrew/bin` is user-writable, so an
+//! "attempt and record the failure" design would succeed there and could leave a
+//! developer's machine without `git` or `jj`. The suite is reachable from the
+//! bare `mise run` every contributor is told to run before pushing, so this is
+//! the difference between a test and a hazard.
+//!
+//! The in-repo precedent, `strip_binary_from_path`
+//! (`hooks/test-vcs-detect.sh`), is likewise purely non-destructive: it edits a
+//! `PATH` string and touches no file.
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::Error;
+
+/// Names the workflow step and the harness agree on, so neither assumes the
+/// other did the work.
+pub const MODE_VARIABLE: &str = "ACCELERATOR_ZERO_SPAWN_MODE";
+pub const SHADOWED_VARIABLE: &str = "ACCELERATOR_ZERO_SPAWN_SHADOWED";
+
+/// How thoroughly the real binaries were made unreachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// `PATH` stubs only. Absolute paths remain reachable and are reported.
+    PathOnly,
+    /// `PATH` stubs *and* the absolute paths shadowed by the workflow step.
+    Strong,
+}
+
+impl Mode {
+    /// Reads the mode the workflow step declared.
+    ///
+    /// **Fail-closed on malformed input**, not just on an unshadowed path: an
+    /// unrecognised value is an error rather than a silent downgrade to
+    /// `PathOnly`, and a non-empty shadow list without `strong` is an error too.
+    /// Otherwise a typo, a renamed variable or a step-ordering change that drops
+    /// the export silently weakens the one job that proves the property.
+    ///
+    /// # Errors
+    ///
+    /// When the mode is unrecognised, or the two variables disagree.
+    pub fn from_environment() -> Result<Self, Error> {
+        let declared = env::var(MODE_VARIABLE).unwrap_or_default();
+        let shadowed = env::var(SHADOWED_VARIABLE).unwrap_or_default();
+        let mode = match declared.as_str() {
+            "" | "path-only" => Self::PathOnly,
+            "strong" => Self::Strong,
+            other => {
+                return Err(Error::message(format!(
+                    "{MODE_VARIABLE}={other} is not a recognised zero-spawn \
+                     mode; expected `strong` or `path-only`"
+                )));
+            }
+        };
+        if mode == Self::PathOnly && !shadowed.trim().is_empty() {
+            return Err(Error::message(format!(
+                "{SHADOWED_VARIABLE} names shadowed paths but \
+                 {MODE_VARIABLE} is not `strong` — the workflow step and the \
+                 harness disagree about what was done"
+            )));
+        }
+        Ok(mode)
+    }
+}
+
+/// A synthetic `PATH` whose `git` and `jj` write a marker instead of running.
+#[derive(Debug)]
+pub struct Stubs {
+    directory: PathBuf,
+    marker: PathBuf,
+    path: String,
+}
+
+impl Stubs {
+    /// Writes the stubs beneath `base` and computes the synthetic `PATH`.
+    ///
+    /// # Errors
+    ///
+    /// When the stubs cannot be written or made executable.
+    pub fn rooted_at(base: &Path) -> Result<Self, Error> {
+        let directory = base.join("zero-spawn-stubs");
+        fs::create_dir_all(&directory)?;
+        let marker = base.join("zero-spawn-marker");
+
+        for binary in ["git", "jj"] {
+            let stub = directory.join(binary);
+            fs::write(
+                &stub,
+                format!(
+                    "#!/bin/sh\nprintf '%s %s\\n' {binary} \"$*\" >> {}\nexit 0\n",
+                    marker.display()
+                ),
+            )?;
+            make_executable(&stub)?;
+        }
+
+        // Every directory that can resolve git or jj is dropped, not just the
+        // first: macOS commonly provides git in both /opt/homebrew/bin and
+        // /usr/bin, so stripping a single dirname leaves it resolvable.
+        let existing = env::var("PATH").unwrap_or_default();
+        let kept: Vec<&str> = existing
+            .split(':')
+            .filter(|entry| {
+                !entry.is_empty()
+                    && !["git", "jj"].iter().any(|binary| {
+                        is_executable(&Path::new(entry).join(binary))
+                    })
+            })
+            .collect();
+        let path = format!("{}:{}", directory.display(), kept.join(":"));
+
+        Ok(Self {
+            directory,
+            marker,
+            path,
+        })
+    }
+
+    /// The synthetic `PATH`, with the stub directory first and every directory
+    /// that could resolve a real `git`/`jj` removed.
+    #[must_use]
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    /// Applies the synthetic `PATH` to `command`.
+    pub fn apply(&self, command: &mut Command) {
+        command.env("PATH", &self.path);
+    }
+
+    /// Whatever a stub recorded, or `None` when none ran.
+    ///
+    /// # Errors
+    ///
+    /// When the marker exists but cannot be read.
+    pub fn spawns(&self) -> Result<Option<String>, Error> {
+        if !self.marker.exists() {
+            return Ok(None);
+        }
+        Ok(Some(fs::read_to_string(&self.marker)?))
+    }
+}
+
+/// Absolute paths that would still resolve a real `git` or `jj` even with the
+/// synthetic `PATH` in force.
+///
+/// Resolved at run time by asking the environment where each binary actually
+/// lives, because the meaningful targets differ per platform: on Linux CI the jj
+/// target is the mise install path and there is no system `jj` at all, while on
+/// a developer's macOS machine `/opt/homebrew/bin/jj` **is** the real binary.
+///
+/// # Errors
+///
+/// When `PATH` cannot be read.
+pub fn unshadowed_paths() -> Result<Vec<PathBuf>, Error> {
+    let mut found = Vec::new();
+    let path = env::var("PATH").unwrap_or_default();
+    for entry in path.split(':').filter(|entry| !entry.is_empty()) {
+        for binary in ["git", "jj"] {
+            let candidate = Path::new(entry).join(binary);
+            if is_executable(&candidate) && !found.contains(&candidate) {
+                found.push(candidate);
+            }
+        }
+    }
+    // The conventional absolute locations, whether or not they are on PATH —
+    // a caller reaching them by absolute path does not consult PATH at all.
+    for candidate in [
+        "/usr/bin/git",
+        "/usr/local/bin/git",
+        "/opt/homebrew/bin/git",
+        "/usr/bin/jj",
+        "/usr/local/bin/jj",
+        "/opt/homebrew/bin/jj",
+    ] {
+        let candidate = PathBuf::from(candidate);
+        if is_executable(&candidate) && !found.contains(&candidate) {
+            found.push(candidate);
+        }
+    }
+    found.sort();
+    Ok(found)
+}
+
+/// Fails when `strong` was declared but a listed path is still executable.
+///
+/// Without this, a runner image that relocates `git` turns the workflow's
+/// `sudo mv` into a no-op and the job goes green with the property unproven.
+///
+/// # Errors
+///
+/// When the mode is malformed, or any path the step claimed to shadow still
+/// resolves.
+pub fn assert_shadowing_holds(mode: Mode) -> Result<(), Error> {
+    if mode != Mode::Strong {
+        return Ok(());
+    }
+    let claimed = env::var(SHADOWED_VARIABLE).unwrap_or_default();
+    let still_live: Vec<&str> = claimed
+        .split(':')
+        .filter(|entry| !entry.trim().is_empty())
+        .filter(|entry| is_executable(Path::new(entry)))
+        .collect();
+    if !still_live.is_empty() {
+        return Err(Error::message(format!(
+            "{MODE_VARIABLE}=strong was declared but these paths are still \
+             executable: {}",
+            still_live.join(", ")
+        )));
+    }
+
+    let remaining = unshadowed_paths()?;
+    if !remaining.is_empty() {
+        return Err(Error::message(format!(
+            "{MODE_VARIABLE}=strong was declared but a real git/jj is still \
+             reachable at: {}",
+            remaining
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), Error> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), Error> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    fs::metadata(path).is_ok_and(|metadata| {
+        metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+    })
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// The compiled `vcs-adapters-fixture` binary, resolved beside the calling test
+/// binary.
+///
+/// `CARGO_BIN_EXE_*` is injected only for the declaring crate's own integration
+/// tests, so a consumer in another crate derives the path from its test exe
+/// instead. An absent binary fails loudly rather than silently skipping the one
+/// assertion that proves the property.
+///
+/// # Errors
+///
+/// When the target directory cannot be derived, or the binary is not built.
+pub fn reference_artefact() -> Result<PathBuf, Error> {
+    let exe = env::current_exe()?;
+    // .../target/<profile>/deps/<testbin> -> .../target/<profile>
+    let profile = exe.parent().and_then(Path::parent).ok_or_else(|| {
+        Error::message(
+            "could not locate the target profile dir from the test exe",
+        )
+    })?;
+    let binary = profile.join("vcs-adapters-fixture");
+    if !binary.is_file() {
+        return Err(Error::message(format!(
+            "the reference artefact is not built at {} — build the workspace \
+             first (`cargo build -p vcs-adapters`)",
+            binary.display()
+        )));
+    }
+    Ok(binary)
+}

--- a/cli/vcs-test-support/tests/matrix.rs
+++ b/cli/vcs-test-support/tests/matrix.rs
@@ -1,0 +1,152 @@
+//! The matrix builds, and every shape it claims is the shape it produced.
+//!
+//! These assertions are structural — markers, file-vs-directory, formats — and
+//! deliberately independent of any library that reads them, so a fixture defect
+//! fails here rather than as a wrong expected value in a query table.
+
+use std::fs;
+
+use vcs_test_support::fixtures::Matrix;
+use vcs_test_support::hermetic::assert_git_is_recent_enough;
+
+type TestError = Box<dyn std::error::Error>;
+
+fn matrix() -> Result<(tempfile::TempDir, Matrix), TestError> {
+    assert_git_is_recent_enough()?;
+    let base = tempfile::Builder::new().prefix("vcs-matrix-").tempdir()?;
+    let built = Matrix::build_in(base.path())?;
+    Ok((base, built))
+}
+
+#[test]
+fn every_recorded_fixture_key_is_built() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+
+    let expected = [
+        "CR", "CG", "JS-r", "JS-s", "PG-r", "PG-s", "NJG-i", "NJG-o", "NGJ-i",
+        "NGJ-o", "WT-l", "WT-m", "SM-1", "SM-2", "SM-s", "SO", "BARE", "NONE",
+        "PJ", "PJS", "NGPJ-i", "NGPJ-o", "PJG-i", "PJG-o", "JS-in", "SM-m",
+        "SM-w", "SM-wt", "RF", "S256", "HOSTILE", "D1", "D2", "D3",
+    ];
+    for key in expected {
+        matrix.start(key)?;
+    }
+    assert_eq!(
+        matrix.fixtures.len(),
+        expected.len(),
+        "the matrix grew or shrank without the key list moving with it"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_nested_inner_shapes_carry_only_one_marker() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+
+    // The jj-inside-git shapes must carry `.jj` only, or a `.git`-inclusive
+    // walk would stop at them for the wrong reason and the fixture would prove
+    // nothing about the three-walk requirement.
+    for key in ["NJG-i", "PJG-i", "JS-in"] {
+        let start = matrix.start(key)?;
+        assert!(start.join(".jj").exists(), "{key} should carry .jj");
+        assert!(
+            !start.join(".git").exists(),
+            "{key} must carry .jj only, or it proves nothing"
+        );
+    }
+
+    // The git-inside-jj shapes are linked worktrees, so `.git` is a *file*.
+    for key in ["NGJ-i", "NGPJ-i"] {
+        let start = matrix.start(key)?;
+        assert!(
+            start.join(".git").is_file(),
+            "{key}'s .git should be a worktree file"
+        );
+        assert!(!start.join(".jj").exists(), "{key} should carry no .jj");
+    }
+    Ok(())
+}
+
+#[test]
+fn the_pure_jj_shapes_have_no_git_marker() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+    for key in ["PJ", "NGPJ-o"] {
+        let start = matrix.start(key)?;
+        assert!(
+            !start.join(".git").exists(),
+            "{key} was built --no-colocate and must have no .git"
+        );
+        assert!(start.join(".jj").is_dir(), "{key} should carry .jj");
+    }
+    Ok(())
+}
+
+#[test]
+fn the_colocated_shapes_differ_as_recorded() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+
+    // A real colocated main owns its store, so `.jj/repo` is a directory.
+    let real = matrix.start("CR")?;
+    assert!(real.join(".jj/repo").is_dir(), "CR should own its store");
+    assert!(
+        real.join(".git").is_dir(),
+        "CR's .git should be a directory"
+    );
+
+    // The hand-grafted shape shares a store and is simultaneously a linked
+    // worktree, which is what makes it the only `colocated` classification.
+    let grafted = matrix.start("CG")?;
+    assert!(
+        grafted.join(".jj/repo").is_file(),
+        "CG should share a store via a .jj/repo file"
+    );
+    assert!(
+        grafted.join(".git").is_file(),
+        "CG's .git should be a worktree file"
+    );
+    let pointer = fs::read_to_string(grafted.join(".jj/repo"))?;
+    assert!(
+        !pointer.ends_with('\n'),
+        "jj reads .jj/repo verbatim, so a trailing newline breaks the pointer"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_degenerate_shapes_are_actually_broken() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+
+    let deleted = matrix.start("D1")?;
+    let target = fs::read_to_string(deleted.join(".jj/repo"))?;
+    assert!(
+        !std::path::Path::new(&target).exists(),
+        "D1's pointer target should be gone"
+    );
+
+    let broken = matrix.start("D2")?;
+    assert!(broken.join(".git").is_file());
+
+    // D3 is the load-bearing one: the target exists but is not a store, so
+    // `jj workspace root` succeeds and only the post-condition catches it.
+    let wrong = matrix.start("D3")?;
+    let target = fs::read_to_string(wrong.join(".jj/repo"))?;
+    let target = std::path::Path::new(&target);
+    assert!(target.is_dir(), "D3's pointer target should exist");
+    assert!(
+        !target.join("store").exists(),
+        "D3's pointer target should not be a real jj store"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_submodule_shapes_nest_as_recorded() -> Result<(), TestError> {
+    let (_guard, matrix) = matrix()?;
+
+    assert!(matrix.start("SM-1")?.join(".git").exists());
+    assert!(matrix.start("SM-2")?.join(".git").exists());
+    // The path-clash shape is what a bare `rposition` over `modules`
+    // components misresolves.
+    assert!(matrix.start("SM-m")?.ends_with("modules/foo"));
+    Ok(())
+}

--- a/cli/vcs-test-support/tests/matrix.rs
+++ b/cli/vcs-test-support/tests/matrix.rs
@@ -43,9 +43,8 @@ fn every_recorded_fixture_key_is_built() -> Result<(), TestError> {
 fn the_nested_inner_shapes_carry_only_one_marker() -> Result<(), TestError> {
     let (_guard, matrix) = matrix()?;
 
-    // The jj-inside-git shapes must carry `.jj` only, or a `.git`-inclusive
-    // walk would stop at them for the wrong reason and the fixture would prove
-    // nothing about the three-walk requirement.
+    // These must carry `.jj` only, or a `.git`-inclusive walk stops at them for
+    // the wrong reason and the fixture proves nothing.
     for key in ["NJG-i", "PJG-i", "JS-in"] {
         let start = matrix.start(key)?;
         assert!(start.join(".jj").exists(), "{key} should carry .jj");

--- a/cli/vcs-test-support/tests/matrix.rs
+++ b/cli/vcs-test-support/tests/matrix.rs
@@ -6,16 +6,15 @@
 
 use std::fs;
 
+use vcs_test_support::fixtures;
 use vcs_test_support::fixtures::Matrix;
-use vcs_test_support::hermetic::assert_git_is_recent_enough;
 
 type TestError = Box<dyn std::error::Error>;
 
-fn matrix() -> Result<(tempfile::TempDir, Matrix), TestError> {
-    assert_git_is_recent_enough()?;
-    let base = tempfile::Builder::new().prefix("vcs-matrix-").tempdir()?;
-    let built = Matrix::build_in(base.path())?;
-    Ok((base, built))
+fn matrix() -> Result<(Option<tempfile::TempDir>, Matrix), TestError> {
+    let (guard, root) = fixtures::matrix_root()?;
+    let built = Matrix::build_or_adopt(&root)?;
+    Ok((guard, built))
 }
 
 #[test]

--- a/cli/vcs-test-support/tests/stubs.rs
+++ b/cli/vcs-test-support/tests/stubs.rs
@@ -6,6 +6,8 @@
 //! is the one failure mode that would leave the story's headline property
 //! unproven while every suite stayed green.
 
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use vcs_test_support::stubs::Mode;
@@ -22,10 +24,11 @@ fn a_spawn_through_the_stub_path_is_recorded() -> Result<(), TestError> {
 
     assert_eq!(stubs.spawns()?, None, "nothing has run yet");
 
-    // Resolve `git` through the synthetic PATH exactly as a spawning adapter
-    // would, rather than by absolute path.
-    let mut command = Command::new("sh");
-    command.arg("-c").arg("git --version >/dev/null 2>&1");
+    // Resolved through the synthetic PATH exactly as the spawning adapter does
+    // it. Not via a shell: on a usrmerge Linux both /bin and /usr/bin resolve
+    // git, so both are stripped and `sh` is no longer on the PATH at all.
+    let mut command = Command::new("git");
+    command.arg("--version");
     stubs.apply(&mut command);
     let status = command.status()?;
     assert!(status.success());
@@ -62,17 +65,25 @@ fn the_synthetic_path_drops_every_directory_that_resolves_a_real_binary(
     let base = tempfile::Builder::new().prefix("stub-strip-").tempdir()?;
     let stubs = Stubs::rooted_at(base.path())?;
 
-    let mut command = Command::new("sh");
-    command.arg("-c").arg("command -v git");
-    stubs.apply(&mut command);
-    let output = command.output()?;
-    let resolved = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let resolvable: Vec<PathBuf> = stubs
+        .path()
+        .split(':')
+        .filter(|entry| !entry.is_empty())
+        .flat_map(|entry| {
+            ["git", "jj"].map(|binary| Path::new(entry).join(binary))
+        })
+        .filter(|candidate| candidate.is_file())
+        .collect();
 
-    assert_eq!(
-        std::path::Path::new(&resolved).parent(),
-        Some(stubs.directory()),
-        "git resolved to {resolved}, not to the stub"
-    );
+    for candidate in &resolvable {
+        assert_eq!(
+            candidate.parent(),
+            Some(stubs.directory()),
+            "{} resolves a real binary",
+            candidate.display()
+        );
+    }
+    assert_eq!(resolvable.len(), 2, "both stubs should be resolvable");
     Ok(())
 }
 

--- a/cli/vcs-test-support/tests/stubs.rs
+++ b/cli/vcs-test-support/tests/stubs.rs
@@ -1,0 +1,87 @@
+//! The harness itself, checked.
+//!
+//! "No marker was written" only means something if a marker *would* have been
+//! written by a real spawn. A broken stub — unwritable, non-executable, or
+//! never first on `PATH` — makes the zero-spawn assertion pass vacuously, which
+//! is the one failure mode that would leave the story's headline property
+//! unproven while every suite stayed green.
+
+use std::process::Command;
+
+use vcs_test_support::stubs::Mode;
+use vcs_test_support::stubs::Stubs;
+use vcs_test_support::stubs::MODE_VARIABLE;
+use vcs_test_support::stubs::SHADOWED_VARIABLE;
+
+type TestError = Box<dyn std::error::Error>;
+
+#[test]
+fn a_spawn_through_the_stub_path_is_recorded() -> Result<(), TestError> {
+    let base = tempfile::Builder::new().prefix("stub-live-").tempdir()?;
+    let stubs = Stubs::rooted_at(base.path())?;
+
+    assert_eq!(stubs.spawns()?, None, "nothing has run yet");
+
+    // Resolve `git` through the synthetic PATH exactly as a spawning adapter
+    // would, rather than by absolute path.
+    let mut command = Command::new("sh");
+    command.arg("-c").arg("git --version >/dev/null 2>&1");
+    stubs.apply(&mut command);
+    let status = command.status()?;
+    assert!(status.success());
+
+    let recorded = stubs.spawns()?.ok_or(
+        "the stub recorded nothing — the marker mechanism is broken, and every \
+         zero-spawn assertion built on it would pass vacuously",
+    )?;
+    assert!(
+        recorded.contains("git"),
+        "expected the git stub to record its invocation, got: {recorded}"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_stub_directory_leads_the_synthetic_path() -> Result<(), TestError> {
+    let base = tempfile::Builder::new().prefix("stub-order-").tempdir()?;
+    let stubs = Stubs::rooted_at(base.path())?;
+    let first = stubs
+        .path()
+        .split(':')
+        .next()
+        .ok_or("the synthetic PATH is empty")?;
+    assert_eq!(std::path::Path::new(first), stubs.directory());
+    Ok(())
+}
+
+#[test]
+fn the_synthetic_path_drops_every_directory_that_resolves_a_real_binary(
+) -> Result<(), TestError> {
+    // macOS commonly provides git in both /opt/homebrew/bin and /usr/bin, so
+    // stripping a single dirname leaves it resolvable.
+    let base = tempfile::Builder::new().prefix("stub-strip-").tempdir()?;
+    let stubs = Stubs::rooted_at(base.path())?;
+
+    let mut command = Command::new("sh");
+    command.arg("-c").arg("command -v git");
+    stubs.apply(&mut command);
+    let output = command.output()?;
+    let resolved = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+
+    assert_eq!(
+        std::path::Path::new(&resolved).parent(),
+        Some(stubs.directory()),
+        "git resolved to {resolved}, not to the stub"
+    );
+    Ok(())
+}
+
+#[test]
+fn the_mode_contract_fails_closed_on_malformed_input() {
+    // These read the process environment, which the harness never sets itself —
+    // only the CI step does. Asserting the parse in-process is safe because the
+    // variables are absent here.
+    assert!(std::env::var(MODE_VARIABLE).is_err());
+    assert!(std::env::var(SHADOWED_VARIABLE).is_err());
+    assert!(matches!(Mode::from_environment(), Ok(Mode::PathOnly)));
+}

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -1210,36 +1210,36 @@ justification for the extra Python machinery over a one-line `denied` clause.
 
 #### Automated Verification
 
-- [ ] `mise run deny:check` passes with the `uluru` exception
-- [ ] `mise run pup:check` passes
-- [ ] `mise run cli:check` passes (clippy `--locked`, pedantic + nursery)
-- [ ] `mise run test:integration:deny` passes, including the new graph test
-- [ ] `mise run test:unit:tasks` passes, including the new lockstep test
-- [ ] Unit test: `InProcessProbe::discover` returns the boundary, never an
+- [x] `mise run deny:check` passes with the `uluru` exception
+- [x] `mise run pup:check` passes
+- [x] `mise run cli:check` passes (clippy `--locked`, pedantic + nursery)
+- [x] `mise run test:integration:deny` passes, including the new graph test
+- [x] `mise run test:unit:tasks` passes, including the new lockstep test
+- [x] Unit test: `InProcessProbe::discover` returns the boundary, never an
       ancestor, on the colocated and `.git`-file shapes `detection.rs` already
       builds — plus the paired negative assertion that an unbounded
       `gix::discover` on the same fixture *does* escape to the parent repository.
       The **both-nesting-directions** form of this criterion moves to Phase 2,
       which owns the nesting fixtures; Phase 1 must not duplicate them
-- [ ] `kind` and `repository_root` agree with `CommandProbe` on the plain-git,
+- [x] `kind` and `repository_root` agree with `CommandProbe` on the plain-git,
       colocated, commitless and jj-secondary fixtures; `revision` agrees for
       `VcsKind::Git` and returns `None` (warn-logged) for `VcsKind::Jj`, per the
       spike-resolved descope above
-- [ ] Non-vacuity is **committed**, not demonstrated by hand: probe cases in
+- [x] Non-vacuity is **committed**, not demonstrated by hand: probe cases in
       `tests/integration/pup/test_import_rule.py` for the new rule — a
       `std::process::Command` import rejected with `"is denied"` and the rule
       name present, a compliant single-item-import module as the positive
       control (catching a rule whose scope silently matched nothing, which
       0169's module rename would otherwise cause), and a grouped-import case
       pinning the `use a::{b, c}` behaviour
-- [ ] The lockstep test also asserts the `gix` pin comment in `cli/Cargo.toml`
+- [x] The lockstep test also asserts the `gix` pin comment in `cli/Cargo.toml`
       and the `uluru` exception comment in `cli/deny.toml` are present and
       non-empty
-- [ ] `mise run` green end to end
+- [x] `mise run` green end to end
 
 #### Manual Verification
 
-- [ ] `cli/vcs/src/**` is unmodified (`jj diff --stat`)
+- [x] `cli/vcs/src/**` is unmodified (`jj diff --stat`)
 - [ ] The `accelerator-visualiser` musl-static size is recorded before and after
       this phase, so a later regression has a baseline (the trees enter its
       closure via `vcs-adapters` → `corpus-adapters` → `visualiser/server`)
@@ -1248,9 +1248,9 @@ justification for the extra Python machinery over a one-line `denied` clause.
       (`.github/workflows/main.yml:125`), and the budget raised in this same
       change if the margin is thin — this plan guarantees a cold cache by
       changing the lock
-- [ ] `CommandProbe` and `MarkerWalkRoot` have no new methods
-- [ ] `vcs_adapters::facts` still names `MarkerWalkRoot`/`CommandProbe`
-- [ ] `cli/vcs-adapters/Cargo.toml` gains no `[features]` entry beyond
+- [x] `CommandProbe` and `MarkerWalkRoot` have no new methods
+- [x] `vcs_adapters::facts` still names `MarkerWalkRoot`/`CommandProbe`
+- [x] `cli/vcs-adapters/Cargo.toml` gains no `[features]` entry beyond
       `bash-parity`
 
 ---

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -1,0 +1,2694 @@
+---
+type: plan
+id: "2026-08-03-0188-library-backed-vcs-adapter"
+title: "Library-Backed VCS Adapter over gix and jj-lib Implementation Plan"
+date: "2026-08-03T09:10:56+00:00"
+author: "Toby Clemson"
+producer: create-plan
+status: draft
+work_item_id: "work-item:0188"
+parent: "work-item:0188"
+derived_from: ["codebase-research:2026-08-02-0188-library-backed-vcs-adapter"]
+relates_to: ["work-item:0169", "work-item:0185", "work-item:0125"]
+tags: [rust, vcs, dependencies, gix, jj-lib]
+revision: "2ec1cc10961f3070ff6432cd2ebe54c52886b13e"
+repository: "accelerator"
+last_updated: "2026-08-03T09:10:56+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Library-Backed VCS Adapter over gix and jj-lib Implementation Plan
+
+## Overview
+
+Add an in-process implementation of `cli/vcs`'s `RepoRoot` and `VcsProbe` ports
+over `gix` 0.85 and `jj-lib` 0.43, plus six inherent taxonomy queries and the
+test apparatus that proves the whole thing reads git and jj without spawning a
+subprocess. `CommandProbe` and `MarkerWalkRoot` are retained; nothing is wired
+to the new type. The value delivered is risk isolation: two dependency trees, a
+workspace-wide licence exception and a pre-1.0 API bet land where they can be
+reviewed and reverted alone.
+
+## Current State Analysis
+
+`cli/vcs` (193 lines, zero dependencies) defines `VcsKind`, `RepoFacts`,
+`RepoRoot` and `VcsProbe` (`cli/vcs/src/lib.rs:46-67`) and the composition
+function `facts` (`:74-91`). **This crate is not touched by this plan.**
+
+`cli/vcs-adapters` (323 lines) holds `MarkerWalkRoot`
+(`cli/vcs-adapters/src/lib.rs:32`), `CommandProbe` (`:73`), the two subprocess
+invocations (`:110-125`), the single spawn chokepoint (`:168`), the environment
+scrub (`:139-154`) and the hard-wired composition root (`:224-227`). The jj
+secondary-workspace rule is already implemented by pure file reads
+(`jj_repository_root`, `:57-68`).
+
+The dependency work is entirely unstarted: `gix`, `jj-lib` and `uluru` appear
+nowhere in `cli/Cargo.lock` (358 packages), `cli/deny.toml`, `cli/pup.ron` or
+`cli/Cargo.toml`. The only landed prerequisite is the `mise.toml` `jj` pin at
+0.43.0 with its lockstep comment (`mise.toml:12-16`), and — as of this planning
+session — `mise install` on this machine.
+
+`cli/corpus-adapters` reaches the free function `vcs_adapters::facts`
+(`src/metadata.rs:201`), not the adapter types, so leaving `facts` hard-wired
+keeps the retained pair in place with no consumer change.
+
+## Desired End State
+
+`cli/vcs-adapters` exports a module `library` containing one type,
+`InProcessProbe`, that implements both ports over `gix`/`jj-lib` and carries six
+inherent taxonomy queries returning plain domain values behind
+`Result<Option<_>, _>`, with every returned path canonicalised. A new workspace
+crate `cli/vcs-test-support` publishes the fixture matrix, the zero-spawn
+harness and the named pure-jj builder, consumed by both `cli/vcs-adapters` and
+`cli/corpus-adapters`. Two reference artefact binaries link the trees,
+cross-compile to static musl on all four release triples, and are measured
+against a committed size floor. A Linux-only CI job proves the strong form of
+zero-spawn against prebuilt fixtures and prebuilt binaries. `mise run` is green;
+`CommandProbe`, `MarkerWalkRoot`, `cli/vcs/src/**` and every existing consumer
+are behaviourally unchanged — though both dependency trees do enter the build
+graph of `cli/corpus-adapters` and `cli/visualiser/server`.
+
+### Key Discoveries
+
+Established empirically during this planning session (jj 0.43.0, git 2.54.0,
+Rust 1.90.0, darwin-arm64). The full oracle mapping is in
+[Oracle Mapping](#oracle-mapping) below.
+
+1. **`jj git init` colocates by default at 0.43, and `--no-colocate` exists.**
+   A bare `jj git init` produces both `.jj` and `.git`. The pure-jj fixture is
+   therefore a one-flag construction, not a post-hoc `.git` deletion — and the
+   shell suite's `make_main_jj_workspace` (`hooks/test-vcs-detect.sh:47-52`) has
+   been building *colocated* repositories all along.
+
+2. **Three distinct walks are required, not one.** The work item names only the
+   combined `.jj`-or-`.git` boundary walk. Measurement shows queries 4, 5 and
+   the jj half of query 6 need a **`.jj`-only** walk: from
+   `nested-git-in-jj`'s inner git worktree the boundary walk yields `sub`, and
+   `DefaultWorkspaceLoaderFactory::create(sub)` returns
+   `Err(There is no Jujutsu repo in …)`, whereas a `.jj`-only walk yields the
+   outer jj root — which is exactly what the `jj workspace root` oracle
+   returns. Using the boundary walk for query 4 would report absence where the
+   oracle reports a root.
+
+3. **`gix::open` for the boundary, `gix::discover` for the queries.** Both
+   mechanisms live in the same type. `gix::open(boundary)` performs no walk and
+   is the `RepoRoot` mechanism; `gix::discover(start)` legitimately escapes the
+   boundary and is required by queries 1, 2, 3 and the git half of 6. Confirmed:
+   on `nested-jj-in-git`'s inner workspace, `gix::open(boundary)` errors while
+   `gix::discover(start)` returns the outer git root, matching
+   `git rev-parse --show-toplevel`.
+
+4. **`common_dir()` is not normalised.** For a linked worktree gix returns
+   `…/.git/worktrees/<id>/../..` where the oracle returns `…/.git`. The two are
+   equal only after canonicalisation. Recorded nowhere previously.
+
+5. **`main_repo()` on a submodule returns the submodule**, so it must not be
+   used for superproject resolution. The hand-rolled derivation (nearest
+   `modules` component in `git_dir()`, then `gix::open` on its parent) matched
+   the oracle at submodule depths 1 and 2.
+
+6. **The scrub invariant holds for free on both sides.** All 24 (fixture, start
+   directory) pairs returned identical values with `GIT_DIR` and
+   `GIT_COMMON_DIR` poisoned at another fixture's real `.git`. The research had
+   proven only the git side; the jj-lib loader is pure filesystem reads and is
+   likewise unaffected. **No scrub is implemented — the invariant is verified.**
+   `gix::discover_with_environment_overrides` diverges under the same poison
+   (returning the poison target) and is the confirmed non-vacuity control.
+   Scope note: this measured two variables. `gix::open`'s default permissions do
+   consult the environment for object directories and for system/global config
+   discovery, and `is_bare()` reads `core.bare` *through* that config — so
+   Phase 2 §3 widens the poisoning matrix to everything `scrub_environment`
+   touches plus the object-directory and `GIT_CONFIG_COUNT` families, rather
+   than generalising from these two to "uniformly immune".
+
+7. **The two-clause cargo-pup rule works.** With `allowed_only` permitting
+   `^(std|core|alloc)(::|$)` and `denied` listing `^std::process(::|$)`, a
+   `use std::process::Command` fails with *"Use of module 'std::process::Command'
+   is denied"*. The grouped-import gotcha still bites under the combined rule:
+   `use std::path::{Path, PathBuf}` fails with *"Use of module '' is not
+   allowed"*. Single-item imports are mandatory throughout the new module.
+
+8. **`jj-lib` 0.43 with default features does pull `gix` 0.85**, enabling
+   `attributes`, `blob-diff`, `index`, `max-performance-safe`, `sha1` and
+   `zlib-rs` on it. The single-graph reasoning behind the pin holds, and
+   `submodules()`' `attributes` feature comes from jj-lib itself.
+
+9. **56 gix-family packages, zero duplicate versions**, no TLS stack, no
+   `git2`/`libgit2-sys`, and **no zstd** — the `include-flate-compress`
+   collision the research anticipated does not materialise. `uluru 3.1.0`
+   (MPL-2.0, via `gix-pack`, reached from both `gix` and `gix-odb`) is the only
+   licence rejection; `bans`, `sources` and `advisories` pass against the real
+   `cli/deny.toml`, and the exception clears `licenses`.
+
+10. **The size-delta criterion is mis-calibrated** — see
+    [Work-Item Amendments](#work-item-amendments). Measured deltas: musl-static
+    stripped 2,031,448 B; darwin stripped 1,639,872 B. The ratio is 6.19×.
+
+11. **MSRV-aware resolution is load-bearing.** Without `rust-version` +
+    `resolver = "3"` the graph selects `kstring 2.0.4`, which requires Rust
+    1.96 and refuses to build on the pinned 1.90.0. The `cli/` workspace has
+    both, so the lock must be generated in-workspace.
+
+12. **The single-query mode is not load-bearing.** `refart all` (six queries +
+    both port methods) measured 3.66 ms against `refart only q4` at 3.65 ms on
+    the pure-jj fixture — process startup dominates. The mode is retained
+    because 0169 will want it, not because the figure would otherwise be
+    unusable.
+
+13. **No cross-crate test-fixture precedent exists** in `cli/` (zero path-based
+    `[dev-dependencies]`); the build-system guards scan `cli/**/src` rather than
+    an enumerated crate list, so a new member costs the workspace `members`
+    array and the lock.
+
+## What We're NOT Doing
+
+- **Not touching `cli/vcs/src/**`.** No port added, widened or changed.
+- **Not removing `CommandProbe` or `MarkerWalkRoot`**, and not adding any
+  method to either. That is 0185's work.
+- **Not wiring anything.** `vcs_adapters::facts` stays hard-wired to
+  `MarkerWalkRoot`/`CommandProbe`. No feature flag, config switch or
+  composition helper routes a caller to `InProcessProbe`.
+- **Not building `classify_checkout`'s arm cascade**, and not implementing
+  `vcs status` / `vcs log`. 0169 owns both, and owns widening the pup rule to
+  cover wherever it puts that code.
+- **Not defining a domain port over the six queries.** 0169 defines whatever
+  port its classifier needs.
+- **Not gating on cost.** Numbers are measured and recorded; 0169 owns the
+  `G ≤ 1.1 × B` gate.
+- **Not migrating the ~26 shell call sites.** They keep running in bash.
+
+## Implementation Approach
+
+Five phases, each independently mergeable and each leaving `mise run` green.
+Phase 1 lands the dependency trees and every enforcement gate, so a
+policy objection surfaces before any query logic exists. Phase 2 builds the six
+queries test-first against the recorded oracle mapping, in the shared
+test-support crate created there. Phase 3 adds the stub harness and proves it
+across a crate boundary. Phase 4 adds the stub artefact, the musl staging
+and the strong-form CI job, and takes the measurements. Phase 5 writes the
+sibling hand-offs and the work-item amendments.
+
+**Phase 1 starts once work-item amendments 5-8 have landed.** The `revision`
+question that previously blocked it was closed by spike on 2026-08-03 (jj
+`revision` is descoped to 0185 — see Phase 1 §4).
+
+Test-driven throughout where the oracle is known: every query's expected values
+come from the mapping table below, written as assertions before the query
+exists.
+
+---
+
+## Oracle Mapping
+
+Established by running each candidate oracle against each fixture on
+**2026-08-03**, jj **0.43.0**, git **2.54.0**, Rust **1.90.0**,
+`Darwin arm64`. Fixtures were built in a hermetic environment (`HOME`,
+`XDG_CONFIG_HOME`, `JJ_CONFIG` at temp dirs; `GIT_CONFIG_NOSYSTEM=1`;
+`GIT_CONFIG_GLOBAL=/dev/null`; `GIT_CEILING_DIRECTORIES` at the temp base) and
+paths are shown relative to that base as `$BASE`. Every oracle command is run
+**with the start directory as cwd**.
+
+Query 2's `PJG-i` common-dir, Query 5's `NGPJ-i` row, and Query 6's `JS-r`,
+`JS-s`, `WT-m`, `SM-2`, `SM-s`, `SO` and `PJS` rows were **re-measured on
+2026-08-03** after plan review 1 found the first draft's table incomplete in
+those cells; the re-measurement used the same environment and tool versions.
+
+`superproject()` deliberately conflates the two absence signals below into
+`None` — it cannot distinguish "in a repository with no superproject" from "not
+in a repository at all", and nothing in the taxonomy needs the distinction.
+
+**Absence signals differ per oracle** and are part of the contract:
+
+| Oracle | Absence signal |
+| --- | --- |
+| `git rev-parse --is-bare-repository` / `--git-dir` / `--git-common-dir` / `--show-toplevel` | exit **128**, empty stdout |
+| `git rev-parse --show-superproject-working-tree`, inside a repository with no superproject | exit **0**, empty stdout |
+| `git rev-parse --show-superproject-working-tree`, outside any repository | exit **128**, empty stdout |
+| `jj workspace root` | exit **1**, empty stdout |
+| `find_git_main_worktree_root` | exit 1, empty stdout |
+| `find_jj_main_workspace_root` | exit 1, empty stdout |
+
+### Fixture keys
+
+| Key | Shape | Start directory |
+| --- | --- | --- |
+| `CR` | colocated, real (`git init` + `jj git init --colocate`) | root |
+| `CG` | colocated, hand-grafted (git linked worktree + grafted `.jj`) | root |
+| `JS-r` | jj secondary workspace | workspace root |
+| `JS-s` | jj secondary workspace | subdirectory `deep/er` |
+| `PG-r` | plain git | root |
+| `PG-s` | plain git | subdirectory `deep/er` |
+| `NJG-i` | nested-jj-in-git — the inner directory is a jj **secondary** workspace of `$BASE/jjmain-colocated` (which is itself colocated); the inner directory carries `.jj` only | inner jj workspace |
+| `NJG-o` | nested-jj-in-git | outer git root |
+| `NGJ-i` | nested-git-in-jj (colocated outer) | inner git worktree |
+| `NGJ-o` | nested-git-in-jj (colocated outer) | outer jj root |
+| `WT-l` | linked git worktree | the linked worktree |
+| `WT-m` | linked git worktree | the main worktree |
+| `SM-1` | git submodule, modern form | the submodule (`super/mid`) |
+| `SM-2` | git submodule nested | depth-2 submodule (`super/mid/leaf`) |
+| `SM-s` | git submodule | the superproject root |
+| `SO` | old-form submodule (nested `.git` **directory**) | the nested repo |
+| `BARE` | bare repository | the bare dir |
+| `NONE` | no repository at all | a marker-less dir |
+| `PJ` | pure jj (`--no-colocate`), root three dirs below temp root | root |
+| `PJS` | secondary workspace of a `--no-colocate` main | workspace root |
+| `NGPJ-i` | nested-git-in-**pure**-jj | inner git worktree |
+| `NGPJ-o` | nested-git-in-**pure**-jj | outer jj root |
+| `PJG-i` | pure-jj-in-git — the inner directory is a jj secondary workspace of a `--no-colocate` main | inner jj workspace |
+| `PJG-o` | pure-jj-in-git | outer git root |
+
+Every row is one (fixture, start directory) pair, so the **core matrix is 24
+pairs**. Ten further fixtures were added after plan review and measured on
+2026-08-03; their keys and oracle values are in
+[Extended fixtures](#extended-fixtures-measured-2026-08-03) below, which also
+records why they are kept separate from the core matrix.
+
+**Shared parents are named per fixture**, because an earlier draft collapsed them
+and produced two impossible identities: a single `$BASE/jjmain` was named as the
+main of both `NJG-i` (a colocated main) and `PJG-i` (a `--no-colocate` main), and
+a single `$BASE/gitparent` was recorded as hosting worktrees keyed `sub` for both
+`NGJ-i` and `NGPJ-i` — which `git worktree add` cannot do, since it derives the id
+from the basename and de-duplicates the second to `sub1`. The `worktrees()` count
+corroborated the collapse: three worktrees of one parent would have counted 3,
+not the recorded 1.
+
+The names, matching the measurement runs:
+
+| Parent | Shape | Fixtures that use it |
+| --- | --- | --- |
+| `$BASE/jjmain-colocated` | `jj git init` (colocated by default at 0.43) | `JS-r`, `JS-s`, `NJG-i` |
+| `$BASE/jjmain-pure` | `jj git init --no-colocate` | `PJG-i` |
+| `$BASE/gitparent-cg` | plain git, hosts the `CG` graft worktree | `CG` |
+| `$BASE/gitparent-ngj` | plain git, hosts `NGJ`'s inner worktree | `NGJ-i` |
+| `$BASE/gitparent-ngpj` | plain git, hosts `NGPJ`'s inner worktree | `NGPJ-i` |
+
+Each `gitparent-*` hosts exactly **one** linked worktree, so `worktrees()` is 1
+from both ends, as recorded.
+
+`CR` and `CG` are **both** carried because the shell's `colocated` arm requires
+`jj_secondary && git_worktree` (`scripts/vcs-common.sh:242-247`): a genuine
+`jj git init --colocate` main repository classifies as `main`, not `colocated`.
+The work item's single "colocated | root" row is ambiguous between them.
+
+### Query 1 — bare-repository check
+
+Oracle: `git rev-parse --is-bare-repository`.
+Library: `gix::discover(start)?.is_bare()`.
+
+| Fixture | Oracle stdout (exit) | Library | Verdict |
+| --- | --- | --- | --- |
+| `CR` | `false` (0) | `false` | agree |
+| `CG` | `false` (0) | `false` | agree |
+| `JS-r` | *empty* (128) | not a git repo → `None` | agree |
+| `JS-s` | *empty* (128) | `None` | agree |
+| `PG-r` | `false` (0) | `false` | agree |
+| `PG-s` | `false` (0) | `false` | agree |
+| `NJG-i` | `false` (0) | `false` | agree |
+| `NJG-o` | `false` (0) | `false` | agree |
+| `NGJ-i` | `false` (0) | `false` | agree |
+| `NGJ-o` | `false` (0) | `false` | agree |
+| `WT-l` | `false` (0) | `false` | agree |
+| `WT-m` | `false` (0) | `false` | agree |
+| `SM-1` | `false` (0) | `false` | agree |
+| `SM-2` | `false` (0) | `false` | agree |
+| `SM-s` | `false` (0) | `false` | agree |
+| `SO` | `false` (0) | `false` | agree |
+| `BARE` | `true` (0) | `true` | agree |
+| `NONE` | *empty* (128) | `None` | agree |
+| `PJ` | *empty* (128) | `None` | agree |
+| `PJS` | *empty* (128) | `None` | agree |
+| `NGPJ-i` | `false` (0) | `false` | agree |
+| `NGPJ-o` | *empty* (128) | `None` | agree |
+| `PJG-i` | `false` (0) | `false` | agree |
+| `PJG-o` | `false` (0) | `false` | agree |
+
+`BARE` is reachable only via `gix::discover`/`gix::open` on the start path — the
+boundary walk returns `None` there (a bare repository carries neither marker),
+confirming the work item's Library-traps consequence. `kind()` for a bare
+repository is `Common`, not a distinct variant.
+
+### Query 2 — worktree detection and common dir
+
+Oracle: `git rev-parse --git-dir` vs `git rev-parse --git-common-dir`
+(different ⇒ linked worktree), and the main worktree root as
+`realpath $(dirname <absolutised common-dir>)`.
+Library: `kind()`, `git_dir()`, `common_dir()`, `main_repo().workdir()`.
+
+**Oracle outputs are relative to the invocation directory** where git chooses to
+emit them; they must be absolutised against the start path before comparison, as
+`scripts/vcs-common.sh:215-216` does by hand.
+
+| Fixture | `--git-dir` (exit 0) | `--git-common-dir` (exit 0) | `kind()` | `git_dir()` | `common_dir()` (raw) | `main_repo().workdir()` | Verdict |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CR` | `.git` | `.git` | `Common` | `$BASE/CR/.git` | `$BASE/CR/.git` | `$BASE/CR` | agree |
+| `CG` | `$BASE/gitparent-cg/.git/worktrees/CG` | `$BASE/gitparent-cg/.git` | `LinkedWorkTree` | `$BASE/gitparent-cg/.git/worktrees/CG` | `$BASE/gitparent-cg/.git/worktrees/CG/../..` | `$BASE/gitparent-cg` | agree **after canonicalising `common_dir()`** |
+| `PG-r` | `.git` | `.git` | `Common` | `$BASE/PG/.git` | `$BASE/PG/.git` | `$BASE/PG` | agree |
+| `PG-s` | `$BASE/PG/.git` | `../../.git` | `Common` | `$BASE/PG/.git` | `$BASE/PG/.git` | `$BASE/PG` | agree after absolutising the oracle |
+| `NJG-i` | `$BASE/NJG/.git` | `../.git` | `Common` | `$BASE/NJG/.git` | `$BASE/NJG/.git` | `$BASE/NJG` | agree |
+| `NJG-o` | `.git` | `.git` | `Common` | `$BASE/NJG/.git` | `$BASE/NJG/.git` | `$BASE/NJG` | agree |
+| `NGJ-i` | `$BASE/gitparent-ngj/.git/worktrees/sub` | `$BASE/gitparent-ngj/.git` | `LinkedWorkTree` | `$BASE/gitparent-ngj/.git/worktrees/sub` | `…/worktrees/sub/../..` | `$BASE/gitparent-ngj` | agree after canonicalising |
+| `NGJ-o` | `.git` | `.git` | `Common` | `$BASE/NGJ/.git` | `$BASE/NGJ/.git` | `$BASE/NGJ` | agree |
+| `WT-l` | `$BASE/main/.git/worktrees/WT` | `$BASE/main/.git` | `LinkedWorkTree` | `$BASE/main/.git/worktrees/WT` | `…/worktrees/WT/../..` | `$BASE/main` | agree after canonicalising |
+| `WT-m` | `.git` | `.git` | `Common` | `$BASE/main/.git` | `$BASE/main/.git` | `$BASE/main` | agree |
+| `SM-1` | `$BASE/super/.git/modules/mid` | `$BASE/super/.git/modules/mid` | `Submodule` | same | same | `$BASE/super/mid` | agree — **equal dirs, so not a worktree** |
+| `SM-2` | `$BASE/super/.git/modules/mid/modules/leaf` | same | `Submodule` | same | same | `$BASE/super/mid/leaf` | agree |
+| `SM-s` | `.git` | `.git` | `Common` | `$BASE/super/.git` | `$BASE/super/.git` | `$BASE/super` | agree |
+| `SO` | `.git` | `.git` | `Common` | `$BASE/old/inner/.git` | same | `$BASE/old/inner` | agree |
+| `BARE` | `.` | `.` | `Common` | `$BASE/bare` | `$BASE/bare` | `workdir() == None` | agree |
+| `NGPJ-i` | `$BASE/gitparent-ngpj/.git/worktrees/sub` | `$BASE/gitparent-ngpj/.git` | `LinkedWorkTree` | as oracle | `…/../..` | `$BASE/gitparent-ngpj` | agree after canonicalising |
+| `PJG-o` | `.git` | `.git` | `Common` | `$BASE/PJG/.git` | same | `$BASE/PJG` | agree |
+| `JS-r`, `JS-s`, `NONE`, `PJ`, `PJS`, `NGPJ-o` | *empty* (128) | *empty* (128) | n/a | n/a | n/a | n/a | agree (absent) |
+| `PJG-i` | `$BASE/PJG/.git` | `../.git` | `Common` | `$BASE/PJG/.git` | same | `$BASE/PJG` | agree after absolutising the oracle |
+
+The `PJG-i` common-dir was recorded as `.git` in the first draft of this table;
+re-measurement on 2026-08-03 returned `../.git`. Absolutised against the start
+directory `$BASE/PJG/sub` that is `$BASE/PJG/.git`, equal to `--git-dir`, so the
+shell oracle sets `git_worktree=0` and `kind() == Common` agrees. The earlier
+value would have made the oracle take the `colocated` arm.
+
+The `main_worktree_root` column's oracle is `realpath $(dirname <absolutised
+common-dir>)` **only for `Kind::Common` and `Kind::LinkedWorkTree`**. It is
+undefined for the bare and submodule shapes: applied to `BARE` the formula gives
+`$BASE`, and to `SM-1`/`SM-2` it gives a `.git/modules/…` path — neither of which
+is a worktree root. For those shapes the recorded library values
+(`workdir() == None`, and the submodule's own workdir) are the contract, and
+`WorktreeFacts.main_worktree_root` carries no oracle. The Verdict column covers
+the `kind()`/`git_dir()`/`common_dir()` comparison only.
+
+`worktrees()` enumerated `1` linked worktree by id from **both** the linked and
+the main worktree (`WT-l`, `WT-m`, `CG`, `NGJ-i`, `NGPJ-i`), and `0` elsewhere.
+
+### Query 3 — superproject / submodule resolution
+
+Oracle: `git rev-parse --show-superproject-working-tree` (**exit 0 + empty**
+when there is no superproject).
+Library: no gix API exists — derived from `Kind::Submodule` plus the nearest
+`modules` component of `git_dir()`, then `gix::open` on its parent to recover
+the workdir.
+
+| Fixture | Oracle stdout (exit) | Derived | Verdict |
+| --- | --- | --- | --- |
+| `SM-1` | `$BASE/super` (0) | `$BASE/super` | agree |
+| `SM-2` | `$BASE/super/mid` (0) | `$BASE/super/mid` | agree — **nearest**, not first, `modules` |
+| `SM-s` | *empty* (0) | `None` (`kind() == Common`) | agree |
+| `SO` | *empty* (0) | `None` (`kind() == Common`) | agree — old-form submodules are not submodules to either |
+| every other fixture | *empty* (0) or 128 | `None` | agree |
+
+### Query 4 — jj workspace-root resolution
+
+Oracle: `jj workspace root`.
+Library: **`.jj`-only** upward walk, then
+`DefaultWorkspaceLoaderFactory::create(root)?.workspace_root()`.
+
+| Fixture | Oracle stdout (exit) | Via boundary walk | Via `.jj`-only walk | Verdict |
+| --- | --- | --- | --- | --- |
+| `CR` | `$BASE/CR` (0) | `$BASE/CR` | `$BASE/CR` | agree |
+| `CG` | `$BASE/CG` (0) | `$BASE/CG` | `$BASE/CG` | agree |
+| `JS-r` | `$BASE/JS` (0) | `$BASE/JS` | `$BASE/JS` | agree |
+| `JS-s` | `$BASE/JS` (0) | `$BASE/JS` | `$BASE/JS` | agree |
+| `PG-r`, `PG-s` | *empty* (1) | `Err(no Jujutsu repo)` | walk found nothing | agree |
+| `NJG-i` | `$BASE/NJG/sub` (0) | `$BASE/NJG/sub` | `$BASE/NJG/sub` | agree |
+| `NJG-o` | *empty* (1) | `Err(no Jujutsu repo)` | nothing | agree |
+| **`NGJ-i`** | **`$BASE/NGJ` (0)** | **`Err(There is no Jujutsu repo in $BASE/NGJ/sub)`** | **`$BASE/NGJ`** | **only the `.jj`-only walk agrees** |
+| `NGJ-o` | `$BASE/NGJ` (0) | `$BASE/NGJ` | `$BASE/NGJ` | agree |
+| `WT-l`, `WT-m`, `SM-*`, `SO`, `BARE`, `NONE` | *empty* (1) | nothing / `Err` | nothing | agree |
+| `PJ` | `$BASE/PJ/a/b/c` (0) | same | same | agree |
+| `PJS` | `$BASE/PJS` (0) | same | same | agree |
+| **`NGPJ-i`** | **`$BASE/NGPJ` (0)** | **`Err(no Jujutsu repo in $BASE/NGPJ/sub)`** | **`$BASE/NGPJ`** | **only the `.jj`-only walk agrees** |
+| `NGPJ-o` | `$BASE/NGPJ` (0) | `$BASE/NGPJ` | `$BASE/NGPJ` | agree |
+| `PJG-i` | `$BASE/PJG/sub` (0) | `$BASE/PJG/sub` | `$BASE/PJG/sub` | agree |
+| `PJG-o` | *empty* (1) | `Err(no Jujutsu repo)` | nothing | agree |
+
+The two bold rows are the empirical basis for Key Discovery 2.
+
+### Query 5 — jj main-vs-secondary, and where the main repository is
+
+Oracle: `.jj/repo` is a **file** ⇒ secondary (`_jj_workspace_is_secondary`,
+`scripts/vcs-common.sh:74-81`); main repository root via
+`find_jj_main_workspace_root`.
+Library: `repo_path()` canonicalised ≠ `<workspace_root>/.jj/repo`
+canonicalised ⇒ secondary; main root = `repo_path().parent().parent()`.
+
+| Fixture | `.jj/repo` | Oracle `find_jj_main_workspace_root` (exit) | `repo_path()` | Library verdict | Main root | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| `CR` | directory | `$BASE/CR` (0) | `$BASE/CR/.jj/repo` | main | `$BASE/CR` | agree |
+| `CG` | file → `$BASE/jjparent/.jj/repo` (absolute) | `$BASE/jjparent` (0) | `$BASE/jjparent/.jj/repo` | secondary | `$BASE/jjparent` | agree |
+| `JS-r` | file → `../../jjmain/.jj/repo` (relative) | `$BASE/jjmain-colocated` (0) | `$BASE/jjmain-colocated/.jj/repo` | secondary | `$BASE/jjmain-colocated` | agree |
+| `JS-s` | as `JS-r` | `$BASE/jjmain-colocated` (0) | as `JS-r` | secondary | `$BASE/jjmain-colocated` | agree |
+| `NJG-i` | file → `../../../jjmain/.jj/repo` | `$BASE/jjmain-colocated` (0) | `$BASE/jjmain-colocated/.jj/repo` | secondary | `$BASE/jjmain-colocated` | agree |
+| `NGJ-i` | directory (at the outer root) | `$BASE/NGJ` (0) | `$BASE/NGJ/.jj/repo` | main | `$BASE/NGJ` | agree via the `.jj`-only walk |
+| `NGJ-o` | directory | `$BASE/NGJ` (0) | `$BASE/NGJ/.jj/repo` | main | `$BASE/NGJ` | agree |
+| `PJ` | directory | `$BASE/PJ/a/b/c` (0) | `$BASE/PJ/a/b/c/.jj/repo` | main | same | agree |
+| `PJS` | file | `$BASE/PJ/a/b/c` (0) | `$BASE/PJ/a/b/c/.jj/repo` | secondary | `$BASE/PJ/a/b/c` | agree |
+| `NGPJ-i` | directory (at the outer root) | `$BASE/NGPJ` (0) | `$BASE/NGPJ/.jj/repo` | main | `$BASE/NGPJ` | agree via the `.jj`-only walk |
+| `NGPJ-o` | directory | `$BASE/NGPJ` (0) | `$BASE/NGPJ/.jj/repo` | main | `$BASE/NGPJ` | agree |
+| `PJG-i` | file | `$BASE/jjmain-pure` (0) | `$BASE/jjmain-pure/.jj/repo` | secondary | `$BASE/jjmain-pure` | agree |
+| non-jj fixtures (`PG-*`, `WT-*`, `SM-*`, `SO`, `BARE`, `NONE`, `NJG-o`, `PJG-o`) | absent | *empty* (1) | n/a | `None` | `None` | agree |
+
+`repo_path()` is already canonicalised by jj-lib (`dunce::canonicalize`,
+`jj-lib-0.43.0/src/workspace.rs:576`) while `workspace_root()` is the path
+passed in — both sides must be canonicalised before comparison.
+
+### Query 6 — independent dual-root resolution
+
+Oracle: git root = `git rev-parse --show-toplevel`; jj root =
+`jj workspace root`.
+Library: git root = `gix::discover(start)?.workdir()` (its own walk, permitted
+to escape the boundary); jj root = the `.jj`-only walk.
+
+| Fixture | Oracle git root (exit) | Oracle jj root (exit) | Library git | Library jj | Roots | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| `CR` | `$BASE/CR` (0) | `$BASE/CR` (0) | `$BASE/CR` | `$BASE/CR` | equal | agree |
+| `CG` | `$BASE/CG` (0) | `$BASE/CG` (0) | `$BASE/CG` | `$BASE/CG` | equal | agree |
+| `JS-r` | *empty* (128) | `$BASE/JS` (0) | `None` | `$BASE/JS` | jj only | agree |
+| `JS-s` | *empty* (128) | `$BASE/JS` (0) | `None` | `$BASE/JS` | jj only | agree |
+| `PG-r`/`PG-s` | `$BASE/PG` (0) | *empty* (1) | `$BASE/PG` | `None` | git only | agree |
+| `NJG-i` | `$BASE/NJG` (0) | `$BASE/NJG/sub` (0) | `$BASE/NJG` | `$BASE/NJG/sub` | differ, jj inside git | agree |
+| `NJG-o` | `$BASE/NJG` (0) | *empty* (1) | `$BASE/NJG` | `None` | git only | agree |
+| `NGJ-i` | `$BASE/NGJ/sub` (0) | `$BASE/NGJ` (0) | `$BASE/NGJ/sub` | `$BASE/NGJ` | differ, git inside jj | agree |
+| `NGJ-o` | `$BASE/NGJ` (0) | `$BASE/NGJ` (0) | `$BASE/NGJ` | `$BASE/NGJ` | equal | agree |
+| `WT-l` | `$BASE/WT` (0) | *empty* (1) | `$BASE/WT` | `None` | git only | agree |
+| `WT-m` | `$BASE/main` (0) | *empty* (1) | `$BASE/main` | `None` | git only | agree |
+| `SM-1` | `$BASE/super/mid` (0) | *empty* (1) | `$BASE/super/mid` | `None` | git only | agree |
+| `SM-2` | `$BASE/super/mid/leaf` (0) | *empty* (1) | `$BASE/super/mid/leaf` | `None` | git only | agree |
+| `SM-s` | `$BASE/super` (0) | *empty* (1) | `$BASE/super` | `None` | git only | agree |
+| `SO` | `$BASE/old/inner` (0) | *empty* (1) | `$BASE/old/inner` | `None` | git only | agree |
+| `BARE` | *empty* (128) | *empty* (1) | `workdir() == None` | `None` | neither | agree |
+| `NONE` | *empty* (128) | *empty* (1) | `None` | `None` | neither | agree |
+| `PJ` | *empty* (128) | `$BASE/PJ/a/b/c` (0) | `None` | `$BASE/PJ/a/b/c` | jj only | agree |
+| `PJS` | *empty* (128) | `$BASE/PJS` (0) | `None` | `$BASE/PJS` | jj only | agree |
+| `NGPJ-i` | `$BASE/NGPJ/sub` (0) | `$BASE/NGPJ` (0) | `$BASE/NGPJ/sub` | `$BASE/NGPJ` | differ, git inside jj | agree |
+| `NGPJ-o` | *empty* (128) | `$BASE/NGPJ` (0) | `None` | `$BASE/NGPJ` | jj only | agree |
+| `PJG-i` | `$BASE/PJG` (0) | `$BASE/PJG/sub` (0) | `$BASE/PJG` | `$BASE/PJG/sub` | differ, jj inside git | agree |
+| `PJG-o` | `$BASE/PJG` (0) | *empty* (1) | `$BASE/PJG` | `None` | git only | agree |
+
+The Roots column records the raw comparison only. **Dual-root equality is
+necessary but not sufficient for `colocated`, and inequality is not sufficient
+for either `nested-` arm.** `CR` and `NGJ-o` both have equal roots and classify
+as `main`, because `classify_checkout`'s `colocated` arm also requires
+`jj_secondary && git_worktree` (`scripts/vcs-common.sh:242-247`); a jj *main*
+workspace nested in a git repository has differing roots and still classifies as
+`main`. A classifier reads this column together with the jj-secondary bit
+(Query 5) and the linked-worktree bit (Query 2), never alone — see the
+`classify_checkout` records below for the composite answer.
+
+### `classify_checkout` records, for cross-reference
+
+The composite oracle, for the transitional `detection.rs` comparison and for
+0169's later use. `BOUNDARY` is empty for `main` and `none`, per contract.
+
+| Fixture | KIND | BOUNDARY | JJ_PARENT | GIT_PARENT |
+| --- | --- | --- | --- | --- |
+| `CR` | `main` | *empty* | *empty* | *empty* |
+| `CG` | `colocated` | `$BASE/CG` | `$BASE/jjparent` | `$BASE/gitparent-cg` |
+| `JS-r` / `JS-s` | `jj-secondary` | `$BASE/JS` | `$BASE/jjmain-colocated` | *empty* |
+| `PG-r` / `PG-s` | `main` | *empty* | *empty* | *empty* |
+| `NJG-i` | `nested-jj-in-git` | `$BASE/NJG/sub` | `$BASE/jjmain-colocated` | `$BASE/NJG` |
+| `NJG-o` | `main` | *empty* | *empty* | *empty* |
+| `NGJ-i` | `nested-git-in-jj` | `$BASE/NGJ/sub` | `$BASE/NGJ` | `$BASE/gitparent-ngj` |
+| `NGJ-o` | `main` | *empty* | *empty* | *empty* |
+| `WT-l` | `git-worktree` | `$BASE/WT` | *empty* | `$BASE/main` |
+| `WT-m` | `main` | *empty* | *empty* | *empty* |
+| `SM-1` / `SM-2` / `SM-s` / `SO` | `main` | *empty* | *empty* | *empty* |
+| `BARE` | `none` | *empty* | *empty* | *empty* |
+| `NONE` | `none` | *empty* | *empty* | *empty* |
+| `PJ` | `main` | *empty* | *empty* | *empty* |
+| `PJS` | `jj-secondary` | `$BASE/PJS` | `$BASE/PJ/a/b/c` | *empty* |
+| `NGPJ-i` | `nested-git-in-jj` | `$BASE/NGPJ/sub` | `$BASE/NGPJ` | `$BASE/gitparent-ngpj` |
+| `NGPJ-o` | `main` | *empty* | *empty* | *empty* |
+| `PJG-i` | `nested-jj-in-git` | `$BASE/PJG/sub` | `$BASE/jjmain-pure` | `$BASE/PJG` |
+| `PJG-o` | `main` | *empty* | *empty* | *empty* |
+
+The last five rows were measured on **2026-08-03** by running `classify_checkout`
+directly against the fixtures (an earlier draft omitted them, so the two nested
+arms' pure-jj variants had no composite expected value). This table now covers
+all 24 pairs.
+
+`find_git_main_worktree_root` returns an **ordinary root with exit 0** for every
+non-submodule, non-bare checkout, and the **superproject** for a submodule
+(`$BASE/super` from `SM-1`, `$BASE/super/mid` from `SM-2`) — confirming the work
+item's warning that the underlying `git rev-parse`, not the shell wrapper, is
+the query-3 oracle. For `BARE` it returns exit 1 and empty stdout.
+
+### Extended fixtures (measured 2026-08-03)
+
+Ten fixtures added after plan review. **Oracle columns only.** `gix`/`jj-lib` are
+not in the workspace until Phase 1, so the library columns
+(`is_bare()`, `kind()`, raw `common_dir()`, `main_repo().workdir()`) are **not
+measurable yet** and are filled in Phase 2 against these oracle values. They are
+kept in a separate table rather than folded into Queries 1-6 for exactly that
+reason — folding them in would create half-empty rows that read as gaps.
+
+`dirs` is the absolutised `--git-dir` vs `--git-common-dir` comparison, i.e. the
+`worktree.linked` oracle.
+
+| Key | Shape | Start directory | `--is-bare` | `--show-toplevel` (exit) | `jj workspace root` (exit) | `--git-dir` | `--git-common-dir` (raw) | `dirs` | `--show-superproject…` (exit) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `JS-in` | jj secondary workspace **inside its own colocated main** | `$B/JSIN/workspaces/inner` | `false` | `$B/JSIN` (0) | `$B/JSIN/workspaces/inner` (0) | `$B/JSIN/.git` | `../../.git` | **equal** | *empty* (0) |
+| `SM-m` | submodule whose path contains a `modules` segment | `$B/supm/modules/foo` | `false` | `$B/supm/modules/foo` (0) | *empty* (1) | `$B/supm/.git/modules/modules/foo` | same | equal | `$B/supm` (0) |
+| `SM-w` | linked worktree **of a submodule** | `$B/smw` | `false` | `$B/smw` (0) | *empty* (1) | `$B/supw/.git/modules/mid/worktrees/smw` | `$B/supw/.git/modules/mid` | **differ** | *empty* (0) |
+| `SM-wt` | submodule initialised **inside a linked worktree** of the superproject | `$B/supwt-wt/sub` | `false` | `$B/supwt-wt/sub` (0) | *empty* (1) | `$B/supwt/.git/worktrees/supwt-wt/modules/sub` | same | equal | `$B/supwt-wt` (0) |
+| `RF` | reftable ref backend | `$B/RF` | `false` | `$B/RF` (0) | *empty* (1) | `.git` | `.git` | equal | *empty* (0) |
+| `S256` | sha256 object format | `$B/S256` | `false` | `$B/S256` (0) | *empty* (1) | `.git` | `.git` | equal | *empty* (0) |
+| `HOSTILE` | plain git + adversarial `.git/config` | `$B/HOSTILE` | `false` | `$B/HOSTILE` (0) | *empty* (1) | `.git` | `.git` | equal | *empty* (0) |
+| `D1` | `.jj/repo` pointer → **deleted** directory | `$B/D1` | *empty* (128) | *empty* (128) | *empty* (1) | n/a | n/a | n/a | *empty* (128) |
+| `D2` | `.git`-file worktree, gitdir target **removed** | `$B/D2` | *empty* (128) | *empty* (128) | *empty* (1) | n/a | n/a | n/a | *empty* (128) |
+| `D3` | `.jj/repo` pointer → **existing non-store** directory | `$B/D3` | *empty* (128) | *empty* (128) | **`$B/D3` (0)** | n/a | n/a | n/a | *empty* (128) |
+
+Composite oracle and helper results:
+
+| Key | KIND | BOUNDARY | JJ_PARENT | GIT_PARENT | `find_jj_main…` (exit) | `find_git_main…` (exit) |
+| --- | --- | --- | --- | --- | --- | --- |
+| `JS-in` | `jj-secondary` | `$B/JSIN/workspaces/inner` | `$B/JSIN` | *empty* | `$B/JSIN` (0) | `$B/JSIN` (0) |
+| `SM-m` | `main` | *empty* | *empty* | *empty* | *empty* (1) | `$B/supm` (0) |
+| `SM-w` | `git-worktree` | `$B/smw` | *empty* | **`$B/supw/.git/modules`** | *empty* (1) | **`$B/supw/.git/modules`** (0) |
+| `SM-wt` | `main` | *empty* | *empty* | *empty* | *empty* (1) | `$B/supwt-wt` (0) |
+| `RF` / `S256` / `HOSTILE` | `main` | *empty* | *empty* | *empty* | *empty* (1) | (root) (0) |
+| `D1` / `D2` | `none` | *empty* | *empty* | *empty* | *empty* (1) | *empty* (1) |
+| `D3` | **`jj-secondary`** | `$B/D3` | ***empty*** | *empty* | ***empty* (1)** | *empty* (1) |
+
+What these settle:
+
+1. **`JS-in` confirms the plan's claim exactly.** The workspace carries `.jj` only
+   (no `.git`), `--git-dir` escapes upward to the colocated main's `.git`, and
+   `--git-common-dir` absolutises equal so it is **not** a worktree. Dual roots
+   *differ* (`$B/JSIN` vs `$B/JSIN/workspaces/inner`) yet the classification is
+   `jj-secondary`, **not** `nested-jj-in-git`, because `jj_main_root` and
+   `git_main_root` are both `$B/JSIN` and that arm's `!=` guard fails. This is the
+   shape this repo runs in daily and the one where differing dual roots point at
+   the wrong arm.
+
+2. **`SM-m` confirms the revised `superproject` rule.** `git_dir()` is
+   `$B/supm/.git/modules/modules/foo`; the innermost `modules` has parent
+   `$B/supm/.git/modules`, not a repository, so the scan continues outward to the
+   next `modules`, whose parent `$B/supm/.git` opens — yielding `$B/supm`, the
+   oracle value. A bare `rposition` would stop at the first candidate and return
+   absence.
+
+3. **`SM-wt` downgrades the superproject-accuracy concern.** Git does **not** put
+   the submodule's git dir under the common dir's `modules/` as feared; it puts it
+   under `worktrees/<id>/modules/sub`, and `--show-superproject-working-tree`
+   returns `$B/supwt-wt` — the **worktree**, matching `find_git_main_worktree_root`.
+   The plan's scan anchors on the innermost `modules` whose parent is
+   `$B/supwt/.git/worktrees/supwt-wt`; if `gix::open` accepts a linked-worktree
+   gitdir, its `workdir()` is `$B/supwt-wt` and the rule is correct.
+   **Phase 2 must confirm `gix::open` on a worktree gitdir**; that is the one
+   remaining unknown, not the layout.
+
+4. **`SM-w` exposes a shell-oracle quirk worth inheriting knowingly.**
+   `find_git_main_worktree_root` returns `$B/supw/.git/modules` — a `.git/modules`
+   path, not a worktree root — and `classify_checkout` puts it in `GIT_PARENT`.
+   Also `--show-superproject-working-tree` is *empty* for a linked worktree of a
+   submodule. So if the library's `kind()` reports `Submodule` here, the
+   superproject derivation would return a path where git returns nothing.
+   `dirs differ`, so `worktree.linked = true` is correct either way.
+
+5. **`S256` breaks the revision-shape assertion.** `git rev-parse HEAD` is **64
+   hex characters** in a sha256 repository, while
+   `cli/vcs-adapters/tests/detection.rs:84-86`'s `is_full_revision_id` asserts 40.
+   Any `RepoFacts.revision` validation must either accept both widths or record
+   sha256 as unsupported. `RF` needs no such accommodation — the CLI reports
+   `--show-ref-format=reftable` and behaves normally.
+
+6. **`HOSTILE` runs nothing, as suspected.** With `core.pager`, `core.fsmonitor`,
+   `diff.external`, `filter.*.clean`/`smudge`, an `alias.*` and an `include.path`
+   chain all pointed at marker-writing commands, **none of the seven ran** under
+   `--show-toplevel`, `--git-dir` or `--is-bare-repository`. The oracle does not
+   reach that machinery either, so `HOSTILE`'s value is as a **regression guard
+   for the APIs 0169 adds** (`status`/`log` reach blob-diff, attributes and
+   pagers), not as evidence for this story's call set. State the claim that
+   narrowly in `tasks/README.md`.
+
+7. **`D3` is the load-bearing degenerate, and the defensive invariant works.**
+   `jj workspace root` **succeeds** (exit 0, `$B/D3`) on a pointer targeting an
+   existing non-store directory, while `find_jj_main_workspace_root` returns exit
+   1 — its `[ -d "$candidate/.jj/repo" ]` post-condition firing — so
+   `classify_checkout` degrades gracefully to `jj-secondary` with an **empty**
+   `JJ_PARENT` rather than emitting a wrong-but-non-empty root. The library must
+   reproduce this: `jj_workspace_root` → `Ok(Some($B/D3))`, `jj_repository` →
+   `Err`. `D1` and `D2` report plain absence from both CLIs (`none`), so their
+   expectation is `Ok(None)`, **not** `Err` — correcting the blanket
+   "expected outcome is `Err`" in the construction table.
+
+8. **`jj workspace add` does not create intermediate directories** at 0.43. A
+   bare `jj workspace add --name inner <root>/workspaces/inner` fails with
+   `Error: Cannot access … / No such file or directory` unless `workspaces/`
+   exists. The `JS-in` builder must `mkdir -p` the parent first.
+
+### Recorded divergences
+
+- **`GIT_DIR` scrub asymmetry** — `classify_checkout` reads `GIT_DIR`
+  unscrubbed at `scripts/vcs-common.sh:206-215` while
+  `find_git_main_worktree_root` scrubs at `:130-135`. `InProcessProbe` is
+  immune across the poisoning matrix in Phase 2 §3; this is the one
+  pre-authorised divergence.
+- **Absence-signal conflation** — `superproject()` maps both of
+  `--show-superproject-working-tree`'s absence signals (exit 0 + empty, and
+  exit 128) to `Ok(None)`. Deliberate; nothing in the taxonomy needs the
+  distinction.
+- **The library's absence cells are unfenceable by the environment.** The
+  oracle side's exit-128s come from `GIT_CEILING_DIRECTORIES`; `gix::discover`
+  reads no environment and walks to the filesystem root, so the library side's
+  `None` holds only under the no-`.git`-ancestor precondition the harness
+  asserts (Phase 2 §2). This is a property of the mapping's *provenance*, not a
+  behavioural divergence.
+- **Library error conditions mapped to `Ok(None)` rather than `Err`.** The
+  **rule** is fixed here so 0169 inherits a contract rather than
+  reverse-engineering it, and so Phase 2's assertions can be written before the
+  queries exist: **only the not-found-shaped variant of each library error maps
+  to `Ok(None)`; every other variant is `Err`.** Concretely —
+  `WorkspaceLoadError::NoWorkspaceHere` and `RepoDoesNotExist` → `Ok(None)`
+  (this is what Query 4 already folds into absence); `DecodeRepoPath`, any
+  `PathError`/IO failure, a canonicalisation failure, and a failed
+  `<main_root>/.jj/repo` post-condition → `Err`. On the gix side, "no repository
+  found" → `Ok(None)`; an open/config/odb failure on a repository that *was*
+  found → `Err`. Phase 2 confirms the exact variant names against the crates and
+  records them here; the **partition rule does not change**, only its spelling.
+  The measured extended fixtures pin the observable half already: `D1`/`D2` →
+  `Ok(None)`, `D3` → `Ok(Some)` from `jj_workspace_root` and `Err` from
+  `jj_repository`.
+- **`InProcessProbe::revision` returns `None` for `VcsKind::Jj`** by design —
+  spike-established that jj-lib 0.43 exposes no read-only settings-free route to
+  the working-copy commit id. Warn-logged, and handed to 0185.
+- **sha256 repositories carry 64-hex revision ids.** Measured on `S256`:
+  `git rev-parse HEAD` is 64 hex characters, while
+  `cli/vcs-adapters/tests/detection.rs:84-86`'s `is_full_revision_id` asserts 40.
+  Any `RepoFacts.revision` validation must accept both widths or record sha256 as
+  unsupported — a decision 0185 inherits, since after its switch a user on a
+  sha256 repository is affected. `RF` (reftable) needs no accommodation at the
+  CLI level; whether gix 0.85 serves either format is the Phase 2 question.
+- **`find_git_main_worktree_root` returns a `.git/modules` path** for a linked
+  worktree of a submodule (`SM-w`, measured), which `classify_checkout` then
+  reports as `GIT_PARENT`. That is a pre-existing shell-oracle quirk, not
+  something `InProcessProbe` should reproduce; `WorktreeFacts.main_worktree_root`
+  carries the library value and does not claim parity there.
+- **No other divergence was observed** across the 24 (fixture, start
+  directory) pairs and six queries. Every cell above reads *agree*, after the
+  `PJG-i` common-dir correction noted under Query 2.
+
+---
+
+## Phase 1: Dependencies, Policy Gates and the Boundary-Safe Ports
+
+### Overview
+
+Land both dependency trees, the licence exception, the two-clause import rule
+and every committed invariant check, plus `InProcessProbe` implementing
+`RepoRoot` and `VcsProbe`. After this phase a dependency-policy objection is
+reviewable in isolation and the boundary rule is proven.
+
+### Changes Required
+
+#### 1. Workspace dependency pins
+
+**File**: `cli/Cargo.toml`
+**Changes**: two exact pins in `[workspace.dependencies]`, following the
+`vergen`/`vergen-gitcl` matched-pair precedent (`:17-21`).
+
+```toml
+# jj-lib and gix are a matched pair, pinned asymmetrically on purpose.
+#
+# jj-lib is EXACT: it declares its API unstable, this design leans on its
+# workspace-loader internals, and a patch release can shift its MSRV or its own
+# gix requirement. Adopting one is a deliberate act, not a resolution outcome.
+#
+# gix is TILDE: ~0.85.0 permits 0.85.x only, which is the range jj-lib already
+# requires (^0.85.0), so patch agility costs nothing here. gix 0.86 exists and a
+# caret on a 0.x crate will not cross it, so requesting 0.86 would put two gix
+# graphs in the lock.
+#
+# A jj-lib bump is a coordinated four-pin change: jj-lib, gix, the Rust
+# toolchain (jj-lib's MSRV moved 1.85 -> 1.88 -> 1.89 across eight releases) and
+# the mise jj CLI pin, which writes the format jj-lib reads.
+jj-lib = "=0.43.0"
+gix = "~0.85.0"
+```
+
+The asymmetry is the point. `~0.85.0` lets a `gix` RustSec fix be adopted with a
+lock update rather than a pin edit, which matters under
+`cli/deny.toml:19-31`'s `unmaintained = "all"` + `yanked = "deny"` — otherwise an
+`advisories.ignore` entry becomes the cheapest response to an advisory. The
+single-graph property is unaffected: it comes from jj-lib's own `^0.85.0` plus
+cargo's range unification, not from exactness, and `Cargo.lock` supplies the
+exactness either way. `jj-lib` keeps its `=` pin because the agility argument
+does not apply to the crate whose declared-unstable internals the design
+depends on, and because a transitive advisory anywhere in *its* closure is
+adoptable via `cargo update -p <crate>` without touching the pin at all.
+
+The graph test asserts `gix` matches `0.85.\d+` (consistent with the tilde) and
+`jj-lib` at exactly `0.43.0`. The break-glass procedure for a yank or advisory
+in the closure is documented in `tasks/README.md` (below).
+
+**File**: `cli/vcs-adapters/Cargo.toml`
+**Changes**: consume both. `tempfile` stays in `[dev-dependencies]` and
+`bash-parity` keeps its current empty definition — the fixture builders live in
+`cli/vcs-test-support` from Phase 2, so nothing needs them outside test targets,
+and widening `bash-parity` to enable a dependency would change its meaning for
+no gain.
+
+`cli/vcs-test-support` and `cli/vcs-adapters`' `[dev-dependencies]` edge to it
+are created in **Phase 2**, together with the `members` entry, the lock change
+that entry forces, and the `[[bin]]` declaration for the reference artefact
+Phase 2 §3 needs. Key Discovery 13 records that this workspace has zero
+path-based `[dev-dependencies]` today, so that edge is novel and is stated
+explicitly rather than implied. Phase 1 therefore has no dependency on the
+new member, and the "passes with the new member" gate criterion belongs to
+Phase 2.
+
+Phase 1 also extracts `marker_kind(root)` in `cli/vcs-adapters/src/lib.rs` (a
+crate-private free function that `CommandProbe::kind` and
+`InProcessProbe::kind` both call) and `walk_up(start, predicate)`, so Phase 2
+does not have to dedup code Phase 1 just landed. Both live in a crate-private
+module that **survives 0185's deletion of `CommandProbe`/`MarkerWalkRoot`**:
+`MarkerWalkRoot::discover` and `CommandProbe::kind` delegate *to* them, not the
+other way round, so 0185's deletion stays mechanical and needs no re-homing step.
+
+```toml
+[dependencies]
+vcs = { path = "../vcs" }
+gix = { workspace = true }
+jj-lib = { workspace = true }
+tracing = { workspace = true }
+```
+
+`gix` takes **default features** — network transports are excluded by default,
+so no TLS stack enters the graph, and `attributes` (which `submodules()` needs)
+is present. `jj-lib` takes default features, which is what pulls `gix` 0.85.
+
+**File**: `cli/Cargo.lock` — regenerated and committed in the same change,
+because clippy runs `--locked`.
+
+#### 2. Licence exception
+
+**File**: `cli/deny.toml`
+**Changes**: the workspace's first `[[licenses.exceptions]]` entry, placed after
+`confidence-threshold`.
+
+```toml
+# uluru is gix-pack's LRU object cache (reached from both gix and gix-odb) and
+# is not feature-gatable out of the graph. MPL-2.0 is file-level weak copyleft:
+# we ship no modifications, so §3.1 is satisfied trivially. The obligation that
+# binds is §3.2 — distributing the Executable Form requires telling recipients
+# how to obtain the Source Form — and this crate reaches the published
+# accelerator-visualiser binary, so it is discharged by the third-party licence
+# file staged into the release payload, not by the absence of modifications.
+# Adopted for the library-backed VCS adapter (work item 0188).
+[[licenses.exceptions]]
+crate = "uluru"
+allow = ["MPL-2.0"]
+```
+
+The work-item reference is a deliberate exception to the repo's
+no-references-in-comments convention: the acceptance criterion requires the
+comment to cite this work item.
+
+This is the workspace's first MPL crate, and it enters the closure of a
+*publicly distributed, signed, download-on-first-use* binary rather than a
+dev-only artefact. Nothing in the release pipeline carries third-party licences
+today (`_release_uploads()` enumerates binaries, signatures and the manifest
+only), so the reasoning must not stop at "we ship no modifications" — that
+answers §3.1 and sets the template every future exception will copy. Resolve by
+either generating a third-party attribution artefact (cargo-about or
+cargo-bundle-licenses) and adding it to the release upload set, or recording a
+verified finding that dead-code elimination leaves no `uluru` code in any
+shipped binary, with the exception comment pointing at whichever holds.
+
+**File**: `cli/deny.toml`
+**Changes**: extend `[bans].deny` (`:65-70`) with **`gix-credentials` and
+`curl-sys` only**. Both were confirmed absent from a real resolved lock (spike,
+2026-08-03).
+
+**`gix-transport` and `gix-protocol` must NOT be banned — they are present.** A
+spike crate depending on `jj-lib = "=0.43.0"` resolves both into the graph
+(`gix-transport 0.51.0`, `gix-protocol 0.63.0`, and both compile), because
+jj-lib's default features reach them even with no network client enabled.
+Banning either would fail `deny:check` on the first run, exactly as a bare
+`rustls` ban would. An earlier draft of this section named them as "confirmed
+absent" without checking — they are not.
+
+What this means for the property: the absence of a *TLS stack* (Key Discovery 9)
+is real and worth asserting, but "no gix transport crates in the graph" is
+**false** and cannot be a gate. The enforceable statements are:
+
+- `[bans].deny` on `gix-credentials`, `curl-sys`, plus the existing
+  `native-tls`/`openssl`/`openssl-sys` — all verified absent.
+- The subtree pytest asserts no `rustls`/`openssl`/`native-tls`/`curl-sys` under
+  `-p vcs-adapters`, looped over all five configured targets.
+- The **feature-set** assertion (below) carries the real weight: `gix`'s
+  `blocking-network-client`, `async-network-client` and
+  `blocking-http-transport-*` features must be **off**. That is what keeps the
+  transport crates inert, and it is checkable where their presence is not.
+
+**`rustls` must NOT be added.** It is a first-party workspace dependency:
+`cli/Cargo.toml:35` pins it `=0.23.41` and `cli/launcher/Cargo.toml:31` consumes
+it directly, and the section's own comment reads "rustls only" — meaning rustls
+is the *chosen* TLS stack, not a banned one. A bare `{ crate = "rustls" }` entry
+would fail `mise run deny:check` on the first run, and `deny:check` is in
+`check-supply-chain`, which is in `prerelease.needs`. The same trap applies to
+any gix package that is in the closure with its client features off, which is
+why each name above is verified absent first rather than assumed.
+
+If reachability of `rustls` *from the VCS subtree* is ever the concern, express
+it wrapper-scoped (`{ crate = "rustls", wrappers = ["reqwest", "launcher"] }`)
+so a new direct edge fails while the sanctioned path passes — not as a bare ban.
+
+`[bans]` is evaluated against all five configured targets (`:11-17`, enumerated
+deliberately "so the ubuntu graph a banned edge could hide in is always
+evaluated"). The pytest below additionally loops its
+`cargo tree -e features -p vcs-adapters` assertion over `--target` for each of
+the four release triples plus `x86_64-unknown-linux-gnu`, because the work item's
+criterion is that the **`vcs-adapters` subtree** carries no TLS stack — a
+strictly different and narrower proposition than `[bans]`' whole-graph
+absence, which is false here for `rustls`. Confirm `deny:check` is green with
+these entries before ticking the Phase 1 criterion.
+
+#### 3. The two-clause import rule
+
+**File**: `cli/pup.ron`
+**Changes**: a rule scoped to the new module only — `CommandProbe` legitimately
+spawns, so `vcs_adapters` as a whole must stay unruled.
+
+`tracing` is on the permit list because `VcsProbe::revision`'s contract requires
+it: "A caller cannot distinguish the two; an adapter is expected to log the
+failure" (`cli/vcs/src/lib.rs:63-66`). Omitting it would make `library` the
+crate's only silently-failing adapter, against a sibling that warn-logs all six
+of its failure paths. `kernel::Error` is **not** on the list — `kernel` is not a
+dependency of `vcs-adapters`, so permitting it would be inert.
+
+Two properties this rule does **not** deliver, stated so neither the rule
+comment nor `tasks/README.md` overclaims:
+
+- `RestrictImports` resolves `use` paths in first-party source. An inline
+  fully-qualified `std::process::Command::new(…)` with no `use` is unaffected,
+  and the permitted `^crate(::|$)` reaches `crate::CommandProbe`, which spawns
+  by design. The rule raises the cost of spawning; it does not make it
+  impossible. The zero-spawn *property* is established by the Phase 3 harness.
+- The rule says nothing about `gix` or `jj-lib`. Key Discovery 8 records that
+  jj-lib's defaults enable `attributes` and `blob-diff` on gix — the subsystem
+  that runs clean/smudge filters, external diff drivers and pagers from
+  **repository-controlled** configuration. Phase 3's harness therefore carries a
+  hostile-configuration fixture (below) rather than relying on this rule.
+
+**Alternative considered**: expressing the rule as `denied`-only, which
+`cli/pup.ron:93-98` already chose for `config_command` precisely to avoid the
+grouped-import false positive. That would drop the single-item-import tax at the
+cost of the closed-world property. Kept as `allowed_only` because the module's
+whole point is a small, enumerable import surface, and the constraint is
+recorded in a `//!` note at the top of `library.rs` so it is discoverable where
+it binds rather than only in `pup.ron`.
+
+```
+        // The library-backed adapter reads git and jj in-process. A permit list
+        // alone cannot express this because std::process sits inside the
+        // permitted std, so the rule pairs a permit list with an explicit deny:
+        // verified 2026-08-03 that the deny wins on overlap. Note the permit
+        // list rejects grouped imports (cargo-pup resolves `use a::{b, c}` to
+        // an empty module name), so this module writes one single-item `use`
+        // per import.
+        Module((
+            name: "vcs_adapters_library_reads_in_process",
+            matches: Module("^vcs_adapters::library($|::)"),
+            rules: [
+                RestrictImports(
+                    allowed_only: Some([
+                        "^(std|core|alloc)(::|$)",
+                        "^gix(::|$)",
+                        "^jj_lib(::|$)",
+                        "^tracing(::|$)",
+                        "^vcs(::|$)",
+                        "^crate(::|$)",
+                    ]),
+                    denied: Some([
+                        "^std::process(::|$)",
+                    ]),
+                    severity: Error,
+                ),
+            ],
+        )),
+```
+
+#### 4. `InProcessProbe`
+
+**File**: `cli/vcs-adapters/src/library.rs` (new)
+**Changes**: the type and the two port implementations. Single-item imports
+throughout.
+
+```rust
+use std::path::Path;
+use std::path::PathBuf;
+
+use vcs::RepoRoot;
+use vcs::VcsKind;
+use vcs::VcsProbe;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InProcessProbe;
+
+impl InProcessProbe {
+    fn boundary(start: &Path) -> Option<PathBuf> { /* .jj|.git existence walk */ }
+    fn jj_workspace(start: &Path) -> Option<PathBuf> { /* .jj-only walk */ }
+}
+
+impl RepoRoot for InProcessProbe {
+    fn discover(&self, start: &Path) -> Option<PathBuf> {
+        Self::boundary(start)
+    }
+
+    fn repository_root(&self, working_copy_root: &Path) -> PathBuf { /* loader */ }
+}
+
+impl VcsProbe for InProcessProbe {
+    fn kind(&self, root: &Path) -> VcsKind { /* marker existence, jj wins */ }
+
+    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> { /* gix / jj-lib */ }
+}
+```
+
+##### `revision`: jj is descoped to 0185 — spike-resolved 2026-08-03
+
+The git half is `gix::discover(root)?.head_commit()?.id()`, in scope here.
+
+**The jj half is descoped to 0185.** A spike (throwaway crate, `jj-lib =
+"=0.43.0"`, Rust 1.90.0, resolver 3) established that jj-lib 0.43 offers **no
+read-only, settings-free route to the working-copy commit id**. The chain needs
+four links and two are blocked:
+
+| Link | Settings-free? | Read-only? |
+| --- | --- | --- |
+| `DefaultWorkspaceLoaderFactory::create(root)` → `repo_path()` | ✅ | ✅ |
+| workspace **name** (to index `View::get_wc_commit_id`) | ❌ / ⚠️ | **❌** |
+| `SimpleOpHeadsStore::load(dir)` → `get_op_heads()` | ✅ | ✅ |
+| `SimpleOpStore::load(path, RootOperationData)` → `read_operation` → `read_view` | ✅ | ✅ |
+
+The op stores are genuinely settings-free (both take a path only; the trait
+methods are `async` and jj-lib itself drives them with `pollster`). The
+**workspace name** is the blocker, and both routes to it fail:
+
+- `LocalWorkingCopy::load(...)` requires `&UserSettings` — it builds
+  `TreeStateSettings::try_from_user_settings` (`local_working_copy.rs:2708-2716`).
+  `CheckoutState`, which holds exactly the `operation_id` + `workspace_name` pair
+  needed, is a **private** struct with a private `load`.
+- `SimpleWorkspaceStore::load(repo_path)` is settings-free but **mutates the
+  repository**. Verified empirically: with `.jj/repo/workspace_store` removed, the
+  call recreated the directory and wrote an `index` file
+  (`workspace_store existed before = false` → `exists after = true`). It is
+  therefore unusable in a detection probe, which must be read-only and must work
+  on a read-only filesystem. Its trait also exposes only
+  `get_workspace_path(name)`, with no listing API, so a root→name inversion is not
+  available even setting the write aside.
+
+Reading `.jj/working_copy/checkout`'s protobuf by hand is the only remaining
+path, and that is precisely the "leaning on private internals" this design set
+out to avoid — a private wire format with no compatibility promise.
+
+**Consequences, applied throughout this plan:**
+
+- `InProcessProbe::revision` returns `None` for `VcsKind::Jj`, and warn-logs that
+  the mechanism is unavailable rather than implying an empty repository.
+- The crate-wide `UserSettings` / `Workspace::load` guard **stays crate-wide** —
+  the spike is the evidence that nothing in scope needs it.
+- Phase 3's parity criterion narrows **per `VcsKind`**: full `RepoFacts` parity
+  for `VcsKind::Git`, and `root`/`name`/`kind` only for `VcsKind::Jj`. It is not
+  dropped wholesale — the git path is achievable and
+  `detection.rs:84-86` already pins a 40-hex id there.
+- 0185 inherits the jj revision mechanism as named work, alongside the
+  composition-root switch it already owns. Its options are a jj-lib version that
+  exposes the checkout state publicly, an upstream request for one, or keeping
+  `CommandProbe` for `revision` alone.
+
+For the record, the discarded alternative: narrowing the `UserSettings` ban to
+the detection paths would have put a settings chain abandoned after five
+successive panics into code with no crash isolation, running inside
+`cli/visualiser/server` and on the hook path after 0185's switch. The spike
+removed the need to weigh that at all.
+
+<details>
+<summary>Original framing, kept because it records what was unknown</summary>
+
+The **jj half has no established mechanism**, and two of this plan's own
+constraints may make it unreachable:
+
+- Reading jj's `@` commit id needs the repo loaded (`RepoLoader` /
+  `Workspace::load`), which needs a `UserSettings` — the construct Phase 2's
+  source guard forbids anywhere in `cli/vcs-adapters`.
+- Git `HEAD` is not a substitute: a `--no-colocate` repository has no git HEAD
+  at all, and in a colocated repository jj exports HEAD as `@-`, not `@`, so the
+  ids differ from `CommandProbe`'s `jj log -r @ -T commit_id`.
+
+Phase 3 requires `detection.rs` to produce **identical `RepoFacts`** from both
+implementations, and `RepoFacts.revision` is asserted as a 40-hex id
+(`cli/vcs-adapters/tests/detection.rs:84-86`), so the two constraints are
+mutually unsatisfiable as drafted. Resolve by picking one:
+
+Ranked, most preferred first:
+
+1. **Find a settings-free jj-lib path** (an op-store / view read reached from
+   `WorkspaceLoader::repo_path()`) and prove it in a short spike before Phase 1.
+   Preferred if it exists — it keeps the guard crate-wide and Phase 3's
+   criterion unchanged.
+2. **Descope jj `revision` from 0188** — the **fail-safe** resolution, and the
+   one to take if the spike cannot prove option 1. Return `None` for
+   `VcsKind::Jj` and hand the mechanism to 0185 with the composition-root switch
+   it already owns. Narrow Phase 3's parity criterion **per `VcsKind`** — full
+   `RepoFacts` parity for `VcsKind::Git`, `root`/`name`/`kind` only for
+   `VcsKind::Jj` — rather than dropping `revision` wholesale, which would also
+   discard achievable protection on the git path where
+   `gix::discover(root)?.head_commit()?.id()` is expected to match exactly and
+   `detection.rs:84-86` already pins a 40-hex id.
+3. **Narrow the `UserSettings` ban** from crate-wide to the detection paths.
+   **Least preferred — this carries a real safety cost.** It puts `UserSettings`
+   construction inside `revision`, and the ban exists because those defaults are
+   private to jj-lib and were "discovered one panic at a time" — abandoned after
+   five successive panics with the chain never exhausted. This code has no crash
+   isolation (that is the containment delta this plan documents), and after 0185
+   flips `facts` it runs inside `cli/visualiser/server` and on the hook path.
+   Take it only with a committed `catch_unwind` or error boundary around the
+   construction, and record why the wider statement was abandoned.
+
+</details>
+
+`kind` and `revision` gain oracle rows (`git rev-parse HEAD` for git shapes,
+`jj log -r @ -T commit_id` recorded as the value 0185 must eventually produce,
+plus the commitless-repository and colocated cases `detection.rs` already pins)
+and are tested **in Phase 1** against the plain-git, colocated, commitless and
+secondary-workspace fixtures — not first exercised two phases later.
+
+Every arm of `revision`, `kind` and `repository_root` that cannot answer
+warn-logs before returning, mirroring `CommandProbe`'s six labelled `warn!`
+sites; legitimate absence (a repository with no commits) does not log.
+
+`discover` is the marker walk; the boundary rule is satisfied by composition
+rather than by new code, because `gix::open` at exactly the boundary performs no
+upward walk. **`gix_discover::upwards::Options::ceiling_dirs` must not be used**
+— it computes the ceiling height as
+`start.strip_prefix(ceiling).components().count()` and discards height 0, then
+tests `current_height > max_height` before incrementing, so no anchor confines
+the walk.
+
+`repository_root` resolves a jj secondary workspace through the loader rather
+than by reading `.jj/repo` by hand, so the file-vs-directory rule has one
+implementation.
+
+**File**: `cli/vcs-adapters/src/lib.rs`
+**Changes**: one line — `pub mod library;`. The module is unconditional so the
+pup rule always applies; `facts` (`:224-227`) is untouched.
+
+#### 5. Committed invariant checks
+
+**File**: `tests/integration/deny/test_vcs_library_graph.py` (new)
+**Changes**: modelled on `test_launcher_feature_graph.py:23-51`, over
+`cargo tree -e features -p vcs-adapters`.
+
+Asserts: `gix` resolves to a version matching `0.85.\d+` (a bare
+single-version assertion would hold vacuously if jj-lib's `gix` feature were
+off); no `gix` or `gix-*` package at more than one version; `jj-lib` at `0.43`;
+and no package in the resolved graph declares a `rust-version` above the pinned
+1.90.0 — catching the `kstring` class of trap (Key Discovery 11) directly rather
+than depending on resolver 3's `incompatible-rust-versions = "fallback"`, which
+is a *preference*, not a hard constraint. **The MSRV comes from
+`cargo metadata --locked --format-version 1`, whose per-package `rust_version`
+field carries it — `Cargo.lock` does not record MSRV at all** (zero occurrences
+of `rust-version` in the committed lock; the format holds only `name`, `version`,
+`source`, `checksum` and `dependencies`), so a lock-parsing implementation would
+find nothing and pass vacuously on precisely the mechanism this check exists to
+backstop. The comparison is semver-ordered against the workspace `rust-version`
+(`cli/Cargo.toml:9`), and the test carries a non-vacuity case so a graph with no
+declared `rust_version` anywhere cannot pass silently. Duplicate detection reads
+`cli/Cargo.lock` directly, because the repo's `multiple-versions` policy is
+`warn` (`cli/deny.toml:57`) and would not fail on its own.
+
+The `gix` **enabled feature set** is asserted too, following the
+`_PRESENT`/`_ABSENT` shape of `test_launcher_feature_graph.py` — present:
+`attributes`, `blob-diff`, `index`, `max-performance-safe`, `sha1`, `zlib-rs`;
+absent: `blocking-network-client`, `async-network-client`, the
+`blocking-http-transport-*` family, `credentials`. Version assertions alone are
+insufficient now the pins are tilde ranges taking **default** features: gix
+republishes its `[features] default` with every patch and jj-lib's own patches
+can change what it enables, so the effective surface is upstream-controlled
+within the permitted range. This is the same reasoning that made
+`test_launcher_feature_graph.py` exist alongside `deny.toml`'s name-based bans,
+and that pinned `reqwest` exactly "so a patch cannot re-scope the DNS feature".
+
+It also **snapshots the build-script- and proc-macro-carrying crates** in the
+closure, so an addition is a visible diff. The release workflow already
+documents build-script trust as a live concern — "the Prepare step above runs
+cargo zigbuild over untrusted transitive build scripts, so the secret is never
+in the environment during compilation" (`.github/workflows/main.yml:412-414`) —
+and this change grows that set by ~56 packages, executing new `build.rs` and
+proc-macro code on the release runner and on every developer machine. A future
+lock regeneration could otherwise add one silently.
+
+The transport prohibition lives in `cli/deny.toml`'s `[bans].deny` rather than
+here, because this test is host-target-scoped; see above.
+
+**File**: `tests/unit/tasks/test_vcs_pin_lockstep.py` (new)
+**Changes**: modelled on `test_msrv_coherence.py:30-38` — a bare pytest, no
+invoke task. Asserts `mise.toml`'s `jj` pin and `cli/Cargo.toml`'s `jj-lib` pin
+share a major.minor; that the `mise.toml` pin retains its lockstep comment; and
+that the `gix` pin comment in `cli/Cargo.toml` and the `uluru` exception comment
+in `cli/deny.toml` are both present and non-empty. The work item requires those
+comments, and comments are the first thing lost when a contributor regenerates
+either file — which the Migration Notes anticipate happening on sibling
+contention.
+
+This checks *declarations in files*. The runtime half — that the `jj` binary
+actually building the fixtures matches the pin — is asserted by the fixture
+harness (Phase 3), not here.
+
+Neither adds a mise leaf, so `tests/unit/tasks/test_mise.py`'s topology
+assertions are untouched.
+
+#### 6. Documentation
+
+**File**: `tasks/README.md`
+**Changes**: extend the entity-gate paragraph (`:38-42`, which enumerates
+`deny:check` and `pup:check` and would otherwise go stale) to name the new
+`vcs-adapters` import rule, and add a `### Library-backed VCS dependency pins`
+subsection alongside "Executable-bit invariant" (`:67`) describing the four-pin
+coupling and both committed checks.
+
+That subsection also documents the **break-glass procedure**, because both
+transitive trees enter `cargo deny`'s advisories scope under
+`unmaintained = "all"` with `yanked = "deny"` (`cli/deny.toml:19-31`), and the
+advisory DB is fetched fresh every run. One upstream `unmaintained` or `yanked`
+advisory anywhere in a ~60-crate closure that *no code in the repo calls* turns
+`check-supply-chain` red for every unrelated PR — and that job is in
+`prerelease.needs`, so it also stops releases. Recovery is a scoped, dated
+`[advisories].ignore` entry following the existing `RUSTSEC-2026-0118/0119`
+precedent (`:26-31`), with a review-by date. Writing it down makes recovery a
+known five-minute action rather than an investigation under release pressure.
+
+**The break-glass is scoped to `unmaintained`, `yanked` and `notice` classes
+only.** A `vulnerability`-class advisory requires the escalation path — upgrade,
+patch, or vendor — never an ignore, regardless of release pressure, because this
+closure reaches the publicly distributed signed `accelerator-visualiser` binary.
+`cli/deny.toml`'s `ignore` list is flat with no class distinction, so the scoping
+has to be written down or the pre-authorised action silently covers every class:
+a documented five-minute suppression is exactly what gets applied reflexively to
+a real vulnerability. cargo-deny does not enforce review-by dates either — the
+two existing entries say "Remove when reqwest adopts 0.26" with nothing checking
+it — so `tests/integration/deny/` gains an assertion that every `ignore` entry
+carries a machine-readable review-by date and that none is in the past.
+
+The same subsection documents the **licence-side** failure, which has no `ignore`
+mechanism at all: `[licenses].allow` is deliberately "pruned to exactly the
+licenses the current dependency closure carries" (`:35-40`), so a transitive
+crate acquiring or replacing a licence is a hard failure needing either an
+`allow` addition (permissive) or a justified `[[licenses.exceptions]]` (copyleft),
+with the uluru entry as the template.
+
+It further records the division of labour between the two enforcement
+mechanisms this plan adds, so a contributor knows which is authoritative:
+**cargo-pup owns import prohibitions**; **the `tasks/` source guard owns usage
+prohibitions imports cannot express** — `RestrictImports` resolves `use` paths,
+so a fully-qualified `jj_lib::settings::UserSettings::from_config(…)` or a
+`Workspace::load` method call is invisible to it. That is the whole
+justification for the extra Python machinery over a one-line `denied` clause.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mise run deny:check` passes with the `uluru` exception
+- [ ] `mise run pup:check` passes
+- [ ] `mise run cli:check` passes (clippy `--locked`, pedantic + nursery)
+- [ ] `mise run test:integration:deny` passes, including the new graph test
+- [ ] `mise run test:unit:tasks` passes, including the new lockstep test
+- [ ] Unit test: `InProcessProbe::discover` returns the boundary, never an
+      ancestor, on the colocated and `.git`-file shapes `detection.rs` already
+      builds — plus the paired negative assertion that an unbounded
+      `gix::discover` on the same fixture *does* escape to the parent repository.
+      The **both-nesting-directions** form of this criterion moves to Phase 2,
+      which owns the nesting fixtures; Phase 1 must not duplicate them
+- [ ] `kind` and `repository_root` agree with `CommandProbe` on the plain-git,
+      colocated, commitless and jj-secondary fixtures; `revision` agrees for
+      `VcsKind::Git` and returns `None` (warn-logged) for `VcsKind::Jj`, per the
+      spike-resolved descope above
+- [ ] Non-vacuity is **committed**, not demonstrated by hand: probe cases in
+      `tests/integration/pup/test_import_rule.py` for the new rule — a
+      `std::process::Command` import rejected with `"is denied"` and the rule
+      name present, a compliant single-item-import module as the positive
+      control (catching a rule whose scope silently matched nothing, which
+      0169's module rename would otherwise cause), and a grouped-import case
+      pinning the `use a::{b, c}` behaviour
+- [ ] The lockstep test also asserts the `gix` pin comment in `cli/Cargo.toml`
+      and the `uluru` exception comment in `cli/deny.toml` are present and
+      non-empty
+- [ ] `mise run` green end to end
+
+#### Manual Verification
+
+- [ ] `cli/vcs/src/**` is unmodified (`jj diff --stat`)
+- [ ] The `accelerator-visualiser` musl-static size is recorded before and after
+      this phase, so a later regression has a baseline (the trees enter its
+      closure via `vcs-adapters` → `corpus-adapters` → `visualiser/server`)
+- [ ] Cold-cache `build:server:dev` is timed against
+      `test-visual-regression`'s `timeout-minutes: 20`
+      (`.github/workflows/main.yml:125`), and the budget raised in this same
+      change if the margin is thin — this plan guarantees a cold cache by
+      changing the lock
+- [ ] `CommandProbe` and `MarkerWalkRoot` have no new methods
+- [ ] `vcs_adapters::facts` still names `MarkerWalkRoot`/`CommandProbe`
+- [ ] `cli/vcs-adapters/Cargo.toml` gains no `[features]` entry beyond
+      `bash-parity`
+
+---
+
+## Phase 2: The Six Taxonomy Queries
+
+### Overview
+
+Add the six queries as inherent methods on `InProcessProbe`, test-first against
+the recorded oracle mapping, over the full fixture matrix. Add the source guard
+forbidding `UserSettings` and `Workspace::load`.
+
+### Changes Required
+
+#### 1. The query surface
+
+**File**: `cli/vcs-adapters/src/library.rs`
+**Changes**: six inherent methods returning plain domain values, so no library
+type leaks into what 0169 will build its port over.
+
+```rust
+pub struct WorktreeFacts {
+    pub linked: bool,
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+    pub main_worktree_root: Option<PathBuf>,
+}
+
+pub enum JjWorkspaceRole {
+    Main,
+    Secondary,
+}
+
+pub struct JjRepositoryFacts {
+    pub role: JjWorkspaceRole,
+    pub main_root: PathBuf,
+}
+
+pub struct DualRoots {
+    pub git: Result<Option<PathBuf>, Error>,
+    pub jj: Result<Option<PathBuf>, Error>,
+}
+
+impl InProcessProbe {
+    pub fn is_bare(&self, start: &Path) -> Result<Option<bool>, Error>;
+    pub fn worktree(&self, start: &Path) -> Result<Option<WorktreeFacts>, Error>;
+    pub fn superproject(&self, start: &Path) -> Result<Option<PathBuf>, Error>;
+    pub fn jj_workspace_root(&self, start: &Path) -> Result<Option<PathBuf>, Error>;
+    pub fn jj_repository(&self, start: &Path) -> Result<Option<JjRepositoryFacts>, Error>;
+    pub fn dual_roots(&self, start: &Path) -> DualRoots;
+}
+```
+
+`dual_roots` is **infallible and carries a per-side `Result`**, not
+`Result<DualRoots, Error>`. A whole-struct `Result` cannot say "the git side
+failed but the jj side answered": a one-sided failure would either propagate as
+`Err` and discard a valid answer, or be flattened to `None` — which silently
+reinstates the absence/failure conflation on the *single field* 0169
+discriminates `colocated` from `nested-*` on. A repository whose git side the
+pinned library cannot parse must never be observable as "jj only". Callers
+comparing the two sides for equality must treat any `Err` as "not comparable",
+never as inequality.
+
+**Precondition: `start` is absolutised before any walk.** The three walks
+disagree otherwise. `gix::discover(start)` absolutises against the process cwd
+internally, whereas `walk_up` — extracted from `MarkerWalkRoot`
+(`cli/vcs-adapters/src/lib.rs:35-44`) — is purely lexical: for a relative
+`"sub"`, `Path::new("sub").parent()` is `Some("")` and `Path::new("").parent()`
+is `None`, so it tests `sub` once and exits. Given a relative `start` a colocated
+checkout would report `dual_roots.git = Ok(Some(root))` and
+`dual_roots.jj = Ok(None)` — the wrong arm. The 24-pair matrix cannot catch this
+because every fixture path is absolute, so the choke point absolutises (via
+`std::path::absolute` or a cwd join) and asserts it, and one test per walk uses a
+relative `start`.
+
+`JjRepositoryFacts` carries `role: JjWorkspaceRole` (a two-variant `Main` /
+`Secondary`) rather than `secondary: bool` — 0169 builds its classifier
+vocabulary directly on these names, so a bare boolean whose other state is
+unnamed is the wrong thing to freeze.
+
+`Error` lives in this module. It is deliberately **not** `kernel::Error`:
+`kernel` is not a dependency of `vcs-adapters`, and adding one to carry an error
+type would couple the adapter to the launcher's error vocabulary for no gain.
+0169 maps it into whatever its domain port needs.
+
+**Every `PathBuf` these six queries and both port methods return is
+canonicalised**, at one choke point each return value passes through, and the
+rule is stated as a `//!` doc comment on the module rather than per query.
+Without it the surface is inconsistent — `repo_path()` arrives already
+canonicalised by jj-lib (`dunce::canonicalize`,
+`jj-lib-0.43.0/src/workspace.rs:576`) while `workspace_root()` is whatever path
+was passed in, and a linked worktree's `workdir()` is reconstructed from the
+absolute path git recorded at `git worktree add` time rather than derived from
+`start`. `dual_roots` equality is the colocated-vs-nested discriminator, so
+comparing one canonicalised side against one uncanonicalised side is exactly how
+a macOS `/var` → `/private/var` split produces a wrong classification. The
+recorded `CG` equality survives today only because Phase 2's fixtures
+canonicalise at construction; production callers have arbitrary cwds.
+
+**Failure is distinguishable from absence.** Every query returns
+`Result<Option<T>, Error>` (`dual_roots` is infallible and carries a per-side
+`Result`, per the signatures above):
+`Ok(None)` is "no repository of this kind here", `Err` is "a repository is here
+and the pinned library could not answer". Collapsing both into `None` would be a
+real regression against the adapter being replaced — `CommandProbe` runs its
+parse in a child process with a 10-second cap, a kill-on-timeout and a scrubbed
+environment, and warn-logs every distinct failure (`cli/vcs-adapters/src/lib.rs:171-217`).
+`InProcessProbe` parses repository-controlled data **in the caller's address
+space**, with no time bound, no memory bound and no crash isolation, and once
+0185 flips `vcs_adapters::facts` that parsing runs inside a long-lived HTTP
+server and on the hook path. A corrupt object store or an unreadable `.jj/repo`
+must not read as "no VCS here". The two port methods keep their `Option`
+signatures — the ports are not being changed — and warn-log instead. Which
+library error conditions are deliberately mapped to `Ok(None)` rather than `Err`
+is recorded in [Recorded divergences](#recorded-divergences).
+
+Implementation notes drawn from measurement:
+
+- `is_bare`, `worktree`, `superproject` and `dual_roots.git` resolve through
+  `gix::discover(start)`, which is permitted to escape the boundary. Only
+  `RepoRoot::discover` uses `gix::open` at the boundary.
+- `worktree` canonicalises `common_dir()` before exposing it — the raw value
+  carries `../..` for a linked worktree.
+- `worktree.linked` is the canonicalised `git_dir() != common_dir()`
+  comparison, matching the oracle exactly; `kind()` is used only as the
+  submodule signal for `superproject`. `Kind` is a single mutually-exclusive
+  enum, so it cannot represent a checkout that is *both* a submodule and a
+  linked worktree — `git worktree add` from inside `super/mid` has `--git-dir`
+  `…/modules/mid/worktrees/x` against `--git-common-dir` `…/modules/mid`, unequal,
+  so the oracle says worktree while `kind()` can report only one of the two facts.
+- `superproject` is bespoke path logic. The rule is: **scan the `modules`
+  components of `git_dir()` from the innermost outward and take the first whose
+  parent opens as a repository.** The two discriminating cases:
+  - `SM-2` — `git_dir() == $super/.git/modules/mid/modules/leaf`. The innermost
+    `modules` has parent `$super/.git/modules/mid`, which opens (it is the `mid`
+    submodule's git dir), so the answer is `$super/mid` — matching the measured
+    oracle. Taking the *outermost* would give `$super`, which is wrong.
+  - `SM-m` — a submodule added at `modules/foo`, so
+    `git_dir() == $super/.git/modules/modules/foo`. The innermost `modules` has
+    parent `$super/.git/modules`, which is **not** a repository, so the scan
+    continues outward to the next `modules`, whose parent `$super/.git` opens,
+    giving `$super` — matching git. A bare `rposition` stops at the first
+    candidate and returns `Ok(None)` here.
+
+  It is extracted as a function taking a **fallible** probe alongside the path —
+  `impl Fn(&Path) -> Result<bool, Error>`, not `-> bool` — so the method passes a
+  `gix::open`-backed closure while the unit tests pass a total closure over known
+  paths. A `bool` return makes "this candidate is not a repository"
+  indistinguishable from "this candidate is a repository the pinned library could
+  not open", so on a corrupt or hostile superproject the scan would silently
+  continue outward and return a plausible wrong path — exactly what the
+  degenerate and `HOSTILE` fixtures exist to forbid ("`Err`, not a panic, and not
+  a plausible wrong path"). An unopenable candidate short-circuits to `Err`.
+
+  Without the injected probe the derivation is not pure — it must consult the
+  filesystem to decide which candidate anchors — and the stated testability win
+  (edge cases exercised without the matrix's most expensive fixtures) would be
+  unreachable.
+
+  Measured (`SM-wt`, 2026-08-03): a submodule initialised inside a linked
+  worktree does **not** put its git dir under the common dir's `modules/` — it
+  goes to `$super/.git/worktrees/<id>/modules/sub`, and the oracle returns the
+  *worktree*. The scan therefore anchors on `$super/.git/worktrees/<id>`, whose
+  `workdir()` is the worktree — the right answer. **The one thing Phase 2 must
+  confirm is that `gix::open` accepts a linked-worktree gitdir**; the directory
+  layout is settled.
+
+  `SM-w` (a linked worktree *of* a submodule) is the shape to be careful with:
+  `--show-superproject-working-tree` is **empty** there, so if `kind()` reports
+  `Submodule` the scan must not run at all. Gate on the measured oracle, not on
+  `kind()` alone.
+
+  Old-form submodules report `Kind::Common` and yield `Ok(None)`, agreeing with
+  git.
+- `jj_workspace_root`, `jj_repository` and `dual_roots.jj` use the **`.jj`-only**
+  walk, then `DefaultWorkspaceLoaderFactory::create`. `jj_repository.role`
+  compares canonicalised `repo_path()` against canonicalised
+  `<root>/.jj/repo`; `main_root` is `repo_path().parent().parent()`, which
+  returns `Err` rather than panicking when the path is too short — **and then
+  asserts `<main_root>/.jj/repo` is a directory, else `Err`**. That
+  post-condition mirrors the shell oracle's, which carries it explicitly:
+  `[ -d "$candidate/.jj/repo" ] || return 1`, commented "so a future jj layout
+  change cannot silently produce a wrong-but-non-empty answer"
+  (`scripts/vcs-common.sh:106-112`). Without it, a `.jj/repo` pointer resolving
+  to any *existing* directory that is not a jj store yields a real-looking
+  `main_root` two levels up and `role` compares unequal, so the query reports
+  `Secondary` with a bogus root — which becomes `RepoFacts.name` once 0185 flips
+  `facts`, stamping artefacts with the wrong repository. The degenerate fixture
+  set covers a *deleted* pointer target; it needs one whose target is an existing
+  non-store directory. Hand-written `.jj/repo` pointers are in scope: the `CG`
+  builder writes one.
+- `dual_roots` resolves each side by its own walk so neither is truncated by the
+  other's marker, and `dual_roots.jj` calls `jj_workspace_root` rather than
+  re-walking.
+- `discover` and `kind` call the crate-private `walk_up(start, predicate)` and
+  `marker_kind(root)` extracted in Phase 1, so the "never test the filesystem
+  root" rule has one implementation and the `.jj`-only walk shares it. The
+  delegation direction matters: `MarkerWalkRoot` and `CommandProbe` delegate *to*
+  those helpers, so 0185's deletion of the retained pair is mechanical and
+  requires no re-homing. Pointing the surviving code at the code 0185 deletes
+  would have made `^crate(::|$)` — the one pup clause that reaches the spawning
+  `CommandProbe` — permanently load-bearing.
+
+#### 2. The fixture matrix
+
+**File**: `cli/vcs-test-support/{Cargo.toml,src/lib.rs}` (new; see Phase 3 §1
+for the manifest), carrying the `fixtures` and `hermetic` modules
+**Changes**: builders for every shape, written in their final home. Phase 3 adds
+only `stubs`, the `detection.rs` seam and the cross-crate proof.
+
+The crate is created here rather than in Phase 3 for two reasons. The builders
+are the most intricate code in the change — the depth-1 and depth-2 submodules
+"exist nowhere in the repo, in any language" — and writing, reviewing and
+merging them once only to relocate them next phase means the move's diff noise
+obscures any behavioural change smuggled in with it. And Phase 2's own
+hermeticity criterion depends on the `hermetic` module, so a reviewer of Phase 2
+could not otherwise verify it. Phase 3's rationale for a dedicated crate (it
+satisfies the no-extra-`[features]` criterion with no interpretation, and
+sidesteps CI's `--all-features` turning a fixture feature on workspace-wide)
+applies just as well here, and Phase 1's dependency-policy review is unaffected
+by a test-only workspace member.
+
+**File**: `cli/vcs-adapters/tests/queries.rs` (new), `#![cfg(feature =
+"bash-parity")]`
+**Changes**: one table-driven test **per (fixture, start directory) pair**,
+asserting all six query values at once, including explicit not-applicable
+expectations. Values come from the mapping above; the tests are written before
+the query methods.
+
+Per-pair rather than per-query: nextest is process-per-test with no sharing, so
+one test per query would rebuild the whole ~19-fixture matrix six times — and
+with the poisoned duplicates, on both legs of the OS matrix, that is on the
+order of a hundred-plus fixture constructions per CI run, each driving several
+`git`/`jj` subprocesses. This repo already has a fixture-flake history under
+parallel CI load. Per-pair keeps the per-cell traceability the acceptance
+criterion demands, localises a failure to a shape rather than a query, and costs
+roughly a sixth of the fixture builds.
+
+Existing shapes reusable from `cli/vcs-adapters/tests/detection.rs`: plain git
+(`:61-80`), nested subdir (`:114-125`), colocated-real (`:144-169`), jj
+secondary (`:171-209`), `.git`-file worktree (`:211-248`), bare (`:250-277`).
+
+New construction required:
+
+| Fixture | Cost | Note |
+| --- | --- | --- |
+| git submodule (depth 1 and 2) | substantial | **Exists nowhere in the repo, in any language.** Needs `git -c protocol.file.allow=always submodule add` and a recursive `submodule update --init` |
+| old-form submodule | small | a nested `git init` directory |
+| colocated, hand-grafted | substantial | port the graft from `hooks/test-vcs-detect.sh:96-157`; `.jj/repo` must be written with `%s` and no trailing newline |
+| nested-jj-in-git / nested-git-in-jj | moderate | port from `hooks/test-vcs-detect.sh:516-536` |
+| pure jj | small | `jj git init --no-colocate`, root three dirs below the temp root, one commit, plus a `.git`-absent assertion |
+| linked worktree, main-worktree start | trivial | second start directory on the existing fixture |
+| **`JS-in`** — jj secondary workspace *inside* its own colocated main | small | `mkdir -p workspaces` **then** `jj workspace add` — 0.43 does not create intermediate directories. **This repo's own `workspaces/<name>` shape.** Measured: dual roots differ while `classify_checkout` reports `jj-secondary`, because `jj_main_root == git_main_root` |
+| **`SM-m`** — submodule whose path contains a `modules` segment | small | `git submodule add … modules/foo`; produces `git_dir() == $super/.git/modules/modules/foo`, the case a bare `rposition` misresolves |
+| **`SM-w`** — linked worktree of a submodule | moderate | `git worktree add` from within `super/mid`. Measured: dirs differ, superproject **empty**, and `find_git_main_worktree_root` returns a `.git/modules` path |
+| **`SM-wt`** — submodule inside a linked worktree of the superproject | moderate | settles whether `superproject()` is worktree-accurate; measured git dir is under `worktrees/<id>/modules/`, oracle returns the worktree |
+| **`RF`** / **`S256`** — reftable ref backend, sha256 object format | small | `git init --ref-format=reftable`, `git init --object-format=sha256`. **`S256`'s HEAD is 64 hex, not 40** — see the revision-shape note below |
+| **degenerate shapes** (`D1`/`D2`/`D3`) | small | `.jj/repo` → a deleted directory; a `.git`-file worktree whose gitdir target is removed; `.jj/repo` → an **existing non-store** directory |
+| **`HOSTILE`** — adversarial configuration | small | a plain git repository whose `.git/config` sets `core.pager`, `core.fsmonitor`, `diff.external`, `filter.*.clean`/`smudge`, an `alias.*` and an `include.path` chain |
+
+All ten are measured; oracle values and per-fixture expectations are in
+[Extended fixtures](#extended-fixtures-measured-2026-08-03).
+
+The degenerate shapes exist because every query consumes repository-supplied
+data: Query 5 reads a `.jj/repo` pointer and takes `parent().parent()`, Query 3
+string-searches a repository-supplied `git_dir()`, and Query 2 exposes a
+`common_dir()` that a `.git` file can point anywhere. **Their expectations are
+not uniform**, contrary to an earlier draft that said all of them yield `Err`:
+
+- `D1`, `D2` — both CLIs report plain **absence**, so `Ok(None)`.
+- `D3` — `jj workspace root` **succeeds**, so `jj_workspace_root` is
+  `Ok(Some(root))` while `jj_repository` must be **`Err`**, because the
+  `<main_root>/.jj/repo`-is-a-directory post-condition fails. This is the fixture
+  that proves the invariant.
+
+The **truncated pack index** shape from the earlier draft is dropped: none of the
+six queries reads object data (only `revision` does, and it is a port method
+returning `Option`), so it would have proved nothing.
+
+`HOSTILE` runs through the strong-form harness asserting no stub marker is
+written. Measured caveat: **none of its seven configured commands ran** under the
+oracle's own calls, and none of the eight delivered library calls enters gix's
+filter/pager/external-diff machinery either. So it is a **regression guard for
+the APIs 0169 adds**, not evidence for this story's call set — state it that
+narrowly wherever the zero-spawn property is described.
+
+**Precondition, asserted once by the harness with a named diagnostic**: no
+ancestor of the temp base carries `.git` or `.jj`. Roughly a quarter of the
+mapping's cells assert absence for the gix-backed queries, and `gix::discover`
+reads **no environment** — so `GIT_CEILING_DIRECTORIES`, which produced the
+oracle side's exit-128s, cannot fence the library side. On a host whose `TMPDIR`
+resolves inside a repository those cells silently resolve the enclosing
+repository instead. `hooks/test-vcs-detect.sh:35-40` guards the same hazard for
+the shell suite. The harness walks from the temp base to the filesystem root and
+fails with one legible message rather than a mass of confusing per-cell
+failures.
+
+Temp dirs follow `tempfile::Builder::new().prefix(…).tempdir()` returning the
+owned guard (`detection.rs:32-39`); every path is canonicalised immediately
+after construction, and nested paths canonicalise the parent then join
+(`:179-180`), because on macOS `$TMPDIR` resolves `/var` → `/private/var`.
+
+#### 3. Scrub-invariant verification
+
+**File**: `cli/vcs-adapters/tests/queries.rs`
+**Changes**: every query, over every pair, asserted equal with and without the
+environment poisoned — where "poisoned" means pointed at **another fixture's
+real `.git`**, not an empty or non-existent path. Plus the control:
+`gix::discover_with_environment_overrides` on the same fixture under the same
+poison must return the poison target, proving the poisoning live.
+
+**The poisoned variable set is everything `scrub_environment` scrubs or forces**
+(`cli/vcs-adapters/src/lib.rs:139-154`) — `GIT_DIR`, `GIT_WORK_TREE`,
+`GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_CONFIG`, `GIT_CONFIG_COUNT`,
+`JJ_CONFIG`, `GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM` —
+**plus** `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES` and a
+`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` triple. The first
+draft verified two variables and generalised to "uniformly immune", which is
+broader than the evidence: `gix::open`'s default `Permissions` do consult the
+environment for object directories and for system/global config discovery, and
+`is_bare()` reads `core.bare` *through* that config. At least one case runs with
+a **populated** global config asserting a divergent `core.bare`, because the
+Phase 2 empty-config criterion otherwise masks exactly the config influence this
+invariant is meant to exclude.
+
+The `gix::open`/`gix::discover` `Options` and `Permissions` the module passes
+are recorded in its doc comment. Where an isolated permission set can be
+requested explicitly, it is — **constructing** immunity beats relying on an
+observed default of a pre-1.0 crate, and the difference is invisible at the call
+site otherwise.
+
+Coverage is the six queries and `RepoRoot`. `VcsProbe` parity against
+`CommandProbe` is out of scope for this criterion — `CommandProbe` shells out
+and does honour an ambient `GIT_DIR`.
+
+**Both arms run through the same child binary**, poisoned and clean invocations
+of the reference artefact compared on captured stdout, and the live-poison
+control is asserted inside the poisoned child in the same run. Comparing an
+in-process value against a child's rendered output would compare two
+serialisation routes — producing false failures across the whole matrix, and the
+more dangerous false pass where both arms render absence identically for
+different reasons. The reason a child is needed at all is that libtest runs each
+test on a spawned thread, so in-process `set_var` is racy by construction;
+nextest's process-per-test model (`tasks/test/cli.py:31-35`) mitigates
+cross-*test* interference but not this. The child is the Phase 4 reference
+artefact, built in this phase so there is exactly one linked binary and one
+stubbed one across the whole plan rather than a third interim target.
+
+#### 4. The `UserSettings` source guard
+
+**File**: `tasks/lint/vcs_settings.py` (new), exported in
+`tasks/lint/__init__.py`, registered in `tasks/__init__.py`
+**Changes**: a pure function scanning `cli/vcs-adapters/**/*.rs` for
+`UserSettings` and `Workspace::load`, with a thin `@task` wrapper.
+
+It **strips comments before matching**. The model it copies
+(`tasks/lint/store_duplication.py:48-50`) matches a regex against every raw
+line, which would make it impossible to document *why* `UserSettings` is avoided
+in the very crate it guards — and that reason (private defaults abandoned after
+five successive panics with the chain never exhausted) is exactly the
+extremely-non-obvious kind of fact this repo's comment bar admits. Without the
+strip, an implementer hits the self-flagging problem immediately and works
+around it by mangling the word.
+
+Stated crate-wide, deliberately wider than the detection paths require. The
+scope narrows to the detection paths only if the `revision` question above is
+resolved by option 2.
+
+A `denied` clause on the cargo-pup rule this plan is already adding would be
+cheaper, and is not sufficient: `RestrictImports` resolves `use` paths, so it
+cannot see a fully-qualified
+`jj_lib::settings::UserSettings::from_config(…)` or the `Workspace::load`
+method call. That is what buys the extra Python module, its two `__init__.py`
+registrations, the mise leaf and the `test_mise.py` constants.
+
+**File**: `mise.toml`
+**Changes**: a `lint:vcs-settings:check` leaf joining **both**
+`cli:check.depends` (`:422-424`) and `lint:check.depends` (`:464-466`) — the
+bare `default` task depends on `lint:check` but not on `check`. Pure guard, no
+autofixer, so it stays out of `fix`.
+
+**File**: `tests/unit/tasks/test_vcs_settings.py` (new)
+**Changes**: synthetic `tmp_path` trees for each branch plus a real-tree
+assertion, mirroring `test_store_duplication.py`.
+
+**File**: `tests/unit/tasks/test_mise.py`
+**Changes**: add the new leaf to `_CHECK_GATES` and `_CLI_CHECK_GATES` — the
+exhaustive equality assertions fail if skipped.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] All six queries pass against every (fixture, start directory) pair:
+      `cargo nextest run --manifest-path cli/Cargo.toml -p vcs-adapters --all-features`
+- [ ] The scrub invariant holds across the whole matrix, and the unscrubbed
+      control diverges under the same poisoning
+- [ ] `mise run lint:vcs-settings:check` passes
+- [ ] `mise run test:unit:tasks` passes, including the new guard tests
+- [ ] Non-vacuity: a deliberately added `UserSettings::from_config(…)` in
+      `cli/vcs-adapters/src/library.rs` fails the guard, and is reverted
+- [ ] Every jj query succeeds under the hermetic environment exactly as
+      enumerated in the `hermetic` module (`GIT_CONFIG_NOSYSTEM=1` as a
+      boolean, not a path)
+- [ ] The extended fixtures match their measured per-fixture expectations:
+      `D1`/`D2` → `Ok(None)`; `D3` → `jj_workspace_root` `Ok(Some)` but
+      `jj_repository` `Err`; `JS-in` → dual roots differ; `SM-m` → superproject
+      `$B/supm`; `SM-wt` → superproject the worktree; `SM-w` → `linked` true and
+      superproject `Ok(None)`; and none of them panics
+- [ ] `gix::open` on a linked-worktree gitdir is confirmed (the one open question
+      `SM-wt` leaves), and `RF`/`S256` outcomes are recorded in Recorded
+      divergences
+- [ ] The fixture harness fails with a named diagnostic when an ancestor of the
+      temp base carries `.git` or `.jj`
+- [ ] `mise run` green end to end
+
+#### Manual Verification
+
+- [ ] Every expected value in `queries.rs` is traceable to a cell in the mapping
+      table above, and every (fixture, start directory) pair has a cell in every
+      query table — no query table is partial
+- [ ] The pure-jj fixture asserts `.git` absent, not merely `.jj` present
+- [ ] Whatever gix 0.85 does with the `RF`/`S256` fixtures is recorded in
+      Recorded divergences rather than assumed
+
+---
+
+## Phase 3: The Shared Test-Support Crate and the Zero-Spawn Harness
+
+### Overview
+
+Complete the harness crate created in Phase 2 with its `stubs` module, add the
+`detection.rs` injection seam, and prove the harness across a crate boundary
+from `cli/corpus-adapters` — the crate 0185 will extend.
+
+A dedicated crate rather than a feature on `vcs-adapters`: it satisfies the
+"no `[features]` beyond `bash-parity`" criterion with no interpretation, and
+sidesteps CI's `--all-features` turning a fixture feature on workspace-wide.
+
+### Changes Required
+
+#### 1. The crate
+
+Created in Phase 2 with `fixtures` and `hermetic`; this phase adds `stubs`. The
+manifest and the three modules are specified together here for readability.
+
+**File**: `cli/vcs-test-support/Cargo.toml` — created in **Phase 2** together
+with its `cli/Cargo.toml` `members` entry and the lock change that forces;
+restated here because all three modules are specified together
+**Changes**: the full inheriting manifest every other member declares —
+`version.workspace`, `edition.workspace`, `rust-version.workspace`,
+`license.workspace`, `publish.workspace`, `[lints] workspace = true` — depending
+on `vcs` and `tempfile` only.
+
+Spelling the inheritance out matters: a member omitting `edition` silently
+defaults to the 2015 edition, and one omitting `rust-version` drops out of the
+MSRV-aware fallback that Key Discovery 11 identifies as load-bearing, which
+`test_msrv_coherence.py` would not notice (it compares `mise.toml`,
+`cli/Cargo.toml` and `cli/clippy.toml` only).
+
+It depends on `vcs` (the ports), **not** on `vcs-adapters`. The fixtures, stubs
+and hermetic environment need only `tempfile` and the real `git`/`jj` binaries,
+so the `vcs-adapters` edge is unnecessary — and taking it would create an
+undeclared dev-dependency cycle (`vcs-adapters` tests → `vcs-test-support` →
+`vcs-adapters`) that also forces `vcs-adapters` to be compiled with
+`bash-parity` on via a *normal* edge, weakening the very rationale for a
+separate crate.
+
+**File**: `cli/vcs-test-support/src/lib.rs` (new)
+**Changes**: three public modules.
+
+- `fixtures` — every builder, written here in Phase 2, including the **named
+  reusable pure-jj builder** 0169 must be able to reconstruct identically.
+- `stubs` — marker-writing `git`/`jj` stubs on a synthetic `PATH`, plus a
+  **platform-aware report of the absolute paths it cannot control**. On Linux CI
+  the meaningful jj target is the mise install path
+  (`$HOME/.local/share/mise/installs/jj/<version>/jj`) and its shim, not
+  `/usr/bin/jj` — there is no system `jj` on the runner at all
+  (`mise.lock:89-106`). On a developer's macOS machine `/opt/homebrew/bin/jj`
+  **is** the real binary. git keeps `/usr/bin/git`, `/usr/local/bin/git`,
+  `/opt/homebrew/bin/git`. The list is resolved at runtime by asking the
+  environment where each binary actually lives.
+
+  **This crate never writes outside its own temp directories.** It resolves and
+  *reports* absolute paths; it does not move, replace or chmod them, and it
+  never invokes `sudo`. All privileged mutation lives in the CI workflow step,
+  which is the only thing that can move a root-owned binary anyway — but the
+  boundary is stated because `/opt/homebrew/bin` is user-writable, so an
+  "attempt and record the failure" design would succeed there and could leave a
+  developer's machine without `git` or `jj`. `test:integration:zero-spawn` is
+  reachable from the bare `mise run` every contributor is told to run before
+  pushing, so this is the difference between a test and a hazard. The harness
+  reads `ACCELERATOR_ZERO_SPAWN_MODE`/`ACCELERATOR_ZERO_SPAWN_SHADOWED` to learn
+  what the workflow shadowed, and hard-fails if `strong` is claimed but a listed
+  path is still executable.
+
+  The in-repo precedent, `strip_binary_from_path`
+  (`hooks/test-vcs-detect.sh:164-188`), is likewise purely non-destructive — it
+  edits a `PATH` string and touches no file.
+- `hermetic` — the empty-config environment, and a `Command` decorator applying
+  it plus the stub `PATH`. It **enumerates the exact variables and value shapes
+  the oracle mapping was measured with**, in one place, so the recorded mapping
+  and the shipped harness cannot drift apart per platform: `HOME`,
+  `XDG_CONFIG_HOME` and `JJ_CONFIG` at temp dirs, `GIT_CONFIG_GLOBAL=/dev/null`,
+  `GIT_CEILING_DIRECTORIES` at the temp base, and `GIT_CONFIG_NOSYSTEM=1` — a
+  **boolean, not a path**, and the only thing suppressing the *system*
+  gitconfig, which lives at `/etc/gitconfig` on ubuntu and inside the Command
+  Line Tools on macOS. Pointing it at a temp dir, as a loose reading of "GIT_CONFIG_*
+  at empty temp dirs" would, leaves host config leaking into fixture
+  construction on one platform and not the other.
+
+  It also asserts, at fixture-build time under `bash-parity`, that
+  `jj --version` matches the jj-lib version **at major.minor only**, and that
+  `git --version` meets a documented minimum with a named diagnostic. The
+  `mise.toml` ↔ `cli/Cargo.toml` lockstep test compares two *declarations*;
+  nothing otherwise checks the binaries that write the repository formats the
+  libraries read. This planning session hit exactly that skew — the local `jj`
+  was 0.42.0 from Homebrew because `mise.toml` was untrusted — and the failure
+  would otherwise surface as an apparently wrong answer in a 24×6
+  expected-value table rather than as a version mismatch. The same argument
+  applies to `git`: the whole mapping is calibrated to 2.54.0 and `git` is
+  pinned nowhere, so a floor with a diagnostic beats recording a version nobody
+  reads.
+
+  Two mechanics this needs: `vcs-test-support` depends on `vcs` and `tempfile`
+  only, so it has **no jj-lib edge** and cannot observe a compiled-in version —
+  the linking crate (`vcs-adapters`' test target) injects it as a parameter,
+  sourced from a `build.rs`-emitted constant, since `env!("CARGO_PKG_VERSION")`
+  yields the *calling* crate's version and jj-lib publishes no version constant.
+  And the comparison is major.minor because the tilde ranges deliberately permit
+  `mise.toml`'s exact `0.43.0` CLI to sit alongside a resolved `jj-lib 0.43.x`;
+  an exact-equality assertion would fail the entire fixture matrix, for every
+  contributor and both CI legs, on a skew this plan pre-authorises.
+
+  Fixture builders pin the format-relevant knobs per invocation via the
+  **documented mechanisms** — `git init --object-format=<fmt>` /
+  `--ref-format=<fmt>` (or `GIT_DEFAULT_HASH` / `GIT_DEFAULT_REF_FORMAT`), plus
+  `-c init.defaultBranch=main` — except in the `RF`/`S256` fixtures that exist to
+  vary them. Note that `extensions.objectFormat` is a *repository-format
+  extension* read from the repo's own config, not an `init` knob: injecting it
+  via `-c` into a `core.repositoryformatversion = 0` repository drives git's
+  "repo version is 0, but v1-only extension found" failure path, and
+  `init.defaultRefFormat` is not a documented `init.*` key across the supported
+  range. Each constructed fixture asserts it actually has the intended object
+  format and ref backend, so a silently-ignored knob fails loudly rather than
+  restoring the cross-runner drift the pinning exists to remove.
+
+  Fixture builders also supply an identity explicitly —
+  `-c user.name=… -c user.email=… -c commit.gpgsign=false`, and a written
+  `user.name`/`user.email` in `JJ_CONFIG` rather than an empty temp dir. With
+  `HOME` at a temp dir, `GIT_CONFIG_GLOBAL=/dev/null` and
+  `GIT_CONFIG_NOSYSTEM=1`, `git commit` otherwise falls back to an auto-detected
+  `user@hostname` identity and **refuses** the commit when the hostname carries
+  no domain — the normal case on CI runners and in containers. Several fixtures
+  need commits, and `hooks/test-vcs-detect.sh:58` already sets both keys on every
+  git fixture for exactly this reason.
+
+  No fixture builder writes outside its own `TempDir`, and
+  `protocol.file.allow=always` (needed by the submodule fixtures) is passed
+  per-invocation via `git -c`, never written into a config file — not even one
+  under a temp `HOME`.
+
+The `PATH`-stripping technique is ported from `strip_binary_from_path`
+(`hooks/test-vcs-detect.sh:164-188`) with both recorded gotchas preserved:
+macOS provides `git` in two directories, so a single dirname is insufficient;
+and `type -p` must not be used.
+
+Fixture builders use `tempfile::TempDir`, **not** `NamedTempFile`/`.persist`/
+`fs::rename`, which the store-duplication guard flags anywhere under
+`cli/**/src`.
+
+#### 2. The injection seam
+
+**File**: `cli/vcs-adapters/tests/detection.rs`
+**Changes**: replace the seven direct `vcs_adapters::facts` calls (`:95`,
+`:121`, `:134`, `:155`, `:191`, `:234`, `:272`) with a helper parameterised by
+`(&dyn RepoRoot, &dyn VcsProbe)`, and run every existing case against **both**
+the retained `MarkerWalkRoot`/`CommandProbe` pair and `InProcessProbe`,
+asserting the suite's existing fixed expected values — agreement between two
+implementations is not on its own an oracle.
+
+Parity is asserted **per `VcsKind`**, per the spike-resolved `revision` descope:
+full `RepoFacts` equality for `VcsKind::Git`, and `root`/`name`/`kind` only for
+`VcsKind::Jj`, where `InProcessProbe::revision` is `None` by design while
+`CommandProbe` returns a 40-hex id. The jj cases therefore assert the
+`CommandProbe` arm against the suite's fixed values as today, and the
+`InProcessProbe` arm against the three fields it owns — so neither adapter's
+coverage is silently dropped.
+
+The `.git`-as-file worktree case keeps **today's** `RepoFacts` value, and the
+identical-facts assertion applies to it unrelaxed. The `colocated` discussion
+concerns `classify_checkout`'s taxonomy, not `RepoFacts` — the relevant
+`RepoFacts` field is `VcsKind`, so no divergence arises there. `classify_checkout`
+reports `main` for that shape with the git side unseen; 0169 owns correcting it
+to `colocated`, and that correction is out of scope here.
+
+This dual comparison is transitional: 0185 deletes `CommandProbe` and collapses
+the suite to `InProcessProbe` alone.
+
+#### 3. The cross-crate proof
+
+**File**: `cli/corpus-adapters/Cargo.toml`
+**Changes**: a **new `[dev-dependencies]` table** carrying
+`vcs-test-support = { path = "../vcs-test-support" }`. Under resolver 3 a
+dev-dependency's features stay out of the normal build, which matters because
+`cli/visualiser/server` depends on `corpus-adapters`. The existing normal
+`vcs-adapters` dependency (`:25`) is untouched.
+
+**File**: `cli/corpus-adapters/tests/zero_spawn.rs` (new)
+**Changes**: one test running a **full strong-form assertion end to end** —
+stubs *and* shadow list *and* empty-config environment — through
+`vcs-test-support`'s public API only, with no fixture-private helpers. It runs
+the query × fixture table and asserts no stub marker was written **and** that
+every value matches an unrestricted run, because an adapter degrading to `None`
+also writes no marker.
+
+The assertion is scoped to `git`/`jj` specifically, not "no subprocess at all":
+`SystemClock::try_new` spawns `date` unconditionally
+(`cli/corpus-adapters/src/metadata.rs:106-110`) and a blanket marker would trip
+on it.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mise run test:unit:cli` passes; `detection.rs` runs every existing case
+      through the seam against both implementations, producing identical
+      `RepoFacts`
+- [ ] `cli/corpus-adapters`' `zero_spawn.rs` passes: no marker written and every
+      value matches the unrestricted run
+- [ ] `mise run cli:check`, `deny:check`, `pup:check` pass (the new workspace
+      member landed in Phase 2 and was gated there)
+- [ ] `cli/corpus-adapters`' metadata parity suite passes unchanged:
+      `derive_at_agrees_with_the_live_metadata_helper`
+      (`cli/corpus-adapters/tests/metadata.rs:265`) — note this is
+      `tests/metadata.rs`, **not** `tests/parity.rs`, which is the linkage suite
+      and never touches VCS
+- [ ] `mise run` green end to end
+
+#### Manual Verification
+
+- [ ] `zero_spawn.rs` imports only `vcs_test_support`'s public API — all three
+      parts, not one
+- [ ] The shadow list records which absolute paths it could not shadow on the
+      host it ran on, and `vcs-test-support` modified nothing outside `TMPDIR`
+      (checksum the resolved absolute paths before and after)
+- [ ] `cli/vcs-test-support` does not depend on `cli/vcs-adapters`, so no
+      dev-dependency cycle exists
+
+---
+
+## Phase 4: Reference Artefact, Strong-Form CI, and Measurements
+
+### Overview
+
+Add the stub artefact (the linked one landed in Phase 2), wire both into the musl cross-compile, add the
+Linux-only strong-form zero-spawn job, and take the cost and size measurements.
+
+### Changes Required
+
+#### 1. The reference artefact
+
+**File**: `cli/vcs-adapters/tests/fixtures/vcs_adapters_fixture_stub.rs` (new) —
+the **linked** artefact `vcs_adapters_fixture.rs` and its `[[bin]]` declaration
+landed in **Phase 2**, which needs it as the child process for the poisoned
+scrub-invariant runs. Both follow the `config-adapters-fixture` convention
+(`cli/config-adapters/Cargo.toml:12-17`)
+**Changes**: a composition root calling every query and both port methods and
+**printing each result**, so the calls are not eliminable. Modes: `all`, and
+`only <query>` for the cold per-process figure. Carries the required prelude:
+
+```rust
+#![allow(clippy::exit, clippy::print_stdout, clippy::print_stderr,
+         clippy::restriction)]
+```
+
+A `stub` feature replaces every query call with a constant, for the size delta.
+This is a feature on `vcs-adapters`, which the "no `[features]` beyond
+`bash-parity`" criterion forbids — so the stubbed build is produced by a
+**second `[[bin]]`** (`vcs_adapters_fixture_stub.rs`) that calls stubs directly,
+adding no feature. Both binaries are staged and measured.
+
+Because `CARGO_BIN_EXE_*` does not cross crate boundaries
+(`cli/launcher/Cargo.toml:17-18`), `vcs-test-support` exposes a path resolver
+derived from `current_exe()`, as
+`cli/corpus-adapters/tests/common/mod.rs:62-86` does.
+
+#### 2. musl staging
+
+**File**: `tasks/build.py`
+**Changes**: a **new `_CLI_FIXTURE_BINARIES` constant and its own staging loop**,
+reusing `_assert_magic_bytes` and `_assert_static_elf` (`:132-159`) but asserting
+in place under `cli/target/<triple>/release/` rather than copying into
+`dist/release/`.
+
+`_CLI_RELEASE_BINARIES` (`:37`) is **not** extended. That constant means
+"binaries we ship": it drives `cli_binary_path()` staging into `dist/release/`,
+the tree the signed manifest and release assets are assembled from, and whose
+`accelerator-*` members are provenance-attested (`.github/workflows/main.yml:420-425`).
+Nothing would be published today — `_release_uploads()` enumerates assets
+explicitly rather than globbing — but two unshipped diagnostic binaries that
+print absolute repository paths would sit in the release staging directory on
+every release run, one glob change away from being published as product. The
+sibling convention says the same: `cli/config-adapters/Cargo.toml:12-14` keeps
+fixture binaries "off the crate's normal build surface" as "not a shipped
+artifact". A unit assertion checks `_release_uploads()` never contains a fixture
+name, and the fixture bin names avoid the `accelerator-` prefix so they cannot
+be swept into the attestation glob.
+
+**The size floor is a committed check, not a number written once.** This is the
+guard against the story's headline false-pass — dead-code elimination letting
+the musl and size checks succeed while linking almost none of `gix`/`jj-lib` —
+and leaving it as a Validation Results figure would mean nothing catches a later
+edit that stops printing a query result and lets the linker drop the trees.
+
+Two scoping rules, because a heuristic threshold that first executes in the
+release pipeline can abort a whole product release:
+
+- The **ratio** floor (`linked ≥ 3× stubbed`) is asserted on every triple. It has
+  wide margin — the measured darwin figure is 5.42× and musl 6.19×.
+- The **absolute-byte** floor (`delta ≥ 1,500,000`) is asserted for **musl
+  triples only**, matching how `_assert_static_elf` is already guarded
+  (`if "musl" in triple`, `tasks/build.py:329-330`). The darwin stripped delta is
+  1,639,872 B — only **9.3%** above the floor, and `[profile.release] strip =
+  true` (`cli/Cargo.toml:76`) means every triple is stripped. Applying the
+  absolute floor to darwin would put a 9%-margin heuristic on the critical path
+  of `prerelease:prepare`, which builds the launcher, the verify shims and the
+  visualiser too. Darwin figures are recorded, not gated.
+
+A **host-native ratio assertion** also runs in `check-zero-spawn` (linked vs stub
+under `cli/target/release/`), so the invariant has PR-level feedback rather than
+first executing in a release. Without it, a contributor who deletes a result
+print sees green everywhere they look. A unit test covers the comparison
+function against synthetic sizes — threshold logic only, not a real build.
+
+Recovery when the floor fires is documented in `tasks/README.md` alongside the
+advisories break-glass: re-measure, and raise or lower the constant in
+`tasks/build.py`.
+
+This is a **release-pipeline change**: `cli_cross_compile` (`:312-331`) is
+invoked only from `tasks/release.py:82-94` / `:109-125`, wired to the
+`prerelease`/`release` jobs, both `runs-on: macos-latest`
+(`.github/workflows/main.yml:343`, `:464`). No `check-*` job cross-compiles and
+no test exercises `_assert_static_elf` against a real build today.
+
+Verified this session: both binaries cross-compile to
+`aarch64-unknown-linux-musl` via `cargo zigbuild --release` and `file -b`
+reports `statically linked, stripped`, which `_is_statically_linked` (`:118-129`)
+accepts unmodified.
+
+**All four triples must be verified in this phase**, not just that one.
+`cli_cross_compile` iterates the whole of `TARGETS` (`tasks/shared/targets.py`):
+`aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-musl`,
+`x86_64-unknown-linux-musl`. And this is not confined to the fixtures —
+`gix`/`jj-lib` are **normal** dependencies of `vcs-adapters`, which
+`cli/corpus-adapters` depends on (`Cargo.toml:25`), which `cli/visualiser/server`
+depends on (`Cargo.toml:23`), so both trees must compile for all four triples in
+the shipped visualiser cross-compile too. Since no `check-*` job cross-compiles,
+an `x86_64-musl` or darwin failure inside the enlarged closure would land on
+`main` and first surface in the `prerelease` job on `macos-latest`. Each
+triple's result is recorded in Validation Results, alongside the
+`accelerator-visualiser` binary size before and after, so any dead-code
+elimination shortfall in the artefact that actually ships is visible rather than
+inferred from the fixture's 391 KB stub figure.
+
+Contention: 0187 rewrites `validate_dispatch_coherence` in the same file, at
+`:189-208` — roughly 130 lines from this plan's regions (`:118-159`, `:290-331`)
+with three unrelated functions between. The genuine collision surface is the
+import block (`:11-32`) and the module constants (`:34-56`). Whichever lands
+second regenerates rather than merges.
+
+#### 3. The strong-form CI job
+
+**File**: `.github/workflows/main.yml`
+**Changes**: a new Linux-only job modelled on `check-architecture`
+(`:286-321`) — the closest precedent for a single Linux runner that
+self-provisions unusual infrastructure and is deliberately isolated.
+
+```yaml
+  check-zero-spawn:
+    name: Check zero-spawn
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - Checkout
+      - Route the rust toolchain into the cached mise data dir
+      - Install dependencies (mise-action, cache_key_prefix: mise-zero-spawn-v1)
+      - Cache cargo build (workspaces: cli)
+      - Compile the test binaries          # cargo nextest run --no-run
+      - Build the fixture matrix           # needs real git/jj; writes $MATRIX_DIR
+      - Shadow the absolute VCS paths      # sudo mv -> $RUNNER_TEMP/shadowed
+      - Run the strong-form zero-spawn suite  # prebuilt binaries, prebuilt fixtures
+      - Restore the absolute VCS paths     # if: always()
+      - Assert the restore worked          # if: always(); git --version && jj --version
+```
+
+Constraints satisfied: the job's `run:` text contains none of `pup:check`,
+`deps:install:pup` or `+nightly`, so the nightly-isolation invariant
+(`tests/unit/tasks/test_workflows.py:294-337`) still sees exactly
+`{check-architecture}`; it declares no `needs: check-architecture`; it lives in
+`main.yml` because actionlint lints only that file
+(`tasks/lint/workflows.py:7`); and it carries its own `RUSTUP_HOME` routing step
+plus `cache_key_prefix`, per the comment replicated to six jobs
+(`main.yml:191-198`).
+
+It is added to `prerelease.needs` (`:344-355`) so a red zero-spawn check blocks
+a prerelease, matching every other check job.
+
+The job must **not** be placed in `test-unit` or `test-integration`: both are OS
+matrices (`:20-21`, `:60-61`) and `test:unit:cli` runs on both legs, so a
+strong-form assertion there would fail on macOS under SIP. macOS degrades to
+`PATH`-only with unshadowable paths recorded.
+
+The shadow step uses `sudo mv` on GitHub-hosted Ubuntu VMs, where the `runner`
+user has passwordless sudo and no container is needed. Corroborating in-repo
+evidence: `test-visual-regression` (`:122-145`) already runs `docker run` with
+bind mounts from a step. The jj target is the mise install path, not
+`/usr/bin/jj`.
+
+**The shadow window is deliberately narrow, and must stay that way.** Everything
+that needs a real `git` or `jj` happens *before* it:
+
+- **Compilation.** `cli/launcher` carries a `vergen-gitcl` build dependency that
+  shells out to `git`, and cargo may need `git` on a cold registry cache. The
+  cargo cache makes this a no-op on warm runs and a failure on cold ones — and
+  this plan guarantees a cold run by changing `cli/Cargo.lock`. The suite is
+  therefore compiled with `--no-run` first and only executed inside the window.
+- **Fixture construction.** Every fixture in the matrix is built by invoking the
+  real `git`/`jj` CLIs — that is what `bash-parity` means. Building them inside
+  the window would leave the suite with an empty matrix, which would pass
+  vacuously. The matrix is built beforehand into `$MATRIX_DIR` and the suite
+  consumes prebuilt fixtures, asserting the expected fixture count so an empty
+  or truncated matrix fails loudly rather than passing.
+
+  **The handoff needs an API the plan must specify, because `TempDir` cannot do
+  it.** Phase 2/3 mandate owned `tempfile::TempDir` guards, which delete on drop,
+  so a builder that owns a guard leaves the consuming step an empty directory.
+  The workflow creates the root (`MATRIX_DIR=$(mktemp -d -p "$RUNNER_TEMP")`) and
+  the builder writes beneath a caller-supplied root **without owning a guard**;
+  `TempDir` stays for the in-process test paths. The builder never deletes
+  `$MATRIX_DIR` — no `rm -rf "$MATRIX_DIR"` idempotency step, which becomes a
+  wildcard delete if the variable is unset. Name the binary or test target that
+  drives construction, and compile it in the `--no-run` step. Do **not** reach
+  for `TempDir::keep()`/`into_path()` to work around this: the store-duplication
+  guard does not catch it, and the same builder would then leak a ~19-fixture
+  tree of git/jj repositories into `TMPDIR` on every developer `mise run`.
+
+  `$MATRIX_DIR` must also satisfy the no-`.git`-ancestor precondition, asserted
+  at the start of the consuming step — `$RUNNER_TEMP` satisfies it on
+  GitHub-hosted runners, but it is a provider-specific variable and self-hosted
+  or containerised runners commonly point `TMPDIR` inside the workspace, where
+  every absence cell would silently resolve the enclosing accelerator repository.
+- **`mise` tool resolution.** If `mise run` is the entry point inside the
+  window, mise may observe `jj` as missing and reinstall it, silently restoring
+  the binary and making the assertion vacuous. The post-shadow step invokes the
+  prebuilt test binary directly, not through `mise run`.
+
+Binaries are moved to `$RUNNER_TEMP/shadowed`, **not renamed in place**, because
+the meaningful jj target lives inside `$HOME/.local/share/mise/installs/` — the
+tree `mise-action` saves to the cache on its post step, which runs *after* the
+restore. An in-place shadow that failed to restore would persist a `jj`-less
+mise install into the `mise-zero-spawn-v1` namespace, making every subsequent
+run of this job fail or pass vacuously until someone bumped the prefix.
+
+Shadow and restore are both **idempotent per path** — test-then-move each entry,
+tolerate a missing source, and exit non-zero at the end only if a path is still
+shadowed — so a partial shadow does not leave a straight-line `set -e` restore
+aborting on the first missing source. The final `if: always()` assertion that
+`git --version` and `jj --version` both succeed turns a failed restore into a
+red job rather than a poisoned cache; note that `actions/checkout`'s own post
+step runs `git` to strip the auth token, so an unrestored `git` breaks it.
+
+This containment relies on GitHub-hosted runners being **ephemeral VMs**, and on
+`git` at `/usr/bin/git` and `jj` under the mise install tree. Both are recorded
+as inline comments on the job and in `tasks/README.md`, because a move to
+self-hosted, containerised or reusable runners turns a contained hazard into a
+persistently broken runner. Targets are resolved at run time (`mise which jj`,
+and an enumeration of *every* `PATH` hit rather than the first, per the recorded
+macOS two-directory gotcha) and the step fails closed when a resolved target
+cannot be shadowed.
+
+The workflow step and the harness have an explicit contract rather than each
+assuming the other did the work: the step exports
+`ACCELERATOR_ZERO_SPAWN_MODE=strong` and `ACCELERATOR_ZERO_SPAWN_SHADOWED=<paths>`,
+and the harness hard-fails when the mode is `strong` and any listed path is
+still executable, or any expected target went unshadowed. Without that, a runner
+image that relocates `git` turns the `sudo mv` into a no-op and the job goes
+green with the property unproven.
+
+The contract is **fail-closed on malformed input**, not just on an unshadowed
+path. The harness accepts exactly `strong` or `path-only`; any other non-empty
+value is a hard error, and a non-empty `ACCELERATOR_ZERO_SPAWN_SHADOWED` with a
+mode other than `strong` is a hard error. The harness also *reports* the mode it
+ran in and the paths it verified, and the CI step asserts `strong` was observed
+after the suite exits. Otherwise a typo, a renamed variable or a step-ordering
+change that drops the export silently downgrades the one job that proves the
+property — the fail-open case for a gate the work item calls non-degradable.
+
+**The restore is a shell guarantee, not a scheduler guarantee.** Shadow → run →
+restore live in a single step whose script installs a `trap restore EXIT`, with
+`timeout-minutes` on **that step** (shorter than the job's), so the step rather
+than the job is what expires. A job-level `timeout-minutes` cancels the job, and
+whether trailing `if: always()` steps run then is not a contract a system-binary
+restore should rest on — a hard second cancel will not run them at all, and a
+hanging suite is the most likely unattended failure. The separate `if: always()`
+liveness assertion stays as the backstop.
+
+Consider `cache: false` on this job's `mise-action`. The `jj` shadow target sits
+inside the tree the action saves on its post step, so a failed restore persists a
+`jj`-less tool tree into `mise-zero-spawn-v1` that every later run restores —
+self-perpetuating until someone bumps the prefix. Moving the binary to
+`$RUNNER_TEMP` does not avoid that (both shapes leave the tree without a working
+`jj`); it only makes the loss unrecoverable within the run. The job installs one
+toolchain plus `jj`, so disabling its cache is cheap and removes the hazard
+outright. If the cache is kept, "bump `cache_key_prefix`" is the documented
+recovery in `tasks/README.md`.
+
+**File**: `mise.toml`
+**Changes**: a `test:integration:zero-spawn` leaf running the strong-form suite,
+classified `_NO_LAUNCHER_NEEDED` and placed in **`_NOT_IN_INTEGRATION_ROLLUP`**
+(`tests/unit/tasks/test_mise.py:127-137`), following the precedent
+`test:integration:pup` already sets for a suite owned by one dedicated job.
+
+It stays out of the roll-up because membership would construct the ~19-fixture
+matrix a *second* time per run — on both legs of `test-integration`
+(`.github/workflows/main.yml:55-61`) and on every bare `mise run` via
+`default` → `test` → `test:integration` — on top of `queries.rs`. Each fixture
+drives several `git`/`jj` subprocesses including recursive submodule adds, and
+this is the code path with a documented flake history under parallel CI load; a
+flake there reddens `test-integration`, which is in `prerelease.needs`. It also
+keeps the harness that reads the shadow contract off the local path. The leaf
+stays runnable on demand.
+
+**File**: `tasks/README.md`
+**Changes**: a `### Zero-spawn strong form` subsection and a row in the CI table
+(`:153-157`).
+
+#### 4. Measurements
+
+Recorded in the work item's Validation Results. Host and OS recorded; darwin-arm64
+is chosen deliberately to match 0186's `B = 35.1 ms`
+(`meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md:46-63`), because
+the ~97 ms probe delta is macOS-specific and cross-host comparison would leave
+0169's gate ill-posed.
+
+Baseline figures already taken this session (median of 20, darwin-arm64,
+warm cache, jj 0.43.0, git 2.54.0, Rust 1.90.0):
+
+| Measurement | Median | Min | Max |
+| --- | --- | --- | --- |
+| cold per-process, single query (`only q4`, pure-jj) | **3.65 ms** | 3.27 | 4.18 |
+| cold per-process, single query (`only q1`, plain git) | 3.65 ms | 3.46 | 3.86 |
+| cold per-process, all six queries + both ports (pure-jj) | 3.66 ms | 3.20 | 4.35 |
+| cold per-process, all six queries + both ports (plain git) | 4.49 ms | 3.96 | 5.21 |
+| `CommandProbe` jj subprocess (`jj log -r @ -T commit_id`) | **7.05 ms** | 6.34 | 7.79 |
+| `CommandProbe` git subprocess (`git rev-parse HEAD`) | 4.40 ms | 4.13 | 5.00 |
+
+Warm in-process, same host, median of 20: first-call jj-lib 13.2 µs, first-call
+gix 41.2 µs; per-query 2.6 µs (`jj_workspace_root`) to 31.0 µs (`dual_roots`).
+
+The library-backed cold per-process cost is roughly **half** a single `jj`
+subprocess, which is favourable for 0169's `G ≤ 1.1 × B` gate. Two provenance
+notes carried forward: `B = 35.1 ms` is from 0186's table, not 0169's; and the
+"~41 ms warm bootstrap" 0169 cites is **derived** (`149.1 − 107.9`), not
+measured.
+
+Size, `aarch64-unknown-linux-musl`, `--release`, stripped by the toolchain:
+
+| Build | Size | Ratio |
+| --- | --- | --- |
+| linked | 2,422,864 B | — |
+| stubbed | 391,416 B | — |
+| delta | **2,031,448 B** | **6.19×** |
+
+Darwin comparison: unstripped delta 2,058,656 B (5.62×); stripped delta
+1,639,872 B (5.42×).
+
+**These figures were taken with a feature-gated prototype** (one binary, built
+twice, with the query calls stubbed by `--features stub`), whereas the delivered
+shape is two sibling `[[bin]]` targets in a crate that declares both
+dependencies either way. Dead-code elimination is what produces the delta in
+both shapes — the prototype's stubbed build was 391 KB despite declaring `gix`
+and `jj-lib` — so the figures are expected to transfer, but **Phase 4 must
+re-measure against the delivered two-binary shape** and record those numbers,
+not these.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Both fixture binaries build and print every query result
+- [ ] `mise run test:integration:zero-spawn` passes locally in `PATH`-only mode
+- [ ] The strong-form run passes in the named Linux CI job, with absolute paths
+      shadowed
+- [ ] Both binaries cross-compile to musl and pass `_assert_static_elf`
+- [ ] Size: linked ≥ 3× stubbed **and** delta ≥ 1,500,000 bytes, on the
+      musl-static stripped artefact (see
+      [Work-Item Amendments](#work-item-amendments))
+- [ ] `mise run test:unit:tasks` passes, including the updated
+      `test_mise.py` and `test_workflows.py`
+- [ ] `mise run` green end to end
+
+#### Manual Verification
+
+- [ ] The strong-form job's shadow step actually replaced the binaries (assert
+      `git --version` fails inside the step before restoring), and the harness
+      hard-fails when `ACCELERATOR_ZERO_SPAWN_MODE=strong` but a listed path is
+      still executable
+- [ ] Both size figures and all six cost figures are written into Validation
+      Results with host and OS, plus one `x86_64-unknown-linux-musl` cold
+      per-process figure — the gate-comparable figure stays darwin-arm64, but
+      the shipped artefact is static musl and 0169 otherwise sets a threshold
+      with no Linux datapoint
+- [ ] All four release triples cross-compile, each recorded individually
+- [ ] The restore step runs `if: always()`, is idempotent per path, and is
+      followed by an `if: always()` assertion that `git --version` and
+      `jj --version` both succeed — `if: always()` alone does not establish the
+      guarantee, and the containment additionally assumes ephemeral runners
+- [ ] Nothing was staged into `dist/release/` that `_release_uploads()` does not
+      enumerate
+
+---
+
+## Phase 5: Sibling Hand-Offs and Closeout
+
+### Overview
+
+Dated notes on three siblings, then Validation Results and the Open Questions on
+0188 itself. The four work-item amendments already landed before implementation,
+so this phase does not carry them.
+
+**Every sibling edit is an append-only dated amendment block**, the same pattern
+0188 used for its own four amendments — not an in-place rewrite of the host's
+Summary, Context, Assumptions or acceptance criteria. These are live items in
+the same epic that other work may be editing concurrently, and the only
+automated gate (`test:integration:work`) validates frontmatter and linkage, not
+content. An in-place rewrite that loses a criterion to a botched conflict
+resolution is invisible; an append-only block surfaces the same conflict
+visibly and leaves the prior text in the file. Where a statement is now wrong,
+the amendment block says so and quotes it rather than deleting it.
+
+### Changes Required
+
+#### 1. `meta/work/0125-*.md`
+
+**Changes**: a dated note in `## Dependencies` (`:141-146`) recording that 0188
+dissolves the lexical-fallback rationale **for consumers that reach the Rust
+adapter** — the ~26 shell call sites keep running in bash until later epic-0136
+phases migrate them. Constraints 3, 4 and 5 (`:90-95`) are untouched and must
+survive the note; only constraints 1 and 2 are dissolved. Add `work-item:0188`
+to `relates_to` (`:11`), which currently reciprocates no edges — leaving 0169
+and 0185 one-directional is a conscious choice, not an oversight.
+
+#### 2. `meta/work/0185-*.md`
+
+**Changes**: a dated amendment block repointing the adapter and the zero-spawn
+harness from 0169 to **0188** wherever its Summary, Context, Assumptions,
+Technical Notes and acceptance criteria name the wrong owner; recording that its
+harness criterion (`:82-84`) describes `PATH` stubs only whereas it inherits
+0188's strictly larger three-part strong form; recording that **0185 owns the
+`vcs_adapters::facts` switch** and that the switch and the `CommandProbe`
+deletion are one atomic change (closing Open Question 2); and that the
+transitional dual-adapter `detection.rs` comparison must be collapsed when
+`CommandProbe` goes. Note the two stale References anchors (`:148-153`): 0169
+has no "Adapter-swap boundary" heading, and its Dependencies bullet is titled
+"Unowned debt this story creates" (`0169:436`). Note that the
+"0169 will need to alter this anyway" assumption (`:117-121`) is now stale.
+
+Three further inheritances, new from the review of this plan:
+
+- **0185 must re-home the boundary walk and `marker_kind` before deleting**
+  `MarkerWalkRoot`/`CommandProbe` — `InProcessProbe` delegates to both rather
+  than duplicating them, so the deletion is not mechanical.
+- **The containment delta.** `CommandProbe` parses in a child process with a
+  10-second cap, kill-on-timeout and a scrubbed environment.
+  `InProcessProbe` parses repository-controlled data in the caller's address
+  space with no time or memory bound and no crash isolation, and after the
+  switch that runs inside `cli/visualiser/server` and on the hook path. 0185
+  decides whether an equivalent bound is needed before flipping `facts`.
+- **jj `revision` — descoped to 0185, spike-established.** jj-lib 0.43 exposes no
+  read-only, settings-free route to the working-copy commit id: the op stores are
+  settings-free but the workspace name is reachable only through
+  `LocalWorkingCopy::load` (needs `UserSettings`) or
+  `SimpleWorkspaceStore::load` (**writes** to `.jj/repo/workspace_store`,
+  verified empirically), and `CheckoutState` is private. 0185's options are a
+  jj-lib version exposing the checkout state publicly, an upstream request for
+  one, or retaining `CommandProbe` for `revision` alone — which would make the
+  "atomic switch plus deletion" sizing wrong, so it needs deciding early.
+  `InProcessProbe` therefore implements `VcsProbe` **partially**: `kind` fully,
+  `revision` for `VcsKind::Git` only.
+
+#### 3. `meta/work/0169-*.md`
+
+**Changes**: a dated note recording that it inherits the closed six-query
+contract; must define its own domain port over the inherent methods; must widen
+the pup rule to cover wherever it puts `status`/`log`; must reuse 0188's named
+pure-jj builder; that its 0125 hand-off sub-clause is now redundant; and — new
+from this planning session — that **queries 4, 5 and the jj half of 6 resolve
+through a `.jj`-only walk**, so a classifier built on the combined boundary walk
+would report absence where `jj workspace root` reports a root.
+
+Four further inheritances, new from the review of this plan:
+
+- **`WorktreeFacts`, `JjRepositoryFacts`, `JjWorkspaceRole` and `DualRoots` must
+  move into `cli/vcs`** when 0169 defines its port. They are domain-shaped value
+  types currently declared in the adapter crate, and
+  `vcs_domain_imports_only_permitted` (`cli/pup.ron:75-89`) restricts `vcs` to
+  `std`/`kernel::Error`/`crate` — so a domain port structurally cannot reference
+  them where they sit. 0188 cannot pre-empt the move because its own criteria
+  forbid touching `cli/vcs/src/**`. This is a planned move, not a defect; expect
+  it to churn the `queries.rs` expected-value tables.
+- **Dual-root equality is necessary but not sufficient** for `colocated`, and
+  inequality is not sufficient for either `nested-` arm — see the note under
+  Query 6. The arms also need the jj-secondary bit (Query 5) and the
+  linked-worktree bit (Query 2).
+- **The `JS-in` fixture** (jj secondary workspace inside its own colocated main —
+  this repo's `workspaces/<name>` shape) is where differing dual roots point at
+  the wrong arm: `classify_checkout` reports `jj-secondary` because its
+  `nested-jj-in-git` arm additionally requires
+  `jj_main_root != git_main_root`, and there they are equal.
+- **The queries return `Result<Option<T>, _>`**, so 0169's classifier must decide
+  what a repository the pinned library cannot parse classifies as. It is not
+  `none`.
+
+#### 4. Work-item closeout
+
+**File**: `meta/work/0188-library-backed-vcs-adapter.md`
+**Changes**: Validation Results filled in from Phases 1–4, and both Open
+Questions marked closed with the answers recorded in
+[Open Questions Closed](#open-questions-closed).
+
+The four amendments are **already applied** (2026-08-03, before implementation)
+— see [Work-Item Amendments](#work-item-amendments). Nothing to re-apply here.
+
+Note that the size and cost figures quoted in this plan came from a prototype;
+Phase 4's measurements against the delivered artefact are what get written into
+Validation Results.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mise run test:integration:work` passes (frontmatter and linkage
+      validation on all four edited work items)
+- [ ] `mise run` green end to end
+
+#### Manual Verification
+
+- [ ] Each of the three sibling notes is dated and raises information without
+      re-scoping its host
+- [ ] 0125's `relates_to` edge is present and 0188's reciprocal edge already
+      exists
+- [ ] Every *pending* line in 0188's Validation Results is resolved or
+      explicitly carried forward with a reason
+
+---
+
+## Work-Item Amendments
+
+Measurement during planning forced four amendments; plan review 1 forced two
+more; the pin decision and the `revision` spike force a further two. Each is a
+change to *this* work item, recorded here rather than absorbed silently.
+
+**Amendments 1-4 were applied to `meta/work/0188-library-backed-vcs-adapter.md`
+on 2026-08-03, before implementation started**, together with the two
+informational corrections below. The work item carries a summary at the head of
+its Requirements and the detail inline at each affected criterion.
+
+**Amendments 5-8 are not yet applied** — 5 and 6 arose from plan review 1, 7 from
+the pin decision and 8 from the `revision` spike. All four must land on the work
+item before Phase 1 starts, by the same route.
+
+Phase 5 does *not* apply any of them — it only fills in Validation Results and
+writes the sibling hand-offs.
+
+1. **The size-delta floor is mis-calibrated.** The criterion demands the linked
+   artefact be "at least **2 MB** larger" than the stubbed one. Measured:
+   musl-static stripped delta **2,031,448 B**, darwin stripped **1,639,872 B**,
+   darwin unstripped 2,058,656 B. The criterion passes only on a decimal-MB
+   reading of the musl build, by 1.6%, and fails outright on the stripped darwin
+   build and on every MiB reading — while the trees are unambiguously linked
+   (ratio **6.19×**). **Amended to**: linked ≥ 3× stubbed **and** delta
+   ≥ 1,500,000 bytes (decimal, unit stated), measured on the musl-static
+   stripped artefact, with darwin figures also recorded.
+
+2. **Three walks, not one.** The Requirements describe a single boundary walk.
+   Queries 4, 5 and the jj half of 6 need a **`.jj`-only** walk; using the
+   boundary walk makes `DefaultWorkspaceLoaderFactory::create` return
+   `Err(There is no Jujutsu repo …)` on both nested-git-in-jj shapes, where the
+   oracle reports a root. Add the distinction to the Requirements.
+
+3. **The "colocated" matrix row is two shapes.** A real
+   `jj git init --colocate` main repository classifies as `main`
+   (`Kind::Common`, jj main); the shell suite's hand-grafted shape classifies as
+   `colocated` (`Kind::LinkedWorkTree`, jj secondary). Both are carried; the
+   matrix names one row. Related: **`jj git init` colocates by default at 0.43**
+   and `--no-colocate` exists, so the pure-jj fixture is a one-flag build and
+   the shell's `make_main_jj_workspace` is misnamed.
+
+4. **The single-query-mode rationale is measurably false.** The criterion states
+   that timing a binary running all six queries plus both port methods "would
+   inflate it by an unknown factor". Measured inflation: **0%** on pure-jj
+   (3.66 vs 3.65 ms) and 23% on plain git — process startup dominates. The mode
+   is retained because 0169 will want it, not because the figure would otherwise
+   be unusable. Reword the rationale.
+
+5. **The size-delta criterion needs a mechanism, not just a number.** Amendment 1
+   recalibrated the threshold but left it as a figure recorded in Validation
+   Results. It is now a committed assertion in `tasks/build.py`'s fixture
+   staging with a unit test over the comparison, because it guards the story's
+   headline false-pass and a one-off number catches no later regression.
+
+6. **The six queries return `Result<Option<T>, _>`, not `Option<T>`.** The
+   Requirements describe `Option`-returning queries. That conflates "no
+   repository of this kind here" with "a repository is here and the pinned
+   pre-1.0 library could not answer", and silently drops `CommandProbe`'s time
+   cap, crash isolation and warn-logging when 0185 switches the composition
+   root. Add the error channel to the Requirements.
+
+7. **The pins are asymmetric, and the coupling is four-way not two-way.** The
+   work item states "`jj-lib` pinned exactly at `=0.43`" (`:264`, `:538`) and
+   frames upgrades as a "coordinated two-crate bump". Delivered: `jj-lib =
+   "=0.43.0"` (unchanged in spirit) but `gix = "~0.85.0"`, permitting `0.85.x`
+   patches so a gix RustSec fix is a lock update rather than a pin edit — the
+   range is anyway identical to jj-lib's own `^0.85.0`, so the single-graph
+   property is untouched. The coupling is jj-lib + gix + the Rust toolchain + the
+   `mise.toml` jj CLI pin. **Amend to**: state the asymmetry and the four-way
+   coupling.
+
+8. **jj `revision` is out of scope; `InProcessProbe` implements `VcsProbe`
+   partially.** The work item assumes both port methods are fully implemented.
+   A spike established that jj-lib 0.43 has no read-only, settings-free route to
+   the working-copy commit id (details in Phase 1 §4). **Amend to**: `revision`
+   covers `VcsKind::Git`; the jj mechanism transfers to 0185, and the crate-wide
+   `UserSettings` guard stays crate-wide because nothing in scope needs it.
+
+Two further corrections, informational:
+
+- **The `gix` feature-gating assumption resolves in favour of the pin.**
+  `jj-lib` 0.43 with default features *does* pull `gix` 0.85 and enables
+  `attributes`, `blob-diff`, `index`, `max-performance-safe`, `sha1`, `zlib-rs`.
+  The single-graph reasoning holds as written, and `submodules()`' `attributes`
+  feature comes from jj-lib rather than from gix's defaults.
+- **The scrub invariant is a property to verify, not to implement**, on both
+  sides — not just the git side the research had proven.
+
+## Open Questions Opened by Plan Review 1
+
+- ~~**How does `InProcessProbe::revision` read a jj working-copy commit id
+  without a `UserSettings`?**~~ **Closed 2026-08-03 by spike**: it cannot, in
+  jj-lib 0.43. Descoped to 0185; see Phase 1 §4 for the evidence and the
+  consequences applied throughout.
+- **Does the MPL-2.0 §3.2 notice obligation need a third-party licence artefact
+  in the release payload, or does dead-code elimination remove `uluru` from every
+  shipped binary?** Either answer is acceptable; the exception comment must name
+  the one that holds.
+- **Can gix 0.85 serve reftable and sha256 repositories?** The `RF`/`S256`
+  fixtures answer it; whatever they find is recorded as a known boundary rather
+  than assumed.
+
+## Open Questions Closed
+
+- **Who owns the CI job for the strong-form run, and does the runner permit
+  it?** 0188 owns it. Feasible on the existing GitHub-hosted `ubuntu-latest`
+  runners with passwordless `sudo` and no container; placed in `main.yml`
+  because actionlint lints nothing else; modelled on `check-architecture` to
+  stay clear of the nightly-isolation invariant. **The shadow list is rewritten**
+  to be platform-aware: on CI the meaningful jj target is the mise install path
+  (there is no system `jj` at all), on developer macOS it is
+  `/opt/homebrew/bin/jj`. Built directly rather than behind a smoke test, per
+  decision this session.
+- **Who changes `vcs_adapters::facts`, 0169 or 0185?** **0185**, atomically with
+  the `CommandProbe` deletion — the composition root cannot switch until nothing
+  else needs the subprocess pair. 0169 wires its own classifier port without
+  touching `facts`. Recorded on 0185.
+- **Does a combined `allowed_only` + `denied` cargo-pup rule behave as
+  intended?** Yes — verified 2026-08-03; the deny wins on overlap.
+- **How is the shared fixture published?** A new `cli/vcs-test-support` crate.
+- **Which "colocated" does the matrix mean?** Both; see amendment 3.
+- **Does `jj git init` produce a colocated repo by default at 0.43?** Yes, and
+  `--no-colocate` exists.
+- **Which host do the cost measurements run on?** darwin-arm64, matching
+  0186's `B`.
+
+## Testing Strategy
+
+### Unit Tests
+
+- The boundary walk against both nesting directions, with the paired negative
+  assertion that unbounded `gix::discover` escapes
+- Each of the six queries against every (fixture, start directory) pair, with
+  expected values traceable to the oracle mapping
+- Absence: `None` for every query on `NONE`, and the per-query absence signals
+- The superproject derivation at submodule depths 1 and 2, plus the old-form
+  shape that must yield `None` while `Kind::Submodule`-only logic would miss it
+- `jj_repository.role` for both the relative (`jj workspace add`) and
+  absolute (hand-grafted) `.jj/repo` pointer forms
+
+### Integration Tests
+
+- `detection.rs` running every existing case through the injection seam against
+  both implementations, with fixed expected values retained
+- The scrub invariant across the whole matrix, with the live-poison control
+- `cli/corpus-adapters`' cross-crate strong-form zero-spawn test
+- The lockfile version invariants and the `mise.toml` ↔ `jj-lib` pin lockstep
+- Non-vacuity: `std::process` failing cargo-pup, `UserSettings` failing the
+  source guard, and the unscrubbed control diverging
+
+### Manual Testing Steps
+
+1. Confirm the strong-form CI job's shadow step took effect by asserting
+   `git --version` fails inside the step before restoring.
+2. Re-run the shell suites that build jj fixtures, last green against the
+   pre-bump `jj` 0.36 pin: `hooks/test-vcs-detect.sh`, the work-item script
+   suite under `skills/work/scripts/`, and — per the unabsorbed correction at
+   `meta/prs/35-description.md:52`, which 0188 `:413-416` still omits —
+   `scripts/test-metadata-helpers.sh`,
+   `skills/config/migrate/scripts/test-migrate.sh`,
+   `skills/config/migrate/scripts/test-migrate-interactive.sh`, and the Python
+   task tests under `tests/unit/tasks/`.
+3. Verify `mise install` has been run on each development machine — this session
+   found the local `jj` was 0.42.0 from Homebrew because `mise.toml` was
+   untrusted.
+4. Read the four edited work items end to end to confirm no note re-scoped its
+   host.
+
+## Performance Considerations
+
+Cost is measured, not gated. The figures above show the library-backed cold
+per-process path at ~3.65 ms against ~7.05 ms for a single `jj` subprocess, and
+warm in-process calls in the low tens of microseconds. Two ongoing costs are
+structural rather than measurable here: both transitive trees enter `cargo
+deny`'s `advisories` scope under `unmaintained = "all"` (`cli/deny.toml:22`), so
+an unmaintained crate anywhere in the `gix`/`jj-lib` closure fails the
+workspace-wide check for every unrelated change (break-glass documented in
+`tasks/README.md`); and any future `jj-lib` minor bump is a coordinated
+four-pin change.
+
+Two costs the cold per-process figures do not capture: every downstream crate —
+including the shipped `accelerator-visualiser` — now compiles both trees, so
+cold-cache CI compiles lengthen (measured against
+`test-visual-regression`'s 20-minute budget in Phase 1); and `InProcessProbe`
+parses repository-controlled data in-process, trading `CommandProbe`'s
+subprocess containment for speed. That trade is priced in Phase 2 §1 and handed
+to 0185.
+
+## Migration Notes
+
+Nothing migrates at runtime. `InProcessProbe` ships unwired;
+`vcs_adapters::facts` keeps naming `MarkerWalkRoot`/`CommandProbe`, so
+`cli/corpus-adapters` and `cli/visualiser/server` are behaviourally unaffected by
+construction. They are **not** unaffected at the build-graph level: both new
+trees enter their dependency closure, and thence the shipped visualiser binary.
+
+### Revert order
+
+Rollback is a multi-file ordered operation, not a single-module `jj restore`,
+and one ordering is actively dangerous. In order:
+
+1. **`needs: check-zero-spawn` in `.github/workflows/main.yml`, before the job
+   itself.** Removing the job while leaving the `needs` edge is a workflow-level
+   validation error that stops the *whole* Main workflow from running, not just
+   that job.
+2. `_CLI_FIXTURE_BINARIES` and its staging loop in `tasks/build.py`, before the
+   `[[bin]]` targets they name.
+3. The `mise.toml` leaves: **the `depends` references first** — `lint:check`
+   (`mise.toml:466`) and `cli:check` (`:424`) name `lint:vcs-settings:check`, and
+   removing the task definition while a `depends` entry still names it makes
+   `mise run`, `mise run check` and every lint job error out — then the task
+   definitions, then the `test_mise.py` assertions (`_CHECK_GATES`,
+   `_CLI_CHECK_GATES`, `_LAUNCHER_DEPENDENTS`/`_NO_LAUNCHER_NEEDED`, the
+   integration roll-up), which are exhaustive equality assertions and fail if
+   either side moves alone.
+4. **The two `[dev-dependencies]` path edges to `cli/vcs-test-support` before the
+   crate directory** — `cli/vcs-adapters` (Phase 2) and `cli/corpus-adapters`
+   (Phase 3 §3), together with the test files that import it (`queries.rs`,
+   `zero_spawn.rs`). Deleting the directory while either
+   `path = "../vcs-test-support"` remains makes cargo fail to load the workspace
+   manifest graph, which breaks *every* cargo invocation: `cli:check`,
+   `server:check` (the visualiser server is a `cli/` member), `test:unit:cli`, and
+   `deny:check`/`test:integration:deny`, which shell `cargo metadata`. A
+   wrong-order revert fails the whole Rust and lint surface, not the module being
+   reverted.
+5. Then `cli/vcs-adapters/src/library.rs`, `cli/vcs-test-support` and its
+   `members` entry, the two fixture binaries, the pins, the licence exception, the
+   `[bans]` additions and the pup rule.
+6. `cli/Cargo.lock` is **regenerated, not reverted** — once a sibling has landed
+   on top, the prior lock is not a valid state to return to.
+
+### Lock contention
+
+`cli/Cargo.lock` is shared-artefact contention with any epic-0136 item adding
+crates under `cli/`. No ordering is imposed. On conflict, drop the conflicted hunk, re-resolve `cli/Cargo.toml` first, then
+run `cargo metadata --manifest-path cli/Cargo.toml`, which performs a **minimal**
+lock update adding only the missing entries. Never `cargo generate-lockfile`.
+
+Note what does and does not float. `reqwest = "=0.12.28"` and
+`rustls = "=0.23.41"` are **exact** requirements (`cli/Cargo.toml:30`, `:35`), so
+resolution cannot move them whatever happens to the lock — an earlier draft of
+this section cited them, wrongly. What a wholesale regeneration actually floats
+is the caret/tilde-bounded workspace set (`thiserror`, `tracing`, `time`,
+`sha2`, `serde`, `serde_json`, `regex`, `tempfile`, `rand`, `rustix`) and the
+whole ~360-package transitive closure — including the MSRV trap of Key
+Discovery 11, where an unconstrained re-resolution selects a crate requiring a
+Rust newer than the pinned 1.90.0. That lands an unaudited whole-graph
+dependency change disguised as merge cleanup, on a repo whose supply-chain
+failures block releases.
+
+Do **not** reach for `cargo update -p gix -p jj-lib` in this scenario: after
+dropping the conflicted hunk in favour of a sibling's lock, those packages are
+absent from it and the command fails with "package ID specification did not
+match any packages" — which is exactly the moment someone reaches for
+`generate-lockfile`. `cargo add` is also wrong here: it rewrites the manifest,
+replacing `{ workspace = true }` inheritance or the tilde requirement and
+dropping the adjacent lockstep comment that the new test asserts is present.
+
+The lock diff must contain only the new closure plus crates cargo was forced to
+move, and the full `mise run deny:check` plus `test_vcs_library_graph.py` must
+pass against the regenerated lock — not merely the single-`gix`-version
+assertion.
+
+## References
+
+- Original work item: `meta/work/0188-library-backed-vcs-adapter.md`
+- Related research:
+  `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`
+- Feasibility probe and the two traps:
+  `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md` §9
+- Split rationale:
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md` pass 4
+- Behavioural oracle: `scripts/vcs-common.sh`
+- Ports implemented: `cli/vcs/src/lib.rs:46-67`
+- Retained pair and composition root: `cli/vcs-adapters/src/lib.rs:32`, `:73`,
+  `:224-227`
+- Reference-artefact template:
+  `cli/config-adapters/tests/fixtures/config_adapters_fixture.rs:1-49`
+- Invariant-check shapes: `tests/integration/deny/test_launcher_feature_graph.py:23-51`,
+  `tests/unit/tasks/test_msrv_coherence.py:30-38`
+- CI job template: `.github/workflows/main.yml:286-321`
+- jj loader internals: `jj-lib-0.43.0/src/workspace.rs:499-600`
+- ADRs: ADR-0053 (thin CLI over a hexagonal ports-and-adapters core)

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -687,6 +687,55 @@ What these settle:
   directory) pairs and six queries. Every cell above reads *agree*, after the
   `PJG-i` common-dir correction noted under Query 2.
 
+#### Confirmed during implementation (2026-08-03, all 34 pairs)
+
+The delivered queries were measured against the live CLIs across the whole
+matrix. Every cell agrees except the three below, each deliberate.
+
+- **`superproject` gates on the worktree comparison, not on `kind()`.** The plan
+  proposed gating the derivation on `kind() == Submodule`. Measured, that is
+  wrong in *both* directions and the two extended fixtures added after plan
+  review are exactly what exposed it. `SM-w` (a linked worktree of a submodule)
+  reports `kind() == Submodule`, so the gate admits it and the scan returns
+  `$B/supw` where git returns **empty**. `SM-wt` (a submodule inside a linked
+  worktree) does **not** report `Submodule`, so the gate rejects it and the scan
+  never runs, where git returns `$B/supwt-wt`. The delivered gate is the
+  oracle's own discriminator — canonicalised `git_dir() != common_dir()` means
+  "linked worktree, no superproject" — after which the `modules` scan runs
+  unconditionally. All seven submodule shapes then agree.
+- **`gix::open` accepts a linked-worktree gitdir — confirmed.** This was the one
+  open question Phase 2 was asked to settle for query 3. `SM-wt` resolves
+  through `$B/supwt/.git/worktrees/supwt-wt`, whose `workdir()` is
+  `$B/supwt-wt`, matching the oracle.
+- **gix 0.85 cannot read a sha256 repository**, answering the open question.
+  `S256` returns `Err` from every gix-backed query —
+  `open::Error::Config(ConfigTypedString { key: "extensions.objectFormat" })` —
+  rather than misreading it. `Err` is the correct outcome under the partition
+  rule (a repository *is* here and the pinned library cannot answer) and is
+  precisely why the queries carry an error channel; collapsing it to `Ok(None)`
+  would report "no repository" for a valid checkout. **`RF` (reftable) reads
+  normally.** 0185 inherits the sha256 consequence, since its switch is what
+  exposes a user on such a repository.
+- **`D1` returns `Err`, not `Ok(None)` — a deliberate departure from this plan's
+  own extended-fixture cell.** A `.jj/repo` pointing at a deleted directory makes
+  jj-lib's loader fail `dunce::canonicalize` and return `WorkspaceLoadError::Path`,
+  which the partition rule maps to `Err`. The `Ok(None)` recorded above was read
+  off the *CLI's* exit code, and the CLI conflates. There **is** a jj workspace
+  at `D1` — `.jj` is a directory carrying a repo pointer — and it is broken, so
+  reporting absence is exactly the "a corrupt store must not read as no VCS
+  here" failure the error channel exists to prevent. The partition rule wins;
+  the cell was wrong. `D2` (no `.jj` at all) remains `Ok(None)`, and `D3`
+  remains `Ok(Some)` from `jj_workspace_root` with `Err` from `jj_repository`,
+  both as recorded.
+- **`superproject_of` does not canonicalise.** The plan put every returned path
+  through the canonicalisation choke point. Applied inside the scan that makes
+  the injected-probe unit tests impossible — they drive it over paths that do
+  not exist, and canonicalisation fails. Canonicalisation moved to the probe
+  closure the method supplies, which is the only place a real filesystem path
+  appears. The injected probe also returns `Result<Option<PathBuf>, Error>`
+  rather than the planned `Result<bool, Error>`, so the anchor is opened once
+  rather than twice; the three-state distinction the plan required is preserved.
+
 ---
 
 ## Phase 1: Dependencies, Policy Gates and the Boundary-Safe Ports
@@ -1644,37 +1693,42 @@ exhaustive equality assertions fail if skipped.
 
 #### Automated Verification
 
-- [ ] All six queries pass against every (fixture, start directory) pair:
+- [x] All six queries pass against every (fixture, start directory) pair:
       `cargo nextest run --manifest-path cli/Cargo.toml -p vcs-adapters --all-features`
-- [ ] The scrub invariant holds across the whole matrix, and the unscrubbed
+- [x] The scrub invariant holds across the whole matrix, and the unscrubbed
       control diverges under the same poisoning
-- [ ] `mise run lint:vcs-settings:check` passes
-- [ ] `mise run test:unit:tasks` passes, including the new guard tests
-- [ ] Non-vacuity: a deliberately added `UserSettings::from_config(…)` in
+- [x] `mise run lint:vcs-settings:check` passes
+- [x] `mise run test:unit:tasks` passes, including the new guard tests
+- [x] Non-vacuity: a deliberately added `UserSettings::from_config(…)` in
       `cli/vcs-adapters/src/library.rs` fails the guard, and is reverted
-- [ ] Every jj query succeeds under the hermetic environment exactly as
+- [x] Every jj query succeeds under the hermetic environment exactly as
       enumerated in the `hermetic` module (`GIT_CONFIG_NOSYSTEM=1` as a
       boolean, not a path)
-- [ ] The extended fixtures match their measured per-fixture expectations:
-      `D1`/`D2` → `Ok(None)`; `D3` → `jj_workspace_root` `Ok(Some)` but
-      `jj_repository` `Err`; `JS-in` → dual roots differ; `SM-m` → superproject
-      `$B/supm`; `SM-wt` → superproject the worktree; `SM-w` → `linked` true and
+- [x] The extended fixtures match their measured per-fixture expectations —
+      **with one amendment**: `D1` is `Err`, not `Ok(None)`, because a `.jj/repo`
+      pointing at a deleted directory is a broken workspace rather than an absent
+      one and the partition rule maps it so; the `Ok(None)` here was read off the
+      CLI's exit code, and the CLI conflates. Otherwise as recorded: `D2` →
+      `Ok(None)`; `D3` → `jj_workspace_root` `Ok(Some)` but `jj_repository`
+      `Err`; `JS-in` → dual roots differ; `SM-m` → superproject `$B/supm`;
+      `SM-wt` → superproject the worktree; `SM-w` → `linked` true and
       superproject `Ok(None)`; and none of them panics
-- [ ] `gix::open` on a linked-worktree gitdir is confirmed (the one open question
+- [x] `gix::open` on a linked-worktree gitdir is confirmed (the one open question
       `SM-wt` leaves), and `RF`/`S256` outcomes are recorded in Recorded
       divergences
-- [ ] The fixture harness fails with a named diagnostic when an ancestor of the
+- [x] The fixture harness fails with a named diagnostic when an ancestor of the
       temp base carries `.git` or `.jj`
-- [ ] `mise run` green end to end
+- [x] `mise run` green end to end
 
 #### Manual Verification
 
-- [ ] Every expected value in `queries.rs` is traceable to a cell in the mapping
+- [x] Every expected value in `queries.rs` is traceable to a cell in the mapping
       table above, and every (fixture, start directory) pair has a cell in every
       query table — no query table is partial
-- [ ] The pure-jj fixture asserts `.git` absent, not merely `.jj` present
-- [ ] Whatever gix 0.85 does with the `RF`/`S256` fixtures is recorded in
-      Recorded divergences rather than assumed
+- [x] The pure-jj fixture asserts `.git` absent, not merely `.jj` present
+- [x] Whatever gix 0.85 does with the `RF`/`S256` fixtures is recorded in
+      Recorded divergences rather than assumed — `RF` reads normally, `S256`
+      returns `Err` from every gix-backed query
 
 ---
 

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -5,7 +5,7 @@ title: "Library-Backed VCS Adapter over gix and jj-lib Implementation Plan"
 date: "2026-08-03T09:10:56+00:00"
 author: "Toby Clemson"
 producer: create-plan
-status: draft
+status: done
 work_item_id: "work-item:0188"
 parent: "work-item:0188"
 derived_from: ["codebase-research:2026-08-02-0188-library-backed-vcs-adapter"]
@@ -190,8 +190,9 @@ and the strong-form CI job, and takes the measurements. Phase 5 writes the
 sibling hand-offs and the work-item amendments.
 
 **Phase 1 starts once work-item amendments 5-8 have landed.** The `revision`
-question that previously blocked it was closed by spike on 2026-08-03 (jj
-`revision` is descoped to 0185 — see Phase 1 §4).
+question that previously blocked it was closed twice: a spike descoped the jj
+half to 0185, and re-examination during validation reversed that and delivered it
+here — see Phase 1 §4.
 
 Test-driven throughout where the oracle is known: every query's expected values
 come from the mapping table below, written as assertions before the query
@@ -668,9 +669,13 @@ What these settle:
   The measured extended fixtures pin the observable half already: `D1`/`D2` →
   `Ok(None)`, `D3` → `Ok(Some)` from `jj_workspace_root` and `Err` from
   `jj_repository`.
-- **`InProcessProbe::revision` returns `None` for `VcsKind::Jj`** by design —
-  spike-established that jj-lib 0.43 exposes no read-only settings-free route to
-  the working-copy commit id. Warn-logged, and handed to 0185.
+- **`InProcessProbe::revision` answers for `VcsKind::Jj`** — the spike's
+  "no read-only, settings-free route" finding was **wrong** and was reversed
+  during validation. It reports the commit as of the last recorded operation,
+  where asking the `jj` binary snapshots the working copy first and so reports —
+  and writes — a new commit when files changed since the last jj command. That is
+  the only divergence, it is the read-only direction, and it is pinned by
+  `an_unsnapshotted_edit_is_the_one_documented_divergence`. See Phase 1 §4.
 - **sha256 repositories carry 64-hex revision ids.** Measured on `S256`:
   `git rev-parse HEAD` is 64 hex characters, while
   `cli/vcs-adapters/tests/detection.rs:84-86`'s `is_full_revision_id` asserts 40.
@@ -1014,12 +1019,22 @@ impl VcsProbe for InProcessProbe {
 }
 ```
 
-##### `revision`: jj is descoped to 0185 — spike-resolved 2026-08-03
+##### `revision`: both halves are in scope — the descope was reversed 2026-08-03
 
-The git half is `gix::discover(root)?.head_commit()?.id()`, in scope here.
+The git half is `gix::discover(root)?.head_commit()?.id()`.
 
-**The jj half is descoped to 0185.** A spike (throwaway crate, `jj-lib =
-"=0.43.0"`, Rust 1.90.0, resolver 3) established that jj-lib 0.43 offers **no
+**The jj half is delivered here.** The spike below concluded it was impossible in
+jj-lib 0.43 and descoped it to 0185; re-examination during validation found that
+conclusion **wrong**, and the route is implemented in this story. See
+[The delivered jj revision route](#the-delivered-jj-revision-route). The
+superseded spike reasoning is kept because it records what was believed and why
+the belief was wrong:
+
+<details>
+<summary>Superseded: the descope argument (wrong — see above)</summary>
+
+A spike (throwaway crate, `jj-lib =
+"=0.43.0"`, Rust 1.90.0, resolver 3) concluded that jj-lib 0.43 offers **no
 read-only, settings-free route to the working-copy commit id**. The chain needs
 four links and two are blocked:
 
@@ -1051,12 +1066,73 @@ Reading `.jj/working_copy/checkout`'s protobuf by hand is the only remaining
 path, and that is precisely the "leaning on private internals" this design set
 out to avoid — a private wire format with no compatibility promise.
 
-**Consequences, applied throughout this plan:**
+**This last sentence is the error.** `jj-lib` declares `pub mod protos`, so the
+`Checkout` schema is published API, not a private wire format. The two
+"blocked" links were both avoidable, because the checkout state supplies the
+workspace name directly and the op store reads need no settings.
+
+</details>
+
+##### The delivered jj revision route
+
+Measured 2026-08-03 against the live CLI. The chain is the one jj itself walks,
+and every link is public API:
+
+```
+DefaultWorkspaceLoaderFactory::create(root)            // settings-free, already used
+  -> repo_path(), workspace_root()
+<workspace_root>/.jj/working_copy/checkout
+  -> protos::local_working_copy::Checkout::decode()    // pub mod protos
+  -> (operation_id, workspace_name)
+SimpleOpStore::load(repo_path/"op_store", root_data)   // takes a path only
+  -> read_operation(op_id).view_id -> read_view(view_id)
+  -> View.wc_commit_ids[workspace_name]                // pub field
+```
+
+What makes it correct rather than merely plausible:
+
+- **The workspace-name lookup is load-bearing.** A repository with several
+  workspaces has one view entry per workspace holding *different* commits, so
+  taking the view's sole entry would answer for the wrong workspace the moment
+  anyone runs `jj workspace add`. Pinned by
+  `each_workspace_reports_its_own_commit_not_its_neighbour_s`, which asserts the
+  two answers differ *and* that each matches its own oracle.
+- **No settings anywhere.** The crate-wide `UserSettings` / `Workspace::load`
+  guard is untouched and still passes — this route never approaches either.
+- **Read-only, verified by fingerprint.** `reading_the_revision_writes_nothing`
+  fingerprints the whole `.jj` tree around the call. This matters because a
+  sibling loader in the same area *does* create directories on load.
+- **Two path facts are convention, not API** — `<workspace_root>/.jj/working_copy`
+  and `<repo_path>/op_store`; `DefaultWorkspaceLoader`'s equivalent field is
+  private. Mitigated by asserting `get_working_copy_type() == "local"` before
+  reading, and by decode failure being `Err`. The *schema* — the part that could
+  silently misparse — is public and versioned with a crate pinned at `=0.43.0`,
+  so a layout change can only arrive through the deliberate pin bump.
+- **`prost` and `pollster` become direct dependencies**, both already in the lock
+  via jj-lib. The lock delta is two lines: two new edges on `vcs-adapters`, no
+  new packages, no new licences. Pinned to jj-lib's majors because the decoded
+  type comes from jj-lib, and guarded by a single-version assertion in
+  `test_vcs_library_graph.py`.
+
+**The one divergence from asking the `jj` binary**, and it is not a regression:
+`jj log -r @` **snapshots the working copy first**, so with unsnapshotted changes
+present it reports a newly created commit — and *writes* it to the repository.
+The in-process route reports the commit as of the last recorded operation and
+writes nothing, which is what a probe that must work on a read-only filesystem
+can do. Measured: with an external edit present the subprocess probe returns a
+new id and advances `@` on disk, after which both agree again. Pinned by
+`an_unsnapshotted_edit_is_the_one_documented_divergence`. Every fixture in
+`detection.rs` is built then read with no intervening edit, so **full `RepoFacts`
+equality holds for both idioms** there.
+
+<details>
+<summary>Superseded consequences of the descope</summary>
 
 - `InProcessProbe::revision` returns `None` for `VcsKind::Jj`, and warn-logs that
   the mechanism is unavailable rather than implying an empty repository.
 - The crate-wide `UserSettings` / `Workspace::load` guard **stays crate-wide** —
-  the spike is the evidence that nothing in scope needs it.
+  the spike is the evidence that nothing in scope needs it. *(This one still
+  holds, for a better reason: the delivered route needs no settings either.)*
 - Phase 3's parity criterion narrows **per `VcsKind`**: full `RepoFacts` parity
   for `VcsKind::Git`, and `root`/`name`/`kind` only for `VcsKind::Jj`. It is not
   dropped wholesale — the git path is achievable and
@@ -1071,6 +1147,15 @@ the detection paths would have put a settings chain abandoned after five
 successive panics into code with no crash isolation, running inside
 `cli/visualiser/server` and on the hook path after 0185's switch. The spike
 removed the need to weigh that at all.
+
+Also worth recording, since it shaped the wrong conclusion: `UserSettings::from_config`
+returns `Result`, not a panic, and needs exactly five keys (`user.name`,
+`user.email`, `operation.hostname`, `operation.username`, `signing.behavior` —
+`settings.rs:135-166`). "Abandoned after five successive panics with the chain
+never exhausted" was in fact the chain *being* exhausted. So the settings route
+was viable too; it is simply worse than the one delivered.
+
+</details>
 
 <details>
 <summary>Original framing, kept because it records what was unknown</summary>
@@ -1270,10 +1355,11 @@ justification for the extra Python machinery over a one-line `denied` clause.
       `gix::discover` on the same fixture *does* escape to the parent repository.
       The **both-nesting-directions** form of this criterion moves to Phase 2,
       which owns the nesting fixtures; Phase 1 must not duplicate them
-- [x] `kind` and `repository_root` agree with `CommandProbe` on the plain-git,
-      colocated, commitless and jj-secondary fixtures; `revision` agrees for
-      `VcsKind::Git` and returns `None` (warn-logged) for `VcsKind::Jj`, per the
-      spike-resolved descope above
+- [x] `kind`, `repository_root` **and `revision`** agree with `CommandProbe` on
+      the plain-git, colocated, commitless and jj-secondary fixtures — for both
+      idioms, the jj half included, per the delivered route in §4. A failure on
+      either side is warn-logged and reported as absence, which is the port's
+      existing contract
 - [x] Non-vacuity is **committed**, not demonstrated by hand: probe cases in
       `tests/integration/pup/test_import_rule.py` for the new rule — a
       `std::process::Command` import rejected with `"is denied"` and the rule
@@ -1886,13 +1972,12 @@ the retained `MarkerWalkRoot`/`CommandProbe` pair and `InProcessProbe`,
 asserting the suite's existing fixed expected values — agreement between two
 implementations is not on its own an oracle.
 
-Parity is asserted **per `VcsKind`**, per the spike-resolved `revision` descope:
-full `RepoFacts` equality for `VcsKind::Git`, and `root`/`name`/`kind` only for
-`VcsKind::Jj`, where `InProcessProbe::revision` is `None` by design while
-`CommandProbe` returns a 40-hex id. The jj cases therefore assert the
-`CommandProbe` arm against the suite's fixed values as today, and the
-`InProcessProbe` arm against the three fields it owns — so neither adapter's
-coverage is silently dropped.
+Parity is **full `RepoFacts` equality for every `VcsKind`**, the jj `revision`
+included, since the delivered route answers it (Phase 1 §4). Every fixture here
+is built and then read with no intervening edit, so the jj working copy's
+recorded operation is current and the snapshot the `jj` binary takes is a no-op;
+the shape where the two legitimately differ is pinned in `library.rs` rather than
+relaxed here.
 
 The `.git`-as-file worktree case keeps **today's** `RepoFacts` value, and the
 identical-facts assertion applies to it unrelaxed. The `colocated` discussion
@@ -2387,17 +2472,17 @@ Three further inheritances, new from the review of this plan:
   space with no time or memory bound and no crash isolation, and after the
   switch that runs inside `cli/visualiser/server` and on the hook path. 0185
   decides whether an equivalent bound is needed before flipping `facts`.
-- **jj `revision` — descoped to 0185, spike-established.** jj-lib 0.43 exposes no
-  read-only, settings-free route to the working-copy commit id: the op stores are
-  settings-free but the workspace name is reachable only through
-  `LocalWorkingCopy::load` (needs `UserSettings`) or
-  `SimpleWorkspaceStore::load` (**writes** to `.jj/repo/workspace_store`,
-  verified empirically), and `CheckoutState` is private. 0185's options are a
-  jj-lib version exposing the checkout state publicly, an upstream request for
-  one, or retaining `CommandProbe` for `revision` alone — which would make the
-  "atomic switch plus deletion" sizing wrong, so it needs deciding early.
-  `InProcessProbe` therefore implements `VcsProbe` **partially**: `kind` fully,
-  `revision` for `VcsKind::Git` only.
+- **jj `revision` is NOT inherited — 0188 delivers it.** An earlier draft handed
+  it over on a spike finding that jj-lib 0.43 exposes no read-only, settings-free
+  route to the working-copy commit id. That finding was wrong and was reversed on
+  2026-08-03: `jj_lib::protos` is public, so the checkout state decodes through
+  published API, and `SimpleOpStore::load` takes a path only. Consequences for
+  0185: the atomic switch-plus-deletion sizing holds, `InProcessProbe` implements
+  `VcsProbe` fully, and there is no reason to retain `CommandProbe` for
+  `revision`. The one behavioural difference it inherits is that asking the `jj`
+  binary snapshots the working copy — and writes — where the in-process route
+  reports the last recorded commit and writes nothing, so after the switch
+  metadata derivation stops mutating the user's repository.
 
 #### 3. `meta/work/0169-*.md`
 
@@ -2537,12 +2622,34 @@ writes the sibling hand-offs.
    `mise.toml` jj CLI pin. **Amend to**: state the asymmetry and the four-way
    coupling.
 
-8. **jj `revision` is out of scope; `InProcessProbe` implements `VcsProbe`
-   partially.** The work item assumes both port methods are fully implemented.
-   A spike established that jj-lib 0.43 has no read-only, settings-free route to
-   the working-copy commit id (details in Phase 1 §4). **Amend to**: `revision`
-   covers `VcsKind::Git`; the jj mechanism transfers to 0185, and the crate-wide
-   `UserSettings` guard stays crate-wide because nothing in scope needs it.
+8. ~~**jj `revision` is out of scope; `InProcessProbe` implements `VcsProbe`
+   partially.**~~ **WITHDRAWN 2026-08-03 — see amendment 10.** The spike this
+   rested on was wrong. Original text: the work item assumes both port methods
+   are fully implemented; a spike established that jj-lib 0.43 has no read-only,
+   settings-free route to the working-copy commit id, so `revision` covers
+   `VcsKind::Git` and the jj mechanism transfers to 0185. The crate-wide
+   `UserSettings` guard does stay crate-wide, for the better reason that the
+   delivered route needs no settings either.
+
+9. **`gix` takes `default-features = false`, not default features.** gix's
+   `default` reaches `extras` → `credentials` → `gix-credentials`, which spawns
+   `git credential-*` helper programs, against a module whose whole point is
+   reading git without a subprocess. `jj-lib`'s own selection still supplies
+   every feature the adapter calls. **Amend to**: state the disabled defaults and
+   why (Dependency policy).
+
+10. **jj `revision` is IN scope after all, and amendment 8 is withdrawn.**
+    Re-examination on 2026-08-03 found the spike's premise false:
+    `jj_lib::protos` is a **public** module, so the workspace's checkout state
+    (`operation_id` + `workspace_name`) decodes through published API rather than
+    a private wire format, and `SimpleOpStore::load` takes a path only. The full
+    chain is delivered and verified against the live CLI on pure-jj, colocated,
+    commitless, secondary-workspace and multi-workspace shapes, writing nothing
+    (fingerprint-asserted). **Amend to**: `InProcessProbe` implements `VcsProbe`
+    **fully**; nothing transfers to 0185 but the recorded snapshot divergence;
+    `prost` and `pollster` join the pins as jj-lib-coupled direct edges, making
+    the coupling six-way rather than four (Delivered surface, Dependency policy,
+    Acceptance Criteria).
 
 Two further corrections, informational:
 
@@ -2560,10 +2667,19 @@ Two further corrections, informational:
   without a `UserSettings`?**~~ **Closed 2026-08-03 by spike**: it cannot, in
   jj-lib 0.43. Descoped to 0185; see Phase 1 §4 for the evidence and the
   consequences applied throughout.
-- **Does the MPL-2.0 §3.2 notice obligation need a third-party licence artefact
+- ~~**Does the MPL-2.0 §3.2 notice obligation need a third-party licence artefact
   in the release payload, or does dead-code elimination remove `uluru` from every
-  shipped binary?** Either answer is acceptable; the exception comment must name
-  the one that holds.
+  shipped binary?**~~ **Closed 2026-08-03 by measurement: dead-code elimination
+  removes it**, so no artefact is required and `_release_uploads()` is unchanged.
+  `uluru` is in the normal closure of exactly one shipped binary
+  (`accelerator-visualiser`), and an unstripped `--release` build of it carries
+  zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or `uluru`
+  against 26,247 total, and none of the distinctive literals
+  (`extensions.objectFormat`, `There is no Jujutsu repo`) that the linked
+  reference artefact does carry. The cause is broader than the pin: nothing in
+  the visualiser reaches `vcs-adapters` at all today, `CommandProbe` included.
+  The finding is therefore **conditional**, and its re-check trigger — 0185's
+  `facts` switch — is recorded both in the `cli/deny.toml` comment and on 0185.
 - **Can gix 0.85 serve reftable and sha256 repositories?** The `RF`/`S256`
   fixtures answer it; whatever they find is recorded as a known boundary rather
   than assumed.

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -2314,8 +2314,8 @@ not these.
       only**. The harness half *is* verified: it hard-fails when
       `ACCELERATOR_ZERO_SPAWN_MODE=strong` and a listed path is still
       executable, and fails closed on a malformed mode
-- [ ] Both size figures and all six cost figures are written into Validation
-      Results with host and OS (**done in Phase 5**), plus one
+- [x] Both size figures and all six cost figures are written into Validation
+      Results with host and OS. **Except** one
       `x86_64-unknown-linux-musl` cold per-process figure — the gate-comparable figure stays darwin-arm64, but
       the shipped artefact is static musl and 0169 otherwise sets a threshold
       with no Linux datapoint
@@ -2450,17 +2450,17 @@ Validation Results.
 
 #### Automated Verification
 
-- [ ] `mise run test:integration:work` passes (frontmatter and linkage
+- [x] `mise run test:integration:work` passes (frontmatter and linkage
       validation on all four edited work items)
-- [ ] `mise run` green end to end
+- [x] `mise run` green end to end
 
 #### Manual Verification
 
-- [ ] Each of the three sibling notes is dated and raises information without
+- [x] Each of the three sibling notes is dated and raises information without
       re-scoping its host
-- [ ] 0125's `relates_to` edge is present and 0188's reciprocal edge already
+- [x] 0125's `relates_to` edge is present and 0188's reciprocal edge already
       exists
-- [ ] Every *pending* line in 0188's Validation Results is resolved or
+- [x] Every *pending* line in 0188's Validation Results is resolved or
       explicitly carried forward with a reason
 
 ---

--- a/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
+++ b/meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md
@@ -1930,28 +1930,28 @@ on it.
 
 #### Automated Verification
 
-- [ ] `mise run test:unit:cli` passes; `detection.rs` runs every existing case
+- [x] `mise run test:unit:cli` passes; `detection.rs` runs every existing case
       through the seam against both implementations, producing identical
       `RepoFacts`
-- [ ] `cli/corpus-adapters`' `zero_spawn.rs` passes: no marker written and every
+- [x] `cli/corpus-adapters`' `zero_spawn.rs` passes: no marker written and every
       value matches the unrestricted run
-- [ ] `mise run cli:check`, `deny:check`, `pup:check` pass (the new workspace
+- [x] `mise run cli:check`, `deny:check`, `pup:check` pass (the new workspace
       member landed in Phase 2 and was gated there)
-- [ ] `cli/corpus-adapters`' metadata parity suite passes unchanged:
+- [x] `cli/corpus-adapters`' metadata parity suite passes unchanged:
       `derive_at_agrees_with_the_live_metadata_helper`
       (`cli/corpus-adapters/tests/metadata.rs:265`) — note this is
       `tests/metadata.rs`, **not** `tests/parity.rs`, which is the linkage suite
       and never touches VCS
-- [ ] `mise run` green end to end
+- [x] `mise run` green end to end
 
 #### Manual Verification
 
-- [ ] `zero_spawn.rs` imports only `vcs_test_support`'s public API — all three
+- [x] `zero_spawn.rs` imports only `vcs_test_support`'s public API — all three
       parts, not one
-- [ ] The shadow list records which absolute paths it could not shadow on the
+- [x] The shadow list records which absolute paths it could not shadow on the
       host it ran on, and `vcs-test-support` modified nothing outside `TMPDIR`
       (checksum the resolved absolute paths before and after)
-- [ ] `cli/vcs-test-support` does not depend on `cli/vcs-adapters`, so no
+- [x] `cli/vcs-test-support` does not depend on `cli/vcs-adapters`, so no
       dev-dependency cycle exists
 
 ---
@@ -2295,35 +2295,38 @@ not these.
 
 #### Automated Verification
 
-- [ ] Both fixture binaries build and print every query result
-- [ ] `mise run test:integration:zero-spawn` passes locally in `PATH`-only mode
+- [x] Both fixture binaries build and print every query result
+- [x] `mise run test:integration:zero-spawn` passes locally in `PATH`-only mode
 - [ ] The strong-form run passes in the named Linux CI job, with absolute paths
-      shadowed
-- [ ] Both binaries cross-compile to musl and pass `_assert_static_elf`
-- [ ] Size: linked ≥ 3× stubbed **and** delta ≥ 1,500,000 bytes, on the
+      shadowed — **not verifiable locally**; the job is written and lands with
+      this branch, and macOS degrades to `PATH`-only under SIP
+- [x] Both binaries cross-compile to musl and pass `_assert_static_elf`
+- [x] Size: linked ≥ 3× stubbed **and** delta ≥ 1,500,000 bytes, on the
       musl-static stripped artefact (see
       [Work-Item Amendments](#work-item-amendments))
-- [ ] `mise run test:unit:tasks` passes, including the updated
+- [x] `mise run test:unit:tasks` passes, including the updated
       `test_mise.py` and `test_workflows.py`
-- [ ] `mise run` green end to end
+- [x] `mise run` green end to end
 
 #### Manual Verification
 
-- [ ] The strong-form job's shadow step actually replaced the binaries (assert
-      `git --version` fails inside the step before restoring), and the harness
-      hard-fails when `ACCELERATOR_ZERO_SPAWN_MODE=strong` but a listed path is
-      still executable
+- [ ] The strong-form job's shadow step actually replaced the binaries — **CI
+      only**. The harness half *is* verified: it hard-fails when
+      `ACCELERATOR_ZERO_SPAWN_MODE=strong` and a listed path is still
+      executable, and fails closed on a malformed mode
 - [ ] Both size figures and all six cost figures are written into Validation
-      Results with host and OS, plus one `x86_64-unknown-linux-musl` cold
-      per-process figure — the gate-comparable figure stays darwin-arm64, but
+      Results with host and OS (**done in Phase 5**), plus one
+      `x86_64-unknown-linux-musl` cold per-process figure — the gate-comparable figure stays darwin-arm64, but
       the shipped artefact is static musl and 0169 otherwise sets a threshold
       with no Linux datapoint
-- [ ] All four release triples cross-compile, each recorded individually
-- [ ] The restore step runs `if: always()`, is idempotent per path, and is
-      followed by an `if: always()` assertion that `git --version` and
-      `jj --version` both succeed — `if: always()` alone does not establish the
+- [x] All four release triples cross-compile, each recorded individually
+- [ ] The restore step is a `trap restore EXIT` inside the single shadow-run
+      step (stronger than `if: always()`, which a job-level cancel need not
+      honour), is idempotent per path, and is followed by an `if: always()`
+      assertion that `git --version` and `jj --version` both succeed —
+      **observable only on a CI run** — `if: always()` alone does not establish the
       guarantee, and the containment additionally assumes ephemeral runners
-- [ ] Nothing was staged into `dist/release/` that `_release_uploads()` does not
+- [x] Nothing was staged into `dist/release/` that `_release_uploads()` does not
       enumerate
 
 ---

--- a/meta/prs/48-description.md
+++ b/meta/prs/48-description.md
@@ -12,9 +12,9 @@ relates_to: ["work-item:0125", "work-item:0169", "work-item:0185"]
 pr_url: "https://github.com/atomicinnovation/accelerator/pull/48"
 pr_number: 48
 tags: [rust, vcs, dependencies, gix, jj-lib]
-revision: "9a14ffe9c182ad421bc7c400ef52b4a6429f5310"
+revision: "53fe29fdd423a3f0617d9fa1a762928d88b77744"
 repository: "accelerator"
-last_updated: "2026-08-03T23:18:17+00:00"
+last_updated: "2026-08-03T23:58:14+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
@@ -199,8 +199,16 @@ the window.
 cost, or migrate the ~26 shell call sites. `cli/vcs/src/**` is byte-for-byte
 unmodified.
 
-**Sizing:** 14 commits, +14,356/−516 across 51 files. Roughly 6,600 lines are
+**Sizing:** 16 commits, +14,268/−528 across 51 files. Roughly 6,700 lines are
 `meta/` documents (plan, research, review, validation, work-item amendments) and
-1,449 are `cli/Cargo.lock`, whose delta is worth reading only for the
-`vcs-adapters` dependency edges. That leaves about 4,700 lines of Rust — two
-thirds of it fixtures and tests — and about 1,450 of Python task and guard code.
+1,447 are `cli/Cargo.lock`, whose delta is worth reading only for the
+`vcs-adapters` dependency edges. That leaves about 4,200 lines of Rust — two
+thirds of it fixtures and tests — and about 1,400 of Python task and guard code.
+
+**Two commits are housekeeping over this branch's own additions**, not delivered
+capability: one extracts the retained subprocess pair out of the crate root into
+`subprocess.rs` so each file holds one adapter, and one cuts the comments back
+to this repo's bar — 900 comment lines down to 635, with every reference to work
+items, ADRs, ACs and plan documents removed, since those go stale across work
+item boundaries. Neither changes behaviour, and both are worth skipping when
+reading the diff for correctness.

--- a/meta/prs/48-description.md
+++ b/meta/prs/48-description.md
@@ -23,192 +23,81 @@ schema_version: 1
 
 ## Summary
 
-Adds `InProcessProbe` — an implementation of `cli/vcs`'s `RepoRoot` and
-`VcsProbe` ports that reads git through `gix` and jj through `jj-lib` in the
-calling process rather than by spawning the VCS binaries — plus six taxonomy
-queries the subprocess pair has no equivalent for, and the test apparatus that
-proves both idioms are read without a subprocess.
+Adds `InProcessProbe` — an implementation of `cli/vcs`'s `RepoRoot` and `VcsProbe` ports that reads git through `gix` and jj through `jj-lib` in the calling process rather than by spawning the VCS binaries — plus six taxonomy queries the subprocess pair has no equivalent for, and the test apparatus that proves both idioms are read without a subprocess.
 
-**Nothing is wired.** `vcs_adapters::facts` still names the subprocess pair, so
-no runtime behaviour changes. The value delivered is risk isolation: two
-dependency trees, the workspace's first copyleft licence exception and a pre-1.0
-API bet land where they can be reviewed and reverted on their own.
+**Nothing is wired.** `vcs_adapters::facts` still names the subprocess pair, so no runtime behaviour changes. The value delivered is risk isolation: two dependency trees, the workspace's first copyleft licence exception and a pre-1.0 API bet land where they can be reviewed and reverted on their own.
 
 ## Changes
 
 ### The adapter (`cli/vcs-adapters`)
 
-- **`library.rs`** — `InProcessProbe`, both port implementations, and six
-  inherent queries returning `Result<Option<T>, Error>` so failure is
-  distinguishable from absence: `is_bare`, `worktree`, `superproject`,
-  `jj_workspace_root`, `jj_repository`, and `dual_roots` (infallible, with a
-  per-side `Result` so a one-sided failure can't read as "jj only").
-- **Three distinct walks, not one.** The combined `.jj`-or-`.git` boundary walk
-  answers `RepoRoot::discover` only; a **`.jj`-only** walk answers the jj
-  queries, because jj-lib's loader performs no walk of its own and feeding it the
-  combined boundary reports absence on a git checkout nested inside a jj
-  workspace — where `jj workspace root` reports a root; `gix::discover` performs
-  the third.
-- **`subprocess.rs`** — the retained `MarkerWalkRoot`/`CommandProbe` pair, moved
-  out of the crate root so each file holds one shape. `lib.rs` drops from 315
-  lines to 59: module declarations, `facts`, one test.
-- **`markers.rs`** — the ancestor walk and marker reading both adapters share.
-  Each delegates *to* it, so retiring either strands nothing.
-- Every returned path is canonicalised at one choke point, and `start` is
-  absolutised before any walk — without it a relative start makes a colocated
-  checkout report a git root and no jj root, which is the wrong classifier arm.
+- **`library.rs`** — `InProcessProbe`, both port implementations, and six inherent queries returning `Result<Option<T>, Error>` so failure is distinguishable from absence: `is_bare`, `worktree`, `superproject`, `jj_workspace_root`, `jj_repository`, and `dual_roots` (infallible, with a per-side `Result` so a one-sided failure can't read as "jj only").
+- **Three distinct walks, not one.** The combined `.jj`-or-`.git` boundary walk answers `RepoRoot::discover` only; a **`.jj`-only** walk answers the jj queries, because jj-lib's loader performs no walk of its own and feeding it the combined boundary reports absence on a git checkout nested inside a jj workspace — where `jj workspace root` reports a root; `gix::discover` performs the third.
+- **`subprocess.rs`** — the retained `MarkerWalkRoot`/`CommandProbe` pair, moved out of the crate root so each file holds one shape. `lib.rs` drops from 315 lines to 59: module declarations, `facts`, one test.
+- **`markers.rs`** — the ancestor walk and marker reading both adapters share. Each delegates *to* it, so retiring either strands nothing.
+- Every returned path is canonicalised at one choke point, and `start` is absolutised before any walk — without it a relative start makes a colocated checkout report a git root and no jj root, which is the wrong classifier arm.
 
 ### Dependency policy and enforcement
 
-- `jj-lib = "=0.43.0"` (exact — declared-unstable internals) and
-  `gix = { version = "~0.85.0", default-features = false }`. Defaults are off
-  because gix's `default` reaches `gix-credentials`, the one gix subsystem that
-  spawns `git credential-*` helpers.
-- `prost` and `pollster` as direct edges for the jj revision route. Both were
-  already in the lock through jj-lib, so this adds **two edges and no packages**.
-- The workspace's first `[[licenses.exceptions]]` — `uluru`, MPL-2.0, reached
-  from `gix-pack` and not feature-gatable out.
-- A cargo-pup rule scoping `vcs_adapters::library`'s imports to a permit list and
-  denying `std::process`, with probe cases for the rule.
-- A source guard (`lint:vcs-settings:check`) forbidding jj settings construction
-  crate-wide — cargo-pup resolves `use` paths and cannot see a fully-qualified
-  call.
-- Graph invariants: single gix/prost/pollster versions, the enabled gix feature
-  set, no TLS in the subtree on all five targets, and no package requiring a Rust
-  newer than the pin.
+- `jj-lib = "=0.43.0"` (exact — declared-unstable internals) and `gix = { version = "~0.85.0", default-features = false }`. Defaults are off because gix's `default` reaches `gix-credentials`, the one gix subsystem that spawns `git credential-*` helpers.
+- `prost` and `pollster` as direct edges for the jj revision route. Both were already in the lock through jj-lib, so this adds **two edges and no packages**.
+- The workspace's first `[[licenses.exceptions]]` — `uluru`, MPL-2.0, reached from `gix-pack` and not feature-gatable out.
+- A cargo-pup rule scoping `vcs_adapters::library`'s imports to a permit list and denying `std::process`, with probe cases for the rule.
+- A source guard (`lint:vcs-settings:check`) forbidding jj settings construction crate-wide — cargo-pup resolves `use` paths and cannot see a fully-qualified call.
+- Graph invariants: single gix/prost/pollster versions, the enabled gix feature set, no TLS in the subtree on all five targets, and no package requiring a Rust newer than the pin.
 
 ### Test apparatus (`cli/vcs-test-support`, new crate)
 
-- A 34-pair fixture matrix covering colocated, secondary-workspace, nested,
-  submodule (depths 1 and 2, plus three awkward shapes), worktree, bare,
-  reftable, sha256, hostile-config and three degenerate shapes.
-- The hermetic environment, the marker-writing stubs, and a platform-aware report
-  of the absolute paths it cannot shadow. The Rust harness never writes outside
-  its own temp directories.
-- Zero-spawn proven **across a crate boundary** from `cli/corpus-adapters`, the
-  crate that will converge onto the adapter.
+- A 34-pair fixture matrix covering colocated, secondary-workspace, nested, submodule (depths 1 and 2, plus three awkward shapes), worktree, bare, reftable, sha256, hostile-config and three degenerate shapes.
+- The hermetic environment, the marker-writing stubs, and a platform-aware report of the absolute paths it cannot shadow. The Rust harness never writes outside its own temp directories.
+- Zero-spawn proven **across a crate boundary** from `cli/corpus-adapters`, the crate that will converge onto the adapter.
 
 ### Build system and CI
 
-- `test:integration:zero-spawn` (PATH-only) and
-  `test:integration:zero-spawn:strong` (shadows the real binaries; gated behind
-  `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`), plus a `check-zero-spawn` Linux job.
-- A committed size floor on the reference artefact — linked ≥ 3× stubbed
-  everywhere, plus an absolute byte floor on musl — guarding this story's
-  headline false pass, where dead-code elimination lets the musl and size checks
-  succeed while linking almost none of the trees.
-- `version.write` now syncs `cli/Cargo.lock`, which carries a copy of the version
-  per workspace member and was being left behind.
+- `test:integration:zero-spawn` (PATH-only) and `test:integration:zero-spawn:strong` (shadows the real binaries; gated behind `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`), plus a `check-zero-spawn` Linux job.
+- A committed size floor on the reference artefact — linked ≥ 3× stubbed everywhere, plus an absolute byte floor on musl — guarding this story's headline false pass, where dead-code elimination lets the musl and size checks succeed while linking almost none of the trees.
+- `version.write` now syncs `cli/Cargo.lock`, which carries a copy of the version per workspace member and was being left behind.
 
 ## Context
 
 - Work item: `meta/work/0188-library-backed-vcs-adapter.md`
-- Plan: `meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md`, carrying the
-  full oracle mapping — every query against every fixture, with the shell
-  implementation in `scripts/vcs-common.sh` as the behavioural oracle
+- Plan: `meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md`, carrying the full oracle mapping — every query against every fixture, with the shell implementation in `scripts/vcs-common.sh` as the behavioural oracle
 - Research: `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`
 - Plan review: `meta/reviews/plans/2026-08-03-0188-library-backed-vcs-adapter-review-1.md`
 - Validation: `meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md`
-- Dated hand-off notes are appended to **0125**, **0169** and **0185**; ADR-0053
-  (thin CLI over a hexagonal core) is the governing decision
+- Dated hand-off notes are appended to **0125**, **0169** and **0185**; ADR-0053 (thin CLI over a hexagonal core) is the governing decision
 
 ## Testing
 
 - [x] `mise run` green end to end (601s, zero task failures, no formatter drift)
-- [x] `test:unit:cli` — 625 tests. Includes the six queries against all 34
-      (fixture, start directory) pairs, every expected value traceable to a cell
-      in the recorded oracle mapping
-- [x] The scrub invariant across the whole matrix, with a live-poison control
-      (`gix::discover_with_environment_overrides` resolving the poison target) so
-      the assertion can't hold vacuously
-- [x] `detection.rs` runs every pre-existing case through an injection seam
-      against **both** implementations, asserting identical `RepoFacts` for both
-      idioms while keeping its own fixed expected values — agreement between two
-      implementations is not on its own an oracle
-- [x] `test:integration:deny` (65), `test:unit:tasks` (660),
-      `test:integration:pup`, `lint:vcs-settings:check`
-- [x] Non-vacuity committed rather than demonstrated by hand: a `std::process`
-      import fails cargo-pup naming the rule, a deliberate settings construction
-      fails the source guard, and a compliant module passes as the positive
-      control
+- [x] `test:unit:cli` — 625 tests. Includes the six queries against all 34 (fixture, start directory) pairs, every expected value traceable to a cell in the recorded oracle mapping
+- [x] The scrub invariant across the whole matrix, with a live-poison control (`gix::discover_with_environment_overrides` resolving the poison target) so the assertion can't hold vacuously
+- [x] `detection.rs` runs every pre-existing case through an injection seam against **both** implementations, asserting identical `RepoFacts` for both idioms while keeping its own fixed expected values — agreement between two implementations is not on its own an oracle
+- [x] `test:integration:deny` (65), `test:unit:tasks` (660), `test:integration:pup`, `lint:vcs-settings:check`
+- [x] Non-vacuity committed rather than demonstrated by hand: a `std::process` import fails cargo-pup naming the rule, a deliberate settings construction fails the source guard, and a compliant module passes as the positive control
 - [x] `test:integration:zero-spawn` in PATH-only mode
-- [x] All four release triples cross-compile; both musl builds pass the
-      static-ELF assertion; size ratios 6.86×–7.37× against a 3× floor
-- [x] The jj-fixture shell suites (`hooks/test-vcs-detect.sh`,
-      `scripts/test-metadata-helpers.sh`) green under the jj 0.43 pin
+- [x] All four release triples cross-compile; both musl builds pass the static-ELF assertion; size ratios 6.86×–7.37× against a 3× floor
+- [x] The jj-fixture shell suites (`hooks/test-vcs-detect.sh`, `scripts/test-metadata-helpers.sh`) green under the jj 0.43 pin
 - [x] The strong-form task refuses to run without its opt-in, and touches nothing
-- [ ] **The strong-form zero-spawn run itself — see Notes.** It has never
-      executed and will not pass as written
-- [ ] Cold-cache CI timings against `test-visual-regression`'s 20-minute cap.
-      Measured locally: the two new trees cost 16.92s wall / 65.8s CPU cold, so
-      roughly a minute or two on a 4-vCPU runner. No budget raise expected —
-      worth confirming on the first run
+- [ ] **The strong-form zero-spawn run itself — see Notes.** It has never executed and will not pass as written
+- [ ] Cold-cache CI timings against `test-visual-regression`'s 20-minute cap. Measured locally: the two new trees cost 16.92s wall / 65.8s CPU cold, so roughly a minute or two on a 4-vCPU runner. No budget raise expected — worth confirming on the first run
 
 ## Notes for Reviewers
 
-**Start with the dependency policy.** `cli/Cargo.toml`, `cli/deny.toml` and
-`cli/pup.ron` are the reviewable core; the adapter is replaceable, a licence
-exception and a pre-1.0 pin are not. The trees enter the build graph of the
-shipped `accelerator-visualiser`, though dead-code elimination removes them from
-the binary — verified, and the basis for the MPL-2.0 finding below.
+**Start with the dependency policy.** `cli/Cargo.toml`, `cli/deny.toml` and `cli/pup.ron` are the reviewable core; the adapter is replaceable, a licence exception and a pre-1.0 pin are not. The trees enter the build graph of the shipped `accelerator-visualiser`, though dead-code elimination removes them from the binary — verified, and the basis for the MPL-2.0 finding below.
 
-**The MPL-2.0 §3.2 question is closed by measurement, conditionally.** `uluru`
-reaches exactly one shipped binary, and an unstripped release build of it carries
-zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or `uluru`
-against 26,247 total, and none of the distinctive literals the linked reference
-artefact does carry. So the notice obligation does not bind and no attribution
-artefact is needed. The finding is **contingent** on nothing in the visualiser
-reaching `vcs-adapters`, so its re-check trigger is recorded in the `deny.toml`
-comment and on 0185.
+**The MPL-2.0 §3.2 question is closed by measurement, conditionally.** `uluru` reaches exactly one shipped binary, and an unstripped release build of it carries zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or `uluru` against 26,247 total, and none of the distinctive literals the linked reference artefact does carry. So the notice obligation does not bind and no attribution artefact is needed. The finding is **contingent** on nothing in the visualiser reaching `vcs-adapters`, so its re-check trigger is recorded in the `deny.toml` comment and on 0185.
 
-**A spike conclusion was reversed during review.** The plan descoped the jj half
-of `revision` to 0185, on a finding that jj-lib 0.43 offers no read-only,
-settings-free route to the working-copy commit id. That was wrong —
-`jj_lib::protos` is a **public** module, so the workspace's checkout state
-decodes through published API rather than a private wire format. The route is
-delivered here and matches the CLI exactly across pure-jj, colocated, commitless,
-secondary-workspace and multi-workspace shapes, writing nothing. Amendment 8 is
-withdrawn by amendment 10.
+**A spike conclusion was reversed during review.** The plan descoped the jj half of `revision` to 0185, on a finding that jj-lib 0.43 offers no read-only, settings-free route to the working-copy commit id. That was wrong — `jj_lib::protos` is a **public** module, so the workspace's checkout state decodes through published API rather than a private wire format. The route is delivered here and matches the CLI exactly across pure-jj, colocated, commitless, secondary-workspace and multi-workspace shapes, writing nothing. Amendment 8 is withdrawn by amendment 10.
 
-**One deliberate behavioural divergence, and it is the read-only direction.**
-Asking the `jj` binary snapshots the working copy first, so with unsnapshotted
-edits present it reports — and *writes* — a new commit. The in-process route
-reports the commit as of the last recorded operation and writes nothing. After
-0185's switch, deriving metadata therefore stops mutating the user's repository.
-Pinned by `an_unsnapshotted_edit_is_the_one_documented_divergence`.
+**One deliberate behavioural divergence, and it is the read-only direction.** Asking the `jj` binary snapshots the working copy first, so with unsnapshotted edits present it reports — and *writes* — a new commit. The in-process route reports the commit as of the last recorded operation and writes nothing. After 0185's switch, deriving metadata therefore stops mutating the user's repository. Pinned by `an_unsnapshotted_edit_is_the_one_documented_divergence`.
 
-**Known defect, not fixed here.** The strong-form zero-spawn suite builds its own
-fixture matrix, which needs the real binaries — so on CI that build lands inside
-the shadow window with no `git` or `jj` to run it. The job has never executed, so
-this is latent rather than a regression. Fixing it needs a Rust-side handoff
-(build the matrix outside the window, pass its root in), which is scoped
-separately rather than smuggled into this branch.
+**Known defect, not fixed here.** The strong-form zero-spawn suite builds its own fixture matrix, which needs the real binaries — so on CI that build lands inside the shadow window with no `git` or `jj` to run it. The job has never executed, so this is latent rather than a regression. Fixing it needs a Rust-side handoff (build the matrix outside the window, pass its root in), which is scoped separately rather than smuggled into this branch.
 
-**Pre-existing flake worth knowing about.** `test:integration:entrypoint` failed
-in two of five full local runs, always because
-`tests/integration/support/installation.py:125-141` builds into the shared
-`cli/target/debug` and asserts the artefact's presence with no tolerance for a
-concurrent rebuild. CI is structurally immune — `test-unit` and
-`test-integration` are separate jobs — so the exposure is to the local `mise run`
-gate. Deserves its own item; this branch enlarges the Rust build and so widens
-the window.
+**Pre-existing flake worth knowing about.** `test:integration:entrypoint` failed in two of five full local runs, always because `tests/integration/support/installation.py:125-141` builds into the shared `cli/target/debug` and asserts the artefact's presence with no tolerance for a concurrent rebuild. CI is structurally immune — `test-unit` and `test-integration` are separate jobs — so the exposure is to the local `mise run` gate. Deserves its own item; this branch enlarges the Rust build and so widens the window.
 
-**What this deliberately does not do:** wire anything (`facts` stays hard-wired,
-0185 owns the switch), build `classify_checkout`'s arm cascade or `vcs status`
-/ `vcs log` (0169), define a domain port over the six queries (0169), gate on
-cost, or migrate the ~26 shell call sites. `cli/vcs/src/**` is byte-for-byte
-unmodified.
+**What this deliberately does not do:** wire anything (`facts` stays hard-wired, 0185 owns the switch), build `classify_checkout`'s arm cascade or `vcs status` / `vcs log` (0169), define a domain port over the six queries (0169), gate on cost, or migrate the ~26 shell call sites. `cli/vcs/src/**` is byte-for-byte unmodified.
 
-**Sizing:** 16 commits, +14,268/−528 across 51 files. Roughly 6,700 lines are
-`meta/` documents (plan, research, review, validation, work-item amendments) and
-1,447 are `cli/Cargo.lock`, whose delta is worth reading only for the
-`vcs-adapters` dependency edges. That leaves about 4,200 lines of Rust — two
-thirds of it fixtures and tests — and about 1,400 of Python task and guard code.
+**Sizing:** 16 commits, +14,268/−528 across 51 files. Roughly 6,700 lines are `meta/` documents (plan, research, review, validation, work-item amendments) and 1,447 are `cli/Cargo.lock`, whose delta is worth reading only for the `vcs-adapters` dependency edges. That leaves about 4,200 lines of Rust — two thirds of it fixtures and tests — and about 1,400 of Python task and guard code.
 
-**Two commits are housekeeping over this branch's own additions**, not delivered
-capability: one extracts the retained subprocess pair out of the crate root into
-`subprocess.rs` so each file holds one adapter, and one cuts the comments back
-to this repo's bar — 900 comment lines down to 635, with every reference to work
-items, ADRs, ACs and plan documents removed, since those go stale across work
-item boundaries. Neither changes behaviour, and both are worth skipping when
-reading the diff for correctness.
+**Two commits are housekeeping over this branch's own additions**, not delivered capability: one extracts the retained subprocess pair out of the crate root into `subprocess.rs` so each file holds one adapter, and one cuts the comments back to this repo's bar — 900 comment lines down to 635, with every reference to work items, ADRs, ACs and plan documents removed, since those go stale across work item boundaries. Neither changes behaviour, and both are worth skipping when reading the diff for correctness.

--- a/meta/prs/48-description.md
+++ b/meta/prs/48-description.md
@@ -1,0 +1,206 @@
+---
+type: pr-description
+id: "48"
+title: "Add a library-backed VCS adapter over gix and jj-lib"
+date: "2026-08-03T23:18:17+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "0188"
+parent: "work-item:0188"
+relates_to: ["work-item:0125", "work-item:0169", "work-item:0185"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/48"
+pr_number: 48
+tags: [rust, vcs, dependencies, gix, jj-lib]
+revision: "9a14ffe9c182ad421bc7c400ef52b4a6429f5310"
+repository: "accelerator"
+last_updated: "2026-08-03T23:18:17+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Add a library-backed VCS adapter over gix and jj-lib
+
+## Summary
+
+Adds `InProcessProbe` — an implementation of `cli/vcs`'s `RepoRoot` and
+`VcsProbe` ports that reads git through `gix` and jj through `jj-lib` in the
+calling process rather than by spawning the VCS binaries — plus six taxonomy
+queries the subprocess pair has no equivalent for, and the test apparatus that
+proves both idioms are read without a subprocess.
+
+**Nothing is wired.** `vcs_adapters::facts` still names the subprocess pair, so
+no runtime behaviour changes. The value delivered is risk isolation: two
+dependency trees, the workspace's first copyleft licence exception and a pre-1.0
+API bet land where they can be reviewed and reverted on their own.
+
+## Changes
+
+### The adapter (`cli/vcs-adapters`)
+
+- **`library.rs`** — `InProcessProbe`, both port implementations, and six
+  inherent queries returning `Result<Option<T>, Error>` so failure is
+  distinguishable from absence: `is_bare`, `worktree`, `superproject`,
+  `jj_workspace_root`, `jj_repository`, and `dual_roots` (infallible, with a
+  per-side `Result` so a one-sided failure can't read as "jj only").
+- **Three distinct walks, not one.** The combined `.jj`-or-`.git` boundary walk
+  answers `RepoRoot::discover` only; a **`.jj`-only** walk answers the jj
+  queries, because jj-lib's loader performs no walk of its own and feeding it the
+  combined boundary reports absence on a git checkout nested inside a jj
+  workspace — where `jj workspace root` reports a root; `gix::discover` performs
+  the third.
+- **`subprocess.rs`** — the retained `MarkerWalkRoot`/`CommandProbe` pair, moved
+  out of the crate root so each file holds one shape. `lib.rs` drops from 315
+  lines to 59: module declarations, `facts`, one test.
+- **`markers.rs`** — the ancestor walk and marker reading both adapters share.
+  Each delegates *to* it, so retiring either strands nothing.
+- Every returned path is canonicalised at one choke point, and `start` is
+  absolutised before any walk — without it a relative start makes a colocated
+  checkout report a git root and no jj root, which is the wrong classifier arm.
+
+### Dependency policy and enforcement
+
+- `jj-lib = "=0.43.0"` (exact — declared-unstable internals) and
+  `gix = { version = "~0.85.0", default-features = false }`. Defaults are off
+  because gix's `default` reaches `gix-credentials`, the one gix subsystem that
+  spawns `git credential-*` helpers.
+- `prost` and `pollster` as direct edges for the jj revision route. Both were
+  already in the lock through jj-lib, so this adds **two edges and no packages**.
+- The workspace's first `[[licenses.exceptions]]` — `uluru`, MPL-2.0, reached
+  from `gix-pack` and not feature-gatable out.
+- A cargo-pup rule scoping `vcs_adapters::library`'s imports to a permit list and
+  denying `std::process`, with probe cases for the rule.
+- A source guard (`lint:vcs-settings:check`) forbidding jj settings construction
+  crate-wide — cargo-pup resolves `use` paths and cannot see a fully-qualified
+  call.
+- Graph invariants: single gix/prost/pollster versions, the enabled gix feature
+  set, no TLS in the subtree on all five targets, and no package requiring a Rust
+  newer than the pin.
+
+### Test apparatus (`cli/vcs-test-support`, new crate)
+
+- A 34-pair fixture matrix covering colocated, secondary-workspace, nested,
+  submodule (depths 1 and 2, plus three awkward shapes), worktree, bare,
+  reftable, sha256, hostile-config and three degenerate shapes.
+- The hermetic environment, the marker-writing stubs, and a platform-aware report
+  of the absolute paths it cannot shadow. The Rust harness never writes outside
+  its own temp directories.
+- Zero-spawn proven **across a crate boundary** from `cli/corpus-adapters`, the
+  crate that will converge onto the adapter.
+
+### Build system and CI
+
+- `test:integration:zero-spawn` (PATH-only) and
+  `test:integration:zero-spawn:strong` (shadows the real binaries; gated behind
+  `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`), plus a `check-zero-spawn` Linux job.
+- A committed size floor on the reference artefact — linked ≥ 3× stubbed
+  everywhere, plus an absolute byte floor on musl — guarding this story's
+  headline false pass, where dead-code elimination lets the musl and size checks
+  succeed while linking almost none of the trees.
+- `version.write` now syncs `cli/Cargo.lock`, which carries a copy of the version
+  per workspace member and was being left behind.
+
+## Context
+
+- Work item: `meta/work/0188-library-backed-vcs-adapter.md`
+- Plan: `meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md`, carrying the
+  full oracle mapping — every query against every fixture, with the shell
+  implementation in `scripts/vcs-common.sh` as the behavioural oracle
+- Research: `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`
+- Plan review: `meta/reviews/plans/2026-08-03-0188-library-backed-vcs-adapter-review-1.md`
+- Validation: `meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md`
+- Dated hand-off notes are appended to **0125**, **0169** and **0185**; ADR-0053
+  (thin CLI over a hexagonal core) is the governing decision
+
+## Testing
+
+- [x] `mise run` green end to end (601s, zero task failures, no formatter drift)
+- [x] `test:unit:cli` — 625 tests. Includes the six queries against all 34
+      (fixture, start directory) pairs, every expected value traceable to a cell
+      in the recorded oracle mapping
+- [x] The scrub invariant across the whole matrix, with a live-poison control
+      (`gix::discover_with_environment_overrides` resolving the poison target) so
+      the assertion can't hold vacuously
+- [x] `detection.rs` runs every pre-existing case through an injection seam
+      against **both** implementations, asserting identical `RepoFacts` for both
+      idioms while keeping its own fixed expected values — agreement between two
+      implementations is not on its own an oracle
+- [x] `test:integration:deny` (65), `test:unit:tasks` (660),
+      `test:integration:pup`, `lint:vcs-settings:check`
+- [x] Non-vacuity committed rather than demonstrated by hand: a `std::process`
+      import fails cargo-pup naming the rule, a deliberate settings construction
+      fails the source guard, and a compliant module passes as the positive
+      control
+- [x] `test:integration:zero-spawn` in PATH-only mode
+- [x] All four release triples cross-compile; both musl builds pass the
+      static-ELF assertion; size ratios 6.86×–7.37× against a 3× floor
+- [x] The jj-fixture shell suites (`hooks/test-vcs-detect.sh`,
+      `scripts/test-metadata-helpers.sh`) green under the jj 0.43 pin
+- [x] The strong-form task refuses to run without its opt-in, and touches nothing
+- [ ] **The strong-form zero-spawn run itself — see Notes.** It has never
+      executed and will not pass as written
+- [ ] Cold-cache CI timings against `test-visual-regression`'s 20-minute cap.
+      Measured locally: the two new trees cost 16.92s wall / 65.8s CPU cold, so
+      roughly a minute or two on a 4-vCPU runner. No budget raise expected —
+      worth confirming on the first run
+
+## Notes for Reviewers
+
+**Start with the dependency policy.** `cli/Cargo.toml`, `cli/deny.toml` and
+`cli/pup.ron` are the reviewable core; the adapter is replaceable, a licence
+exception and a pre-1.0 pin are not. The trees enter the build graph of the
+shipped `accelerator-visualiser`, though dead-code elimination removes them from
+the binary — verified, and the basis for the MPL-2.0 finding below.
+
+**The MPL-2.0 §3.2 question is closed by measurement, conditionally.** `uluru`
+reaches exactly one shipped binary, and an unstripped release build of it carries
+zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or `uluru`
+against 26,247 total, and none of the distinctive literals the linked reference
+artefact does carry. So the notice obligation does not bind and no attribution
+artefact is needed. The finding is **contingent** on nothing in the visualiser
+reaching `vcs-adapters`, so its re-check trigger is recorded in the `deny.toml`
+comment and on 0185.
+
+**A spike conclusion was reversed during review.** The plan descoped the jj half
+of `revision` to 0185, on a finding that jj-lib 0.43 offers no read-only,
+settings-free route to the working-copy commit id. That was wrong —
+`jj_lib::protos` is a **public** module, so the workspace's checkout state
+decodes through published API rather than a private wire format. The route is
+delivered here and matches the CLI exactly across pure-jj, colocated, commitless,
+secondary-workspace and multi-workspace shapes, writing nothing. Amendment 8 is
+withdrawn by amendment 10.
+
+**One deliberate behavioural divergence, and it is the read-only direction.**
+Asking the `jj` binary snapshots the working copy first, so with unsnapshotted
+edits present it reports — and *writes* — a new commit. The in-process route
+reports the commit as of the last recorded operation and writes nothing. After
+0185's switch, deriving metadata therefore stops mutating the user's repository.
+Pinned by `an_unsnapshotted_edit_is_the_one_documented_divergence`.
+
+**Known defect, not fixed here.** The strong-form zero-spawn suite builds its own
+fixture matrix, which needs the real binaries — so on CI that build lands inside
+the shadow window with no `git` or `jj` to run it. The job has never executed, so
+this is latent rather than a regression. Fixing it needs a Rust-side handoff
+(build the matrix outside the window, pass its root in), which is scoped
+separately rather than smuggled into this branch.
+
+**Pre-existing flake worth knowing about.** `test:integration:entrypoint` failed
+in two of five full local runs, always because
+`tests/integration/support/installation.py:125-141` builds into the shared
+`cli/target/debug` and asserts the artefact's presence with no tolerance for a
+concurrent rebuild. CI is structurally immune — `test-unit` and
+`test-integration` are separate jobs — so the exposure is to the local `mise run`
+gate. Deserves its own item; this branch enlarges the Rust build and so widens
+the window.
+
+**What this deliberately does not do:** wire anything (`facts` stays hard-wired,
+0185 owns the switch), build `classify_checkout`'s arm cascade or `vcs status`
+/ `vcs log` (0169), define a domain port over the six queries (0169), gate on
+cost, or migrate the ~26 shell call sites. `cli/vcs/src/**` is byte-for-byte
+unmodified.
+
+**Sizing:** 14 commits, +14,356/−516 across 51 files. Roughly 6,600 lines are
+`meta/` documents (plan, research, review, validation, work-item amendments) and
+1,449 are `cli/Cargo.lock`, whose delta is worth reading only for the
+`vcs-adapters` dependency edges. That leaves about 4,700 lines of Rust — two
+thirds of it fixtures and tests — and about 1,450 of Python task and guard code.

--- a/meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md
+++ b/meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md
@@ -1,0 +1,996 @@
+---
+type: codebase-research
+id: "2026-08-02-0188-library-backed-vcs-adapter"
+title: "Research: Library-Backed VCS Adapter over gix and jj-lib (0188)"
+date: "2026-08-02T21:19:48+00:00"
+author: "Toby Clemson"
+producer: research-codebase
+status: complete
+work_item_id: "0188"
+parent: "work-item:0188"
+relates_to: ["codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
+topic: "Library-backed VCS adapter over gix and jj-lib: enforcement surfaces, test apparatus, fixture matrix, CI capability and sibling hand-offs"
+tags: [research, codebase, vcs, vcs-adapters, gix, jj-lib, cargo-deny, cargo-pup, ci, fixtures]
+revision: "8f64589b3fb56512f7b0a55af5209ffa1babfaa3"
+repository: "accelerator"
+last_updated: "2026-08-03T06:52:09+00:00"
+last_updated_by: "Toby Clemson"
+last_updated_note: "Added the gix 0.85 API spike (2026-08-03) closing the three unevidenced taxonomy queries plus the boundary and scrub riders"
+schema_version: 1
+---
+
+# Research: Library-Backed VCS Adapter over gix and jj-lib (0188)
+
+**Date**: 2026-08-02 21:19 UTC
+**Author**: Toby Clemson
+**Git Commit**: `8f64589b3fb56512f7b0a55af5209ffa1babfaa3`
+**Branch**: detached (`HEAD`); revision unpushed, so references below are local
+paths rather than permalinks
+**Repository**: accelerator
+
+## Research Question
+
+Comprehensive codebase research for the story at
+`meta/work/0188-library-backed-vcs-adapter.md` — a library-backed
+implementation of the `vcs` crate's ports over `gix` and `jj-lib`, plus six
+inherent taxonomy queries and the test apparatus proving in-process reads.
+
+## Summary
+
+The dependency work is **entirely unstarted** — `gix`, `jj-lib` and `uluru`
+appear nowhere in `cli/Cargo.lock`, `cli/deny.toml`, `cli/pup.ron` or
+`cli/Cargo.toml`. The only landed prerequisite is the `mise.toml` `jj` pin at
+0.43.0 with its lockstep comment, which is present and correct
+(`mise.toml:12-16`).
+
+Eight findings materially change how the story should be planned:
+
+1. **The CI open question is answerable, and the answer changes the
+   criterion.** All Linux jobs are GitHub-hosted, non-containerised
+   `ubuntu-latest` VMs where the runner user has passwordless sudo — so
+   shadowing `/usr/bin/git` is feasible. But **`jj` is not a system binary in
+   CI at all**: it is mise-installed under
+   `$HOME/.local/share/mise/installs/jj/0.43.0/…` (`mise.lock:89-106`).
+   Shadowing `/usr/bin/jj`, `/usr/local/bin/jj`, `/opt/homebrew/bin/jj` is a
+   **no-op on the runner**. The shadow list as written in the work item is
+   half-vacuous.
+
+2. **The cargo-pup two-clause rule is unexercised in-repo, and the grouped-
+   import gotcha bites the new module.** No shipped rule sets both
+   `allowed_only` and `denied` (`cli/pup.ron`, six rules, all pure-permit or
+   pure-deny). Separately, `allowed_only` matches *literal use-path text*, and
+   a braced `use std::path::{Path, PathBuf}` resolves to an empty module name
+   that matches no permit pattern — which is exactly what
+   `cli/vcs-adapters/src/lib.rs:13-14` writes today.
+
+3. **There is no cross-crate test-fixture precedent anywhere in the `cli/`
+   workspace** — zero path-based `[dev-dependencies]`, no `test-support` crate,
+   no `#[cfg(feature = "test-fixtures")]` module. Sharing is done today by
+   *duplicating* `tests/common/mod.rs`. 0188 establishes a new convention.
+
+4. **The "no `[features]` beyond `bash-parity`" criterion may forbid the
+   natural implementation of the shared fixture**, and CI's `--all-features`
+   would turn any new feature on workspace-wide regardless.
+
+5. **The musl cross-compile is release-only and runs only on macOS**;
+   `_assert_static_elf` is never exercised by `mise run check` or by any test.
+   Adding the reference artefact to that path is a release-pipeline change.
+
+6. **The fixture matrix is emptier than the work item assumes.** A git
+   submodule fixture exists nowhere in the repo, in any language. The shell
+   "colocated" fixture is a hand-graft — not `jj git init --colocate` — and a
+   real colocated main repo classifies as `main`, not `colocated`. The shell's
+   "main jj workspace" builder almost certainly produces a *colocated* repo, so
+   there is no pure-jj precedent either.
+
+7. **`gix` API evidence for three of the six queries is zero.** The 2026-07-29
+   probe ran exactly one gix entry point (`gix::discover`); the word
+   "submodule" does not appear in that research at all.
+
+8. **No benchmarking machinery exists** — no criterion, no hyperfine, no
+   `bench:*` task, no timing helper. `B = 35.1 ms` comes from 0186's table, not
+   0169; the "~41 ms warm bootstrap" is derived (`149.1 − 107.9`), not measured.
+
+## Detailed Findings
+
+### 1. The crates as they stand (what 0188 extends)
+
+`cli/vcs` is 193 lines with **zero dependencies** — `VcsKind`
+(`cli/vcs/src/lib.rs:14-17`), `RepoFacts { root, name, kind, revision }`
+(`:38-43`), `trait RepoRoot { discover, repository_root }` (`:46-57`),
+`trait VcsProbe { kind, revision }` (`:60-67`), and the composition function
+`facts(start, &dyn RepoRoot, &dyn VcsProbe)` (`:74-91`).
+
+`cli/vcs-adapters` (323 lines) holds `MarkerWalkRoot`
+(`cli/vcs-adapters/src/lib.rs:32`), `CommandProbe` (`:73`), the two subprocess
+invocations (`:110-125`), the environment scrub (`:139-154`), the capped-stdout
+poll loop (`:158-220`), and the hard-wired composition root:
+
+```rust
+pub fn facts(start: &Path) -> Option<RepoFacts> {
+    vcs::facts(start, &MarkerWalkRoot, &CommandProbe::new())
+}
+```
+(`cli/vcs-adapters/src/lib.rs:224-227`)
+
+The single spawn chokepoint is `command.spawn()` at `:168`. The jj
+secondary-workspace rule is already implemented by pure file reads with no
+subprocess (`jj_repository_root`, `:57-68`) — so `jj-lib` is not strictly
+needed for that one query, only for the taxonomy queries around it.
+
+Two facts give 0188 latitude: `RepoFacts.root` and `.kind` currently have **no
+production consumer** (only `.name` and `.revision` are read, at
+`cli/corpus-adapters/src/metadata.rs:185-186`); and six of the crate's seven
+unit tests construct `std::process::Command` directly inside
+`#[cfg(test)] mod tests` (`:231`, `:254`, `:270`, `:279`, `:288`, `:297`,
+`:307`), which is relevant to how the new pup deny clause is scoped.
+
+### 2. Dependency policy machinery
+
+**`cli/deny.toml`** (76 lines):
+
+- **Zero `[[licenses.exceptions]]` entries exist today** — anywhere in the
+  repo. The policy mandating their use is at `:38-40`; there is no worked
+  example to copy a comment style from. The nearest in-file precedent is the
+  `CC0-1.0` allow-entry comment at `:51` (crate name, role in parentheses,
+  why). The house style of citing a work-item *path* exists in `mise.toml:15`,
+  not in `deny.toml`.
+- `multiple-versions = "warn"` at `:57` — the work item's claim is **verified**.
+  This is why the single-`gix`-version invariant must be asserted directly.
+- `unmaintained = "all"` at `:22` — the strictest setting. Two large transitive
+  trees entering `advisories` scope under this setting is a materially bigger
+  ongoing cost than the work item's "a future RustSec advisory" wording
+  suggests: an *unmaintained* crate anywhere in the `gix`/`jj-lib` closure also
+  fails the workspace-wide check.
+- `[graph].targets` lists five triples (`:4-17`) including both musl targets —
+  the new trees must resolve on all five.
+- `deny = [{ crate = "serde-saphyr", wrappers = ["document"] }]` (`:69`) is the
+  existing precedent for "banned except when reached through crate X".
+- Runner: `tasks/deny.py:13-18`, `cargo deny check advisories licenses bans
+  sources` with cwd = `cli/`.
+
+**`cli/Cargo.lock`**: committed, `version = 4`, **358** packages. Verified
+absent: `gix`, any `gix-*`, `jj-lib`, `openssl`, `openssl-sys`, `native-tls`,
+`curl`, `git2`, `libgit2-sys`. Present: `rustls 0.23.41`, `ring 0.17.14`,
+`hickory-resolver 0.25.2`, `webpki-roots 1.0.8`. **`zstd 0.13.3` is already in
+the graph** via `include-flate-compress` (`:1420-1428`) — `jj-lib` also pulls a
+zstd, so this is a live `multiple-versions` warn candidate the plan should
+anticipate.
+
+**`cli/Cargo.toml`**: `resolver = "3"` (`:3`), `rust-version = "1.90.0"`
+(`:9`), `edition = "2021"` (`:8`). Pinning convention is established and
+explicit: exact `=` pins for behaviour-sensitive crates, each carrying a
+comment justifying the pin (`clap = "=4.6.1"`, `reqwest = "=0.12.28"`,
+`rustls = "=0.23.41"`, `serde-saphyr = "=0.0.29"`). **`vergen` /
+`vergen-gitcl` at `:17-21` is the existing precedent for a matched-pair exact
+pin with a comment explaining the coupling** — the shape 0188's `gix`/`jj-lib`
+pins should copy.
+
+`[workspace.lints]` (`:56-70`): `warnings = "deny"`, clippy `pedantic` +
+`nursery` at warn with `-D warnings`, plus `unwrap_used`/`expect_used`/`panic`
+opt-ins. Every new line of adapter code is held to this.
+
+**MSRV is hand-duplicated in three places** — `mise.toml:8`,
+`cli/Cargo.toml:9`, `cli/clippy.toml:1` — guarded by
+`tests/unit/tasks/test_msrv_coherence.py:30-38`. **That file is the exact shape
+0188's `mise.toml` jj-pin ↔ `jj-lib`-pin lockstep assertion should take**: a
+bare pytest under `tests/unit/tasks/`, no invoke task, 39 lines.
+
+### 3. The cargo-pup rule — two unmodelled problems
+
+`cli/pup.ron` has six `Module` lints, all `RestrictImports(allowed_only,
+denied, severity)`. Scoping is by **resolved module path regex**, never file
+glob. Single-module scoping precedent exists (three of six):
+`^accelerator::version::core($|::)` (`:14`), `^accelerator::launch::core($|::)`
+(`:28`), `^accelerator::config_command($|::)` (`:101`). The `vcs` domain rule
+is `^vcs($|::)` (`:76`) — the `($|::)` anchor means **`vcs_adapters` is
+currently unruled**.
+
+**Problem A — the combined rule is unexercised.** `allowed_only` and `denied`
+are independent `Option` fields on the same variant, so structurally they can
+coexist, but **no shipped rule sets both**, and the pup integration tests
+(`tests/integration/pup/test_import_rule.py`) do not cover the combination.
+Which list wins on overlap (`std` permitted, `std::process` denied) is
+unestablished in-repo. This is the mechanism 0188 relies on to make zero-spawn
+*structural*; it needs an empirical check in planning, exactly like the oracle
+mapping.
+
+**Problem B — the grouped-import gotcha.** `cli/pup.ron:90-98` records that
+cargo-pup resolves a grouped `use foo::{a, b}` to an **empty module name**,
+which an `allowed_only` rule rejects as unpermitted. Consequence: every module
+under a permit rule must write one single-item `use` per import — visible at
+`cli/config/src/service.rs:4-13` (ten consecutive single-item lines) and
+`cli/config/src/level.rs:3-4` (splitting `std::fmt::{Display, Formatter}`).
+The current adapter writes the forbidden shape:
+
+```rust
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+```
+(`cli/vcs-adapters/src/lib.rs:13-14`)
+
+So the new library-backed module must adopt single-item imports throughout.
+Note `#[cfg(test)]` modules appear exempt in practice (`cli/vcs/src/lib.rs:95,
+97` use grouped imports under a whole-crate rule).
+
+The narrowed-permit precedent to copy is `"^kernel::Error(::|$)"`
+(`cli/pup.ron:18`), proven discriminating by
+`tests/integration/pup/test_import_rule.py:196-205`. Failure-message contracts
+are `"is not allowed"` (permit violation) vs `"is denied"` (deny violation)
+(`:303`, `:486`) — useful for the non-vacuity demonstration's assertion.
+
+Runner: `tasks/pup.py:16-25`, `cargo +nightly-2026-01-22 pup` from `cli/`;
+nightly + cargo-pup version are a matched pair pinned at
+`tasks/shared/rust.py:6-7`, rustup-managed, deliberately not a mise tool.
+
+### 4. The behavioural oracle and the fixture matrix
+
+`classify_checkout` (`scripts/vcs-common.sh:177-280`) emits the six-line
+KEY=VALUE record. The arm cascade is at `:240-272`, first-match-wins, with
+`colocated` deliberately preceding the `nested-*` arms.
+
+The only real detection oracle suite is `hooks/test-vcs-detect.sh` (713 lines,
+42 cases, ~131 assertions). Its **recorded** oracle mapping:
+
+| Fixture | KIND | BOUNDARY | JJ_PARENT | GIT_PARENT | Source |
+| --- | --- | --- | --- | --- | --- |
+| main jj workspace | `main` | `""` | `""` | `""` | `:338-345` |
+| main git checkout | `main` | `""` | — | — | `:347-352` |
+| jj secondary | `jj-secondary` | secondary | jj parent | `""` | `:354-360` |
+| git linked worktree | `git-worktree` | worktree | `""` | git parent | `:362-368` |
+| colocated (grafted) | `colocated` | target | jj parent | git parent | `:370-376` |
+| nested-jj-in-git | `nested-jj-in-git` | target | jj parent | git parent | `:596-603` |
+| nested-git-in-jj | `nested-git-in-jj` | target | jj parent | git parent | `:605-611` |
+| plain dir | `none` | `""` | — | — | `:378-382` |
+| bare git repo | `none` | (unasserted) | — | — | `:384-385` |
+
+Secondary oracles (`:258-314`, `:424-480`): `find_git_main_worktree_root`
+returns **exit 1 + empty stdout for a bare repo** (`:308-314`) and the parent
+for a linked worktree; `find_jj_main_workspace_root` returns own root for main,
+`$FIXTURE_PARENT` for secondary, exit 1 for a plain dir.
+
+**Three fixture findings that change the matrix's cost and meaning:**
+
+- **A git submodule fixture exists nowhere in the repo** — in shell, Rust or
+  Python. `grep -rl submodule --include='*.sh'` returns nothing;
+  `scripts/vcs-common.sh:124` is the only mention, in a comment. Entirely new
+  construction, and the only shape whose oracle
+  (`git rev-parse --show-superproject-working-tree`) has never been run here.
+- **The shell "colocated" fixture is a hand-graft, not `jj git init
+  --colocate`** (`hooks/test-vcs-detect.sh:96-157`). It is a *jj secondary
+  workspace whose path is simultaneously a git linked worktree of an unrelated
+  git repo*, assembled by moving `.jj/` into a `git worktree add` target and
+  rewriting `.jj/repo` with an absolute path and no trailing newline. Because
+  `classify_checkout`'s `colocated` arm requires `jj_secondary==1 &&
+  git_worktree==1` (`scripts/vcs-common.sh:242-247`), a genuine
+  `jj git init --colocate` main repo classifies as **`main`**, not
+  `colocated`. 0188's matrix row "colocated | root" is ambiguous between the
+  two shapes and must be disambiguated in planning.
+- **There is probably no pure-jj fixture anywhere.** The golden snapshot
+  `hooks/test-fixtures/vcs-detect/main-jj-workspace.json:4` reads
+  `mode: jj-colocated`, and `hooks/vcs-detect.sh:28-33` emits that only when
+  `.git` is a *directory* — yet the fixture that produced it is a bare
+  `jj git init --quiet` (`regenerate.sh:36`). So `jj git init` appears to be
+  colocated-by-default. 0188's pure-jj measurement fixture must explicitly
+  assert `.git` is absent.
+
+The one `--colocate` builder in the tree is
+`scripts/test-metadata-helpers.sh:41-55`, which is also **the only hermetic-env
+suite in the repo** (`:28-40`: unsets `GIT_DIR GIT_WORK_TREE JJ_CONFIG`, sets
+`HOME` and `XDG_CONFIG_HOME` to temp dirs). `hooks/test-vcs-detect.sh` by
+contrast scrubs almost nothing — only `GIT_CEILING_DIRECTORIES="$TMPDIR_BASE"`
+(`:35-40`) and per-repo git identity (`:58`). The developer's `~/.gitconfig`
+and `~/.jjconfig.toml` are in effect for every jj fixture it builds.
+
+The PATH-stripping technique 0188's harness can borrow is
+`strip_binary_from_path` (`hooks/test-vcs-detect.sh:164-188`), carrying two
+recorded gotchas: macOS provides `git` in both `/opt/homebrew/bin` **and**
+`/usr/bin` so stripping one dirname is insufficient; and `type -p` is served
+from bash's command hash table and caused a **hard hang on macOS bash 3.2**.
+The subshell-wrapper scoping idiom (`:387-400`) and the
+`assert_eq "PATH not leaked"` guard (`:680`, `:708`) are both worth copying.
+
+### 5. Test apparatus — what exists and what is new
+
+**Injection seam.** `cli/vcs-adapters/tests/detection.rs` is
+`#![cfg(feature = "bash-parity")]` (`:9`) and calls `vcs_adapters::facts`
+directly at `:95`, `:121`, `:134`, `:155`, `:191`, `:234`, `:272` — no
+injection point. Existing shapes: plain git, nested subdir, no-commits,
+colocated (`:144-169`), jj secondary (`:171-209`), `.git`-as-file worktree
+(`:211-248`), bare (`:250-277`).
+
+**Reference artefact.** Three `[[bin]]`-under-`tests/fixtures/` precedents
+exist: `accelerator-fixture` (`cli/launcher/Cargo.toml:17-21`),
+`document-fixture` (`cli/document/Cargo.toml:12-14`),
+`config-adapters-fixture` (`cli/config-adapters/Cargo.toml:12-17`). The last is
+the best template — it is a composition root that calls the real API and
+*prints* the result
+(`cli/config-adapters/tests/fixtures/config_adapters_fixture.rs:1-49`). Every
+one carries the same required prelude:
+
+```rust
+#![allow(clippy::exit, clippy::print_stdout, clippy::print_stderr,
+         clippy::restriction)]
+```
+
+No `required-features`, no `[[example]]`, no `#[cfg(test)]` binary anywhere in
+`cli/`.
+
+**Cross-crate sharing — no precedent at all.** Zero path-based
+`[dev-dependencies]` in the whole `cli/` workspace; every dev-dep table holds
+only external crates. `corpus-adapters` has no `[dev-dependencies]` table at
+all and pulls `tempfile` as a *runtime* dependency
+(`cli/corpus-adapters/Cargo.toml:28`). Today's sharing mechanism is duplicating
+`tests/common/mod.rs` per crate with `#![allow(dead_code)]`.
+
+Two hard constraints on the shared fixture's shape:
+
+- **`CARGO_BIN_EXE_*` does not cross crate boundaries.** Recorded verbatim at
+  `cli/launcher/Cargo.toml:17-18` and worked around at
+  `cli/corpus-adapters/tests/common/mod.rs:62-86` by deriving the path from
+  `current_exe()`. If the reference artefact is a `[[bin]]` in `vcs-adapters`,
+  `corpus-adapters` cannot locate it via the env var — the fixture's public API
+  must expose a path resolver.
+- **A feature gate conflicts with an acceptance criterion.** The natural route
+  is `vcs-adapters/[features] fixtures = []` plus
+  `vcs-adapters = { path = "…", features = ["fixtures"] }` in a *new*
+  `[dev-dependencies]` table on `corpus-adapters` (resolver 3 keeps dev-dep
+  features out of the normal build, which matters because
+  `cli/visualiser/server` depends on `corpus-adapters`). But 0188's criterion
+  says `vcs-adapters` "gains no `[features]` entry beyond `bash-parity`"
+  (work item `:320-321`). And CI runs `--all-features`
+  (`tasks/test/cli.py:11-14`), so any such feature is on workspace-wide during
+  the CI test run regardless. **Resolve in planning.**
+
+**Temp dirs and path comparison** — solid, reusable as-is. The builder shape is
+`tempfile::Builder::new().prefix("<crate>-<label>-").tempdir()` returning the
+owned guard (`cli/vcs-adapters/tests/detection.rs:32-39`); struct-owned
+`_guard` variants at `cli/launcher/tests/config_read.rs:22-40` and `:79-90`.
+Canonicalise *immediately* after building, then compare against the
+canonicalised value (`detection.rs:92-97`); for a nested path, canonicalise the
+parent then join (`:179-180`).
+
+**Parallelism** — nextest process-per-test is the isolation mechanism
+(`tasks/test/cli.py:31-35`). There is **no `nextest.toml` anywhere in the
+repo**, no `serial_test`, and not a single `std::env::set_var`/`remove_var`
+under `cli/`. The convention is per-child `Command::env` overlays. If the
+zero-spawn suite needs serialisation, that config file is new.
+
+**Non-vacuity precedent** — `the_scrubbed_environment_drops_the_redirecting_variables`
+(`cli/vcs-adapters/src/lib.rs:305-321`) is the closest existing shape to 0188's
+"unscrubbed control must diverge" criterion. The spy-port template for "must
+never fire" is `cli/launcher/tests/crypto_provider.rs:33-55` (`Cell<bool>` spy
+plus a panicking null).
+
+### 6. Build system and enforcement wiring
+
+**`_assert_static_elf`** (`tasks/build.py:132-159`) shells out to `file -b` and
+accepts three phrasings via `_is_statically_linked` (`:118-129`). Its **sole
+production caller** is `cli_cross_compile` (`:312-331`), guarded by
+`if "musl" in triple:` at `:329`, over `_CLI_RELEASE_BINARIES = ("accelerator",
+"accelerator-verify")` (`:37`).
+
+**The musl cross-compile is release-only and macOS-only.** `cli_cross_compile`
+runs `cargo zigbuild --release --target {triple}` and is invoked from
+`tasks/release.py:82-94` / `:109-125`, wired to `mise.toml:512-515` / `:525-528`
+and the `prerelease`/`release` jobs, both `runs-on: macos-latest`
+(`.github/workflows/main.yml:343`, `:464`). **No `check-*` job cross-compiles,
+and no test exercises `_assert_static_elf` against a real build.** Adding the
+reference artefact to that path means editing the staging loop at `:326-331`
+and the constants at `:37` — a release-pipeline change with its own risk, not a
+test addition.
+
+Toolchain: `cargo zigbuild`, with `ziglang` and `cargo-zigbuild` as **PyPI deps
+in the `build` group** (`pyproject.toml:20-21`), not mise tools. No
+`.cargo/config.toml` linker wiring exists.
+
+**Lockfile-assertion precedent** — three shapes, none a standing invariant
+check:
+
+- `_cargo_lock_package_block` / `_strip_lock_dependencies`
+  (`tasks/build.py:341-354`, `:397-412`) feeding `vendor_shim_marker_digest`
+  (`:415-459`) — a *digest-drift* guard scoped to `accelerator-verify` +
+  `minisign-verify`. Adding deps to `vcs-adapters` cannot trip it.
+- `tests/integration/deny/test_launcher_feature_graph.py` — `cargo tree -e
+  features -p accelerator` with `_PRESENT`/`_ABSENT` crate lists matched by a
+  `(?<![\w-]){crate} v\d` regex (`:23-31`, `:48-51`). **This is the nearest
+  architectural precedent for 0188's "exactly one gix version / no TLS stack"
+  assertion**, and it already lives in `test:integration:deny`.
+- `tests/unit/tasks/test_msrv_coherence.py` — hand-duplicated pin coherence as
+  a bare pytest. **The exact shape for the `mise.toml` jj-pin ↔ `jj-lib`-pin
+  lockstep clause.**
+
+**Adding a leaf task** — module under `tasks/lint/` with a thin `@task` wrapper
+over a pure function; export in `tasks/lint/__init__.py:1-27`; register in
+`tasks/__init__.py:102-104` (underscores auto-dash); mise leaf in `mise.toml`
+(`:` where invoke uses `.`). Roll-up membership is the decision point: a
+cli-scoped guard joins **both** `cli:check.depends` (`mise.toml:422-424`) and
+`lint:check.depends` (`:464-466`), because the bare `default` task depends on
+`lint:check` but not on `check`. A standalone entity gate joins
+`check.depends` directly (`:480-482`), as `deny:check` and `pup:check` do.
+Pure guards with no autofixer stay out of `fix` entirely.
+
+**`tests/unit/tasks/test_mise.py` pins the topology with exhaustive equality
+assertions** — `_CHECK_GATES` (`:18`), `_CLI_CHECK_GATES` (`:25-29`), and for
+any new `test:integration:*` task, `_LAUNCHER_DEPENDENTS`/`_NO_LAUNCHER_NEEDED`
+(`:36-56`) plus the roll-up or `_NOT_IN_INTEGRATION_ROLLUP` (`:127-137`). These
+fail if skipped.
+
+**`tasks/README.md`** — a new gate documents in the entity-gate paragraph
+(`:38-42`, which currently *enumerates* "`deny:check` … and `pup:check`" and
+will go stale), a new `### <name>` subsection alongside "Executable-bit
+invariant" (`:67`) and "Rust nightly lane" (`:101`), and a row in the CI table
+(`:153-157`).
+
+**Test invocation**: `cargo nextest run --manifest-path cli/Cargo.toml
+--workspace --exclude accelerator-visualiser --all-features`
+(`tasks/test/cli.py:11-14`, `:31-38`), with `cargo llvm-cov nextest` when
+coverage is on. `bash-parity` is enabled **implicitly by `--all-features`** —
+there is no explicit `--features bash-parity` anywhere.
+
+### 7. CI capability — answering the open question
+
+There is exactly one workflow file, `.github/workflows/main.yml` (564 lines, 14
+jobs). Every Linux job is a bare `ubuntu-latest` label; **no `container:` key
+exists anywhere**; **no `sudo` appears in `.github/`, `tasks/`, `scripts/`,
+`hooks/` or `cli/`** (repo-wide grep — the only hits are substrings in
+design-prototype HTML).
+
+**Feasibility: yes, on the existing runners.** GitHub-hosted Ubuntu VMs run as
+the `runner` user with passwordless sudo, so `sudo mv`, `sudo ln -sf` or
+`sudo mount --bind` on `/usr/bin/git` are all available without a privileged
+container. Corroborating in-repo evidence: `test-visual-regression`
+(`main.yml:122-145`) already runs `docker run` with bind mounts and
+`--ipc=host` from a step (`tasks/test/e2e.py:60-81`), which implies effective
+root on the host; and every cargo job already writes outside the workspace into
+`$HOME` via `$GITHUB_ENV` (`main.yml:31`, `:71`, `:198`, `:237`, `:270`,
+`:295`). The residual risk is that this is **unproven in-repo** — the first run
+is itself the experiment, and it is cheap to settle with a one-step smoke test.
+
+**But the shadow list is wrong for the actual CI layout.** On `ubuntu-latest`,
+`git` is at `/usr/bin/git`, but `jj` is installed by mise from an aqua-backed
+GitHub release into `$HOME/.local/share/mise/installs/jj/0.43.0/…`
+(`mise.toml:16`, `mise.lock:89-106`). There is no `/usr/bin/jj`,
+`/usr/local/bin/jj` or `/opt/homebrew/bin/jj` on the runner at all — shadowing
+them proves nothing. The meaningful jj shadow target in CI is the mise install
+path (or the shim), and the criterion should say so.
+
+**Where the job goes.** `test-unit` and `test-integration` are OS matrices
+(`main.yml:20-21`, `:60-61`), so anything placed there also lands on
+`macos-latest` where the strong form is impossible under SIP. Critically,
+**`test:unit:cli` runs on both legs**, and `detection.rs` is the natural home
+for the query matrix — so a strong-form assertion placed there would fail on
+macOS. `check-cli` (`:223`), `check-supply-chain` (`:259`) and
+`check-architecture` (`:286`) are the Linux-only single-runner template;
+`check-architecture` is the closest precedent for "one Linux-only job that
+self-provisions unusual infrastructure and is deliberately isolated".
+
+**Constraints on a new job**, from `tests/unit/tasks/test_workflows.py`:
+
+- The nightly-isolation invariant (`:287-337`) asserts the set of jobs whose
+  `run:` text contains `pup:check`, `deps:install:pup` or `+nightly` is
+  **exactly `{check-architecture}`**, and that no job outside
+  `{check-architecture}` ∪ the three release jobs declares
+  `needs: check-architecture`.
+- No step may reference `ACCELERATOR_RELEASE_SECRET_KEY` unless its `name`
+  starts with `"Sign"` (`:115-124`).
+- Renaming `check-cli` breaks the guard's own mutation tests (`:346`, `:351`).
+- **actionlint lints only `main.yml`** — `_WORKFLOW = ".github/workflows/main.yml"`
+  (`tasks/lint/workflows.py:7`). A separate new workflow file would not be
+  linted at all. Put the job in `main.yml`.
+
+**mise in CI**: `jdx/mise-action` SHA-pinned, always `install: true, cache:
+true, experimental: true`. There is **no explicit `mise install` step
+anywhere** — the jj bump is picked up because mise-action keys its cache on
+`mise.toml`/`mise.lock` contents. The `RUSTUP_HOME` routing comment
+(`main.yml:191-198`) is now replicated to six jobs and explains why: a cache
+hit makes `mise install` a no-op while the toolchain is absent, and parallel
+cargo tasks race to auto-install. A new cargo job needs the same routing step
+plus its own `cache_key_prefix`.
+
+**Who needs a real `jj`**: `test:integration:hooks` (`hooks/test-vcs-detect.sh:11-16`
+hard-requires `jj git realpath jq`, exit 77 if absent — and `run_shell_suites`
+treats 77 as a *failure*, not a skip) and `test:unit:cli` (`detection.rs:5`).
+Both run on both OS legs.
+
+### 8. Measurement — no machinery, and the provenance of B
+
+Searched the whole repo: **no criterion, no `[[bench]]`, no `benches/`, no
+hyperfine, no `bench:*` mise namespace, no timing helper in `tasks/`.**
+`tasks/shared/clock.py` is a 12-line injectable clock for poll loops, not a
+measurement facility. The only timing code anywhere is an upper-bound
+assertion at `cli/vcs-adapters/src/lib.rs:257-265`. 0188's "median of 20,
+library init / warm in-process / cold per-process" has zero existing machinery
+to hook into — the runner, the timing loop and the results convention are all
+new.
+
+**`B ≈ 35 ms` is `35.1 ms`**, from 0186's table
+(`meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md:46-63`, also
+reproduced at research `2026-07-29-…:622-630`): darwin-arm64, warm cache, 20
+iterations, 2026-07-30. The same table gives `bin/accelerator version` at
+149.1 ms, launcher-direct at 3.0 ms, minisign verify of the 8 MB launcher at
+2.3 ms, and `probe_dir` write+chmod+exec+rm at **107.9 ms**.
+
+**The "~41 ms warm bootstrap" is derived, not measured**: `149.1 − 107.9`,
+i.e. the bootstrap with only 0186's `probe_dir` fix landed and the ~23 ms shim
+double-hash retained. 0186 states this explicitly at `:61-63`. The plan should
+record both provenances rather than citing 41 ms as an observation.
+
+**No gix or jj-lib timing exists at all.** And the platform caveat matters:
+research `:688-690` records that the ~97 ms probe delta is macOS-specific
+(first-exec check), with no Linux equivalent — so darwin is the worst case and
+cross-host comparison is unsound. Review-2 pass 3 (`:652-654`) left exactly
+this open: a threshold calibrated on one host against a baseline captured on
+another is not well-posed. **0188 measuring on a different host from 0169's `B`
+would leave the `G ≤ 1.1 × B` gate ill-defined even though 0188 itself gates
+nothing.** Record host and OS, and state whether they match 0186's.
+
+### 9. Consumer side — `cli/corpus-adapters`
+
+Exactly four references to `vcs`/`vcs_adapters` exist in the crate:
+`Cargo.toml:24-25` (both **normal `[dependencies]`**),
+`src/metadata.rs:14` (`use vcs::RepoFacts;`) and `src/metadata.rs:201`
+(`let facts = vcs_adapters::facts(start);` — the only call site, inside
+`derive_at`). Only `.name` and `.revision` are read (`:185-186`).
+
+**0188 needs to change nothing here.** Because the crate reaches the free
+function rather than naming the adapters, leaving `vcs_adapters::facts`
+hard-wired keeps the pair in place automatically.
+
+**The metadata parity suite is `tests/metadata.rs`, not `tests/parity.rs`.**
+The specific test is `derive_at_agrees_with_the_live_metadata_helper`
+(`:265`, gated at `:263`); it runs `scripts/artifact-derive-metadata.sh`
+against **the live accelerator checkout** (`repo_root()`), compares
+`Current Revision:` and `Repository Name:`, and asserts the bash-side name is
+literally `"accelerator"` as an anti-vacuity guard (`:299-303`).
+`tests/parity.rs` is the *linkage* parity suite and never touches VCS. Naming
+the wrong file would pin the wrong suite.
+
+**Two traps for the cross-crate zero-spawn test:**
+
+- `SystemClock::try_new()` **spawns `date` unconditionally**
+  (`src/metadata.rs:106-110`, rationale at `:96-98`), reached by three ungated
+  tests. A blanket "no subprocess" marker would trip on it — the assertion must
+  be scoped to `git`/`jj` specifically.
+- The dependency edge already exists as a **normal** dependency, so a
+  `corpus-adapters` integration test can `use vcs_adapters::…` today with no
+  manifest change. Adding `features = ["fixtures"]` to that existing
+  `[dependencies]` entry would leak into the production build (and into
+  `cli/visualiser/server`, which depends on `corpus-adapters`); a new
+  `[dev-dependencies]` table is the safe route under resolver 3.
+
+No test in the crate builds a git or jj repo, manipulates PATH, or asserts
+"no spawn". Everything the criterion needs is new here — which is precisely
+what makes it meaningful rather than a formality.
+
+### 10. Sibling hand-offs — verified state
+
+Every claim 0188 makes about its siblings checks out, with three additions:
+
+- **0185 has a sixth stale site 0188 does not name.** Its References
+  (`:148-153`) cite two anchors that no longer exist in 0169: there is no
+  "Adapter-swap boundary" requirement heading, and the Dependencies bullet is
+  titled "Unowned debt this story creates" (`0169:436`, no "or inherits"),
+  whose item 1 is now about `vcs-common.sh` residue. Both should be repointed.
+  Also, 0185's harness criterion (`:82-84`) describes *PATH stubs only* — the
+  harness it inherits is 0188's strictly larger three-part strong form.
+- **0125 reciprocates no edges.** Its `relates_to` is
+  `["work-item:0124", "work-item:0058", "work-item:0020"]` (`:11`), while 0169
+  (`:14`), 0185 (`:13`) and 0188 (`:14`) each already list it. Adding only
+  `work-item:0188` leaves 0169 and 0185 one-directional — a deliberate
+  decision, not an oversight, but worth making consciously. 0125 has a
+  `## Dependencies` section at `:141-146` to append to, and no Validation
+  Results or Open Questions sections.
+- **0125's constraints 3, 4 and 5 are untouched by 0188** and must survive the
+  note: caller audit required for changed submodule semantics (`:90-92`),
+  `find_repo_root` ≠ `find_git_main_worktree_root` (`:93-94`), and `vcs_mode`
+  is a command-set selector that must preserve `.jj`-WINS (`:95`). Only
+  constraints 1 (no git/jj on PATH) and 2 (1-3 subprocesses per call) are what
+  0188 dissolves.
+
+Ground truth on the call sites: `find_repo_root` has 21 production call sites
+outside `workspaces/*/`, of which only four (`hooks/vcs-detect.sh`,
+`hooks/vcs-guard.sh`, `scripts/vcs-status.sh`, `scripts/vcs-log.sh`) are
+retired by 0169. `vcs_mode` has exactly one
+(`skills/work/scripts/work-item-file-dirty.sh`).
+
+**0169's three silences are genuine** — defining a domain port over inherent
+methods, widening the pup rule for `status`/`log`, and reusing 0188's named
+pure-jj builder are absent from 0169, confirmed by exhaustive grep. They are
+silences, not contradictions.
+
+**Contention is minimal.** 0187 has not landed (`tasks/build.py:35` still holds
+`_VISUALISE_SKILL_RELATIVE`, `:189` is unchanged) and its region (`:189-208`)
+is ~130 lines from 0188's (`:118-159`, `:290-331`) with three unrelated
+functions between. The only genuine collision surface is the import block
+(`:11-32`) and the module constants (`:34-56`). 0168 is `done` and its
+restructuring landed; `mise.toml` contention is already discharged.
+
+**One unabsorbed correction**: `meta/prs/35-description.md:52` records that
+0188's affected-suite list is incomplete. Four more sites build or read jj
+fixtures: `scripts/test-metadata-helpers.sh`,
+`skills/config/migrate/scripts/test-migrate.sh`, `…/test-migrate-interactive.sh`,
+and Python task tests under `tests/unit/tasks/`. 0188 `:413-416` still names
+only two.
+
+## Code References
+
+- `cli/vcs/src/lib.rs:46-67` — the two ports 0188 implements; untouched by the story
+- `cli/vcs-adapters/src/lib.rs:13-14` — grouped imports the new pup rule would reject
+- `cli/vcs-adapters/src/lib.rs:57-68` — jj secondary resolution already done by pure file reads
+- `cli/vcs-adapters/src/lib.rs:139-154` — the production scrub list (no `HOME`/`XDG_CONFIG_HOME`)
+- `cli/vcs-adapters/src/lib.rs:168` — the single spawn chokepoint `CommandProbe` retains
+- `cli/vcs-adapters/src/lib.rs:224-227` — the hard-wired composition root that stays hard-wired
+- `cli/vcs-adapters/src/lib.rs:305-321` — the non-vacuity template for the scrub control
+- `cli/vcs-adapters/tests/detection.rs:9` — the `bash-parity` gate; `:32-39` the tempdir builder
+- `cli/corpus-adapters/src/metadata.rs:106-110` — `SystemClock` spawns `date` unconditionally
+- `cli/corpus-adapters/tests/metadata.rs:265` — the metadata parity test that must pass unchanged
+- `cli/corpus-adapters/tests/common/mod.rs:62-86` — the `current_exe()` cross-crate binary derivation
+- `cli/config-adapters/tests/fixtures/config_adapters_fixture.rs:1-49` — reference-artefact template
+- `cli/config-adapters/Cargo.toml:12-17` — the `[[bin]]`-under-`tests/fixtures/` convention
+- `cli/deny.toml:38-40` — the policy mandating `[[licenses.exceptions]]`; `:57` the warn-level bans
+- `cli/pup.ron:90-98` — the grouped-import resolution gotcha; `:14`, `:28`, `:101` single-module scoping
+- `cli/Cargo.toml:17-21` — the matched-pair exact-pin precedent (`vergen`/`vergen-gitcl`)
+- `mise.toml:12-16` — the landed `jj = "0.43.0"` pin and its lockstep comment
+- `scripts/vcs-common.sh:130-135` — the scrubbed branch; `:206-215` the unscrubbed one
+- `scripts/vcs-common.sh:240-272` — the first-match-wins arm cascade
+- `scripts/test-metadata-helpers.sh:28-55` — the only hermetic-env suite, and the only `--colocate` builder
+- `hooks/test-vcs-detect.sh:96-157` — the hand-grafted "colocated" fixture
+- `hooks/test-vcs-detect.sh:164-188` — `strip_binary_from_path` and its bash-3.2 hang post-mortem
+- `hooks/test-fixtures/vcs-detect/main-jj-workspace.json:4` — evidence `jj git init` is colocated-by-default
+- `tasks/build.py:132-159` — `_assert_static_elf`; `:312-331` its only caller
+- `tasks/test/cli.py:11-14` — `--all-features` is what enables `bash-parity`
+- `tests/unit/tasks/test_msrv_coherence.py:30-38` — the shape for the pin-lockstep assertion
+- `tests/integration/deny/test_launcher_feature_graph.py:23-51` — the shape for the version invariants
+- `tests/unit/tasks/test_workflows.py:287-337` — the nightly-isolation invariant a new job must satisfy
+- `tasks/lint/workflows.py:7` — actionlint lints only `main.yml`
+- `.github/workflows/main.yml:122-145` — the docker/bind-mount precedent on `ubuntu-latest`
+- `.github/workflows/main.yml:286-321` — `check-architecture`, the Linux-only isolated-job template
+
+## Architecture Insights
+
+- **The hexagon boundary forces the design.** `cli/pup.ron:76` restricts the
+  `vcs` domain to `std`/`kernel::Error`/`crate::`, so `gix` and `jj-lib` can
+  only ever live in `vcs-adapters`. That is why the six queries must be
+  inherent methods and why 0169's port has to be defined over plain domain
+  values with no library types leaking in.
+- **Enforcement is layered but uneven.** `cargo deny` and `cargo-pup` are
+  standalone entity gates wired straight into top-level `check`, *not* into
+  `cli:check` — so a `cli:check` inner loop will not catch a licence or import
+  violation. The musl guarantee has an even bigger hole: it is only ever
+  verified during release, on macOS.
+- **The `-e` existence test is a deliberate, load-bearing choice.**
+  `find_repo_root` (`scripts/vcs-common.sh:11`), `vcs_mode` (`:28`, `:30`) and
+  `MarkerWalkRoot` (`cli/vcs-adapters/src/lib.rs:38`) all test existence so a
+  `.git` *file* counts. 0188's boundary rule is written to preserve exactly
+  this, which is why `MarkerWalkRoot` stays the reference implementation for
+  `RepoRoot` even after the library-backed type lands.
+- **Cross-crate test sharing is genuinely unmodelled here.** The workspace's
+  answer to "two crates need the same helper" has always been "write it twice".
+  0188 introduces the first shared fixture, and the two mechanisms the
+  workspace already sanctions — a mirrored feature gate, and a `[[bin]]`
+  located by path derivation — pull in different directions.
+- **Closed lists written by inference have a poor track record here.** The
+  review record shows the oracle mapping wrong twice and each zero-spawn
+  mechanism found evadable in the *next* pass. 0188 contains three more closed
+  lists — the six-query contract, the four TLS crate names, the three absolute
+  shadow paths — and the third is already demonstrably wrong for CI (§7).
+
+## Historical Context
+
+- `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  §9 — the feasibility probe. `cargo deny` passes `bans`/`advisories`/`sources`
+  with one licence rejection (`uluru 3.1.0`, MPL-2.0, `gix-pack`'s LRU cache);
+  `jj-lib` 0.43 no longer depends on `git2`/`libgit2-sys`; `gix` default
+  features exclude network transports (compression resolves to `zlib-rs`); a
+  binary calling `gix::discover` and jj-lib's loader cross-compiles to
+  `aarch64-unknown-linux-musl` and reports `statically linked, stripped`,
+  accepted by `_assert_static_elf` unmodified. §12 holds the latency table.
+- Same document, §9 — the two traps. `gix::discover` walked up past a jj
+  workspace boundary and returned the parent repo's `.git` from inside
+  `workspaces/build-system`. `UserSettings` was abandoned after five
+  successive panics (`user.name` → `operation.hostname` → `operation.username`
+  → `debug.randomness-seed` → `signing.behavior` → …) — **the chain was never
+  exhausted**, which is the empirical basis for the crate-wide prohibition.
+- `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md` pass 4
+  (`:811-825`) — the split recommendation. 0188 is item 3 of four. Pass 3
+  (`:720-725`) recorded its independent value as dissolving 0125's rationale.
+  The zero-spawn escalation ladder runs pass 1 (semantic contradiction) → pass
+  2 (an in-crate seam cannot see inside `gix`/`jj-lib`) → pass 3 (`PATH` stubs
+  evaded by `/usr/bin/git`) — each rung reached only because the previous was
+  found insufficient one pass later.
+- `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md:46-63` — the
+  measurement table that is the true provenance of `B = 35.1 ms`, and `:61-63`
+  where the ~41 ms figure is derived rather than measured.
+- `meta/prs/35-description.md:52` — an unabsorbed correction to 0188's
+  affected-suite list.
+- `meta/reviews/work/0188-library-backed-vcs-adapter-review-1.md` — verdict
+  APPROVE; `:1195-1207` moved the 0125 note from 0169 to 0188; `:1053-1071`
+  repointed the 0185 harness attribution; `:1860` is the origin of the open
+  ordering question. Note `:554-556` suggests naming `tests/parity.rs` as the
+  suite to keep green — **that is the wrong file** (see §9).
+
+## Open Questions
+
+**Now answerable from the codebase:**
+
+- **The strong-form CI job.** Feasible on the existing `ubuntu-latest` runners
+  with `sudo`, no container needed; put it in `main.yml` (actionlint sees
+  nothing else) as a Linux-only job modelled on `check-architecture`, avoiding
+  the three nightly markers. **But the shadow list must be rewritten**: there
+  is no system `jj` on the runner, so the meaningful target is the mise install
+  path. Unproven in-repo — settle with a one-step `sudo` smoke test before
+  committing the criterion.
+
+**Newly surfaced, and gating:**
+
+- **Does a combined `allowed_only` + `denied` cargo-pup rule behave as
+  intended?** No shipped rule sets both and no test covers the combination.
+  The entire structural zero-spawn guarantee rests on `std::process` being
+  denied while `std` is permitted. Verify empirically alongside the oracle
+  mapping.
+- **How is the shared fixture published, given the "no features beyond
+  `bash-parity`" criterion?** There is no cross-crate precedent, `CARGO_BIN_EXE_`
+  does not cross crates, and `--all-features` makes any new feature global in
+  CI. The criterion and the mechanism need reconciling.
+- **Which "colocated" does the matrix mean?** The shell fixture is a hand-graft
+  that classifies as `colocated`; a real `jj git init --colocate` main repo
+  classifies as `main`. Both are legitimate shapes; the matrix currently names
+  one row.
+- **Does `jj git init` produce a colocated repo by default at 0.43?** The
+  golden snapshot says the 0.36-era bare `jj git init` did. If so, the pure-jj
+  measurement fixture needs an explicit non-colocating construction and a
+  `.git`-absent assertion, and `make_main_jj_workspace` is misnamed.
+- ~~**Does `gix` 0.85 expose usable APIs for bare detection, worktree/common-dir
+  resolution, and superproject resolution?**~~ **ANSWERED 2026-08-03 by spike**
+  — see Follow-up Research below. Queries 1 and 2 are served by library calls
+  (`is_bare()`, `kind()`, `git_dir()`, `common_dir()`, `main_repo()`); **query 3
+  has no gix API** and needs a ~15-line hand-rolled derivation, validated
+  against the oracle at submodule depths 1 and 2. The spike also overturned the
+  boundary mechanism (no ceiling can enforce the rule) and showed the git-side
+  scrub invariant holds for free.
+- **Which host do the cost measurements run on?** `B = 35.1 ms` is
+  darwin-arm64 and the probe delta is macOS-specific. Measuring 0188's figures
+  on a different host leaves 0169's gate ill-posed — an unresolved review-2
+  pass-3 finding now spanning two work items.
+- **Who changes `vcs_adapters::facts`** — 0169 or 0185 — remains open, and 0185
+  currently *assumes* 0169 will ("0169 will need to alter this anyway",
+  `0185:117-121`), which 0188 contradicts by design.
+
+## Follow-up Research: gix 0.85 API spike (2026-08-03T06:52:09+00:00)
+
+Closes the open question "Does `gix` 0.85 expose usable APIs for bare detection,
+worktree/common-dir resolution, and superproject resolution?" and two riders
+that shared the same fixtures. Method: a throwaway Rust prototype
+(`gix` 0.85.0, **default features**) against real git fixtures, with every gix
+answer printed beside the `git rev-parse` oracle for the same start directory.
+Environment: darwin-arm64, `git` 2.54.0, Rust 1.90.0. Prototype discarded.
+
+**One environment finding first**: the machine had `jj` **0.42.0** on `PATH`
+from Homebrew, not the pinned 0.43.0 — `mise.toml` is untrusted there so mise
+was not activating. This confirms 0188's outstanding "`mise install` on each
+machine" item, and sharpens the CI shadow-list finding in §7: on a developer's
+macOS machine `/opt/homebrew/bin/jj` **is** the real binary, whereas on CI no
+system `jj` exists at all. The shadow list is wrong in *opposite* directions on
+the two platforms.
+
+### Q1 — bare-repository detection: available
+
+`Repository::is_bare()` at `gix-0.85.0/src/repository/worktree.rs:64`:
+
+```rust
+pub fn is_bare(&self) -> bool {
+    self.config.is_bare.unwrap_or_else(|| self.workdir().is_none())
+}
+```
+
+Against a `git init --bare` fixture: `is_bare() == true`, `workdir() == None`,
+`git_dir() == common_dir() == ./bare.git`, oracle
+`--is-bare-repository == true`. Agreement.
+
+Note it consults `core.bare` before falling back to workdir absence — the only
+one of the six probed calls that reads configuration, which is why Q5 poisoned
+`GIT_CONFIG_GLOBAL` as well as `GIT_DIR`.
+
+### Q2 — worktree detection and common-dir: first-class
+
+`Repository::kind()` (`src/repository/location.rs:127`) returns
+`gix::repository::Kind` (`src/repository/mod.rs:6-16`), whose three variants map
+directly onto the distinctions 0188 needs:
+
+```rust
+pub enum Kind {
+    /// An ordinary Git repository.
+    Common,
+    /// A submodule worktree, whose `git` repository lives in `.git/modules/**/<name>` …
+    Submodule,
+    /// A worktree, whose `git` repository lives in `.git/worktrees/**/<name>` …
+    LinkedWorkTree,
+}
+```
+
+So "is this a linked worktree" is a single enum read, not the `--git-dir` vs
+`--git-common-dir` string comparison the shell performs
+(`scripts/vcs-common.sh:217-219`). Observed, linked worktree fixture:
+
+| Query | From the linked worktree | From the main worktree |
+| --- | --- | --- |
+| `kind()` | `LinkedWorkTree` | `Common` |
+| `git_dir()` | `./wt-main/.git/worktrees/wt-linked` | `./wt-main/.git` |
+| oracle `--git-dir` | `./wt-main/.git/worktrees/wt-linked` | `./wt-main/.git` |
+| `common_dir()` | `./wt-main/.git` | `./wt-main/.git` |
+| oracle `--git-common-dir` | `./wt-main/.git` | `./wt-main/.git` |
+| `main_repo().workdir()` | `./wt-main` | `./wt-main` |
+| `worktrees()` | `1 [wt-linked]` | `1 [wt-linked]` |
+
+Full agreement on both start directories. `main_repo()`
+(`src/repository/worktree.rs`, "Return the repository owning the main worktree")
+answers "what is the common (main) git directory" directly, returning a full
+`Repository` whose `workdir()` is the main worktree root.
+
+**A method-note for the plan**: the oracle emits `--git-dir` /
+`--git-common-dir` **relative to the invocation directory** — from a
+subdirectory, `--git-common-dir` returned `../../.git`. Resolve against the
+start path before comparing, exactly as `vcs-common.sh:215-216` does by hand.
+An early version of the prototype canonicalised against the process CWD instead
+and produced spurious mismatches; the oracle mapping's cells must record which
+directory each relative path is relative to.
+
+### Q3 — superproject resolution: no API, but hand-rollable
+
+**There is no superproject-ward API in `gix` 0.85, `gix-discover` or
+`gix-submodule`.** Confirmed two ways: a search for
+`pub fn .*superproject|superproject_dir|show_superproject|fn superproject`
+across all three crates returns nothing; and behaviourally, `main_repo()` called
+on a submodule returns `./super/mod` — the submodule itself. The one submodule
+API, `Repository::submodules()` (`src/repository/submodule.rs:93`), resolves
+only the **opposite** direction and is gated on the `attributes` feature:
+
+```
+submodule (modern) @ the superproject   GIX submodules(): [mod->./super/mod]
+submodule (modern) @ the submodule      GIX submodules(): None (no .gitmodules)
+```
+
+A hand-rolled derivation does work. `Kind::Submodule` identifies the case, and
+the superproject's git dir is the grandparent of the nearest `modules` path
+component in `git_dir()`. Validated against the oracle:
+
+| Start | `kind()` | `git_dir()` | oracle superproject | derived | |
+| --- | --- | --- | --- | --- | --- |
+| `./super/mid` | `Submodule` | `./super/.git/modules/mid` | `./super` | `./super` | MATCH |
+| `./super/mid/leaf` | `Submodule` | `./super/.git/modules/mid/modules/leaf` | `./super/mid` | `./super/mid` | MATCH |
+| `./super` | `Common` | `./super/.git` | `-` | `-` | MATCH |
+
+The depth-2 row matters: the `modules` segment repeats when submodules nest, and
+taking the *nearest* such ancestor (not the first) is what makes the derivation
+correct. About 15 lines, plus the bare-superproject branch (a superproject whose
+git dir is not named `.git` needs a `gix::open` to recover its workdir).
+
+**This is a sizing correction for the story**: five of the six queries are
+library calls; query 3 is bespoke path logic with its own edge cases and
+therefore its own tests.
+
+**Old-form submodules agree with git, so they are not a divergence.** A nested
+`.git` *directory* inside a superproject reports `Kind::Common` — as gix's own
+docs warn — and `git rev-parse --show-superproject-working-tree` also returns
+empty for it. Both say "no superproject". The fixture matrix should still carry
+the shape, because a `Kind::Submodule`-only implementation would silently miss
+it and no oracle disagreement would reveal the omission.
+
+### Q4 — boundary containment: the ceiling route cannot work
+
+Fixture: `git-outer/` is a git repository; `git-outer/inner-jj/` carries only a
+`.jj` marker. Under 0188's rule the boundary for any start inside `inner-jj` is
+`inner-jj`, so the only acceptable answers are "no repository" or `inner-jj`.
+
+```
+start=boundary, ceil=boundary, strict  ->  Err(None of the passed ceiling
+                                           directories prefixed the git-dir
+                                           candidate, making them ineffective.)
+start=boundary, ceil=boundary, lax     ->  ./git-outer   <<< VIOLATES THE RULE
+start=boundary, ceil=parent,   strict  ->  ./git-outer   <<< VIOLATES THE RULE
+start=deep,     ceil=boundary, strict  ->  Err(… within ceiling height of 3)
+start=deep,     ceil=parent,   strict  ->  ./git-outer   <<< VIOLATES THE RULE
+```
+
+**No anchor works, and the reason is structural.**
+`gix-discover-0.54.0/src/upwards/util.rs`, `find_ceiling_height`, computes
+`search_dir.strip_prefix(ceiling_dir).components().count()` and then
+`.filter(|height| *height > 0)` — so a ceiling equal to the start directory
+yields height 0 and is **discarded**, matching the field's own doc ("we ignore
+ceiling directories if the search directory is directly on top of one"). With
+the ceiling discarded and `match_ceiling_dir_or_error: false`, `max_height`
+becomes `None` and the walk is *unbounded*. And where a ceiling does apply, the
+loop in `upwards/mod.rs:96-103` tests `current_height > max_height` before
+incrementing `current_height` from 0, permitting one level of ascent past the
+ceiling. There is no configuration that confines the walk to the start
+directory alone.
+
+`gix::open` is the right instrument — it does not walk:
+
+```
+open(boundary)  [.jj only, no .git]  ->  Err(… does not appear to be a git repository)
+open(git-outer) [real git repo]      ->  ./git-outer   (no walk)
+open(deep)      [plain subdir]       ->  Err(… does not appear to be a git repository)
+```
+
+Composing the existing marker walk with a non-walking open gives exactly the
+required behaviour on every start:
+
+| Start | Marker-walk boundary | `gix::open(boundary)` |
+| --- | --- | --- |
+| `./git-outer/inner-jj` | `./git-outer/inner-jj` | None (not a git repo) |
+| `./git-outer/inner-jj/x/y` | `./git-outer/inner-jj` | None (not a git repo) |
+| `./git-outer` | `./git-outer` | `./git-outer` |
+
+`MarkerWalkRoot` (`cli/vcs-adapters/src/lib.rs:34-44`) already *is* that walk,
+so the boundary rule is satisfied by composition rather than by new code. 0188's
+Library traps section has been rewritten accordingly.
+
+The **paired negative assertion** the criterion requires is available and
+reproducible: unbounded `gix::discover` from `./git-outer/inner-jj` escapes to
+`./git-outer`. Note also that plain `gix::discover` never reads
+`GIT_CEILING_DIRECTORIES` — only `discover_with_environment_overrides` consults
+the environment — so the criterion's concern that the environment might be what
+makes the rule hold does not arise on this path.
+
+**A consequence for query 1**: a bare repository has neither marker, so
+`marker_walk(bare)` returns `None` (verified in a directory with no ancestor
+marker), while `gix::discover(bare)` and `gix::open(bare)` both succeed with
+`is_bare = true`. Under a marker-walk-first design bare detection is unreachable
+via the boundary path and needs its own entry point. This is consistent with
+today's pinned behaviour (`cli/vcs-adapters/tests/detection.rs:250-277`,
+`facts(&bare) == None`), but it means query 1's start path is *not* the boundary.
+
+### Q5 — the scrub invariant holds for free on the git side
+
+Poison: `GIT_DIR` and `GIT_COMMON_DIR` pointed at another fixture's real `.git`,
+plus `GIT_CONFIG_GLOBAL` at a config asserting `core.bare = true`.
+
+| Query | Linked worktree | Main worktree |
+| --- | --- | --- |
+| `kind()` | STABLE | STABLE |
+| `is_bare()` | STABLE | STABLE |
+| `git_dir()` | STABLE | STABLE |
+| `common_dir()` | STABLE | STABLE |
+| `workdir()` | STABLE | STABLE |
+| `main_repo().workdir()` | STABLE | STABLE |
+| **oracle `--git-dir`** | **DIVERGED** | **DIVERGED** |
+
+The oracle divergence is the control: under the same poisoning
+`git rev-parse --git-dir` returned `./plain/.git` from both start directories,
+so the poison was live and effective. Separately,
+`discover_with_environment_overrides` diverged (returning `./plain`) while plain
+`gix::discover` did not.
+
+Two consequences:
+
+- **No explicit scrub is needed for the git-side queries.** 0188's invariant
+  ("`GIT_DIR`/`GIT_COMMON_DIR` are scrubbed for the duration of any detection
+  call") is satisfied by construction when the code uses `gix::discover` /
+  `gix::open` rather than the `_with_environment_overrides` variants. The
+  invariant becomes a property to **verify**, not to implement — which is a
+  cheaper and stronger position than the work item assumes.
+- **The non-vacuity control is ready-made.** The criterion demands that "an
+  unscrubbed control must diverge under the same poisoning".
+  `discover_with_environment_overrides` is exactly that control, in-library, no
+  fixture surgery required.
+
+The jj-lib side is untested — this spike was scoped to the git-side queries.
+
+### Residual risks and what remains open
+
+- **jj-lib is untested here.** Queries 4 and 5 (jj workspace root, main vs
+  secondary) and the jj half of query 6 still rest only on the 2026-07-29
+  probe — which, per §Historical Context, was run with a `jj` **0.36** CLI
+  writing fixtures for `jj-lib` 0.43. That skew is unretired.
+- **Single platform.** darwin-arm64, git 2.54.0. The Linux behaviour of
+  `is_bare()`'s config fallback and of `main_repo()` on a bare main repository
+  is unverified.
+- **Config poisoning was global, not repo-local.** A repository-local
+  `core.bare = true` lie in `.git/config` was not tested; `is_bare()` reads
+  config, so that is the one plausible route to a query-1 divergence.
+- **`submodules()` needs the `attributes` feature.** Confirmed present under
+  gix's default features, but if the plan narrows features to shrink the
+  binary, the superproject-ward direction is unaffected (it is hand-rolled)
+  while `submodules()` would be lost.

--- a/meta/reviews/plans/2026-08-03-0188-library-backed-vcs-adapter-review-1.md
+++ b/meta/reviews/plans/2026-08-03-0188-library-backed-vcs-adapter-review-1.md
@@ -1,0 +1,1391 @@
+---
+type: plan-review
+id: "2026-08-03-0188-library-backed-vcs-adapter-review-1"
+title: "Plan Review: Library-Backed VCS Adapter over gix and jj-lib Implementation Plan"
+date: "2026-08-03T11:42:20+00:00"
+author: "Toby Clemson"
+producer: review-plan
+status: complete
+parent: "work-item:0188"
+target: "plan:2026-08-03-0188-library-backed-vcs-adapter"
+reviewer: "Toby Clemson"
+verdict: "REVISE"
+lenses: [architecture, code-quality, test-coverage, correctness, compatibility, portability, safety, security]
+review_number: 1
+review_pass: 4
+tags: [rust, vcs, dependencies, gix, jj-lib]
+last_updated: "2026-08-03T15:30:00+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Library-Backed VCS Adapter over gix and jj-lib
+
+**Verdict:** REVISE
+
+This is an exceptionally well-evidenced plan — the oracle mapping is empirical
+rather than inferred, every guard carries a non-vacuity control, the phases are
+genuinely independently mergeable, and the risk-isolation framing (unwired
+adapter, deletion-only rollback) is the right response to adopting two pre-1.0
+dependency trees. The findings cluster in three places rather than being spread
+thin: the strong-form CI job's shadow window is drawn far too wide and would
+prevent its own suite from running; `VcsProbe::revision` is the one method with
+no design and its jj half appears unreachable under the plan's own crate-wide
+`UserSettings` ban while Phase 3 demands byte-identical `RepoFacts`; and the
+oracle mapping — the plan's central artefact — has incomplete tables, one cell
+that contradicts its siblings, and a verdict column stating an inference its own
+amendment refutes. Beneath those, a consistent thread runs through six lenses:
+the plan's *declared* surfaces (pins, licences, graph invariants) are rigorously
+policed, while its *runtime and environmental* surfaces (error channels,
+canonicalisation, environment immunity, cross-target verification) are asserted
+rather than constructed.
+
+### Cross-Cutting Themes
+
+- **The shadowed CI window encloses everything, not just the code under test**
+  (flagged by: test-coverage, architecture, portability, safety) — moving `git`
+  and `jj` aside before a step that compiles the workspace *and* builds 24
+  fixtures with those same binaries breaks the suite, risks a vergen/cargo
+  build-script failure, and can let `mise` silently reinstall `jj` and make the
+  assertion vacuous.
+
+- **The pup `allowed_only` list contradicts the crate's own contract**
+  (flagged by: architecture, code-quality, correctness, compatibility) — the
+  permit list omits `tracing`, which `VcsProbe::revision`'s documented contract
+  ("an adapter is expected to log the failure") and `CommandProbe`'s six `warn!`
+  sites both require; it permits `kernel::Error`, which is not a dependency.
+
+- **`Option`-only signatures with no error channel** (flagged by: architecture,
+  compatibility, security, code-quality) — "no repository here" and "the pinned
+  pre-1.0 library could not parse this repository" collapse to the same `None`,
+  and the plan drops `CommandProbe`'s time cap, crash isolation and warn-logging
+  without replacement.
+
+- **Path canonicalisation is specified per-query, not at the boundary**
+  (flagged by: correctness, code-quality, portability) — `dual_roots` equality
+  is the colocated-vs-nested discriminator, yet its git side comes from gix's
+  own reconstruction and its jj side from a pass-through `workspace_root()`;
+  on macOS the `/var` → `/private/var` split can make them differ spuriously.
+
+- **The two new trees enter the shipped visualiser's closure, verified on one
+  triple of four** (flagged by: architecture, compatibility, portability,
+  safety) — `vcs-adapters` → `corpus-adapters` → `visualiser/server` is a
+  normal-dependency chain, so gix and jj-lib must cross-compile for all four
+  release targets, and no `check-*` job cross-compiles at all.
+
+- **Test-fixture binaries acquire release-artefact shape** (flagged by:
+  architecture, safety, security, compatibility, portability) — adding them to
+  `_CLI_RELEASE_BINARIES` stages them into `dist/release/` and puts fixture
+  build failures on the release critical path.
+
+- **Environment immunity and structural zero-spawn are both narrower than
+  claimed** (flagged by: security, correctness) — the scrub invariant was tested
+  against 2 of the 10+ variables `CommandProbe` scrubs, and cargo-pup's
+  `RestrictImports` constrains first-party `use` paths only, saying nothing
+  about gix's `attributes`/`blob-diff` filter machinery.
+
+### Tradeoff Analysis
+
+- **Structural enforcement vs. contract compliance**: the pup `allowed_only`
+  list buys a closed-world zero-spawn property, but as drafted it forbids the
+  logging the port contract mandates and imposes an invisible single-item-import
+  rule the repo already rejected once (`cli/pup.ron:93-98`). Recommendation:
+  add `tracing`, and consider expressing the rule as `denied`-only — the
+  zero-spawn guarantee comes from the deny clause, not the permit list.
+
+- **Exact pins vs. patch agility**: `=0.85.0`/`=0.43.0` buy a reproducible
+  single graph, but under `unmaintained = "all"` + `yanked = "deny"` they make
+  `advisories.ignore` the cheapest response to an upstream advisory in a
+  56-package closure that no code calls. Recommendation: keep the exactness in
+  `Cargo.lock`, relax the manifest to patch-permitting, and document the
+  break-glass procedure.
+
+- **Test rigour vs. CI cost**: one table-driven test per query rebuilds the full
+  ~19-fixture matrix six times per leg, on a repo with a known fixture-flake
+  history. Recommendation: invert to one test per (fixture, start directory)
+  pair — same per-cell traceability, roughly a sixth of the fixture builds.
+
+### Findings
+
+#### Critical
+
+- 🔴 **Test Coverage + Architecture + Portability + Safety**: The strong-form CI
+  shadow window encloses fixture construction and compilation
+  **Location**: Phase 4 §3 (The strong-form CI job)
+  The job moves `git` and `jj` aside, then runs a step that must build 24
+  fixtures *using those binaries* and compile the `cli` workspace (whose
+  `vergen-gitcl` build script shells out to `git`). As written the suite cannot
+  construct a single fixture, and `mise run` may reinstall the shadowed `jj`
+  and make the assertion vacuous.
+
+- 🔴 **Correctness + Code Quality + Test Coverage**: `VcsProbe::revision` has no
+  specified mechanism and its jj half conflicts with the `UserSettings` ban
+  **Location**: Phase 1 §4 (`InProcessProbe`); Phase 3 §2 (injection seam)
+  `revision` is sketched as `/* gix / jj-lib */` and never returned to, yet
+  Phase 3 requires identical `RepoFacts` against `CommandProbe`'s
+  `jj log -r @ -T commit_id`. Reading jj's `@` commit id in-process needs a
+  `UserSettings`, which Phase 2's guard forbids crate-wide; git HEAD is not an
+  escape (pure-jj has none, colocated exports `@-`). Phase 1 also ships `kind`,
+  `revision` and `repository_root` with no oracle rows and no test.
+
+- 🔴 **Safety + Portability**: The `stubs` shadow list is specified as if the
+  test crate itself mutates absolute system binaries
+  **Location**: Phase 3 §1 (`stubs` module); Phase 4 §3
+  The crate is described as resolving and shadowing absolute paths "recording
+  which paths it could not shadow", including `/opt/homebrew/bin/git` — a
+  user-writable location — while the actual privileged move lives in workflow
+  YAML. `test:integration:zero-spawn` is reachable from the bare `mise run`
+  every contributor is told to run before pushing.
+
+#### Major
+
+- 🟡 **Architecture + Code Quality + Correctness + Compatibility**: The pup
+  `allowed_only` list omits `tracing` and permits an inert `kernel::Error`
+  **Location**: Phase 1 §3 (The two-clause import rule)
+  The first `use tracing::warn;` in `library.rs` fails `pup:check`, forcing the
+  module to be the crate's only silently-failing adapter.
+
+- 🟡 **Architecture + Compatibility + Security**: No error channel anywhere in
+  the new surface
+  **Location**: Phase 2 §1 (The query surface)
+  All six queries return `Option` with no error arm, so a corrupt object store,
+  a locked jj repo or an unparseable repository reads identically to "no
+  repository here" — and the plan drops `CommandProbe`'s 10s cap, crash
+  isolation and warn-logging with nothing in their place.
+
+- 🟡 **Correctness**: Query 6's "roots equal → colocated" verdict contradicts
+  Amendment 3 and the `classify_checkout` table
+  **Location**: Oracle Mapping — Query 6 (`CR`, `NGJ-o` rows)
+  Both `CR` and `NGJ-o` have equal dual roots yet classify as `main`. A
+  classifier built from this column would misclassify every real colocated main
+  repository — the commonest shape in the wild.
+
+- 🟡 **Correctness**: Three mapping tables have missing cells
+  **Location**: Oracle Mapping — Queries 5 and 6, `classify_checkout` records
+  Query 6 covers 17 of 24 pairs, Query 5 omits `NGPJ-i` (which is a jj fixture,
+  so the catch-all does not reach it), and the `classify_checkout` table omits
+  five fixtures — breaking the traceability criterion the whole empirical
+  deferral exists to serve.
+
+- 🟡 **Correctness**: `PJG-i`'s recorded `--git-common-dir` contradicts its
+  structurally identical siblings
+  **Location**: Oracle Mapping — Query 2 (`PJG-i` row)
+  `.git` where `NJG-i` records `../.git`. Under the plan's own absolutisation
+  rule this makes the shell oracle take the `colocated` arm rather than
+  `nested-jj-in-git`, so "no other divergence was observed" cannot stand.
+
+- 🟡 **Correctness + Code Quality + Portability**: Canonicalisation specified for
+  two queries only; `dual_roots` compares two different regimes
+  **Location**: Phase 2 §1 (implementation notes); Oracle Mapping — Query 6
+  `git_dir`, `main_worktree_root`, `superproject`, `jj_workspace_root` and both
+  `DualRoots` arms are silent. The recorded `CG` equality is protected only by
+  the fixture-construction rule, which does not hold in production.
+
+- 🟡 **Test Coverage + Correctness**: Every gix-based absence cell rests on an
+  unstated precondition
+  **Location**: Phase 2 §2 (fixture matrix); Oracle Mapping preamble
+  `gix::discover` reads no environment, so `GIT_CEILING_DIRECTORIES` cannot fence
+  it — the `None` expectations hold only because no ancestor of `$TMPDIR`
+  carried a `.git` on the measuring host.
+
+- 🟡 **Correctness**: `rposition` on `modules` components misresolves a submodule
+  whose own path contains `modules`
+  **Location**: Phase 2 §1 (`superproject`)
+  A submodule at `modules/foo` yields `git_dir() == $super/.git/modules/modules/foo`;
+  `rposition` selects the inner one and `gix::open` on its parent fails, silently
+  returning `None` where git returns `$super`.
+
+- 🟡 **Correctness**: No fixture for a jj secondary workspace nested inside its
+  own main repository
+  **Location**: Fixture keys table
+  This is the shape this repository uses daily (`workspaces/<name>`), and it is
+  precisely where differing dual roots point at the wrong `classify_checkout`
+  arm — `jj-secondary`, not `nested-jj-in-git`.
+
+- 🟡 **Correctness**: `kind() == Kind::LinkedWorkTree` cannot represent a
+  repository that is both a submodule and a linked worktree
+  **Location**: Phase 2 §1 (`worktree.linked`)
+  `Kind` is mutually exclusive; `git worktree add` from within a submodule has
+  unequal `--git-dir`/`--git-common-dir` but `kind()` can report only one fact.
+  No fixture combines them.
+
+- 🟡 **Correctness**: Query 2's `main_worktree_root` column has no matching
+  oracle for the bare and submodule fixtures
+  **Location**: Oracle Mapping — Query 2 (`BARE`, `SM-1`, `SM-2`)
+  `realpath $(dirname <common-dir>)` gives `$BASE/super/.git/modules` for `SM-1`
+  where the library records `$BASE/super/mid`, yet every Verdict cell reads
+  "agree" — one verdict is carried for five independent columns.
+
+- 🟡 **Architecture + Compatibility + Portability + Safety**: The trees enter the
+  shipped visualiser's closure; one of four release triples verified
+  **Location**: Phase 1 §1 (pins); Phase 4 §2 (musl staging)
+  `vcs-adapters` → `corpus-adapters` → `visualiser/server` is a normal-dependency
+  chain, `cli_cross_compile` iterates four triples, and no `check-*` job
+  cross-compiles — so a break lands on `main` and first fails in the release job.
+
+- 🟡 **Architecture + Safety + Security**: Test-fixture binaries added to
+  `_CLI_RELEASE_BINARIES`
+  **Location**: Phase 4 §2 (musl staging)
+  This stages them into `dist/release/`, puts fixture build failures on the
+  release critical path, and places the guard against the story's headline
+  false-pass (dead-code elimination) in the one stage that never runs on a PR.
+
+- 🟡 **Test Coverage**: The cargo-pup rule's non-vacuity is a manual
+  add-then-revert, though a committed harness exists
+  **Location**: Phase 1 §3 Success Criteria
+  `tests/integration/pup/test_import_rule.py` already drives the shipped
+  `pup.ron` against synthetic workspaces with a positive control for exactly the
+  "rule matched nothing" failure — and 0169 is expected to rename the module.
+
+- 🟡 **Test Coverage**: The size-floor criterion is listed as automated with no
+  named mechanism
+  **Location**: Phase 4 §4 Success Criteria
+  No test file, no `tasks/` check, no mise leaf — so the guard against dead-code
+  elimination becomes a number written once into Validation Results.
+
+- 🟡 **Test Coverage**: The scrub-invariant comparison runs its two arms through
+  different execution paths
+  **Location**: Phase 2 §3
+  The poisoned arm runs in a child binary, the clean arm presumably in-process,
+  so a formatting mismatch fails 144 cells and a shared absence rendering passes
+  vacuously. The stated rationale ("because nextest is process-per-test") also
+  reads backwards — that property makes `set_var` safer, not less safe.
+
+- 🟡 **Compatibility**: The lockstep test compares two declarations, not the `jj`
+  binary that builds the fixtures
+  **Location**: Phase 1 §5; Manual Testing step 3
+  The planning session itself hit this: `jj 0.42.0` from Homebrew was on `PATH`
+  because `mise.toml` was untrusted. The mitigation offered is a manual step.
+
+- 🟡 **Compatibility**: The `git` CLI is an unpinned oracle for the whole matrix
+  **Location**: Oracle Mapping preamble; Phase 1 §1
+  Every cell was recorded against git 2.54.0 and every fixture is built by
+  whatever `git` is on `PATH`; `mise.toml` has no `git` entry. The coupling is
+  five-way, not the three-way the pin comment describes.
+
+- 🟡 **Compatibility + Safety**: "Regenerate the lock" re-resolves crates the
+  workspace deliberately fenced
+  **Location**: Migration Notes; Phase 1 §1
+  `reqwest = "=0.12.28"` (pinned so a patch cannot re-scope DNS onto
+  getaddrinfo), `rustls = "=0.23.41"`, and two RUSTSEC ignores tied to
+  `hickory-proto` all sit behind fences a wholesale regeneration floats — and it
+  lands disguised as merge cleanup.
+
+- 🟡 **Compatibility**: No non-default git repository formats in the matrix
+  **Location**: Phase 2 §2; Fixture keys
+  All 24 shapes are files-backend + sha1. Reftable and sha256 repositories —
+  which gix 0.85 supports only partially — would silently return `None` from
+  `revision` after 0185's switch, where `CommandProbe` succeeds today.
+
+- 🟡 **Safety**: The rollback claim omits the workflow, mise and lock footprint,
+  and one revert ordering bricks CI
+  **Location**: Migration Notes
+  Reverting the job while leaving the `needs: check-zero-spawn` edge is a
+  workflow validation error that stops the *whole* Main workflow — not the
+  single-module `jj restore` the notes describe.
+
+- 🟡 **Safety**: `unmaintained = "all"` over a 56-package expansion can block all
+  releases, with no break-glass documented
+  **Location**: Performance Considerations; Phase 1
+  One upstream advisory anywhere in a closure no code calls turns
+  `check-supply-chain` red for every unrelated PR, and that job is in
+  `prerelease.needs`.
+
+- 🟡 **Safety + Portability**: Shadowing inside the cached mise install tree can
+  poison the job's own cache
+  **Location**: Phase 4 §3
+  `$HOME/.local/share/mise/installs/jj/<version>/jj` is inside the tree
+  `mise-action` saves on its post step, which runs after the restore — so an
+  incomplete restore persists a broken toolchain to `mise-zero-spawn-v1`.
+
+- 🟡 **Safety**: `if: always()` is necessary but not sufficient for the stated
+  restore guarantee
+  **Location**: Phase 4 Manual Verification
+  A partial shadow leaves a straight-line `set -e` restore aborting on the first
+  missing source; cancellation gives only a bounded grace window. The claim holds
+  only because runners are ephemeral — an assumption never stated.
+
+- 🟡 **Security**: The scrub invariant is far narrower than the "uniformly
+  immune" claim
+  **Location**: Key Discoveries #6; Phase 2 §3
+  Verified over `GIT_DIR`/`GIT_COMMON_DIR` only; `CommandProbe` scrubs seven and
+  forces three. `gix::open`'s default permissions do consult
+  `GIT_OBJECT_DIRECTORY`/`GIT_ALTERNATE_OBJECT_DIRECTORIES` and system/global
+  config, and `is_bare()` reads `core.bare` from config.
+
+- 🟡 **Security**: The pup rule is not a structural zero-spawn guarantee
+  **Location**: Phase 1 §3; Key Discoveries #7
+  `RestrictImports` sees first-party `use` paths only — an inline
+  `std::process::Command::new` is unaffected, `^crate(::|$)` reaches the
+  retained `CommandProbe`, and nothing constrains gix's `attributes`/`blob-diff`
+  filter and external-command machinery, which is repository-config-driven.
+
+- 🟡 **Security + Compatibility**: Exact `=` pins block patch remediation, and
+  the manifest contradicts the graph test
+  **Location**: Phase 1 §1 and §5
+  `=0.85.0` forbids every `0.85.x` patch while the committed test asserts
+  `0.85.\d+`. Under `yanked = "deny"` the cheapest response to an advisory
+  becomes an `ignore` entry.
+
+- 🟡 **Security**: The no-TLS assertion is host-target-scoped
+  **Location**: Phase 1 §5
+  `cargo tree` with no `--target` evaluates only the host triple, whereas
+  `cli/deny.toml:11-17` enumerates five deliberately. `[bans].deny` — the
+  target-aware, fail-closed mechanism — is not extended at all.
+
+- 🟡 **Security + Compatibility**: The uluru MPL-2.0 justification answers §3.1,
+  not §3.2
+  **Location**: Phase 1 §2
+  "We ship no modifications" addresses modified Source Form. The obligation that
+  bites is the Executable Form notice, and the release payload carries no
+  third-party licence artefact.
+
+#### Minor
+
+- 🔵 **Architecture**: The three query value types are declared in the adapter
+  crate, but ADR-0053 and the `vcs_domain_imports_only_permitted` pup rule mean
+  0169's domain port structurally cannot reference them — a guaranteed later
+  move that Phase 5's hand-off does not record.
+  **Location**: Phase 2 §1; Phase 5 §3
+
+- 🔵 **Architecture + Code Quality**: A dev-dependency cycle
+  (`vcs-adapters` tests → `vcs-test-support` → `vcs-adapters`) is created but
+  never stated, and it weakens the stated rationale for the separate crate.
+  **Location**: Phase 3 §1
+
+- 🔵 **Architecture + Code Quality**: Three marker-walk / marker-kind
+  implementations duplicate `MarkerWalkRoot::discover` and `CommandProbe::kind`
+  ten lines away in the same crate, including the "never test the filesystem
+  root" rule documented only on `MarkerWalkRoot`.
+  **Location**: Phase 1 §4
+
+- 🔵 **Code Quality**: The `UserSettings` text guard will flag its own rationale
+  comment (the model it copies matches raw lines), and the plan never says why
+  the one-line pup `denied` clause was rejected in favour of a new Python lint,
+  two `__init__.py` registrations, a mise leaf and two `test_mise.py` constants.
+  **Location**: Phase 2 §4
+
+- 🔵 **Code Quality**: The `allowed_only` clause reintroduces a pup pattern
+  `cli/pup.ron:93-98` already carries a comment warning against, imposing an
+  invisible single-item-import rule enforced by a message naming neither the
+  import nor the real cause.
+  **Location**: Phase 1 §3
+
+- 🔵 **Code Quality + Test Coverage**: The most intricate fixture builders are
+  written in Phase 2 in a location Phase 3 immediately moves them out of, and
+  Phase 2's own hermeticity criterion depends on a `hermetic` module that does
+  not exist until Phase 3.
+  **Location**: Phase 2 §2; Phase 3 §1
+
+- 🔵 **Code Quality**: The Phase 2 interim helper binary's relationship to the
+  two Phase 4 `[[bin]]` targets is never stated — potentially three
+  near-identical composition roots in one crate.
+  **Location**: Phase 2 §3; Phase 4 §1
+
+- 🔵 **Test Coverage**: One table-driven test per query rebuilds the ~19-fixture
+  matrix six times per leg, on a repo with a known fixture-flake history;
+  inverting to one test per (fixture, start) pair keeps traceability at a sixth
+  the cost.
+  **Location**: Phase 2 §2
+
+- 🔵 **Test Coverage + Security**: No malformed or adversarial fixture anywhere —
+  a `.jj/repo` pointer to a deleted path, a `.git` file whose gitdir target is
+  gone, a truncated pack, or a hostile `.git/config` setting `core.pager` /
+  `filter.*.clean` / `include.path`.
+  **Location**: Testing Strategy; Phase 2 §2
+
+- 🔵 **Test Coverage**: Neither Phase 1 verification list checks that the `gix`
+  pin comment and the `uluru` exception comment are present, though the work
+  item requires both.
+  **Location**: Phase 1 §5
+
+- 🔵 **Test Coverage**: The `.git`-as-file worktree case is required to produce
+  identical `RepoFacts` from both implementations *and* to possibly diverge to
+  `colocated`; the plan never resolves which assertion governs.
+  **Location**: Phase 3 §2
+
+- 🔵 **Correctness**: The `NJG` fixture key says "colocated inner main" but
+  Query 5 records `.jj/repo` as a *file* (secondary) and Query 2 shows no inner
+  `.git` — a builder written to the key would produce wrong values for every
+  `NJG-*` cell.
+  **Location**: Fixture keys table
+
+- 🔵 **Correctness**: Pair count is 24 in one place and 25 in another, and
+  `--show-superproject-working-tree` is given one absence signal in the table
+  while Query 3 records two.
+  **Location**: Key Discoveries #6; absence-signal table
+
+- 🔵 **Compatibility**: The new member's manifest omits `edition`/`rust-version`
+  inheritance; a missing `rust-version` drops it out of the MSRV-aware fallback
+  Key Discovery 11 identifies as load-bearing.
+  **Location**: Phase 3 §1
+
+- 🔵 **Portability**: The GitHub-hosted-runner and mise install-layout
+  assumptions (passwordless sudo, `/usr/bin/git`, a versioned installs path) are
+  encoded rather than derived or documented as coupling.
+  **Location**: Phase 4 §3
+
+- 🔵 **Portability**: The `hermetic` module is under-specified relative to the
+  environment the mapping was measured in — `GIT_CONFIG_NOSYSTEM` is a boolean,
+  not a path, and is the only thing suppressing the system gitconfig, which
+  differs between ubuntu and macOS.
+  **Location**: Phase 3 §1; Phase 2 Success Criteria
+
+- 🔵 **Portability**: All six cost figures are darwin-arm64 while the shipped
+  artefact is static musl, so 0169 inherits a gate with no Linux datapoint.
+  **Location**: Phase 4 §4
+
+- 🔵 **Safety**: `accelerator-visualiser`'s musl-static size is never recorded
+  before/after, so a future LTO or profile change adding ~2 MB to a fetched,
+  hashed artefact has no baseline to fail against.
+  **Location**: Phase 1 §1
+
+- 🔵 **Safety**: `test-visual-regression` carries `timeout-minutes: 20` and
+  depends on `build:server:dev`, which now compiles both new trees — and this
+  plan guarantees a cold cache by changing the lock.
+  **Location**: Phase 1 Success Criteria
+
+- 🔵 **Safety**: Phase 5 rewrites 0185's Summary, Context, Assumptions, Technical
+  Notes and acceptance criteria in place, and removes an assumption — where 0188
+  itself used append-only dated amendment blocks.
+  **Location**: Phase 5 §2
+
+- 🔵 **Security**: No build-script or proc-macro policy for the 56-package
+  expansion, though the release workflow already documents build-script trust as
+  a live concern.
+  **Location**: Phase 1 §1 and §5
+
+#### Suggestions
+
+- 🔵 **Architecture + Code Quality**: Split `library.rs` into `library/git.rs`
+  and `library/jj.rs` — the pup matcher already covers submodules — so the
+  pre-1.0 jj-lib bet the story exists to isolate is isolated inside the module
+  too.
+
+- 🔵 **Architecture**: Extract the superproject path derivation as a pure
+  function unit-testable against string paths, so the story's only hand-rolled
+  edge-case logic is not gated behind its most expensive fixtures.
+
+- 🔵 **Architecture**: Consider `in_process` over `library` for the module name
+  before it is baked into `pup.ron` and 0169's hand-off, and document the
+  division of labour between cargo-pup (import prohibitions) and the source
+  guard (usage prohibitions imports cannot express).
+
+- 🔵 **Code Quality**: Rename `JjRepository` → `JjRepositoryFacts` and replace
+  `secondary: bool` with a two-variant `JjWorkspaceRole`, since 0169 builds its
+  domain vocabulary directly on these names.
+
+- 🔵 **Compatibility + Portability + Security**: Stage and measure the fixture
+  binaries outside `dist/release/` via a separate constant, and assert
+  `_release_uploads()` never contains a fixture name.
+
+- 🔵 **Compatibility**: Extend the graph test to assert no package in
+  `cli/Cargo.lock` declares a `rust-version` above 1.90.0 — catching the
+  `kstring` class of trap directly rather than relying on a resolver preference.
+
+### Strengths
+
+- ✅ The oracle mapping is established by measurement against real oracles, per
+  (fixture, start directory) pair, with per-oracle absence signals tabulated
+  rather than assumed uniform — and the tests are written before the queries.
+- ✅ The three-walk discovery is a genuine insight caught by measurement; an
+  earlier framing would have made 0169's nested arms unimplementable.
+- ✅ Every guard carries a designed-in non-vacuity control:
+  `discover_with_environment_overrides` for the poison, an unbounded
+  `gix::discover` for the boundary, and the "no marker written **and** values
+  match" rule that closes the degrade-to-`None` false pass.
+- ✅ The adapter ships genuinely unwired — `vcs_adapters::facts` keeps naming the
+  retained pair — so no consumer can regress at runtime regardless of what the
+  new module does.
+- ✅ Phase ordering is deliberate and correct: the entire dependency-policy
+  surface lands in Phase 1 so an objection is reviewable before any query logic
+  exists.
+- ✅ Non-obvious library behaviours (`ceiling_dirs` structurally unable to bound
+  the walk, unnormalised `common_dir()`, `main_repo()` returning the submodule,
+  `repo_path()` pre-canonicalised while `workspace_root()` is not) are recorded
+  where an implementer will hit them.
+- ✅ The `CR`/`CG` split correctly identifies that the shell's `colocated` arm
+  needs `jj_secondary && git_worktree`, which a single fixture row would have
+  papered over.
+- ✅ Dependency selection is portability-aware: default features chosen so no TLS
+  stack enters the graph, no `git2`/`libgit2-sys`, no duplicate gix versions, and
+  MSRV-aware resolution identified as load-bearing.
+- ✅ The size criterion was recalibrated against measurement rather than left to
+  fail at verification time, and Phase 4 is explicitly required to re-measure
+  against the delivered two-binary shape.
+- ✅ Shared-artefact contention (`Cargo.lock`, `deny.toml`, `pup.ron`,
+  `tasks/build.py` vs 0187) is identified with a stated resolution rule rather
+  than an implicit ordering assumption.
+- ✅ Fixture temp dirs use owned `TempDir` guards with immediate canonicalisation
+  and explicitly reject `NamedTempFile`/`.persist`, matching the convention
+  adopted after the nextest pid-reuse collisions.
+- ✅ The plan declines to reproduce the shell's `GIT_DIR` scrub asymmetry,
+  closing an ambient-environment redirection vector rather than porting it.
+
+### Recommended Changes
+
+1. **Redraw the strong-form CI job's shadow window** (addresses: the critical
+   shadow-window finding, the mise-cache and `if: always()` findings)
+   Build the fixtures and compile the test binaries in steps *before* the shadow
+   step; have the post-shadow step execute prebuilt binaries against prebuilt
+   fixtures only. Move shadowed binaries to `$RUNNER_TEMP`, not within the cached
+   mise tree. Make shadow and restore idempotent per path, add a post-restore
+   `git --version && jj --version` assertion, and add `timeout-minutes`.
+
+2. **Resolve `VcsProbe::revision` before Phase 1 starts** (addresses: the
+   critical revision finding)
+   Either name a settings-free jj-lib path and prove it in a short spike, or
+   narrow the `UserSettings` ban to the detection module, or declare jj
+   `revision` out of scope for 0188 and narrow Phase 3's parity criterion to
+   `root`/`name`/`kind`. Add oracle rows for `kind` and `revision` and test the
+   port methods within Phase 1.
+
+3. **State that `vcs-test-support` never writes outside its own temp dirs**
+   (addresses: the critical `stubs` finding)
+   All privileged mutation lives in the CI workflow step, guarded on
+   `GITHUB_ACTIONS`; the crate only *reports* absolute paths it cannot control.
+   Give the two halves an explicit contract (`ACCELERATOR_ZERO_SPAWN_MODE=strong`
+   plus the shadowed list) so the harness hard-fails when strong mode is claimed
+   but a target is still executable.
+
+4. **Add `tracing` to the pup permit list and drop `kernel::Error`** (addresses:
+   the pup-list finding, and partly the no-error-channel finding)
+   State per query which arms warn-log and which are legitimate absence,
+   mirroring `CommandProbe`'s labelled `warn!` sites. Consider expressing the
+   whole rule as `denied`-only to avoid the grouped-import tax the repo already
+   rejected once.
+
+5. **Decide the error channel explicitly** (addresses: the no-error-channel
+   finding, the adversarial-fixture finding, the containment finding)
+   Either `Result<Option<T>, _>` or a recorded decision that failures map to
+   absence *and* are warn-logged. Record which library error conditions are
+   deliberately mapped to `None`, and note the loss of `CommandProbe`'s time cap
+   and crash isolation as a hand-off constraint to 0185.
+
+6. **Fix and complete the oracle mapping** (addresses: the Query 6 verdict, the
+   missing cells, the `PJG-i` cell, the `NJG` key, the count discrepancy)
+   Re-run `--git-common-dir` from `$BASE/PJG/sub`; replace Query 6's verdict
+   column with raw equality plus a note that equality is necessary but not
+   sufficient; complete Query 5 (`NGPJ-i`), Query 6 (seven fixtures) and the
+   `classify_checkout` table; correct the `NJG`/`PJG` keys; reconcile 24 vs 25.
+
+7. **State one canonicalisation contract at the module boundary** (addresses: the
+   canonicalisation finding)
+   Every `PathBuf` the six queries and both port methods return is canonicalised,
+   implemented at a single choke point and documented on the module — then
+   re-check whether `CG`'s dual-root equality survives with the fixture built at
+   an uncanonicalised path.
+
+8. **Add the missing fixtures** (addresses: the `workspaces/*` shape,
+   submodule-with-`modules`-path, submodule+worktree, adversarial, non-default
+   format)
+   Prioritise the jj-secondary-inside-its-own-main shape — it is what this repo
+   runs in daily and it is where differing dual roots point at the wrong arm.
+
+9. **Assert the fixture-matrix preconditions** (addresses: the absence-cell
+   finding, the git-pin finding, the jj-lockstep finding)
+   Walk from the temp base to `/` and fail if any ancestor carries `.git`/`.jj`;
+   assert `jj --version` matches the compiled-in `jj-lib` version; record the
+   observed `git --version` and pin the format-relevant knobs via `git -c`.
+
+10. **Take the fixture binaries off the release path** (addresses: the
+    `_CLI_RELEASE_BINARIES` finding, the DCE-guard finding)
+    Give them their own constant and staging directory, and assert the size ratio
+    and absolute floor inside a task that a `check-*` job runs — so the guard
+    against the headline false-pass runs on the PR that could break it.
+
+11. **Verify all four release triples in Phase 4** (addresses: the cross-target
+    finding) and record the `accelerator-visualiser` musl-static size before and
+    after Phase 1.
+
+12. **Tighten the supply-chain surface** (addresses: the host-target TLS
+    assertion, the exact-pin remediation path, the MPL §3.2 finding, the
+    build-script finding)
+    Move the transport prohibition into `[bans].deny` so all five configured
+    triples are evaluated; reconcile the manifest pin with the `0.85.\d+`
+    assertion and document the yank/advisory break-glass in
+    `tasks/README.md`; rewrite the uluru comment to address the Executable Form
+    notice; snapshot the build-script-carrying crates in the graph test.
+
+13. **Specify the minimal lock operation on contention** (addresses: the
+    lock-regeneration finding) — `cargo update -p gix -p jj-lib`, never
+    `generate-lockfile`, with a review step requiring the lock diff to contain
+    only the new closure.
+
+14. **Document the revert order in Migration Notes** (addresses: the rollback
+    finding) — workflow `needs` edge before the job; `_CLI_RELEASE_BINARIES`
+    before the `[[bin]]` targets; mise leaves together with their `test_mise.py`
+    assertions; the lock regenerated rather than reverted.
+
+15. **Commit the pup rule's non-vacuity** (addresses: the manual-non-vacuity
+    finding) — add probe cases to `tests/integration/pup/test_import_rule.py`
+    including a positive control and the grouped-import case.
+
+16. **Create `cli/vcs-test-support` at the start of Phase 2** (addresses: the
+    write-then-move finding, Phase 2's unverifiable hermeticity criterion) with
+    `fixtures` and `hermetic`; leave `stubs` and the cross-crate proof to Phase 3.
+
+17. **Invert the query test table** (addresses: the fixture-runtime finding) —
+    one test per (fixture, start directory) pair asserting all six values, so
+    each fixture is built once and failures localise to a shape.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: An unusually well-grounded plan: the ports in `cli/vcs` are left
+untouched, the new adapter is unwired by design, every phase is independently
+mergeable and revertible, and the risky decisions are deliberately isolated. The
+structural weaknesses are concentrated in three places: the query surface's
+vocabulary and error channel are frozen in the adapter layer where ADR-0053 says
+domain vocabulary does not belong; the heavy dependency trees land as *normal*
+dependencies of a crate transitively in the shipped visualiser's build graph;
+and the guard against the story's stated headline false-pass is wired into the
+release pipeline, the one stage that never runs on a change.
+
+**Strengths**: `cli/vcs` genuinely untouched with dependency direction staying
+inward; zero-spawn enforced structurally rather than only by assertion; the
+three-walk discovery correctly scoped so containment constrains only
+`RepoRoot::discover`; unwired shipping gives a deletion-only rollback; shared
+artefact contention identified with a stated resolution rule; the test-support
+crate verified across a real crate boundary; quality-attribute tradeoffs
+explicitly priced.
+
+**Findings**:
+- **major/high** — Query value types declared in the adapter crate while
+  ADR-0053 and `vcs_domain_imports_only_permitted` mean 0169's port cannot
+  reference them (Phase 2 §1)
+- **major/high** — pup `allowed_only` omits `tracing`, permits inert
+  `kernel::Error` (Phase 1 §3)
+- **major/medium** — gix/jj-lib as normal deps enter `corpus-adapters` →
+  `visualiser/server`; compile-time impact unmeasured (Phase 1 §1)
+- **major/medium** — fixture binaries in `_CLI_RELEASE_BINARIES` put the DCE
+  guard in a stage that never runs on a PR (Phase 4 §2)
+- **major/medium** — no error channel; absence signals contractually distinct
+  per oracle all collapse to `None` (Phase 2 §1)
+- **major/medium** — the strong-form job compiles inside the shadow window with
+  `vergen-gitcl` present (Phase 4 §3)
+- **minor/medium** — undeclared dev-dependency cycle via `vcs-test-support`
+  (Phase 3 §1)
+- **minor/medium** — `boundary` reimplements vs delegates to `MarkerWalkRoot`
+  is left ambiguous, and the choice determines 0185's deletion cost (Phase 1 §4)
+- **suggestion/medium** — split `library.rs` into `git`/`jj` submodules
+- **suggestion/medium** — extract the superproject derivation as a pure function
+- **suggestion/low** — `in_process` over `library`; document the pup-vs-source-
+  guard division
+
+### Code Quality
+
+**Summary**: Unusually well-evidenced — an empirical oracle mapping,
+non-vacuity demonstrations for every guard, and a clean extension shape leaving
+the `vcs` domain crate and both retained adapters untouched. The weak points are
+concentrated in one place: the internals of `InProcessProbe` are sketched rather
+than designed.
+
+**Strengths**: Clean extension shape with provable non-modification and a pure
+deletion rollback; queries return plain domain value types so no library type
+leaks into 0169's port; the `detection.rs` injection seam retains fixed expected
+values rather than degrading to implementation-agreement; every guard is paired
+with a non-vacuity demonstration; non-obvious library behaviours recorded at the
+point an implementer hits them; the dual comparison explicitly labelled
+transitional with a named owner.
+
+**Findings**:
+- **major/high** — pup permit list forbids `tracing`, so the module cannot
+  honour the crate's documented warn-log-on-failure contract (Phase 1 §3/§4)
+- **major/medium** — `VcsProbe::revision` entirely undesigned yet Phase 3
+  asserts `RepoFacts` parity on it (Phase 1 §4; Phase 3 §2)
+- **major/medium** — three marker-walk/marker-kind implementations duplicated
+  from code already in the crate (Phase 1 §4; Phase 2 §1)
+- **major/medium** — canonicalisation specified per-query, leaving the module's
+  output contract inconsistent (Phase 2 §1)
+- **minor/high** — the `UserSettings` text guard will flag its own rationale
+  comment; the pup alternative is rejected without stated reason (Phase 2 §4)
+- **minor/medium** — the `allowed_only` clause re-adopts a pup pattern
+  `cli/pup.ron:93-98` warns against (Phase 1 §3)
+- **minor/medium** — substantial fixture builders written in Phase 2 in a
+  location Phase 3 moves them from (Phase 2 §2; Phase 3 §1)
+- **minor/medium** — interim helper binary of unclear identity, justified by a
+  rationale that reads backwards (Phase 2 §3; Phase 4 §1)
+- **suggestion/medium** — `JjRepositoryFacts` + `JjWorkspaceRole` over
+  `JjRepository` + `secondary: bool`
+- **suggestion/medium** — `library/mod.rs` + `git.rs` + `jj.rs`
+
+### Test Coverage
+
+**Summary**: Unusually strong on test design: a 24-pair × 6-query oracle mapping
+established by measurement, explicit non-vacuity controls for every guard, and a
+transitional dual-implementation comparison that retains fixed expected values.
+The weaknesses are architectural rather than conceptual — the strong-form job
+removes the binaries the fixture matrix needs to be built by; the two `VcsProbe`
+port methods land in Phase 1 with no oracle rows and no test until Phase 3; and
+two guards the work item calls load-bearing are one-off manual demonstrations.
+
+**Strengths**: Per-pair expected values from actual measurement including
+per-oracle absence signals; non-vacuity controls designed in throughout,
+including the "no marker **and** values match" rule that defeats the
+degrade-to-`None` false pass; the injection seam keeps fixed expectations and
+notes that cross-implementation agreement is not an oracle; the cross-crate
+proof correctly scopes the spawn assertion to `git`/`jj` so `SystemClock`'s
+`date` spawn does not trip it; test-runner realities accounted for; the new
+`tasks/` guard ships with unit tests and matching `test_mise.py` updates.
+
+**Findings**:
+- **critical/high** — the strong-form job shadows the binaries every fixture is
+  built with; the suite cannot construct its own matrix (Phase 4 §3; Phase 3 §3)
+- **major/high** — Phase 1 ships `kind`/`revision`/`repository_root` with no
+  oracle rows and no test until Phase 3 (Phase 1 §4)
+- **major/high** — the pup rule's non-vacuity is manual though
+  `tests/integration/pup/test_import_rule.py` exists for exactly this
+  (Phase 1 §3)
+- **major/medium** — absence cells depend on an unasserted no-`.git`-ancestor
+  precondition; `gix::discover` cannot be fenced by the environment (Phase 2 §2)
+- **major/medium** — the scrub-invariant arms run through different execution
+  paths, risking both false failures and a shared-absence false pass (Phase 2 §3)
+- **major/medium** — the size-floor criterion is listed as automated with no
+  named mechanism (Phase 4 §4)
+- **minor/medium** — one test per query rebuilds the whole matrix six times
+  (Phase 2 §2)
+- **minor/medium** — infrastructure written twice; Phase 2's hermeticity
+  criterion depends on a Phase 3 module (Phase 2/3)
+- **minor/medium** — no malformed-repository fixtures despite `Option`-only
+  returns (Testing Strategy)
+- **minor/high** — no verification that the `gix` pin and `uluru` exception
+  comments are present (Phase 1 §5)
+- **minor/medium** — the `.git`-file worktree case is required to both match and
+  possibly diverge (Phase 3 §2)
+
+### Correctness
+
+**Summary**: Unusually rigorous for a planning document — the oracle mapping is
+empirically derived, absence signals are tabulated per oracle, and several
+genuine traps were caught by measurement. However the mapping does not hold
+together under scrutiny: one query table contains a cell contradicting both its
+sibling rows and the plan's own absolutisation rule, Query 6's verdict column
+asserts an inference the plan's own amendment refutes, three tables have missing
+cells despite a traceability criterion, and canonicalisation is specified for two
+of six queries. Most seriously, `VcsProbe::revision` is sketched as
+`/* gix / jj-lib */` and its jj half appears unreachable under the crate-wide
+`UserSettings` ban.
+
+**Strengths**: The three-walk discovery established by measurement with the
+divergent rows bolded; absence signals tabulated per oracle rather than assumed
+uniform; the unnormalised `common_dir()` and `repo_path()`-vs-`workspace_root()`
+asymmetries recorded; non-vacuity controls well chosen and paired to the property
+they guard; the `CR`/`CG` split correctly identified; the `rposition` derivation
+validated at the only depth that distinguishes nearest from first.
+
+**Findings**:
+- **critical/high** — jj `revision` has no mechanism and conflicts with the
+  `UserSettings` ban vs Phase 3's identical-`RepoFacts` criterion
+- **major/high** — `PJG-i`'s `--git-common-dir` contradicts `NJG-i`/`PG-s` and
+  the plan's own absolutisation rule (Query 2)
+- **major/high** — Query 6's "roots equal → colocated" contradicts Amendment 3
+  and the `classify_checkout` table (`CR`, `NGJ-o`)
+- **major/high** — canonicalisation specified for two queries only;
+  `dual_roots` compares two regimes (Phase 2 §1; Query 6)
+- **major/medium** — `rposition` misresolves a submodule whose path contains
+  `modules` (Phase 2 §1)
+- **major/high** — Query 5 omits `NGPJ-i`, Query 6 omits seven fixtures, the
+  `classify_checkout` table omits five
+- **major/high** — no fixture for a jj secondary inside its own main repository,
+  the repo's own `workspaces/*` shape
+- **major/medium** — `Kind` cannot represent submodule + linked worktree
+  simultaneously (Phase 2 §1)
+- **major/medium** — Query 2's `main_worktree_root` has no matching oracle for
+  `BARE`/`SM-1`/`SM-2` yet all rows read "agree"
+- **major/medium** — every gix-based absent cell rests on an unstated
+  no-`.git`-ancestor precondition
+- **major/medium** — pup `allowed_only` omits `tracing` while the port contract
+  requires logging (Phase 1 §3)
+- **minor/high** — the `NJG` fixture key says "colocated inner main" but the
+  data says jj secondary (Fixture keys)
+- **minor/high** — 24 vs 25 pair count; `--show-superproject-working-tree` has
+  two absence signals but one table row
+
+### Compatibility
+
+**Summary**: Unusually rigorous on the dependency-graph side: both pins carry
+inline rationale following the workspace's matched-pair precedent, the
+single-gix-graph invariant is enforced with an explicit vacuity guard, and the
+gix-0.86 caret trap and kstring/MSRV trap were established empirically. The weak
+edges are the *runtime* compatibility surfaces: nothing asserts the `jj` binary
+building the fixtures matches the pin, the `git` CLI is not pinned anywhere, and
+the six query signatures collapse "no repository" and "repository the pinned
+library cannot parse" into the same `None`.
+
+**Strengths**: Pins carry rationale in the exact existing style; the gix-0.86
+caret reasoning is correct and load-bearing; the single-version invariant is a
+committed test with the vacuity trap explicitly guarded; MSRV-aware resolution
+established empirically; the jj CLI ↔ jj-lib skew designed out rather than
+measured around; the adapter ships unwired so no consumer contract changes;
+environment independence verified across all pairs with a live non-vacuity
+control; the shadow list correctly handles the CI-vs-developer-macOS divergence;
+macOS `/var` canonicalisation and the jj-lib canonicalisation asymmetry recorded.
+
+**Findings**:
+- **major/high** — the lockstep test compares two declarations, not the `jj`
+  binary that builds the fixtures (Phase 1 §5; Manual Testing step 3)
+- **major/high** — the `git` CLI is an unpinned oracle for the entire matrix and
+  is absent from the stated coupling (Oracle Mapping preamble; Phase 1 §1)
+- **major/high** — all six signatures conflate absent with unparseable
+  (Phase 2 §1; Phase 3 §3)
+- **major/high** — gix and jj-lib become non-optional transitive dependencies of
+  the shipped visualiser; only one of four triples verified (Migration Notes;
+  Phase 4 §2)
+- **major/medium** — "regenerate the lock" re-resolves deliberately fenced
+  crates (`reqwest`, `rustls`, the hickory RUSTSEC ignores) (Migration Notes)
+- **major/medium** — no non-default git format fixtures (reftable, sha256) where
+  gix 0.85 support is partial (Phase 2 §2)
+- **minor/medium** — the exact `=0.85.0` pin blocks patch remediation under
+  `yanked = "deny"` and contradicts the test's `0.85.\d+` assertion (Phase 1 §1/§5)
+- **minor/medium** — the new member's manifest omits `edition`/`rust-version`
+  inheritance (Phase 3 §1)
+- **minor/high** — the pup permit list disagrees with the declared dependency set
+  in both directions (Phase 1 §1/§3)
+- **suggestion/medium** — fixture binaries added to the release-binary contract
+  constant (Phase 4 §2)
+- **suggestion/medium** — the MPL-2.0 discharge rationale is untested against a
+  publicly distributed binary (Phase 1 §2)
+
+### Portability
+
+**Summary**: Unusually strong on environment portability: it correctly
+identifies that the work item's absolute shadow list was half-vacuous on
+GitHub-hosted Linux, that macOS must degrade to PATH-only under SIP, and that
+macOS `$TMPDIR` canonicalisation has to be designed into every fixture. The two
+weak points are both about *proof of environment*: the strong-form job splits
+the shadowing mechanism between workflow YAML and a Rust module with no defined
+contract and no automated assertion that the run was actually strong; and the
+two new fixture binaries are wired into a four-target cross-compile that only one
+target has been verified against.
+
+**Strengths**: The OS-matrix placement decision is conscious and correct; the
+closed shadow list is rewritten as runtime resolution after discovering it was a
+no-op on Linux; macOS `/var` → `/private/var` designed into fixture construction
+with the jj-lib asymmetry called out; the size criterion measured on the artefact
+the pipeline actually ships and recalibrated after measurement; dependency
+selection portability-aware (no TLS, no `git2`, no duplicate gix, MSRV-aware);
+`if: always()` restore and a documented rollback.
+
+**Findings**:
+- **major/high** — strong-form shadowing split between YAML and the harness with
+  no contract; nothing automated proves the run was strong (Phase 3 §1; Phase 4 §3)
+- **major/medium** — cargo compilation and mise tool resolution happen inside
+  the shadow window; `mise run` may reinstall `jj` (Phase 4 §3)
+- **major/high** — only one of four release targets verified, and no CI job
+  cross-compiles (Phase 4 §2)
+- **minor/high** — GitHub-hosted-runner and mise install-layout assumptions
+  encoded rather than derived or documented (Phase 4 §3)
+- **minor/medium** — shadowing inside mise's cached install tree risks poisoning
+  the job's own cache (Phase 4 §3)
+- **minor/medium** — cost figures are darwin-only while the shipped artefact is
+  static musl (Phase 4 §4)
+- **minor/medium** — only `common_dir()` canonicalised, but every returned path
+  crosses the macOS `/var` symlink boundary (Phase 2 §1)
+- **minor/medium** — the `hermetic` module under-specified vs the measured
+  environment; `GIT_CONFIG_NOSYSTEM` is a boolean, not a path (Phase 3 §1)
+- **suggestion/medium** — assert magic bytes and static ELF in place rather than
+  staging fixtures into `dist/release/` (Phase 4 §2)
+
+### Safety
+
+**Summary**: The core product-safety posture is strong: the adapter ships
+unwired, `vcs_adapters::facts` stays hard-wired, and no running consumer can be
+affected. The safety risk has instead been displaced entirely into the build and
+release infrastructure: a test-support crate carrying an absolute-system-binary
+shadow list that runs on developer machines, a CI job that `sudo mv`s binaries
+out of a *cached* directory while a cargo compile runs inside the shadowed
+window, ~60 new crates gaining veto power over every PR and release, and a
+release-pipeline edit that cannot be exercised before merge.
+
+**Strengths**: Unwired by construction so consumers cannot regress; the restore
+step's `if: always()` and the shadow-took-effect assertion show the hazard was
+noticed; the job takes its own cache prefix and `RUSTUP_HOME` routing so damage
+is contained; fixture temp dirs use owned `TempDir` guards with RAII cleanup on
+the panic path; the existing release machinery uses explicit expected sets rather
+than directory scans, so a fixture cannot be silently signed or published; phases
+individually mergeable with the policy objection surfaced first; the size
+criterion recalibrated and Phase 4 required to re-measure.
+
+**Findings**:
+- **critical/high** — the `stubs` module is described as attempting to shadow
+  absolute system binaries including user-writable `/opt/homebrew/bin`, on a
+  path reachable from the bare `mise run` (Phase 3 §1)
+- **major/high** — shadowing inside the cached mise tree, with cache-save after
+  restore, makes an incomplete restore self-perpetuating (Phase 4 §3)
+- **major/high** — a cargo compile runs inside the shadowed window; passes warm,
+  fails cold, and this plan guarantees a cold cache (Phase 4 §3)
+- **major/medium** — `if: always()` is necessary but not sufficient; the claim
+  rests on an unstated ephemeral-runner assumption (Phase 4)
+- **major/medium** — `unmaintained = "all"` over the new closure can block all
+  releases with no documented break-glass (Performance Considerations)
+- **major/high** — fixture binaries on the release critical path, verified on one
+  triple, detected only post-merge (Phase 4 §2)
+- **major/medium** — "regenerate the lock" is an unaudited whole-graph
+  dependency change landing as merge cleanup (Migration Notes)
+- **major/high** — the rollback claim omits workflow/mise/lock footprint, and one
+  ordering bricks the whole Main workflow (Migration Notes)
+- **minor/medium** — no baseline recorded for the shipped visualiser's size
+  (Phase 1 §1)
+- **minor/medium** — `test-visual-regression`'s 20-minute budget vs a guaranteed
+  cold-cache compile of both new trees (Phase 1)
+- **minor/medium** — Phase 5 rewrites sibling criteria in place rather than
+  appending dated amendment blocks as 0188 did for itself (Phase 5)
+- **suggestion/low** — state that no fixture builder writes outside its own
+  `TempDir`; keep `protocol.file.allow=always` strictly per-invocation
+
+### Security
+
+**Summary**: Unusually rigorous about *observable* dependency-policy hygiene —
+per-crate licence exception, single-graph gix assertion, no-TLS assertion,
+non-vacuity demonstrations — and it ships the adapter unwired with a clean
+rollback. The gap is on the other side of the trust boundary: it replaces an
+isolated, time-capped, environment-scrubbed subprocess with in-process parsing of
+repository-controlled data, and neither the fixture matrix nor the success
+criteria contain a single adversarial repository. Two headline safety claims are
+materially narrower than stated, and the exact pins interact badly with
+`unmaintained = "all"` by making `advisories.ignore` the cheapest response.
+
+**Strengths**: The poisoning test points at another fixture's *real* `.git` and
+requires a live non-vacuity control — an unusual and correct instinct; every new
+guard must be demonstrated non-vacuous before it is trusted, including the "no
+marker **and** values match" rule; the licence exception is scoped per-crate with
+inline justification, respecting `deny.toml`'s stated convention; Phase 1 lands
+the entire policy surface first so an objection is reviewable in isolation; the
+unwired adapter bounds the blast radius; the plan declines to reproduce the
+shell's `GIT_DIR` scrub asymmetry; default features keep TLS out of the graph.
+
+**Findings**:
+- **major/high** — in-process parsing of repository-controlled data drops the
+  subprocess time cap, crash isolation and warn-logging with no replacement, and
+  the eventual callers include a long-lived HTTP server (Phase 1 §4; Phase 2 §1)
+- **major/medium** — the environment-immunity invariant is much narrower than
+  the "uniformly immune" claim, and immunity is observed rather than constructed
+  (Key Discoveries #6; Phase 2 §3)
+- **major/medium** — the pup rule is not a structural zero-spawn guarantee;
+  `RestrictImports` sees `use` paths only and nothing constrains gix's
+  `attributes`/`blob-diff` filter machinery (Phase 1 §3)
+- **major/high** — exact `=` pins block patch remediation under
+  `unmaintained = "all"`, and the manifest pin contradicts the test's
+  `0.85.\d+` assertion (Phase 1 §1)
+- **major/high** — the no-TLS assertion is host-target-scoped while the property
+  must hold on five triples; `[bans].deny` is not extended (Phase 1 §5)
+- **major/medium** — the uluru justification answers MPL §3.1 (modification),
+  not §3.2 (Executable Form notice), and sets the template for every future
+  exception (Phase 1 §2)
+- **minor/high** — no adversarial fixture in the 24-shape matrix, though
+  Queries 2, 3 and 5 all consume repository-supplied paths (Testing Strategy)
+- **minor/medium** — the `sudo mv` step mutates the cached mise tree and never
+  asserts the restore succeeded; `actions/checkout`'s post step needs `git`
+  (Phase 4 §3)
+- **minor/medium** — test-fixture binaries added to the release staging constant,
+  contrary to the sibling `config-adapters` convention (Phase 4 §2)
+- **minor/medium** — no build-script or proc-macro policy for the 56-package
+  expansion, though the release workflow documents build-script trust as a live
+  concern (Phase 1 §1/§5)
+
+## Re-Review (Pass 2) — 2026-08-03
+
+**Verdict:** REVISE
+
+**Coverage caveat:** 6 of 8 lenses completed. The **correctness** and **safety**
+agents both terminated on an API session limit after substantial work and
+returned no findings. Their pass-1 findings are therefore **unverified** in this
+pass — in particular correctness owned the oracle-mapping audit, which is where
+the largest pass-1 cluster sat, and safety owned the CI/release hazards. Neither
+absence should be read as resolution.
+
+### What the revisions fixed
+
+All three pass-1 criticals are resolved, and the majority of the majors:
+
+- 🔴 **Shadow window** — Resolved. Compilation and fixture construction now
+  precede the shadow step; `$RUNNER_TEMP` rather than in-place rename; idempotent
+  shadow/restore; post-restore liveness assertion; `timeout-minutes`; explicit
+  mode contract. (Portability and security both confirm the reasoning, with
+  residual issues below.)
+- 🔴 **`revision`** — Resolved as a blocking pre-Phase-1 gate with three named
+  resolutions. Architecture and test-coverage both note the gate is correct but
+  Phase 3's criterion carries no matching conditional.
+- 🔴 **`stubs` write boundary** — Resolved. Non-destructive, report-only, no
+  `sudo`, all privileged mutation in the workflow. Security calls this "the right
+  boundary".
+- 🟡 **pup `tracing`** — Resolved.
+- 🟡 **Oracle mapping completeness** — Resolved via re-measurement; test-coverage
+  independently verified all six query tables now reconcile to 24 pairs.
+- 🟡 **Error channel, canonicalisation, `_CLI_RELEASE_BINARIES`, four triples,
+  lock operation, revert order, MPL §3.2, break-glass** — all resolved in
+  substance.
+
+### Two critical defects the revisions INTRODUCED (both now fixed)
+
+- 🔴 **`[bans].deny` on `rustls` would fail `deny:check` outright** — flagged
+  independently and at high confidence by **compatibility** and **security**.
+  Verified: `cli/Cargo.toml:35` pins `rustls = "=0.23.41"` and
+  `cli/launcher/Cargo.toml:31` consumes it directly; the section's own comment
+  reads "rustls only", meaning rustls is the *chosen* TLS stack. `deny:check` is
+  in `check-supply-chain`, which is in `prerelease.needs`, so this would have
+  blocked Phase 1 and all releases. The scope error was substituting a
+  whole-graph assertion for the work item's subtree assertion. **Fixed**: named
+  gix transport crates only (each verified absent first), `rustls` explicitly
+  excluded with the reasoning recorded, and the subtree pytest looped over all
+  five configured targets to restore target-awareness.
+- 🔴 **`rust-version` does not exist in `Cargo.lock`** — flagged by
+  **compatibility**. Verified: zero occurrences in the committed lock; the format
+  carries only `name`, `version`, `source`, `checksum`, `dependencies`. A
+  lock-parsing implementation would find nothing and pass vacuously. **Fixed**:
+  sourced from `cargo metadata --locked`, semver-ordered, with a non-vacuity case.
+
+### Other findings, fixed in this pass
+
+- 🟡 **`superproject` specified two contradictory ways** (code-quality, high) —
+  "outermost `modules`" contradicts the plan's own `SM-2` oracle
+  (`$super/mid`, not `$super`). **Fixed**: restated as innermost-outward,
+  first-whose-parent-opens, with both discriminating cases worked through.
+- 🟡 **The "pure function" cannot be pure** (code-quality) — it must probe the
+  filesystem to pick the anchor. **Fixed**: parameterised with
+  `is_repository: impl Fn(&Path) -> bool`.
+- 🟡 **jj version assertion placed in a crate with no jj-lib edge**
+  (compatibility, high) — and exact equality would fail the whole matrix on a
+  pre-authorised patch skew. **Fixed**: injected from the linking crate via a
+  `build.rs` constant, compared at major.minor.
+- 🟡 **Hermetic env strips the git identity** (portability, high) — with `HOME`
+  at a temp dir and no `user.email`, `git commit` refuses on any host whose
+  hostname lacks a domain, i.e. CI runners and containers.
+  `hooks/test-vcs-detect.sh:58` already does this correctly. **Fixed**.
+- 🟡 **Two of three git format knobs were wrong** (compatibility) —
+  `extensions.objectFormat` is a repository-format extension, not an `init` knob,
+  and drives a v1-extension-in-v0-repo failure; `init.defaultRefFormat` is not
+  documented across the range. **Fixed**: documented `--object-format` /
+  `--ref-format` flags, plus a post-construction format assertion.
+- 🟡 **Delegation pointed the surviving code at the code 0185 deletes**
+  (code-quality) — making `^crate(::|$)` permanently load-bearing and 0185's
+  deletion non-mechanical. **Fixed**: direction inverted; helpers extracted in
+  Phase 1 into a module that survives, with the retained pair delegating to them.
+- 🔵 **Stale `.secondary` and "Phase 3's `hermetic`" references** — **Fixed**.
+
+### Still present — carried forward
+
+Not addressed in this pass; each needs a decision rather than a mechanical edit.
+
+- 🟡 **Phase bookkeeping remains partly split** (architecture, code-quality,
+  test-coverage — three lenses). Partially fixed: the crate, dev-dependency,
+  `members` entry and `[[bin]]` are now assigned to Phase 2. Still stale:
+  Phase 3 §1 heads the manifest file "(new)"; Phase 3's success criterion still
+  says "passes with the new member"; Phase 4 §1 still declares the reference
+  artefact "(new)" with its clippy prelude though Phase 2 §3 requires it built;
+  the Implementation Approach and Phase 4 Overview still say "Phase 4 adds the
+  reference artefact".
+- 🟡 **Phase 1's boundary-containment criterion needs Phase 2's nesting
+  fixtures** (architecture, test-coverage). Either move the criterion to Phase 2
+  or move the `fixtures` module to Phase 1.
+- 🟡 **The 9 new fixtures have no keys, start directories or query-table cells**
+  (test-coverage, high) — so Phase 2's own "no query table is partial" criterion
+  is unsatisfiable and their expected values cannot be written test-first. They
+  need measuring, exactly as the pass-1 cells were.
+- 🟡 **Degenerate/`HOSTILE` expectations are too loose to kill mutations**
+  (test-coverage) — "`Err` where applicable" is undefined, and `HOSTILE` is a
+  well-formed repository for which `Err` is the wrong expectation entirely.
+- 🟡 **`Err` vs `Ok(None)` partition is deferred to implementation**
+  (architecture, code-quality) — the half of the new contract the error channel
+  exists to express has no oracle, while Phase 2 claims tests come first.
+- 🟡 **`Error`'s shape is unspecified** (code-quality) — no variants, no
+  `source()` decision, no `thiserror` in the manifest. 0169 is told to map it
+  with nothing to map.
+- 🟡 **Poisoning matrix omits `HOME`/`XDG_CONFIG_HOME`** (security) — file-based
+  `~/.gitconfig` and `/etc/gitconfig` are the paths that apply in production and
+  are never exercised; gix's config permissions are granular, so an
+  implementation setting only `env: false` passes every specified cell while
+  still reading the user's config.
+- 🟡 **gix `Permissions`/`Trust` direction unspecified** (security) — "construct
+  immunity, don't rely on defaults" could be read as elevating to `Trust::Full`,
+  disabling the ownership check that is gitoxide's `safe.directory` equivalent.
+- 🟡 **Liveness controls cover one variable family** (test-coverage) — most newly
+  added poison cells assert invariance under variables nothing shows would change
+  any answer.
+- 🟡 **`HOSTILE` will pass trivially** (security) — none of the eight delivered
+  calls enters gix's filter/pager/external-diff machinery, so the evidence reads
+  as stronger than it is, and 0169 adds exactly the APIs that do reach it.
+- 🟡 **gix feature-set assertion** — added this pass at security's suggestion;
+  worth confirming the named present/absent sets against the resolved graph.
+- 🟡 **Size floor and four-triple buildability run only on the release path**
+  (architecture, test-coverage, portability) — no PR-level feedback for either.
+- 🟡 **Tilde pins contradict the work item without an amendment**
+  (compatibility) — the work item says "pinned exactly at `=0.43`" and "two-crate
+  bump"; the plan now says `~0.43.0` and four-pin. Needs a seventh amendment.
+  Compatibility also argues the RustSec-agility rationale does not hold for the
+  *transitive* closure it invokes, and that `jj-lib` specifically may deserve to
+  stay exact.
+- 🟡 **Escape-the-boundary queries follow repository-controlled links with no
+  hostile-link fixture** (security) — the degenerate fixtures cover missing
+  targets, not links pointing at a *valid* foreign repository.
+- 🟡 **Strong-form proof is provider-coupled** (portability) — a mount namespace
+  (`unshare -m` + bind-mount) or the repo's existing Docker precedent would remove
+  the restore/cache/ephemerality reasoning entirely.
+- 🟡 **`$MATRIX_DIR` has no location or lifecycle contract** (portability) —
+  `TempDir` guards delete on drop and so cannot hand a matrix to a later step, and
+  the no-`.git`-ancestor precondition must be asserted against it.
+- 🔵 **Dependency-tree placement never weighed against crate-level isolation**
+  (architecture) — recorded as a consequence twice, never as a rejected
+  alternative, though Phase 3 §3 already relies on the dev-dependency property
+  that would deliver it.
+- 🔵 Minor: `WorktreeFacts.linked: bool` keeps the shape `JjWorkspaceRole` was
+  introduced to reject; per-pair tests abort on first mismatch; `RF`/`S256` are
+  record-what-happens with an available oracle unused; warn-logging is unasserted;
+  the emulated-vs-native provenance of the Linux musl figure; licence-side
+  break-glass; `cargo add` in the lock guidance mutates the manifest.
+
+### Assessment
+
+The plan is substantially stronger than at pass 1 — every critical is closed and
+the oracle mapping is now internally complete and empirically grounded. But this
+pass found two *new* critical defects introduced by the pass-1 edits, both in
+`cli/deny.toml`/graph-test territory and both of which would have failed CI on
+Phase 1's first run. That is a signal about the revision process, not just the
+content: supply-chain edits made from reasoning rather than from reading the
+existing config are the risk area, and both were caught only because two lenses
+verified against the actual files.
+
+**Not ready for implementation.** Three things must land first: the seventh
+work-item amendment (tilde pins), the `revision` resolution, and the measurement
+of the 9 new fixtures. The phase-bookkeeping cleanup is mechanical but should be
+done before Phase 1 so the phases really are independently mergeable. A third
+pass should re-run **correctness** and **safety** specifically — they did not
+complete here, and correctness is the lens that owns the mapping this plan is
+built on.
+
+## Re-Review (Pass 3) — 2026-08-03
+
+**Verdict:** REVISE
+
+Scope: the two lenses that failed to complete in pass 2 — **correctness** and
+**safety**. Both completed this time. Every claim below that concerns an existing
+file was verified against that file before acting.
+
+### Pass-1 findings, now verified
+
+Correctness independently re-derived the row counts and confirms **Queries 1, 2,
+4, 5 and 6 each cover exactly 24 pairs with no gaps** — the pass-1 mapping
+findings are genuinely fixed. It also confirms the revised `worktree.linked` rule
+(canonicalised `git_dir() != common_dir()`) is correct on all 24 pairs plus
+`SM-w`, that the revised `superproject` scan produces both worked cases and
+survives shapes not in the plan, that the re-measured `PJG-i` common-dir is now
+self-consistent with `NJG-i`/`PG-s`, and that the `JS-in` reasoning is exactly
+right against `scripts/vcs-common.sh:248-254`.
+
+Safety confirms the containment delta is correctly priced, the `vcs-test-support`
+non-destructive boundary is the right call, each shadow-window exclusion is
+justified from a real mechanism, revert-order claim 1 is correct and
+actionlint-detectable, and that refusing the bare `rustls` ban was right.
+
+### Three more factual errors in my pass-2 edits (all now fixed)
+
+- 🟡 **The lock-contention rationale was wrong.** I cited `reqwest` and `rustls`
+  as crates a regeneration would float. Verified: both are **exact** requirements
+  (`cli/Cargo.toml:30` `=0.12.28`, `:35` `=0.23.41`) and cannot move whatever
+  happens to the lock. A reader who checked would have discounted the whole
+  warning. **Fixed**: names the actually-floating caret/tilde set plus the MSRV
+  trap. Also fixed the prescribed command — `cargo update -p gix -p jj-lib` fails
+  with "package ID specification did not match any packages" in exactly the
+  scenario it was prescribed for, pushing the reader toward
+  `generate-lockfile`; and `cargo add` rewrites the manifest, dropping the
+  lockstep comment a new test asserts.
+- 🟡 **The size floor was unscoped.** `_assert_static_elf` is guarded
+  `if "musl" in triple` (`tasks/build.py:329-330`); my "next to it" wording left
+  the absolute-byte floor applying to darwin, whose stripped delta (1,639,872 B)
+  clears 1,500,000 B by only **9.3%** — a 9%-margin heuristic on
+  `prerelease:prepare`'s critical path. **Fixed**: ratio floor everywhere,
+  absolute floor musl-only, host-native ratio check in `check-zero-spawn` for PR
+  feedback, recovery documented.
+- 🟡 **`Result<DualRoots, Error>` cannot express per-side failure** (correctness,
+  critical). A one-sided failure either discards a valid answer or flattens to
+  `None`, reinstating the absence/failure conflation on the *single field* 0169
+  discriminates `colocated` from `nested-*` on. **Fixed**: `dual_roots` is
+  infallible with `Result` per side; callers must treat `Err` as "not comparable",
+  never as inequality. A stale contradicting sentence was also caught and fixed.
+
+### Other findings fixed this pass
+
+- 🟡 **`main_root` dropped the oracle's defensive invariant.** Verified
+  `scripts/vcs-common.sh:106-112` carries
+  `[ -d "$candidate/.jj/repo" ] || return 1`, commented "so a future jj layout
+  change cannot silently produce a wrong-but-non-empty answer". Without it a
+  pointer resolving to any existing non-store directory yields a confident wrong
+  root that becomes `RepoFacts.name` after 0185. **Fixed**, plus a degenerate
+  fixture for an existing-but-not-a-store target.
+- 🟡 **Relative `start` splits the three walks.** Verified
+  `MarkerWalkRoot::discover` (`cli/vcs-adapters/src/lib.rs:35-44`) is purely
+  lexical while `gix::discover` absolutises — so a relative `"sub"` makes a
+  colocated checkout read as "git only". Invisible to the matrix, whose paths are
+  all absolute. **Fixed**: absolutisation precondition plus a relative-`start`
+  test per walk.
+- 🟡 **`is_repository -> bool` conflated not-a-repo with unopenable** — my own
+  pass-2 edit, and it contradicted the degenerate fixtures' "not a plausible
+  wrong path". **Fixed**: fallible probe.
+- 🟡 **`$BASE` notation is internally contradictory** — `$BASE/jjmain` is claimed
+  both colocated and `--no-colocate`, and `$BASE/gitparent/.git/worktrees/sub` is
+  claimed for two fixtures a single parent cannot host (`git worktree add`
+  de-duplicates to `sub1`), which the recorded `worktrees()` count of 1
+  corroborates. **Fixed**: disambiguation required before the builders are
+  written, with the re-measurement's distinct parents named.
+- 🟡 **`$MATRIX_DIR` handoff impossible under `TempDir`** — guards delete on drop.
+  **Fixed**: workflow-created root, builder writes without owning a guard,
+  `TempDir` retained for in-process paths, `TempDir::keep()` explicitly rejected
+  (the store-duplication guard misses it and it would leak a 19-fixture tree on
+  every developer `mise run`), no `rm -rf "$MATRIX_DIR"`.
+- 🟡 **Revert order omitted the dangling-reference edges.** The two
+  `[dev-dependencies]` path edges must go before the crate directory or cargo
+  cannot load the workspace graph — breaking `cli:check`, `server:check`,
+  `test:unit:cli` and `deny:check`; and the `depends` references must go before
+  the task definitions. **Fixed** and renumbered.
+- 🟡 **Restore rested on a scheduler guarantee** — a job-level timeout cancels the
+  job, and a hanging suite is the likeliest unattended failure. **Fixed**:
+  `trap restore EXIT` in one step with a step-level timeout; `cache: false`
+  recommended, with cache-prefix bump as documented recovery.
+- 🟡 **Advisories break-glass had no class scoping** — a pre-blessed five-minute
+  suppression covering vulnerability-class advisories in a closure reaching the
+  signed binary. **Fixed**: scoped to unmaintained/yanked/notice, escalation
+  required for vulnerabilities, review-by dates enforced by a test, licence-side
+  case documented.
+- 🟡 **Zero-spawn mode contract was fail-open** on absent or misspelled values.
+  **Fixed**: exact accepted values, mode reported back and asserted.
+- 🟡 **`revision` resolutions were unranked** — option 2 (narrow the
+  `UserSettings` ban) would put a chain abandoned after five successive panics
+  into a long-lived server with no crash isolation. **Fixed**: ranked, descope
+  named the fail-safe, parity narrowed per `VcsKind` rather than wholesale.
+- 🔵 **`test:integration:zero-spawn` roll-up membership** was left open; it would
+  double fixture-matrix construction on both CI legs and every `mise run`.
+  **Fixed**: `_NOT_IN_INTEGRATION_ROLLUP`, per the `test:integration:pup`
+  precedent.
+
+### Still open
+
+- 🟡 **`superproject` returns the main worktree, not the containing one**
+  (correctness). A submodule inside a linked worktree `$wt` of `$main` anchors on
+  `$main/.git` and yields `$main`, where the oracle returns `$wt`. Recorded in the
+  plan as unresolved with a measurement required; not fixed, because it needs a
+  new fixture measured.
+- 🟡 **`SM-w`'s `kind()` was asserted, not measured** (correctness). If it is
+  `LinkedWorkTree` the fixture's stated rationale evaporates; if `Submodule`,
+  `superproject` has a wrong answer. Needs measuring.
+- 🟡 **The `Err`/`Ok(None)` partition remains deferred** (correctness, and
+  architecture/code-quality in pass 2 — now three lenses). Recorded divergences
+  still says "record the list as Phase 2 establishes it" while the Implementation
+  Approach claims values come from the table first. The nine new fixtures'
+  expectations are self-fulfilling until an Err set is enumerated per query.
+- 🟡 **`classify_checkout` table covers 19 of 24** — missing `PJS`, `NGPJ-i`,
+  `NGPJ-o`, `PJG-i`, `PJG-o`, i.e. both nested arms' pure-jj variants.
+- 🟡 **Canonicalisation has no defined failure behaviour on the two port
+  methods**, which keep non-`Result` signatures (`repository_root -> PathBuf` has
+  no channel at all).
+- 🟡 **The truncated-pack degenerate fixture proves nothing** — no query reads
+  object data; only `revision` does, and it returns `Option`.
+- 🟡 **`check-zero-spawn` in `prerelease.needs` has no break-glass** for
+  environment-driven failures (safety). Verified `test_workflows.py` does not
+  assert that list exhaustively, so the edge adds cleanly.
+- 🟡 **The containment hand-off to 0185 is prose on a sibling work item** — safety
+  recommends a committed guard asserting `facts` names `CommandProbe`, so 0185
+  deletes a guard deliberately rather than failing to read a note.
+- 🔵 `Kind::Common`/`gix::open` described three incompatible ways for `discover`;
+  `main_worktree_root` holds a value that is neither on submodule shapes;
+  Query 2 Verdict vocabulary inconsistent; append-only amendment blocks leave the
+  stale text first in reading order.
+
+### Assessment
+
+Correctness's structural verdict is the important result: the oracle mapping's
+*coverage* is now genuinely complete and its re-measured cells are
+self-consistent. What remains there is a notation collision, five missing
+composite rows, and two shapes asserted rather than measured — bounded work, not
+a redesign.
+
+The recurring pattern across all three passes is now unmistakable and worth
+recording: **six of the defects found in passes 2 and 3 were introduced by my own
+revisions, and every one was a claim about an existing file made from reasoning
+instead of reading it** — `rustls`'s pin status, `Cargo.lock`'s schema,
+`_assert_static_elf`'s guard, `MarkerWalkRoot`'s lexical walk, the shell's
+defensive invariant, `TempDir`'s drop semantics. Plan edits that assert
+something about the repository must be verified against the repository at the
+moment they are written.
+
+**Not ready for implementation.** The blocking set is unchanged in shape but
+better specified: resolve `revision` (option 1 spike, else option 2); apply the
+work-item amendments (5, 6, and a seventh for the tilde pins); measure the nine
+new fixtures, the five missing `classify_checkout` rows, `SM-w`, and the
+submodule-in-a-linked-worktree shape; disambiguate the `$BASE` notation; and
+enumerate the `Err` set per query. The phase-bookkeeping cleanup from pass 2
+remains outstanding and is still mechanical.
+
+## Addendum — `revision` spike and measurement round 2 (2026-08-03)
+
+### Spike: jj `revision` — resolved NO
+
+A throwaway crate (`jj-lib = "=0.43.0"`, Rust 1.90.0, `resolver = "3"`, built
+clean) established that **jj-lib 0.43 exposes no read-only, settings-free route
+to the working-copy commit id**. The op stores are settings-free
+(`SimpleOpHeadsStore::load(dir)`, `SimpleOpStore::load(path, root_data)`), but the
+workspace name needed to index `View::get_wc_commit_id` is not:
+
+- `LocalWorkingCopy::load` requires `&UserSettings` (`TreeStateSettings`), and
+  `CheckoutState` — which holds exactly the `operation_id` + `workspace_name`
+  pair — is a private struct with a private `load`.
+- `SimpleWorkspaceStore::load(repo_path)` is settings-free but **mutates the
+  repository**. Verified empirically: with `.jj/repo/workspace_store` removed,
+  the call recreated the directory and wrote an `index` file. Unusable in a
+  read-only probe. Its trait also exposes only `get_workspace_path(name)` with no
+  listing API, so root→name inversion is unavailable regardless.
+
+**Outcome**: jj `revision` descoped to 0185; the crate-wide `UserSettings` guard
+stays crate-wide (the spike is the evidence nothing in scope needs it); Phase 3
+parity narrows per `VcsKind`. Recorded as work-item amendment 8.
+
+The spike also independently confirmed **Key Discovery 11**: without
+`resolver = "3"` the graph selected `kstring v2.0.4 (requires Rust 1.96.0)`; with
+it, `kstring v2.0.2`.
+
+### A seventh instance of the same error pattern — in the fix for the sixth
+
+My pass-3 fix for the `rustls` ban said the replacement crates were "each
+confirmed absent from the resolved lock before being named". They were not
+confirmed, and **`gix-transport` and `gix-protocol` are both present** (verified
+in the spike's lock; both compile). Banning either would have failed
+`deny:check` on the first run — the identical failure mode, in the edit written
+to fix it.
+
+Corrected: `[bans].deny` gains only `gix-credentials` and `curl-sys` (both
+verified absent). The enforceable property is the **feature-set** assertion
+(`blocking-network-client`, `async-network-client`,
+`blocking-http-transport-*` off), not transport-crate absence, which is false.
+
+This is the seventh defect of one kind across three passes: a claim about an
+existing file asserted from reasoning rather than read. Every one was caught by
+verification, none by re-reading my own prose.
+
+### Measurement round 2
+
+Ten extended fixtures and the five missing `classify_checkout` rows measured;
+oracle columns only (gix/jj-lib land in Phase 1). Highlights: `JS-in` confirms
+dual roots differ while classification is `jj-secondary`; `SM-wt` **downgrades**
+the pass-3 superproject concern (git puts the submodule git dir under
+`worktrees/<id>/modules/`, and the plan's scan gets the right answer);
+`S256`'s HEAD is 64 hex against `detection.rs`'s 40-hex assertion; `HOSTILE` runs
+none of its seven configured commands, so it is a guard for 0169's APIs rather
+than evidence for this call set; `D3` proves the `.jj/repo` post-condition is
+needed and corrects the blanket "degenerate shapes yield `Err`" to
+`D1`/`D2` → `Ok(None)`, `D3` → `Err`. The truncated-pack fixture was dropped as
+unreachable by any query.
+
+### Remaining before implementation
+
+**Blocking**: apply work-item amendments 5-8 to
+`meta/work/0188-library-backed-vcs-adapter.md`.
+
+**Phase-scoped, not gaps**: `gix::open` on a linked-worktree gitdir (the one
+question `SM-wt` leaves); `RF`/`S256` library behaviour; the extended fixtures'
+library columns; exact `Err` variant spellings (the partition *rule* is now
+fixed). Safety recommendations not yet taken: a `check-zero-spawn` break-glass
+and a committed guard asserting `facts` names `CommandProbe`.

--- a/meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md
+++ b/meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md
@@ -1,0 +1,403 @@
+---
+type: plan-validation
+id: "2026-08-03-0188-library-backed-vcs-adapter-validation"
+title: "Validation Report: Library-Backed VCS Adapter over gix and jj-lib"
+date: "2026-08-03T18:05:57+00:00"
+author: "Toby Clemson"
+producer: validate-plan
+status: complete
+result: "pass"
+parent: "work-item:0188"
+target: "plan:2026-08-03-0188-library-backed-vcs-adapter"
+tags: [rust, vcs, dependencies, gix, jj-lib]
+last_updated: "2026-08-03T18:05:57+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Library-Backed VCS Adapter over gix and jj-lib
+
+Validated against the five implementation commits `lpzkkkzruqsw..rztymnuzussm`
+(44 files, +7,152/−161), working copy clean at `d0acd6b3`.
+
+**Result: pass.** All five phases are implemented and every automated criterion
+passes, including a green end-to-end `mise run`. Four findings were raised and
+all four are resolved in follow-up commits (see Fixes Applied) — three
+documentation and hygiene issues, plus one substantive reversal: the descoped jj
+`revision` mechanism, raised by the author as a regression at 0185's switch, is
+now **delivered**. The remaining unverified criteria are CI-only by construction
+and correctly deferred.
+
+One caveat on the "`mise run` green" criterion: it passed cleanly on two of five
+invocations, most recently on the final state of this work (653s, zero task
+failures, no formatter drift). The failures are all in
+`test:integration:entrypoint` and are attributable to a pre-existing
+shared-target-directory race that this change aggravates but does not
+introduce — see Potential Issues.
+
+### Implementation Status
+
+- ✓ **Phase 1: Dependencies, Policy Gates and the Boundary-Safe Ports** — fully
+  implemented, with one unamended deviation (see Deviations).
+- ✓ **Phase 2: The Six Taxonomy Queries** — fully implemented.
+- ✓ **Phase 3: The Shared Test-Support Crate and the Zero-Spawn Harness** —
+  fully implemented.
+- ✓ **Phase 4: Reference Artefact, Strong-Form CI, and Measurements** — fully
+  implemented; the strong-form CI job is written and wired but by construction
+  first executes on CI.
+- ✓ **Phase 5: Sibling Hand-Offs and Closeout** — fully implemented.
+
+### Automated Verification Results
+
+✓ `mise run` green end to end — 557.70s, zero task failures, working copy still
+clean afterwards (no formatter drift). Includes:
+
+- ✓ `deny:check` passes with the `uluru` MPL-2.0 exception
+- ✓ `pup:check` passes with the new `vcs_adapters_library_reads_in_process` rule
+- ✓ `cli:check` (clippy `--locked`, pedantic + nursery)
+- ✓ `test:unit:cli` — 620 tests, 620 passed
+- ✓ `test:integration:deny` — 62 passed, including the 12 new
+  `test_vcs_library_graph.py` cases and the 4 `test_advisory_ignores.py` cases
+- ✓ `test:unit:tasks` — 649 passed, including `test_vcs_pin_lockstep.py` (7),
+  `test_vcs_settings.py`, the updated `test_mise.py` and the new
+  `test_build.py` size-floor/fixture-staging cases
+- ✓ `lint:vcs-settings:check` passes (125.7ms)
+- ✓ `test:integration:pup` — the three new probe cases for the rule (denied
+  `std::process` naming the rule, compliant single-item positive control,
+  grouped-import behaviour)
+- ✓ `hooks/test-vcs-detect.sh` and `scripts/test-metadata-helpers.sh` both ran
+  green inside the run — this discharges the plan's manual step 2 for the
+  jj-0.43 fixture suites
+
+✓ `mise run test:integration:zero-spawn` — 1 test, passed in PATH-only mode
+(deliberately outside the `test:integration` roll-up, so not covered by
+`mise run`; run separately).
+
+✓ `mise run build:cli:fixture-size` — host-native ratio floor holds. After the
+jj `revision` route landed: `linked 2,513,792 B, stubbed 350,912 B, ratio
+**7.16x**` against a 3.0× floor (6.49× before it).
+
+✓ Full `mise run` re-run green on the final state — 653.15s, zero task failures,
+no formatter drift; `test:unit:cli` 625 tests (620 before, plus the 5 new jj
+`revision` cases), `test:integration:deny` 65, `test:unit:tasks` 650.
+
+✓ Gates re-run individually during the fixes, all green:
+`deny:check`, `test:integration:deny` (62 passed), `test:unit:tasks`
+(649 passed — includes the two comment-presence assertions the reworded
+`cli/deny.toml` block has to satisfy), `test:integration:work`, `cli:check`
+(after the dev-dependency removal), and `cargo test -p vcs-test-support
+--no-run`. `cli/Cargo.lock` is unchanged by the fixes.
+
+⚠️ **`test:integration:entrypoint` failed in two of three full runs** — see
+Potential Issues. Passes in isolation (54 passed) and passed in the green run.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `cli/vcs-adapters/src/library.rs` (845 lines after the jj `revision` route;
+  686 as reviewed) carries `InProcessProbe`, both
+  port impls, and all six inherent queries with the planned signatures —
+  `is_bare`, `worktree`, `superproject`, `jj_workspace_root`, `jj_repository`
+  return `Result<Option<T>, Error>`; `dual_roots` is infallible with a per-side
+  `Result` (`library.rs:184-192`, `:205-359`).
+- The three walks are distinct and correctly assigned: `carries_any_marker` for
+  `RepoRoot::discover`, `carries_jj_marker` for the jj queries, `gix::discover`
+  for the git queries (`markers.rs:31-44`, `library.rs:297`, `:320`).
+- Delegation direction is as specified — `MarkerWalkRoot::discover` and
+  `CommandProbe::kind` delegate *to* `markers::walk_up`/`marker_kind`, so
+  0185's deletion needs no re-homing (`lib.rs:38-41`, `:93-96`).
+- Canonicalisation choke point present and documented in the module `//!`
+  header; `worktree` canonicalises `common_dir()` before exposing it
+  (`library.rs:225-228`).
+- `jj_repository` carries the `<main_root>/.jj/repo`-is-a-directory
+  post-condition that the shell oracle carries (`library.rs:342-344`).
+- Boundary rule: `cli/vcs/src/**` is byte-for-byte unmodified (`jj diff --stat`
+  over the five commits reports 0 files); `vcs_adapters::facts` still names
+  `MarkerWalkRoot`/`CommandProbe` (`lib.rs:217-219`); `CommandProbe` and
+  `MarkerWalkRoot` gained no methods; `cli/vcs-adapters/Cargo.toml` gained no
+  `[features]` entry beyond `bash-parity`.
+- `cli/vcs-test-support` depends on `vcs`-adjacent crates only — no
+  `vcs-adapters` edge, so no dev-dependency cycle. Its `stubs` module resolves
+  and *reports* absolute paths and never mutates outside its own temp root
+  (`stubs.rs:91`, `:171`).
+- The zero-spawn contract is fail-closed on malformed input:
+  `Mode::from_environment`
+  rejects any value other than `strong`/`path-only`/empty, and rejects a
+  non-empty shadow list without `strong` (`stubs.rs:53-72`);
+  `assert_shadowing_holds` hard-fails when `strong` is claimed while a listed
+  path is still executable (`stubs.rs:210-233`).
+- `cli/corpus-adapters/tests/zero_spawn.rs` imports all three parts of the
+  public API (`fixtures`, `hermetic`, `stubs`) and asserts a non-empty matrix so
+  an empty one cannot pass vacuously (`zero_spawn.rs:22-27`, `:75-77`).
+- `detection.rs` runs every case through a `(&dyn RepoRoot, &dyn VcsProbe)` seam
+  against both implementations. Parity was asserted per `VcsKind` as planned; it
+  is now **whole-struct `RepoFacts` equality** for both idioms, since the jj
+  `revision` reversal removed the field neither adapter could answer.
+- CI job `check-zero-spawn` matches the plan's shape exactly: `ubuntu-latest`,
+  `cache: false` on `mise-action`, compile-then-fixtures-then-shadow ordering,
+  `trap restore EXIT` inside a single step with its own `timeout-minutes: 10`,
+  idempotent per-path shadow/restore, and an `if: always()` liveness backstop
+  (`main.yml:323-457`); wired into `prerelease.needs` (`:498`).
+- `tasks/build.py` uses a separate `_CLI_FIXTURE_BINARIES` constant and staging
+  loop; `_CLI_RELEASE_BINARIES` is untouched; the ratio floor applies to every
+  triple and the absolute floor to musl only (`build.py:45-62`, `:203-217`).
+  `test_build.py:466-479` asserts directly that no fixture name appears in
+  `_release_uploads()`.
+- Phase 5's three sibling amendments are all present as dated append-only
+  blocks (`0125:149`, `0169:542`, `0185:146`), and 0125's `relates_to` carries
+  `work-item:0188`.
+- `tasks/README.md` gained both planned subsections (`Library-backed VCS
+  dependency pins` at `:109`, `Zero-spawn strong form` at `:173`), the
+  class-scoped break-glass, the licence-side failure mode, the cargo-pup ↔
+  source-guard division of labour, and the CI-table row (`:436`).
+
+#### Deviations from Plan:
+
+- ✅ **REVERSED — the jj half of `revision` returned `None` by design.** The
+  plan's amendment 8 descoped it to 0185 on a spike finding that no read-only,
+  settings-free route existed. Raised by the author as a regression at 0185's
+  switch; the finding was wrong and the mechanism is now delivered. See
+  Fixes Applied.
+- **`gix` is pinned `default-features = false`, not with default features**
+  (`cli/Cargo.toml:80`). Sound and better than planned: gix's `default` reaches
+  `extras` → `credentials` → `gix-credentials`, the one gix subsystem that
+  spawns `git credential-*` helpers, in a module whose whole point is not
+  spawning. Nothing is lost — jj-lib's own selection still enables `attributes`,
+  `blob-diff`, `index`, `max-performance-safe`, `sha1`, `zlib-rs`, asserted by
+  `test_vcs_library_graph.py:272`. **But it is not recorded as a work-item
+  amendment**, and `meta/work/0188-*.md:388` still states "**`gix` with default
+  features**" as a requirement. Eight smaller deviations got amendments; this
+  one should too.
+- **`queries.rs` is one table-driven test over all 34 pairs, not one test per
+  pair.** The plan chose per-pair to bound fixture rebuild cost and localise
+  failures. Delivered: a single test that builds the matrix once, accumulates
+  per-cell diagnostics (`key/query`, expected, actual) for every mismatch, and
+  asserts `EXPECTED.len() == matrix.fixtures.len()` so the table cannot drift
+  from the matrix (`queries.rs:402-459`). Strictly cheaper (1 fixture build, not
+  34) with per-cell traceability retained. The plan's rationale is superseded
+  rather than violated.
+- **`RepoRoot::discover` does not absolutise `start`** (`library.rs:374-376`),
+  unlike the six queries. Deliberate: `MarkerWalkRoot::discover` is likewise
+  purely lexical, and `detection.rs` asserts parity between them, so
+  absolutising here would *create* a divergence. Consequence: the plan's
+  "one test per walk uses a relative `start`" is satisfied for the gix walk and
+  the `.jj`-only walk only (`queries.rs:467-505`); the boundary walk's
+  relative-start behaviour is inherited, not tested.
+- Four further deviations were found and recorded by the implementation itself,
+  under the plan's `Confirmed during implementation` section — `superproject`
+  gating on canonicalised `git_dir() != common_dir()` rather than
+  `kind() == Submodule`; `superproject_of` canonicalising in the injected probe
+  closure rather than the scan, with the probe returning
+  `Result<Option<PathBuf>, Error>`; `D1` returning `Err` rather than the
+  recorded `Ok(None)`; and gix 0.85 returning `Err` on sha256 repositories. All
+  four are correct under the plan's own partition rule and each carries its
+  reasoning.
+
+#### Potential Issues:
+
+- ✅ **RESOLVED — the `uluru` exception comment asserted a licence resolution
+  that did not exist.** `cli/deny.toml` stated the MPL-2.0 §3.2 notice
+  obligation "is discharged by the third-party licence file staged into the
+  release payload". No such artefact existed: no cargo-about /
+  cargo-bundle-licenses machinery anywhere under `tasks/`, and
+  `_release_uploads()` (`tasks/github.py:231-249`) enumerates launcher
+  binaries, signatures, sub-binary assets, debug archives and the manifest only.
+  Resolved by measurement rather than by adding an artefact — see Fixes Applied.
+- ✅ **RESOLVED — Phase 1's two manual verifications were undone and
+  unrecorded**: the `accelerator-visualiser` size before/after, and cold-cache
+  `build:server:dev` against `test-visual-regression`'s `timeout-minutes: 20`
+  (`main.yml:125`). Both now measured and recorded on the work item; the cap
+  needs no raise.
+- ⚠️ **OPEN, and not 0188's to fix — `test:integration:entrypoint` fails under
+  parallel `mise run` load, in 2 of 3 observed invocations.** Both failures are
+  the same defect observed at two points:
+  `tests/integration/support/installation.py:125-141` runs
+  `cargo build -p accelerator-verify` into the shared `cli/target/debug`, then
+  immediately asserts the artefact is present — and the assertion can observe a
+  torn tree, because concurrent cargo invocations with *differing feature
+  selections* rebuild the same crates and unlink/relink their binaries. Run 1
+  surfaced it as `FileNotFoundError` while copying the shim; run 3 as
+  `Failed: not built: cli/target/debug/accelerator-verify` in 52 fixture
+  setups, immediately after a `cargo build` that exited 0.
+  - **CI is structurally immune**: `test-unit` and `test-integration` are
+    separate jobs on separate runners (`main.yml:20-21`, `:55-61`), so no
+    cross-task sharing of one target directory occurs there. The exposure is to
+    the *local* `mise run` gate the contributor guide tells everyone to run.
+  - **Pre-existing, aggravated here.** 0188 touches none of that machinery, but
+    it enlarges the `--all-features` build surface (`tasks/test/cli.py:11-14`)
+    by ~56 crates, widening the window.
+  - A deliberate reproduction attempt pairing `test:unit:cli` with
+    `test:integration:entrypoint` did **not** trigger it (both green), so the
+    specific racing task is unidentified. Deserves its own item.
+- **The work item's acceptance criteria are all still unticked** (15 `- [ ]`
+  lines) and its `status:` is `ready`, while its Validation Results are filled
+  in comprehensively. Housekeeping, not a defect in the change.
+- ✅ **RESOLVED** — `cli/vcs-test-support/Cargo.toml` listed `tempfile` in both
+  `[dependencies]` and `[dev-dependencies]`.
+
+### Fixes Applied
+
+#### The jj `revision` descope was reversed
+
+Raised by the author on review of the delivered `VcsProbe::revision`: returning
+`None` for `VcsKind::Jj` would regress behaviour at 0185's switch, since
+`CommandProbe` answers there today. Re-examination found **the spike behind
+amendment 8 was wrong**, and the mechanism is now delivered in this story.
+
+The spike's blocking claim was that reading the working-copy commit id needs the
+workspace name, reachable only through `LocalWorkingCopy::load` (needs
+`&UserSettings`) or `SimpleWorkspaceStore::load` (writes), with `CheckoutState`
+private — leaving only "reading the checkout protobuf by hand", dismissed as *"a
+private wire format with no compatibility promise"*. That last step is the
+error: **`jj-lib` declares `pub mod protos`**, so `Checkout` — carrying exactly
+`operation_id` and `workspace_name` — is published API. The delivered code is a
+transcription of jj-lib's own `CheckoutState::load` using the same public type.
+
+Delivered route, every link public API and none of it needing settings:
+
+```
+DefaultWorkspaceLoaderFactory::create(root)
+  → repo_path(), workspace_root()
+<workspace_root>/.jj/working_copy/checkout
+  → protos::local_working_copy::Checkout → (operation_id, workspace_name)
+SimpleOpStore::load(repo_path/"op_store", root_data)
+  → read_operation → read_view → View.wc_commit_ids[workspace_name]
+```
+
+Verified against the live CLI — exact match on this repo, pure jj
+(`--no-colocate`, so no git HEAD to have fallen back to), colocated, commitless,
+a secondary workspace and its main. `detection.rs` now asserts **full
+`RepoFacts` equality for both idioms** (the per-`VcsKind` narrowing is gone) and
+all 7 cases pass; `library.rs` grew 6 cases to 15.
+
+Three properties are pinned by tests rather than asserted in prose:
+
+- **The workspace-name lookup is load-bearing.**
+  `each_workspace_reports_its_own_commit_not_its_neighbour_s` asserts the two
+  workspaces of one repository report *different* commits and that each matches
+  its own oracle. Taking the view's sole entry would pass every single-workspace
+  test and answer for the wrong workspace.
+- **It writes nothing.** `reading_the_revision_writes_nothing` fingerprints the
+  whole `.jj` tree around the call — necessary because a sibling loader in the
+  same area does create directories on load.
+- **The one divergence is documented and tested.**
+  `an_unsnapshotted_edit_is_the_one_documented_divergence`: asking the `jj`
+  binary snapshots the working copy first, so with unsnapshotted edits present
+  it reports *and writes* a new commit, while this route reports the commit as
+  of the last recorded operation. This is the read-only direction — after 0185's
+  switch, metadata derivation stops mutating the user's repository.
+
+Cost and size, re-measured on the delivered shape (darwin-arm64, median of 20):
+all six queries + both ports **4.81 ms** against `jj log -r @ -T commit_id` at
+26.54 ms. The reference artefact's ratio rose from 6.49× to **7.16×**
+host-native (more of jj-lib links), and all four release triples were
+re-cross-compiled to confirm the new edges break no target — 6.86× to 7.37×,
+both musl builds still clearing the absolute floor.
+
+`prost` and `pollster` become direct dependencies. Both were already in
+`cli/Cargo.lock` via jj-lib, so **the lock delta is two lines** — two new edges
+on `vcs-adapters`, no new packages, no new licences. They are pinned to jj-lib's
+majors because the decoded type comes *from* jj-lib, guarded by a new
+single-version assertion in `test_vcs_library_graph.py` and a comment assertion
+in `test_vcs_pin_lockstep.py`. The pin coupling is now six-way, documented in
+`tasks/README.md`.
+
+Two residual risks, recorded rather than resolved: two *paths* are convention
+rather than API (`<workspace_root>/.jj/working_copy`, `<repo_path>/op_store`;
+`DefaultWorkspaceLoader`'s equivalent field is private), mitigated by asserting
+`get_working_copy_type() == "local"` before reading and by decode failure being
+`Err`. The *schema* — the part that could silently misparse — is public and
+versioned with a crate pinned at `=0.43.0`.
+
+Records updated: work-item amendments 9 and 10 added (10 withdraws 8), the
+plan's Phase 1 §4 rewritten with the superseded spike kept in a `<details>`
+block, the Phase 3 parity criterion widened, and 0185's inheritance 3 rewritten
+— it no longer inherits the mechanism, only the snapshot divergence.
+
+Also corrected for the record: `UserSettings::from_config` returns `Result`, not
+a panic, and needs exactly five keys (`settings.rs:135-166`). The spike's
+"abandoned after five successive panics with the chain never exhausted" was the
+chain being exhausted. So the settings route was viable too — just worse than
+the one delivered.
+
+#### The three validation findings
+
+Six follow-up edits, none touching the delivered Rust:
+
+1. **`cli/deny.toml`** — the `uluru` exception comment rewritten around a
+   *verified* finding. Measured 2026-08-03: `uluru` is in the normal closure of
+   exactly one shipped binary (`accelerator-visualiser`; neither `accelerator`
+   nor `accelerator-verify` has it at all), and dead-code elimination removes
+   the whole `gix`/`jj-lib` closure from it. An unstripped `--release` build
+   carries zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or
+   `uluru` against 26,247 total, and none of the distinctive literals
+   (`extensions.objectFormat`, `There is no Jujutsu repo`) that the linked
+   reference artefact does carry — the positive control that makes the absence
+   meaningful. §3.2 therefore does not bind and no attribution artefact is
+   needed. The comment records the evidence **and its re-check trigger**, since
+   the finding's real cause is that nothing in the visualiser reaches
+   `vcs-adapters` at all today (`CommandProbe`'s own `rev-parse` literal is
+   absent too), which 0185's `facts` switch is expected to change.
+2. **`meta/work/0185-*.md`** — inheritance 5 added to the amendment block: the
+   licence exception must be re-checked *as part of* the `facts` switch, with
+   the exact check to re-run, because that switch is what would make §3.2 bind
+   and `_release_uploads()` carries no licence file.
+3. **`meta/work/0188-*.md`** — amendment 9 recorded for the
+   `gix default-features = false` pin, and the stale "**`gix` with default
+   features**" requirement corrected to match `cli/Cargo.toml:80`.
+4. **`meta/work/0188-*.md`** — Validation Results gained the cold-cache compile
+   figures, the shipped-binary size finding, and an entry closing the MPL-2.0
+   question.
+5. **`meta/plans/2026-08-03-0188-*.md`** — the MPL open question struck through
+   and closed with its evidence.
+6. **`cli/vcs-test-support/Cargo.toml`** — duplicate `tempfile` dev-dependency
+   removed (regular dependencies are already visible to test targets;
+   `cargo test --no-run` and `cli:check` confirm).
+
+### Manual Testing Required:
+
+1. Strong-form CI (Linux only, first execution is on this branch's CI run):
+  - [ ] The shadow step actually replaced `git` and `jj` — assert
+        `git --version` fails inside the step before the restore
+  - [ ] The `trap restore EXIT` fired and the `if: always()` liveness step found
+        both binaries restored
+  - [ ] `ACCELERATOR_ZERO_SPAWN_MODE=strong` was observed by the harness (the
+        contract's non-degradability)
+2. Cold-cache budgets — **measured, no action expected**; confirm on the first
+   CI run only:
+  - [ ] `test-visual-regression` stays inside its 20-minute cap (measured cold
+        cost of the two new trees: 16.92 s wall / 65.80 s CPU locally, ~1-2 min
+        scaled to a 4-vCPU runner, against a job whose wall clock is dominated
+        by Playwright and Docker)
+  - [ ] `check-zero-spawn` stays inside its own 20-minute cap
+3. Cross-machine:
+  - [ ] Confirm `mise install` has been run on each development machine (the
+        fixture matrix hard-fails on a jj major.minor skew)
+
+### Recommendations:
+
+- **File the `cli/target/debug` race as its own item** — the one open finding.
+  `tests/integration/support/installation.py:125-141` builds into the shared
+  workspace target directory and asserts the artefact's presence immediately
+  afterwards, with no tolerance for a concurrent rebuild;
+  `test_signing.py:54-70`
+  and `test_manifest.py:67-75` share the same helper shape. Candidate fixes: a
+  dedicated `CARGO_TARGET_DIR` for the suites that shell out to cargo, a
+  session-scoped build fixture that builds once before the parallel tasks fan
+  out, or a bounded retry around the presence assertion. Worth doing because it
+  degrades the local `mise run` gate the contributor guide makes mandatory —
+  2 of 3 invocations here — even though CI is immune by job separation.
+- **Tick the work item's acceptance criteria and transition its status** via
+  `/accelerator:update-work-item`, folding the surviving `[ ]` items into the
+  carried-forward list. Left alone deliberately: which criteria count as met
+  is a call for the author, and status transitions belong to that skill.
+- **Re-check the licence finding when 0185 flips `facts`**, not after. Recorded
+  in the `cli/deny.toml` comment and as inheritance 5 on 0185, but worth
+  restating because a conditional finding with an unowned trigger is how a
+  licence obligation goes quietly unmet.
+- Consider whether the size floor's sibling — the *shipped* binary's link
+  behaviour — deserves a committed check too. The reference artefact's ratio
+  floor is committed (`tasks/build.py:203-217`), but the fact that the shipped
+  visualiser links none of the trees is recorded only in prose, and it is the
+  fact the licence exception now rests on.

--- a/meta/work/0125-converge-vcs-detection-on-probe-layer.md
+++ b/meta/work/0125-converge-vcs-detection-on-probe-layer.md
@@ -8,10 +8,11 @@ producer: create-work-item
 status: draft
 kind: task
 priority: medium
-relates_to: ["work-item:0124", "work-item:0058", "work-item:0020"]
+relates_to: ["work-item:0124", "work-item:0058", "work-item:0020",
+  "work-item:0188"]
 tags: [tech-debt, scripts, vcs, git, jj, worktree, vcs-common]
-last_updated: "2026-06-22T14:38:56+00:00"
-last_updated_by: Phil Helm
+last_updated: "2026-08-03T16:37:02+00:00"
+last_updated_by: Toby Clemson
 schema_version: 1
 external_id: PP-146
 ---
@@ -144,6 +145,27 @@ remains, so other categories can still bite:
   (the immediate fix), [`0058`](0058-workspace-worktree-boundary-detection.md)
   (built the probe layer), [`0020`](0020-vcs-abstraction-layer.md) (origin of
   the VCS abstraction).
+
+### Amendment 2026-08-03 — the lexical-fallback rationale is dissolved, conditionally
+
+[`0188`](0188-library-backed-vcs-adapter.md) landed a library-backed VCS adapter
+that reads git through `gix` and jj through `jj-lib` **in-process**. Two of this
+item's stated reasons for keeping the shell lexical fallback no longer hold *for
+consumers that reach that adapter*:
+
+1. Detection no longer needs `git`/`jj` on `PATH`. Proven, not asserted: a
+   cross-crate suite runs the whole checkout-shape matrix with both binaries
+   stripped from `PATH` and asserts that no stub recorded a spawn **and** that
+   every value matches an unrestricted run.
+2. Probing no longer costs 1-3 subprocesses per call. Measured on darwin-arm64:
+   ~3.6-4.7 ms cold per process for all six taxonomy queries plus both port
+   methods, against ~23.8 ms for the single `jj log -r @` the subprocess probe
+   ran; warm in-process calls are tens of microseconds.
+
+**The dissolution is conditional and this item is not closed by it.** The ~26
+shell call sites in `find_repo_root` and `vcs_mode` keep running in bash and
+cannot reach the Rust adapter until 0169 and the later epic-0136 phases migrate
+them. Constraints 3, 4 and 5 are untouched and still bind.
 
 ## References
 

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -14,7 +14,7 @@ blocks: ["work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173",
 relates_to: ["work-item:0125", "work-item:0165", "work-item:0182", "work-item:0183", "work-item:0185", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, vcs, hooks, migration]
-last_updated: "2026-07-31T11:10:05+00:00"
+last_updated: "2026-08-03T16:37:02+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-190"
@@ -538,6 +538,73 @@ segment matches; the first matching segment names the reported subcommand.
   expanded and argument tokens *are* split; an alternative exec form takes a
   sibling `args` array passed verbatim with no shell. Either way no wrapper is
   needed, so `hooks/config-detect.sh` is inlined and deleted here.
+
+## Amendment 2026-08-03 — 0188 has landed; what this story inherits
+
+[`0188`](0188-library-backed-vcs-adapter.md) delivered the library-backed
+adapter, the six taxonomy queries and the shared fixture matrix. This story
+builds its classifier over them.
+
+- **The six-query contract is closed.** `is_bare`, `worktree`, `superproject`,
+  `jj_workspace_root`, `jj_repository` and `dual_roots` are inherent methods on
+  `vcs_adapters::library::InProcessProbe`. Anything beyond them is a change to
+  0188, not silent growth here. This story defines whatever **domain port** its
+  classifier needs over them; 0188 deliberately defined none.
+- **Widen the cargo-pup rule** (`vcs_adapters_library_reads_in_process`) to
+  cover wherever `vcs status` / `vcs log` land. It is scoped to
+  `^vcs_adapters::library($|::)` and pairs a permit list with an explicit
+  `std::process` deny; the permit list rejects **grouped** imports, so that code
+  must write one single-item `use` per import.
+- **Reuse the named pure-jj builder** (`vcs_test_support::fixtures::pure_jj`)
+  rather than rebuilding the benchmark fixture, so the cost figures stay
+  comparable.
+- **The 0125 hand-off sub-clause is redundant** — 0188 owns that note and it has
+  been appended.
+
+Seven findings that change how the classifier must be built:
+
+1. **Three walks, not one.** Queries 4, 5 and the jj half of 6 resolve through a
+   **`.jj`-only** walk. `DefaultWorkspaceLoaderFactory::create` performs no walk
+   of its own, so feeding it the combined `.jj`-or-`.git` boundary makes it
+   report absence on both nested-git-in-jj shapes — where `jj workspace root`
+   reports a root. A classifier built on the combined walk reports absence where
+   the oracle reports presence.
+2. **Dual-root equality is necessary but not sufficient** for `colocated`, and
+   inequality is not sufficient for either `nested-` arm. A real
+   `jj git init --colocate` main has equal roots and classifies as `main`; the
+   arms also need the jj-secondary bit (query 5) and the linked-worktree bit
+   (query 2).
+3. **`JS-in` is the shape that catches a naive dual-root rule** — a jj secondary
+   workspace inside its own colocated main, which is *this repo's own*
+   `workspaces/<name>` layout. Its dual roots **differ** while
+   `classify_checkout` reports `jj-secondary`, because that arm's
+   `jj_main_root != git_main_root` guard fails. It is in the matrix.
+4. **The queries return `Result<Option<T>, Error>`**, so the classifier must
+   decide what a repository the pinned library cannot parse classifies as. It is
+   **not** `none`. `dual_roots` is infallible with a `Result` per side; callers
+   comparing the sides must treat any `Err` as "not comparable", never as
+   inequality.
+5. **`WorktreeFacts`, `JjRepositoryFacts`, `JjWorkspaceRole` and `DualRoots`
+   must move into `cli/vcs`** when this story defines its port. They are
+   domain-shaped value types currently declared in the adapter crate, and
+   `vcs_domain_imports_only_permitted` restricts `vcs` to `std`/`kernel::Error`/
+   `crate` — so a domain port structurally cannot reference them where they sit.
+   0188 could not pre-empt the move: its own criteria forbid touching
+   `cli/vcs/src/**`. Expect it to churn the `queries.rs` expected-value tables.
+6. **`superproject` gates on the git-dir vs common-dir comparison, not on
+   `kind()`.** Measured, `kind()` is wrong in both directions: a linked worktree
+   *of* a submodule reports `Submodule` and has **no** superproject, while a
+   submodule *inside* a linked worktree does not report `Submodule` and does.
+7. **gix 0.85 cannot read sha256 repositories** — every gix-backed query returns
+   `Err`. Reftable reads normally.
+
+Cost figures, for the `G <= 1.1 x B` gate (darwin-arm64, matching 0186's
+`B = 35.1 ms`): the library-backed cold per-process path is **3.6-4.7 ms** for
+all six queries plus both port methods, against **23.8 ms** for the single
+`jj log -r @` the subprocess probe ran. Warm in-process calls are 14-50 us. Two
+provenance notes carried forward: `B = 35.1 ms` is from 0186's table, not this
+story's, and the "~41 ms warm bootstrap" this item cites is **derived**
+(149.1 - 107.9), not measured.
 
 ## Validation Results
 

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -193,23 +193,52 @@ Four inheritances that change this item's sizing:
    (`Result<Option<T>, Error>`), so a corrupt repository is observable rather
    than silently reported as "no VCS here"; that is containment of *meaning*,
    not of *blast radius*.
-3. **jj `revision` transfers here, and it is not a small decision.** jj-lib 0.43
-   exposes no read-only, settings-free route to the working-copy commit id: the
-   op stores are settings-free, but the workspace name is reachable only through
-   `LocalWorkingCopy::load` (needs `&UserSettings`) or
-   `SimpleWorkspaceStore::load` (settings-free but **writes** to
-   `.jj/repo/workspace_store`, verified empirically), and `CheckoutState` is
-   private. `InProcessProbe::revision` therefore covers `VcsKind::Git` only and
-   warn-logs for jj. Options: a jj-lib version exposing the checkout state
-   publicly, an upstream request, or **retaining `CommandProbe` for `revision`
-   alone** — which makes the "atomic switch plus deletion" sizing wrong, so it
-   needs deciding early.
+3. **jj `revision` does NOT transfer here — 0188 delivers it.** An earlier draft
+   of this block said it did, on a spike finding that jj-lib 0.43 exposes no
+   read-only, settings-free route to the working-copy commit id. That finding was
+   **wrong** and was reversed on 2026-08-03: `jj_lib::protos` is a public module,
+   so the workspace's checkout state (`operation_id` + `workspace_name`) decodes
+   through published API, and `SimpleOpStore::load` takes a path only. 0188
+   implements the full chain, verified against the live CLI across pure-jj,
+   colocated, commitless, secondary-workspace and multi-workspace shapes, with a
+   fingerprint assertion that it writes nothing.
+
+   **What this changes for this story:** the "atomic switch plus deletion" sizing
+   is *right* after all — there is no reason to retain `CommandProbe` for
+   `revision` alone, and `InProcessProbe` implements `VcsProbe` **fully**, not
+   partially. `detection.rs` asserts full `RepoFacts` equality for both idioms
+   today, so the switch has no revision-shaped gap to close.
+
+   **One behavioural difference to carry knowingly**, because this story's switch
+   is what exposes users to it: asking the `jj` binary **snapshots the working
+   copy first**, so it reports — and writes — a newly created commit when files
+   changed since the last jj command. The in-process route reports the commit as
+   of the last recorded operation and writes nothing. So after the switch,
+   deriving metadata stops having a write side effect on the user's repository,
+   and a `RepoFacts.revision` taken with unsnapshotted edits present names the
+   last recorded commit rather than a fresh one. Decide whether any consumer
+   depends on the snapshot semantics; nothing in the corpus writers appears to.
 4. **sha256 repositories are unsupported by gix 0.85** (measured 2026-08-03):
    every gix-backed query returns `Err` on one, rather than misreading it.
    `detection.rs`'s `is_full_revision_id` also asserts 40 hex, and a sha256
    `HEAD` is 64. Any revision validation must accept both widths or record
    sha256 as unsupported — **this item's switch is what exposes a user on such a
    repository**, so the decision lands here. Reftable repositories read normally.
+5. **The MPL-2.0 licence exception has to be re-checked when `facts` flips.**
+   `uluru` (MPL-2.0, `gix-pack`'s LRU pack cache) is in the normal closure of the
+   published `accelerator-visualiser` binary, but 0188 verified that dead-code
+   elimination removes the whole `gix`/`jj-lib` closure from it — because nothing
+   in the visualiser's reachable call graph enters `vcs-adapters` at all today,
+   not even `CommandProbe`. §3.2's notice obligation therefore does not bind, and
+   the `cli/deny.toml` exception comment records that finding **conditionally**.
+   **This item's switch is the expected trigger that invalidates it.** Once the
+   trees link into a distributed binary, distributing the Executable Form
+   requires telling recipients how to obtain the Source Form, which means a
+   third-party attribution artefact joining `_release_uploads()` — an asset set
+   that carries no licence file today, and whose coverage `test_workflows.py`
+   derives from that function. Re-run 0188's check (unstripped `--release` build;
+   grep for `extensions.objectFormat` and `There is no Jujutsu repo`) as part of
+   the switch, not after it.
 
 ## References
 

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -177,12 +177,15 @@ statement is now false it is quoted and marked.
 
 Four inheritances that change this item's sizing:
 
-1. **Re-home the shared walk before deleting.** `InProcessProbe` delegates to
-   the crate-private `walk_up`/`marker_kind`/`carries_any_marker` helpers rather
-   than duplicating them, and `MarkerWalkRoot`/`CommandProbe` delegate to the
-   same ones. The helpers already live in their own module (`markers.rs`) and
-   survive the deletion, so this is now a check rather than work — but deleting
-   the module along with the pair would break the adapter.
+1. **The deletion is a file deletion.** `InProcessProbe` delegates to the
+   crate-private `walk_up`/`marker_kind`/`carries_any_marker` helpers rather than
+   duplicating them, and `MarkerWalkRoot`/`CommandProbe` delegate to the same
+   ones. Those helpers live in their own module (`markers.rs`), and as of
+   2026-08-03 the subprocess pair does too (`subprocess.rs`) — the crate root
+   holds no adapter code, only `facts` and the module declarations. So retiring
+   the pair is: delete `subprocess.rs`, drop its `pub mod` line, repoint `facts`
+   at `InProcessProbe`, and collapse `detection.rs`'s dual comparison. Do **not**
+   delete `markers.rs` with it; the surviving adapter needs it.
 2. **The containment delta is real and unpriced.** `CommandProbe` parses in a
    child process with a 10-second cap, kill-on-timeout and a scrubbed
    environment. `InProcessProbe` parses repository-controlled data in the

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -12,7 +12,7 @@ parent: "work-item:0136"
 blocked_by: ["work-item:0188"]
 relates_to: ["work-item:0125", "work-item:0179"]
 tags: [rust, vcs, cleanup, tech-debt]
-last_updated: "2026-07-31T08:36:03+00:00"
+last_updated: "2026-08-03T16:37:02+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -142,6 +142,74 @@ the four paths.
 - Priority `medium`: nothing is broken while both implementations coexist — the
   cost is a second code path and a narrower zero-spawn guarantee, not a defect.
   It should not block epic 0136's shell-retirement work.
+
+## Amendment 2026-08-03 — 0188 has landed; corrections and inheritances
+
+**Every reference in this item that attributes the library-backed adapter or the
+zero-spawn harness to 0169 is wrong.** Both are
+[`0188`](0188-library-backed-vcs-adapter.md)'s, and both have now landed. This
+block raises the corrections rather than rewriting the sections above; where a
+statement is now false it is quoted and marked.
+
+- **The adapter exists and ships unwired.** `vcs_adapters::library::InProcessProbe`
+  implements both `vcs` ports plus six inherent taxonomy queries.
+  `vcs_adapters::facts` still names `MarkerWalkRoot`/`CommandProbe`, by design.
+- **0185 owns the `vcs_adapters::facts` switch**, and the switch and the
+  `CommandProbe` deletion are **one atomic change** — the composition root
+  cannot move until nothing else needs the subprocess pair. This closes the open
+  question 0188 recorded on the ordering; 0169 wires its own classifier port
+  without touching `facts`.
+- **The harness criterion here describes `PATH` stubs only.** What it inherits
+  is strictly larger: marker-writing stubs *plus* a platform-aware absolute-path
+  shadow list *plus* the empty-config environment, published from
+  `cli/vcs-test-support` and already proven across a crate boundary by
+  `cli/corpus-adapters/tests/zero_spawn.rs`. The strong form runs in the
+  `check-zero-spawn` CI job.
+- **The transitional dual-adapter comparison must be collapsed.**
+  `cli/vcs-adapters/tests/detection.rs` now runs every case through an injected
+  `(&dyn RepoRoot, &dyn VcsProbe)` seam against **both** implementations.
+  Deleting `CommandProbe` means collapsing it to the library-backed pair alone.
+- The assumption at `:117-121` that "0169 will need to alter this anyway" is
+  **stale**.
+- Two References anchors are stale: 0169 has no "Adapter-swap boundary"
+  heading, and its Dependencies bullet is titled "Unowned debt this story
+  creates".
+
+Four inheritances that change this item's sizing:
+
+1. **Re-home the shared walk before deleting.** `InProcessProbe` delegates to
+   the crate-private `walk_up`/`marker_kind`/`carries_any_marker` helpers rather
+   than duplicating them, and `MarkerWalkRoot`/`CommandProbe` delegate to the
+   same ones. The helpers already live in their own module (`markers.rs`) and
+   survive the deletion, so this is now a check rather than work — but deleting
+   the module along with the pair would break the adapter.
+2. **The containment delta is real and unpriced.** `CommandProbe` parses in a
+   child process with a 10-second cap, kill-on-timeout and a scrubbed
+   environment. `InProcessProbe` parses repository-controlled data in the
+   caller's address space with no time bound, no memory bound and no crash
+   isolation — and after the switch that runs inside `cli/visualiser/server` and
+   on the hook path. **Decide whether an equivalent bound is needed before
+   flipping `facts`.** The queries do distinguish failure from absence
+   (`Result<Option<T>, Error>`), so a corrupt repository is observable rather
+   than silently reported as "no VCS here"; that is containment of *meaning*,
+   not of *blast radius*.
+3. **jj `revision` transfers here, and it is not a small decision.** jj-lib 0.43
+   exposes no read-only, settings-free route to the working-copy commit id: the
+   op stores are settings-free, but the workspace name is reachable only through
+   `LocalWorkingCopy::load` (needs `&UserSettings`) or
+   `SimpleWorkspaceStore::load` (settings-free but **writes** to
+   `.jj/repo/workspace_store`, verified empirically), and `CheckoutState` is
+   private. `InProcessProbe::revision` therefore covers `VcsKind::Git` only and
+   warn-logs for jj. Options: a jj-lib version exposing the checkout state
+   publicly, an upstream request, or **retaining `CommandProbe` for `revision`
+   alone** — which makes the "atomic switch plus deletion" sizing wrong, so it
+   needs deciding early.
+4. **sha256 repositories are unsupported by gix 0.85** (measured 2026-08-03):
+   every gix-backed query returns `Err` on one, rather than misreading it.
+   `detection.rs`'s `is_full_revision_id` also asserts 40 hex, and a sha256
+   `HEAD` is 64. Any revision validation must accept both widths or record
+   sha256 as unsupported — **this item's switch is what exposes a user on such a
+   repository**, so the decision lands here. Reftable repositories read normally.
 
 ## References
 

--- a/meta/work/0188-library-backed-vcs-adapter.md
+++ b/meta/work/0188-library-backed-vcs-adapter.md
@@ -15,7 +15,7 @@ relates_to: ["work-item:0125", "work-item:0168", "work-item:0187",
   "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["work-item:0169"]
 tags: [rust, vcs, dependencies]
-last_updated: "2026-08-03T14:35:24+00:00"
+last_updated: "2026-08-03T16:37:02+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -733,11 +733,20 @@ field) is part of the mapping established in planning.
 
 ## Open Questions
 
-Two questions are open and gate planning. Two more are closed, kept for the
-record because their answers carry consequences.
+**Both blocking questions were closed during implementation (2026-08-03).** Two
+older ones are kept below for the record because their answers carry
+consequences.
 
-- **OPEN — who owns the CI job for the strong-form zero-spawn run, and does the
-  runner actually permit it?** The criterion is deliberately non-degradable:
+- **CLOSED 2026-08-03 — who owns the CI job for the strong-form zero-spawn run,
+  and does the runner actually permit it?** **0188 owns it.** Delivered as
+  `check-zero-spawn`: `ubuntu-latest`, passwordless `sudo`, no container, in
+  `main.yml` (actionlint lints nothing else), modelled on `check-architecture`
+  so the nightly-isolation invariant still sees exactly `{check-architecture}`,
+  and wired into `prerelease.needs`. The shadow list is platform-aware and
+  resolved at run time. Original text follows.
+
+  ~~**OPEN — who owns the CI job for the strong-form zero-spawn run, and does the
+  runner actually permit it?**~~ The criterion is deliberately non-degradable:
   the strong form (replacing or bind-mounting `/usr/bin/git` and friends) must
   run somewhere, and "somewhere" is currently a Linux CI job that may not exist
   and whose provider may forbid modifying `/usr/bin` without privileged
@@ -747,7 +756,14 @@ record because their answers carry consequences.
   the provisioning into its own small item that 0188 declares as `blocked_by`,
   rather than silently weakening the criterion to `PATH`-only everywhere —
   which would leave the property unproven on any platform.
-- **OPEN — who changes `vcs_adapters::facts`, 0169 or 0185, and in what order?**
+- **CLOSED 2026-08-03 — who changes `vcs_adapters::facts`, 0169 or 0185, and in
+  what order?** **0185**, atomically with the `CommandProbe` deletion: the
+  composition root cannot switch until nothing else needs the subprocess pair.
+  0169 wires its own classifier port without touching `facts`. Recorded on 0185.
+  Original text follows.
+
+  ~~**OPEN — who changes `vcs_adapters::facts`, 0169 or 0185, and in what
+  order?**~~
   This story deliberately leaves it hard-wired. Requirements say wiring
   "belongs to 0169 and 0185"; the 0185 hand-off says the composition-root change
   is a dependant's own work. Both are currently unblocked by 0188 alone, and
@@ -905,68 +921,111 @@ verbatim per-fixture oracle comparison, are in
 
 ## Validation Results
 
-- **Platform the strong-form zero-spawn run held on** — _pending_; absolute
-  paths shadowed there — _pending_; paths not shadowable on each other platform
-  — _pending_.
-- **`gix` / `gix-*` versions resolved in `Cargo.lock`** — _pending_.
-- **`jj-lib` version resolved in `Cargo.lock`** — _pending_.
+**Implemented 2026-08-03.** Host for every figure: **darwin-arm64**, jj 0.43.0,
+git 2.54.0, Rust 1.90.0 — chosen to match 0186's `B = 35.1 ms`, since the ~97 ms
+probe delta is macOS-specific and a cross-host comparison would leave 0169's
+gate ill-posed.
+
+- **Platform the strong-form zero-spawn run held on** — the `check-zero-spawn`
+  Linux CI job is written, wired into `prerelease.needs`, and lands with this
+  branch; its first execution is on that run. Locally and on macOS the suite
+  degrades to `PATH`-only under SIP, and **records** what it could not shadow:
+  `/usr/bin/git`, `/opt/homebrew/bin/git`, `/opt/homebrew/bin/jj`, and jj's mise
+  install path plus its shim. The harness half of the contract **is** verified:
+  it fails closed on a malformed mode and hard-fails when `strong` is claimed
+  while a listed path is still executable.
+- **`gix` / `gix-*` versions resolved in `Cargo.lock`** — `gix 0.85.0`, 47
+  gix-family packages, **no duplicate versions**. Asserted by
+  `tests/integration/deny/test_vcs_library_graph.py`.
+- **`jj-lib` version resolved in `Cargo.lock`** — `0.43.0`.
 - **MSRV of `gix` 0.85 and `jj-lib` 0.43 vs the pinned Rust toolchain** —
-  _resolved 2026-08-02_: pinned Rust 1.90.0; `jj-lib` 0.43.0 MSRV 1.89; `gix`
-  0.85.0 MSRV 1.85. Both fit, with one minor version of headroom.
-- **Installed `jj` CLI version the fixtures were built with** — _bumped
-  2026-08-02_: `mise.toml` now pins **0.43.0**, matching the `jj-lib` crate pin
-  (prior state: 0.36.0, seven minor versions behind — the skew this bump
-  designs out). Outstanding: `mise install` on each machine and CI, and a
-  re-run of the jj-fixture shell suites, which were last green against 0.36 —
-  _pending_.
-- **Installed `git` CLI version the fixtures were built with** — _recorded
-  2026-08-02_: 2.54.0, against `gix` 0.85. Coherence unverified but low-risk;
-  no format-boundary concern was identified. _Spike 2026-08-03_: gix 0.85.0 read
-  bare, linked-worktree, modern-submodule, nested-submodule and old-form-nested
-  repositories written by git 2.54.0 with no format-boundary problem observed,
-  on darwin-arm64.
-- **gix API coverage for the six queries** — _spiked 2026-08-03_: queries 1 and
-  2 are served by library calls; **query 3 has no gix API and requires a
-  hand-rolled derivation** (validated against the oracle at submodule depths 1
-  and 2). Queries 4-6 not covered by this spike. See Spike Outcome.
-- **`gix` boundary containment mechanism** — _resolved 2026-08-03_:
-  `ceiling_dirs` cannot enforce the rule at any anchor; `gix::open` performs no
-  walk and is the mechanism. A paired negative assertion is available:
-  unbounded `gix::discover` from a `.jj`-only directory nested in a git
-  repository escapes to the parent repository, reproducibly.
-- **`GIT_DIR` scrub invariant, git side** — _measured 2026-08-03_: all six
-  probed gix calls stable under poisoned `GIT_DIR` + `GIT_COMMON_DIR` +
-  `GIT_CONFIG_GLOBAL`; `git rev-parse --git-dir` diverged under the same
-  poisoning (live control).
-- **`GIT_DIR` scrub invariant, jj-lib side** — _measured 2026-08-03_: stable.
-  Every gix **and** jj-lib call returned identical values across **all 25
-  (fixture, start directory) pairs** with `GIT_DIR` and `GIT_COMMON_DIR` pointed
-  at another fixture's real `.git`. The invariant therefore needs no
-  implementation on either side — it is verified, not built. Non-vacuity control
-  confirmed in the same run: `gix::discover_with_environment_overrides` returned
-  the poison target while plain `gix::discover` and `gix::open` did not.
-- **Local toolchain skew** — _found 2026-08-03_: the development machine used
-  for the spike had `jj` **0.42.0** on `PATH` from Homebrew
-  (`/opt/homebrew/bin/jj`), not the pinned 0.43.0, because `mise.toml` is
-  untrusted there and mise was not activating. Reinforces the outstanding
-  `mise install` item above, and is a reminder that on a developer's macOS
-  machine `/opt/homebrew/bin/jj` **is** the real binary — the opposite of CI,
-  where no system `jj` exists at all (see the shadow-list note in the research
-  document).
-- **Adapter/shell divergences recorded** — the `GIT_DIR` scrub asymmetry in
-  `classify_checkout` (`:206-215` unscrubbed vs `:130-135` scrubbed), which the
-  adapter deliberately does not reproduce — _confirmed 2026-08-01_; any further
-  divergence found in implementation — _pending_.
-- **Non-vacuity demonstrations** — the deliberate `std::process` import failing
-  cargo-pup — _pending_; the deliberate `UserSettings` construction failing the
-  source guard — _pending_; the unscrubbed control diverging under the poisoned
-  `GIT_DIR` run — _pending_.
-- **Cost, against this story's pure-jj fixture** (reused by 0169; median of 20,
-  host and OS): library init — _pending_; warm per-call in-process — _pending_;
-  cold per-process via the reference artefact — _pending_; `CommandProbe`
-  baseline for the port methods — _pending_.
-- **Reference artefact size**, linked vs stubbed builds and the delta —
-  _pending_.
+  _resolved 2026-08-02_: pinned 1.90.0; jj-lib 1.89, gix 1.85. Both fit. The
+  graph test additionally asserts **no** package in the closure declares a
+  `rust-version` above the pin (354 packages declare one), catching the
+  `kstring` class of trap directly rather than trusting resolver 3's
+  *preference*.
+- **Installed `jj` CLI version the fixtures were built with** — 0.43.0, matching
+  the crate pin. `mise install` done. A committed test now asserts the **binary**
+  against the **resolved library** at major.minor, not merely the two
+  declarations against each other.
+- **Installed `git` CLI version** — 2.54.0. The harness carries a 2.45 floor
+  with a named diagnostic (`--ref-format=reftable` landed there).
+- **gix API coverage for the six queries** — all six delivered. Query 3
+  (superproject) is the hand-rolled derivation, as the spike predicted, and
+  **`gix::open` accepts a linked-worktree gitdir** — the one open question the
+  spike left, now settled by the `SM-wt` fixture.
+- **`gix` boundary containment mechanism** — `gix::open`/marker-walk, as
+  designed. The paired negative assertion is committed: an unbounded
+  `gix::discover` on the same fixture escapes to the parent repository.
+- **`GIT_DIR` scrub invariant** — _verified 2026-08-03 across all 34 (fixture,
+  start directory) pairs_, over a poisoning matrix widened beyond the original
+  two variables to everything `scrub_environment` touches **plus**
+  `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES` and the
+  `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` triple, with a populated global config
+  asserting a divergent `core.bare`. Every value identical. Non-vacuity control
+  confirmed in the same run: `gix::discover_with_environment_overrides` resolves
+  the poison target, asserted **inside the poisoned child**.
+- **Adapter/oracle divergences recorded** — three, each deliberate:
+  1. **sha256 is unsupported by gix 0.85.** Every gix-backed query returns `Err`
+     on the `S256` fixture rather than misreading it. Correct under the partition
+     rule — a repository *is* here and the pinned library cannot answer — and the
+     reason the queries carry an error channel at all. Reftable reads normally.
+     **0185 inherits the consequence**, since its switch exposes users to it.
+  2. **`D1` returns `Err` where both CLIs report absence.** A `.jj/repo` pointing
+     at a deleted directory is a *broken* workspace, not an absent one;
+     reporting absence is exactly the failure the error channel exists to
+     prevent.
+  3. The pre-existing `GIT_DIR` scrub asymmetry in `classify_checkout`, which the
+     adapter deliberately does not reproduce.
+- **Non-vacuity demonstrations** — all three done, and all three **committed**
+  rather than shown by hand: a `std::process::Command` import fails cargo-pup
+  with *"Use of module 'std::process::Command' is denied"* naming the rule
+  (`tests/integration/pup/test_import_rule.py`, plus a compliant positive
+  control and a grouped-import case); a deliberate `UserSettings::from_config`
+  fails `lint:vcs-settings:check`; the unscrubbed control diverges under the
+  poisoned run.
+- **Reference artefact size** — delivered two-binary shape, `--release`
+  (stripped by the profile), all four release triples:
+
+  | Triple | linked | stubbed | delta | ratio |
+  | --- | --- | --- | --- | --- |
+  | `aarch64-apple-darwin` | 2,277,472 | 350,912 | 1,926,560 | **6.49x** |
+  | `x86_64-apple-darwin` | 2,308,192 | 344,224 | 1,963,968 | **6.71x** |
+  | `aarch64-unknown-linux-musl` | 2,245,528 | 360,864 | 1,884,664 | **6.22x** |
+  | `x86_64-unknown-linux-musl` | 2,426,392 | 386,504 | 2,039,888 | **6.28x** |
+
+  All four cross-compile and pass magic-byte checks; both musl builds pass
+  `_assert_static_elf`. Every triple clears the 3x ratio floor and both musl
+  builds clear the 1,500,000-byte absolute floor. The figures **exceed** the
+  prototype's (5.42x darwin / 6.19x musl), so the two-binary shape linked at
+  least as much as the feature-gated one.
+
+- **Cost, against the pure-jj fixture** (median of 20 with 3 warm-up runs):
+
+  | Measurement | Median | Min | Max |
+  | --- | --- | --- | --- |
+  | cold per-process, all six queries + both ports, pure-jj | **4.03 ms** | 3.64 | 4.67 |
+  | cold per-process, all six queries + both ports, plain git | 4.74 ms | 4.29 | 5.37 |
+  | cold per-process, single query (`jj_workspace_root`), pure-jj | **3.58 ms** | 3.33 | 4.75 |
+  | cold per-process, single query (`is_bare`), plain git | 3.96 ms | 3.48 | 4.41 |
+  | `CommandProbe` jj subprocess (`jj log -r @ -T commit_id`) | **23.84 ms** | 21.52 | 24.75 |
+  | `CommandProbe` git subprocess (`git rev-parse HEAD`) | 5.34 ms | 4.60 | 6.06 |
+
+  Warm in-process, same host, median of 20: first-call jj-lib **30.6 us**,
+  first-call gix **102.5 us**; per query `jj_workspace_root` 13.7,
+  `jj_repository` 29.7, `superproject` 35.3, `worktree` 37.8, `is_bare` 38.6,
+  `dual_roots` 50.1 us.
+
+  Read for 0169's gate: the library-backed cold per-process path costs roughly
+  **one sixth** of a single `jj` subprocess. The single-query mode inflation is
+  ~12% (3.58 vs 4.03 ms) on pure-jj, confirming amendment 4 — process startup
+  dominates and the mode is retained for 0169's convenience, not necessity.
+
+  **Not measured**: an `x86_64-unknown-linux-musl` cold per-process figure. The
+  measurement host is darwin-arm64 and cannot execute a musl binary; the
+  criterion asked for it so 0169 does not set a threshold with no Linux
+  datapoint. **Carried forward** — the `check-zero-spawn` job is the natural
+  place to take it.
 
 ## References
 

--- a/meta/work/0188-library-backed-vcs-adapter.md
+++ b/meta/work/0188-library-backed-vcs-adapter.md
@@ -70,10 +70,12 @@ later epic-0136 phases migrate them.
 
 ## Requirements
 
-**Amended 2026-08-03 during planning**, on measurement rather than inference —
-eight changes, each recorded inline where it applies. Amendments 1-4 came from
-the planning measurement pass; 5-6 from plan review; 7-8 from the pin decision
-and the `revision` spike.
+**Amended 2026-08-03**, on measurement rather than inference — ten changes, each
+recorded inline where it applies. Amendments 1-4 came from the planning
+measurement pass; 5-6 from plan review; 7-8 from the pin decision and the
+`revision` spike; 9-10 from implementation and validation. **Amendment 8 is
+withdrawn by amendment 10** — the spike behind it was wrong, and the jj
+`revision` mechanism it descoped is delivered here.
 
 1. The **reference-artefact size floor** was mis-calibrated and would have failed
    on the artefact it guards; it is now a ratio floor plus a
@@ -106,12 +108,42 @@ and the `revision` spike.
    range is anyway identical to jj-lib's own `^0.85.0`, so the single-graph
    property is untouched. The coupling is jj-lib + gix + the Rust toolchain + the
    `mise.toml` jj CLI pin (Dependency policy, Dependencies).
-8. **jj `revision` is out of scope; the type implements `VcsProbe` partially.**
-   A spike established that jj-lib 0.43 exposes no read-only, settings-free route
-   to the working-copy commit id. `revision` covers `VcsKind::Git`; the jj
-   mechanism transfers to 0185. The crate-wide `UserSettings` guard **stays**
-   crate-wide — the spike is the evidence nothing in scope needs it (Delivered
-   surface, Library traps, Acceptance Criteria).
+8. ~~**jj `revision` is out of scope; the type implements `VcsProbe` partially.**~~
+   **WITHDRAWN 2026-08-03 — superseded by amendment 10.** The spike it rested on
+   was wrong. The crate-wide `UserSettings` guard does stay crate-wide, for the
+   better reason that the delivered route needs no settings either.
+9. **`gix` takes `default-features = false`, not default features.** gix's
+   `default` reaches `extras` → `credentials` → `gix-credentials`, the one gix
+   subsystem that spawns `git credential-*` helper programs — against a module
+   whose whole point is reading git without a subprocess. Nothing is lost:
+   `jj-lib`'s own selection still enables `attributes`, `blob-diff`, `index`,
+   `max-performance-safe`, `sha1` and `zlib-rs`, and the graph test asserts each
+   one present and the network-client family absent. This also makes the
+   `gix-credentials` ban a live guard against a later feature widening rather
+   than a statement about a crate that could never appear (Dependency policy).
+10. **jj `revision` is in scope after all; the type implements `VcsProbe` fully.**
+    Amendment 8's spike premise was **false**: `jj_lib::protos` is a public
+    module, so the workspace's checkout state (`operation_id` +
+    `workspace_name`) decodes through published API rather than a private wire
+    format, and `SimpleOpStore::load` takes a path only — no settings anywhere.
+    The chain is delivered and verified against the live CLI across pure-jj,
+    colocated, commitless, secondary-workspace and multi-workspace shapes, and
+    fingerprint-asserted to write nothing. `prost` and `pollster` join the pins
+    as jj-lib-coupled direct edges (already in the lock, so two new edges and no
+    new packages), making the pin coupling **six-way**. The one divergence from
+    the `jj` binary is that the binary snapshots the working copy first — and
+    writes — where this route reports the last recorded commit; that is the
+    read-only direction and is pinned by a test (Delivered surface, Dependency
+    policy, Acceptance Criteria).
+9. **`gix` takes `default-features = false`, not default features.** gix's
+   `default` reaches `extras` → `credentials` → `gix-credentials`, the one gix
+   subsystem that spawns `git credential-*` helper programs — against a module
+   whose whole point is reading git without a subprocess. Nothing is lost:
+   `jj-lib`'s own selection still enables `attributes`, `blob-diff`, `index`,
+   `max-performance-safe`, `sha1` and `zlib-rs`, and the graph test asserts each
+   one present and the network-client family absent. This also makes the
+   `gix-credentials` ban a live guard against a later feature widening rather
+   than a statement about a crate that could never appear (Dependency policy).
 
 Two assumptions also resolved in the same pass: `gix`'s gating feature *is* on
 under `jj-lib`'s defaults, so the single-graph reasoning holds; and the
@@ -134,24 +166,28 @@ the full empirical oracle mapping.
   both libraries. **The domain crate `cli/vcs` is untouched: no port is added,
   widened or changed.**
 
-  **Amended 2026-08-03 (spike) — `VcsProbe` is implemented *partially*.** `kind`
-  is complete; `revision` covers `VcsKind::Git` (via
-  `gix::discover(root)?.head_commit()?.id()`) and returns `None`, warn-logged, for
-  `VcsKind::Jj`. jj-lib 0.43 exposes no read-only, settings-free route to the
-  working-copy commit id: the op stores are settings-free
-  (`SimpleOpHeadsStore::load`, `SimpleOpStore::load`) but the workspace name
-  needed to index `View::get_wc_commit_id` is reachable only through
-  `LocalWorkingCopy::load` (requires `&UserSettings` for `TreeStateSettings`) or
-  `SimpleWorkspaceStore::load` (settings-free but **writes** to
-  `.jj/repo/workspace_store` — verified empirically, so unusable in a read-only
-  probe), and `CheckoutState` is a private struct. Reading the
-  `.jj/working_copy/checkout` protobuf by hand is the only remaining path and is
-  exactly the private-internals dependency this design avoids. **0185 inherits the
-  jj revision mechanism**, alongside the composition-root switch it already owns;
-  its options are a jj-lib version exposing the checkout state publicly, an
-  upstream request for one, or retaining `CommandProbe` for `revision` alone —
-  which would make its "atomic switch plus deletion" sizing wrong, so it needs
-  deciding early.
+  **Amended 2026-08-03 (validation) — `VcsProbe` is implemented *fully*.** `kind`
+  is complete; `revision` answers for both idioms. The git half is
+  `gix::discover(root)?.head_commit()?.id()`. The jj half reads the workspace's
+  checkout state — `<workspace_root>/.jj/working_copy/checkout`, decoded as
+  `jj_lib::protos::local_working_copy::Checkout`, a **public** module — for the
+  operation id and the workspace's own name, then reads that operation's view out
+  of `SimpleOpStore::load(<repo>/op_store, ..)` and looks the commit up in
+  `View.wc_commit_ids` by name. No settings value is constructed anywhere, so the
+  crate-wide guard is untouched, and the route writes nothing (fingerprint-asserted
+  over the whole `.jj` tree). The name lookup is load-bearing: two workspaces of
+  one repository hold different working-copy commits, so taking the view's sole
+  entry would answer for the wrong one.
+
+  An earlier amendment (8, now withdrawn) descoped the jj half to 0185 on a spike
+  finding that no read-only, settings-free route existed. That finding was wrong —
+  it treated the checkout protobuf as a private wire format when `jj_lib::protos`
+  is public, and it recorded `UserSettings::from_config` as unbounded panics when
+  it returns `Result` and needs exactly five keys. **Nothing transfers to 0185**
+  except the recorded divergence: asking the `jj` binary snapshots the working
+  copy first — and writes a new commit — where this route reports the commit as of
+  the last recorded operation. That is the read-only direction, and after 0185's
+  switch metadata derivation stops mutating the user's repository.
 - **Six taxonomy queries** as *inherent methods* on that type — not port
   methods. `CommandProbe` and `MarkerWalkRoot` gain none of them. 0169 defines
   whatever domain port its classifier needs and implements it over these; that
@@ -331,18 +367,20 @@ These are shipped artefacts, not incidental test code, and are sized as such.
   crate-wide, deliberately wider than the detection paths strictly require, so
   the guard is a simple one.
 
-  **Confirmed 2026-08-03 (spike) — the crate-wide statement holds, and it is why
-  jj `revision` is out of scope.** A spike enumerated every route to the
-  working-copy commit id and found none that is both settings-free and
-  read-only: `LocalWorkingCopy::load` needs `&UserSettings` for
+  **Confirmed 2026-08-03 (validation) — the crate-wide statement holds, and jj
+  `revision` is delivered without narrowing it.** The spike that first looked at
+  this found `LocalWorkingCopy::load` needs `&UserSettings` for
   `TreeStateSettings`; `CheckoutState` (which holds the `operation_id` +
   `workspace_name` pair) is private; and `SimpleWorkspaceStore::load`, though
   settings-free, **creates `.jj/repo/workspace_store` and writes an `index`
-  file** — verified by removing the directory and observing it recreated. The op
-  stores themselves are settings-free (`SimpleOpHeadsStore::load(dir)`,
-  `SimpleOpStore::load(path, root_data)`), so the chain fails only at the
-  workspace-name link. The guard therefore costs nothing in scope, and does not
-  need narrowing.
+  file** — verified by removing the directory and observing it recreated. All
+  three are true, and all three are avoidable: the workspace name those routes
+  were reaching for is recorded in the workspace's own `checkout` file, whose
+  schema is public (`jj_lib::protos::local_working_copy::Checkout`), and the op
+  stores are settings-free (`SimpleOpStore::load(path, root_data)`). The chain
+  never needed the blocked links. So the guard costs nothing in scope and needs
+  no narrowing — now shown by a delivered mechanism rather than by the absence of
+  one.
 
   **The loader does not walk** (verified 2026-08-03 against jj-lib 0.43
   `src/workspace.rs:564-585`): `create(workspace_root)` demands a path whose
@@ -385,8 +423,10 @@ These are shipped artefacts, not incidental test code, and are sized as such.
 - **A `[[licenses.exceptions]]` entry for `uluru`** (MPL-2.0) in
   `cli/deny.toml` — `gix-pack`'s LRU cache, not feature-gatable. It **must**
   carry an inline comment citing this work item.
-- **`gix` with default features** — network transports are excluded by default,
-  so no TLS stack enters the graph.
+- **`gix` with `default-features = false`** (*amendment 9*) — no TLS stack enters
+  the graph either way, but gix's `default` reaches `extras` → `credentials` →
+  `gix-credentials`, which spawns `git credential-*` helper programs. `jj-lib`'s
+  own feature selection supplies everything the adapter calls.
 - **A `cli/pup.ron` rule scoped to the library-backed module only** — not to
   `vcs_adapters` as a whole, since the retained `CommandProbe` legitimately
   spawns. Two clauses, because a permit-list alone cannot express this
@@ -425,15 +465,15 @@ field) is part of the mapping established in planning.
       **transitional**: 0185 deletes `CommandProbe`, and collapsing the suite to
       the library-backed type alone is part of that deletion.
 
-      **Amended 2026-08-03 (spike) — parity is asserted per `VcsKind`.** Full
-      `RepoFacts` equality for `VcsKind::Git`; `root`/`name`/`kind` only for
-      `VcsKind::Jj`, where the library-backed `revision` is `None` by design
-      while `CommandProbe` returns a 40-hex id. The jj cases therefore assert the
-      `CommandProbe` arm against the suite's fixed values as today, and the
-      library-backed arm against the three fields it owns, so neither adapter's
-      coverage is dropped. Narrowing wholesale would also have discarded
-      achievable protection on the git revision path, which
-      `detection.rs:84-86` already pins.
+      **Amended 2026-08-03 (validation) — parity is full `RepoFacts` equality
+      for every `VcsKind`.** An earlier amendment narrowed it per `VcsKind`, on
+      the descope that amendment 10 withdraws. With the jj `revision` route
+      delivered there is no field either adapter cannot answer, so all 7 cases
+      assert whole-struct equality. The one shape where the two legitimately
+      differ — an unsnapshotted edit, where asking the `jj` binary snapshots the
+      working copy and writes a new commit — is pinned separately in `library.rs`
+      rather than relaxed here; every fixture in this suite is built and then read
+      with no intervening edit.
 
       Related, measured 2026-08-03: a **sha256** repository's `HEAD` is 64 hex
       characters, so `is_full_revision_id`'s 40-hex assertion rejects it. Any
@@ -950,6 +990,33 @@ gate ill-posed.
   declarations against each other.
 - **Installed `git` CLI version** — 2.54.0. The harness carries a 2.45 floor
   with a named diagnostic (`--ref-format=reftable` landed there).
+- **jj `revision` — delivered here, not descoped** (amendment 10, reversing 8).
+  Route: the workspace's checkout state
+  (`<workspace_root>/.jj/working_copy/checkout`, decoded as the **public**
+  `jj_lib::protos::local_working_copy::Checkout`) gives the operation id and the
+  workspace's own name; `SimpleOpStore::load(<repo>/op_store, ..)` reads that
+  operation's view; `View.wc_commit_ids` is indexed by name. No settings value is
+  constructed, so `lint:vcs-settings:check` still passes crate-wide.
+
+  Verified against the live CLI, exact match on every shape tried: this repo,
+  pure jj (`--no-colocate`, so there is no git HEAD to have fallen back to),
+  colocated, commitless, a secondary workspace, and that workspace's main.
+  **The multi-workspace case is the load-bearing one** — the two report
+  *different* commits, so indexing by name is doing real work; taking the view's
+  sole entry would pass every single-workspace test and answer for the wrong
+  workspace. Writes nothing: fingerprint-asserted over the whole `.jj` tree,
+  which matters because a sibling loader in the same area does create
+  directories on load. Broken checkout state → warn-logged absence, no panic.
+
+  **`detection.rs` now asserts full `RepoFacts` equality for both idioms** — the
+  per-`VcsKind` narrowing is gone, and all 7 cases pass.
+
+  **One divergence, recorded deliberately**: asking the `jj` binary snapshots the
+  working copy first, so with unsnapshotted edits present it reports *and writes*
+  a new commit, while this route reports the commit as of the last recorded
+  operation and writes nothing. Measured both directions. After 0185's switch,
+  metadata derivation therefore stops mutating the user's repository. Pinned by
+  `an_unsnapshotted_edit_is_the_one_documented_divergence`.
 - **gix API coverage for the six queries** — all six delivered. Query 3
   (superproject) is the hand-rolled derivation, as the spike predicted, and
   **`gix::open` accepts a linked-worktree gitdir** — the one open question the
@@ -989,16 +1056,22 @@ gate ill-posed.
 
   | Triple | linked | stubbed | delta | ratio |
   | --- | --- | --- | --- | --- |
-  | `aarch64-apple-darwin` | 2,277,472 | 350,912 | 1,926,560 | **6.49x** |
-  | `x86_64-apple-darwin` | 2,308,192 | 344,224 | 1,963,968 | **6.71x** |
-  | `aarch64-unknown-linux-musl` | 2,245,528 | 360,864 | 1,884,664 | **6.22x** |
-  | `x86_64-unknown-linux-musl` | 2,426,392 | 386,504 | 2,039,888 | **6.28x** |
+  | `aarch64-apple-darwin` | 2,512,576 | 350,512 | 2,162,064 | **7.17x** |
+  | `x86_64-apple-darwin` | 2,560,820 | 347,504 | 2,213,316 | **7.37x** |
+  | `aarch64-unknown-linux-musl` | 2,476,312 | 360,864 | 2,115,448 | **6.86x** |
+  | `x86_64-unknown-linux-musl` | 2,699,320 | 386,504 | 2,312,816 | **6.98x** |
 
   All four cross-compile and pass magic-byte checks; both musl builds pass
   `_assert_static_elf`. Every triple clears the 3x ratio floor and both musl
   builds clear the 1,500,000-byte absolute floor. The figures **exceed** the
   prototype's (5.42x darwin / 6.19x musl), so the two-binary shape linked at
   least as much as the feature-gated one.
+
+  **Re-measured after the jj `revision` route landed** (amendment 10), which is
+  why these exceed the first pass (6.22x-6.71x): the op-store read and the
+  protobuf decode link more of jj-lib. All four triples were re-cross-compiled to
+  confirm the new direct `prost`/`pollster` edges break no target — they could
+  only have, and did not. Host-native ratio via `build:cli:fixture-size`: 7.16x.
 
 - **Cost, against the pure-jj fixture** (median of 20 with 3 warm-up runs):
 
@@ -1016,6 +1089,12 @@ gate ill-posed.
   `jj_repository` 29.7, `superproject` 35.3, `worktree` 37.8, `is_bare` 38.6,
   `dual_roots` 50.1 us.
 
+  **Re-measured after the jj `revision` route landed** (amendment 10), on this
+  repo's colocated workspace: all six queries + both ports **4.81 ms** (min 4.44,
+  max 6.18), single query 2.80 ms, against `jj log -r @ -T commit_id` at
+  26.54 ms. So the full surface — now including a real jj revision — still costs
+  roughly **a fifth** of one `jj` subprocess.
+
   Read for 0169's gate: the library-backed cold per-process path costs roughly
   **one sixth** of a single `jj` subprocess. The single-query mode inflation is
   ~12% (3.58 vs 4.03 ms) on pure-jj, confirming amendment 4 — process startup
@@ -1026,6 +1105,50 @@ gate ill-posed.
   criterion asked for it so 0169 does not set a threshold with no Linux
   datapoint. **Carried forward** — the `check-zero-spawn` job is the natural
   place to take it.
+
+- **Cold-cache compile cost** (measured 2026-08-03, darwin-arm64, 16 logical /
+  12 performance cores, fresh `CARGO_TARGET_DIR`, no `sccache`). This branch
+  changes `cli/Cargo.lock`, which invalidates the `Swatinem/rust-cache` key on
+  every Rust job, so the first CI run here compiles cold by construction.
+
+  | Cold build | Wall | CPU | Crates |
+  | --- | --- | --- | --- |
+  | `build:server:dev` (whole closure) | **21.20 s** | 102.97 s | 297 |
+  | `-p vcs-adapters` (the two new trees alone) | 16.92 s | 65.80 s | 198 |
+
+  So the two trees are ~64% of the server's cold CPU cost but only ~17 s of wall
+  clock here, and 46 gix-family crates. Scaled to a 4-vCPU `ubuntu-latest`
+  runner the added cost is on the order of a minute or two — comfortably inside
+  `test-visual-regression`'s `timeout-minutes: 20`, whose wall clock is dominated
+  by Playwright and Docker rather than by this build. **No budget raise needed**;
+  `check-zero-spawn` carries the same 20-minute cap and the same cold first run.
+
+- **Shipped-binary size impact: none, because the trees do not link.** Verified
+  2026-08-03 on an unstripped `--release` `accelerator-visualiser`
+  (`CARGO_PROFILE_RELEASE_STRIP=false`, darwin-arm64, 10.7 MB): dead-code
+  elimination removes the whole `gix`/`jj-lib` closure. Distinctive literals
+  (`extensions.objectFormat` from gix, `There is no Jujutsu repo` from jj-lib)
+  are present in the linked reference artefact and absent from the shipped
+  binary, which carries **zero** symbols from `gix`, `gix-pack`, `gix-odb`,
+  `jj_lib`, `clru` or `uluru` against 26,247 total. The cause is broader than
+  this story: nothing in the visualiser's reachable call graph enters
+  `vcs-adapters` at all — `CommandProbe`'s own `rev-parse` literal is absent
+  too. A formal before/after byte comparison against the pre-branch revision was
+  therefore not taken; the delta is nil by construction. **This also closes the
+  MPL-2.0 §3.2 question** (see below) and **must be re-checked when the
+  visualiser starts reaching `vcs_adapters::facts`** — 0185's composition-root
+  switch is the expected trigger, and it is recorded there.
+
+- **MPL-2.0 §3.2 — closed 2026-08-03: the notice obligation does not bind.**
+  `uluru` is in the normal closure of exactly one shipped binary
+  (`accelerator-visualiser`; neither `accelerator` nor `accelerator-verify` has
+  it at all), and the dead-code-elimination evidence above shows no `uluru` code
+  is distributed in it. §3.1 is satisfied trivially — we ship no modifications —
+  so no third-party attribution artefact is required in the release payload, and
+  `_release_uploads()` is unchanged. The `cli/deny.toml` exception comment
+  records the finding, its evidence and its re-check trigger; an earlier draft of
+  that comment asserted the obligation was discharged by a staged licence file
+  that does not exist, which is corrected.
 
 ## References
 

--- a/meta/work/0188-library-backed-vcs-adapter.md
+++ b/meta/work/0188-library-backed-vcs-adapter.md
@@ -15,7 +15,7 @@ relates_to: ["work-item:0125", "work-item:0168", "work-item:0187",
   "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["work-item:0169"]
 tags: [rust, vcs, dependencies]
-last_updated: "2026-08-02T14:39:47+00:00"
+last_updated: "2026-08-03T14:35:24+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -70,6 +70,61 @@ later epic-0136 phases migrate them.
 
 ## Requirements
 
+**Amended 2026-08-03 during planning**, on measurement rather than inference —
+eight changes, each recorded inline where it applies. Amendments 1-4 came from
+the planning measurement pass; 5-6 from plan review; 7-8 from the pin decision
+and the `revision` spike.
+
+1. The **reference-artefact size floor** was mis-calibrated and would have failed
+   on the artefact it guards; it is now a ratio floor plus a
+   headroom-bearing absolute floor with its unit stated (Acceptance Criteria).
+2. **Three walks are required, not one** — queries 4, 5 and the jj half of 6
+   need a `.jj`-only walk, because `jj-lib`'s loader does not walk (Delivered
+   surface, and the Library trap on `Workspace::load`).
+3. The **"colocated" fixture row is two distinct shapes**, the submodule row is
+   three, and `jj git init` **colocates by default** at 0.43 so the pure-jj
+   builder needs `--no-colocate` (Acceptance Criteria, Test-support
+   deliverables).
+4. The **single-query-mode rationale was measurably false** — process startup
+   dominates, so the aggregate figure is not inflated by an unknown factor
+   (Acceptance Criteria).
+5. The **size floor needs a mechanism, not just a number.** Amendment 1 fixed the
+   threshold but left it a figure recorded in Validation Results, which catches no
+   later regression. It is now a committed assertion, with the absolute-byte floor
+   scoped to musl triples and a host-native ratio check on the PR path
+   (Acceptance Criteria).
+6. **The six queries return `Result<Option<T>, Error>`, not `Option<T>`.**
+   `Option` alone conflates "no repository of this kind here" with "a repository
+   is here and the pinned pre-1.0 library could not parse it", and silently drops
+   `CommandProbe`'s time cap, crash isolation and warn-logging when 0185 switches
+   the composition root. `dual_roots` is infallible and carries a `Result` per
+   side, since a whole-struct `Result` cannot express one-sided failure on the
+   field that discriminates `colocated` from `nested-*` (Delivered surface).
+7. **The pins are asymmetric and the coupling is four-way, not two-way.**
+   `jj-lib` stays exact at `=0.43.0`; `gix` becomes `~0.85.0`, permitting
+   `0.85.x` patches so a RustSec fix is a lock update rather than a pin edit — the
+   range is anyway identical to jj-lib's own `^0.85.0`, so the single-graph
+   property is untouched. The coupling is jj-lib + gix + the Rust toolchain + the
+   `mise.toml` jj CLI pin (Dependency policy, Dependencies).
+8. **jj `revision` is out of scope; the type implements `VcsProbe` partially.**
+   A spike established that jj-lib 0.43 exposes no read-only, settings-free route
+   to the working-copy commit id. `revision` covers `VcsKind::Git`; the jj
+   mechanism transfers to 0185. The crate-wide `UserSettings` guard **stays**
+   crate-wide — the spike is the evidence nothing in scope needs it (Delivered
+   surface, Library traps, Acceptance Criteria).
+
+Two assumptions also resolved in the same pass: `gix`'s gating feature *is* on
+under `jj-lib`'s defaults, so the single-graph reasoning holds; and the
+`GIT_DIR` scrub invariant holds for free on **both** library sides, making it a
+property to verify rather than implement. A third correction from plan review:
+that invariant was verified over `GIT_DIR`/`GIT_COMMON_DIR` only, so "uniformly
+immune" overstated it — the verification set is widened to everything
+`scrub_environment` touches plus the object-directory and `GIT_CONFIG_COUNT`
+families.
+
+Plan: `meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md`, which carries
+the full empirical oracle mapping.
+
 ### Delivered surface
 
 - **One library-backed type** in `cli/vcs-adapters` implementing *both* the
@@ -78,6 +133,25 @@ later epic-0136 phases migrate them.
   avoids having to say which of a pair carries the dual-root query, which needs
   both libraries. **The domain crate `cli/vcs` is untouched: no port is added,
   widened or changed.**
+
+  **Amended 2026-08-03 (spike) — `VcsProbe` is implemented *partially*.** `kind`
+  is complete; `revision` covers `VcsKind::Git` (via
+  `gix::discover(root)?.head_commit()?.id()`) and returns `None`, warn-logged, for
+  `VcsKind::Jj`. jj-lib 0.43 exposes no read-only, settings-free route to the
+  working-copy commit id: the op stores are settings-free
+  (`SimpleOpHeadsStore::load`, `SimpleOpStore::load`) but the workspace name
+  needed to index `View::get_wc_commit_id` is reachable only through
+  `LocalWorkingCopy::load` (requires `&UserSettings` for `TreeStateSettings`) or
+  `SimpleWorkspaceStore::load` (settings-free but **writes** to
+  `.jj/repo/workspace_store` — verified empirically, so unusable in a read-only
+  probe), and `CheckoutState` is a private struct. Reading the
+  `.jj/working_copy/checkout` protobuf by hand is the only remaining path and is
+  exactly the private-internals dependency this design avoids. **0185 inherits the
+  jj revision mechanism**, alongside the composition-root switch it already owns;
+  its options are a jj-lib version exposing the checkout state publicly, an
+  upstream request for one, or retaining `CommandProbe` for `revision` alone —
+  which would make its "atomic switch plus deletion" sizing wrong, so it needs
+  deciding early.
 - **Six taxonomy queries** as *inherent methods* on that type — not port
   methods. `CommandProbe` and `MarkerWalkRoot` gain none of them. 0169 defines
   whatever domain port its classifier needs and implements it over these; that
@@ -92,18 +166,74 @@ later epic-0136 phases migrate them.
   5. **jj main-vs-secondary distinction**, and where the main repository is.
   6. **Independent dual-root resolution** — the git repository root and the jj
      workspace root, each resolved by its own library's walk without being
-     truncated by the other's marker, so a consumer can compare them. This is
-     what separates `colocated` (roots equal) from `nested-jj-in-git` and
-     `nested-git-in-jj`; 0169 cannot build those arms without it.
+     truncated by the other's marker, so a consumer can compare them. This
+     comparison is **necessary but not sufficient** to separate `colocated` from
+     `nested-jj-in-git` and `nested-git-in-jj`; 0169 cannot build those arms
+     without it, and cannot build them from it alone.
 
-  **Invariant over all six**: `GIT_DIR`/`GIT_COMMON_DIR` are scrubbed for the
-  duration of any detection call, so every query answers identically whether or
-  not they are set. This matches the one place the shell made the decision
-  deliberately (`vcs-common.sh:130-135`, "cannot be poisoned by ambient env")
-  and diverges from `classify_checkout`'s inline reads, which honour them. The
-  shell is internally inconsistent here — `:206-215` unscrubbed against
-  `:130-135` scrubbed — and it is that asymmetry the adapter declines to carry
-  forward.
+  **Amended 2026-08-03 (measurement) — dual-root equality is not on its own a
+  classification.** An earlier framing implied roots-equal ⇒ `colocated`. It does
+  not: a real `jj git init --colocate` main repository has equal roots and
+  classifies as `main`, because `classify_checkout`'s `colocated` arm also
+  requires `jj_secondary && git_worktree` (`scripts/vcs-common.sh:242-247`).
+  Inequality is likewise insufficient — this repo's own `workspaces/<name>`
+  layout has *differing* roots and classifies as `jj-secondary`, because the
+  `nested-jj-in-git` arm additionally requires
+  `jj_main_root != git_main_root` and there they are equal. A consumer reads this
+  query together with queries 2 and 5, never alone.
+
+  **Amended 2026-08-03 (plan review) — the queries return
+  `Result<Option<T>, Error>`.** `Ok(None)` means "no repository of this kind
+  here"; `Err` means "a repository is here and the pinned library could not
+  answer". `Option` alone would collapse a corrupt object store, an unreadable
+  `.jj/repo` or an unsupported repository format into the same value as genuine
+  absence — a regression against `CommandProbe`, which parses in a child process
+  with a 10-second cap, kill-on-timeout and a scrubbed environment and warn-logs
+  every distinct failure. `InProcessProbe` parses repository-controlled data in
+  the caller's address space with no time or memory bound and no crash isolation,
+  and after 0185's switch that runs inside `cli/visualiser/server` and on the hook
+  path, so the distinction is load-bearing rather than stylistic. The partition
+  rule: only the not-found-shaped variant of each library error maps to
+  `Ok(None)`; every other variant is `Err`. `dual_roots` is **infallible with a
+  `Result` per side** — a whole-struct `Result` cannot say "the git side failed but
+  the jj side answered", and flattening that to `None` would reinstate the
+  conflation on the one field the nested/colocated distinction rests on. The two
+  *port* methods keep their `Option` signatures, since `cli/vcs` is untouched;
+  they warn-log instead.
+
+  **Three walks are required, not one** (established 2026-08-03 by measurement;
+  amends the single-boundary-walk framing this section previously carried):
+
+  1. The **combined `.jj`-or-`.git` boundary walk** — `RepoRoot::discover` only.
+     This is `MarkerWalkRoot`'s existing algorithm.
+  2. A **`.jj`-only walk** — queries 4, 5 and the jj half of query 6. This is
+     what `jj workspace root` answers, and the combined walk is **wrong** for
+     them: `jj_lib`'s `DefaultWorkspaceLoaderFactory::create` performs no upward
+     walk of its own, so feeding it the combined boundary makes it return
+     `Err(There is no Jujutsu repo in …)` on both nested-git-in-jj shapes —
+     where the oracle reports a root. A classifier built on the combined walk
+     would therefore report absence where `jj workspace root` reports presence.
+  3. **`gix`'s own discovery** (`gix::discover`) — queries 1, 2, 3 and the git
+     half of query 6. Its willingness to walk above the boundary is *required*
+     here, and is why the boundary rule below scopes to boundary resolution
+     only.
+
+  **Invariant over all six**: every query answers identically whether or not
+  `GIT_DIR`/`GIT_COMMON_DIR` are set. This matches the one place the shell made
+  the decision deliberately (`vcs-common.sh:130-135`, "cannot be poisoned by
+  ambient env") and diverges from `classify_checkout`'s inline reads, which
+  honour them. The shell is internally inconsistent here — `:206-215` unscrubbed
+  against `:130-135` scrubbed — and it is that asymmetry the adapter declines to
+  carry forward.
+
+  **The invariant is a property to verify, not to implement** (measured
+  2026-08-03, both sides). It holds *for free* across the whole fixture matrix:
+  `gix::discover`/`gix::open` do not consult the environment (only
+  `discover_with_environment_overrides` does), and `jj_lib`'s workspace loader is
+  pure filesystem reads. An earlier draft of this criterion required an explicit
+  scrub "for the duration of any detection call"; no such scrub is needed, and
+  adding one would be dead code. `discover_with_environment_overrides` is the
+  ready-made non-vacuity control the acceptance criteria demand.
 
   Anything 0169 needs beyond this list is a change to *this* work item, not
   silent growth in 0169. Two capabilities are explicitly **not** delivered and
@@ -132,12 +262,16 @@ These are shipped artefacts, not incidental test code, and are sized as such.
   list must serve both suites.
 - **A committed lockfile check** (test or `tasks/` lint) for the version
   invariants below.
-- **The checkout fixture matrix** — ten shapes × their start directories (see
-  the criterion). Bare, submodule, linked-worktree and both nesting shapes are
-  substantial to build; planning should record which already exist in
-  `detection.rs` and which are new.
+- **The checkout fixture matrix** — thirteen shapes × their start directories
+  (see the criterion; the count rose from ten on 2026-08-03 when the colocated
+  and submodule rows were split). Bare, all three submodule shapes,
+  linked-worktree, both colocated shapes and both nesting shapes are substantial
+  to build; planning should record which already exist in `detection.rs` and
+  which are new.
 - **A pure-jj benchmark fixture**, committed as a named reusable builder,
-  plus the cost measurements taken against it. Handed to 0169 ungated.
+  plus the cost measurements taken against it. Handed to 0169 ungated. Built
+  with **`jj git init --no-colocate`** — see the colocation-default note under
+  the cost criterion.
 - **Dated hand-off notes** on 0125, 0185 and 0169, including a `relates_to`
   edge on 0125.
 - **Documentation** of any new `tasks/` leaf task or CI job in
@@ -151,7 +285,7 @@ These are shipped artefacts, not incidental test code, and are sized as such.
 
 ### Library traps
 
-- **Bound `gix`'s discovery — for boundary resolution.** `gix::discover` walks
+- **Never call `gix::discover` on the boundary path.** `gix::discover` walks
   up *past* a jj workspace boundary (verified 2026-07-29: it returned the parent
   repository's `.git` from inside `workspaces/build-system`). The rule:
 
@@ -159,13 +293,36 @@ These are shipped artefacts, not incidental test code, and are sized as such.
   > containing a `.jj` or `.git` marker. `RepoRoot` reports that path and never
   > an ancestor above it, whether or not the environment supplies a ceiling.
 
-  Derive the ceiling from the marker walk rather than trusting the library's
-  default; an inherited `GIT_CEILING_DIRECTORIES` may narrow the walk further
-  but must never be what makes the rule hold. **The rule scopes to boundary
-  resolution only** — queries 2, 3 and 6 legitimately resolve outside the
-  boundary by following a recorded link (gitdir, superproject) or by letting
-  each library complete its own walk. An earlier draft forbade looking above the
-  boundary at all, which would have made 0169's `nested-*` arms unimplementable.
+  **The mechanism is a marker walk followed by `gix::open` at exactly the
+  boundary path** — `gix::open` performs no upward walk and errors cleanly when
+  the path is not a git repository, which is precisely the required behaviour.
+  `MarkerWalkRoot` already implements the walk, so the boundary rule is
+  satisfied by composition rather than by new code.
+
+  **A ceiling cannot enforce this rule and must not be relied on** (spike
+  2026-08-03): `gix_discover::upwards::Options::ceiling_dirs` computes the
+  ceiling height as `start.strip_prefix(ceiling).components().count()` and
+  **discards height 0**, so a ceiling equal to the boundary is silently ignored;
+  the walk's bound is then checked as `current_height > max_height` with the
+  counter incremented after the test, permitting one further level of ascent. No
+  anchor — boundary, boundary's parent, or the filesystem root — confined the
+  walk in testing; every configuration either errored uninformatively or
+  returned the parent repository. An inherited `GIT_CEILING_DIRECTORIES` is
+  irrelevant on this path, because plain `gix::discover` does not read the
+  environment at all (only `discover_with_environment_overrides` does).
+
+  **The rule scopes to boundary resolution only** — queries 2, 3 and 6
+  legitimately resolve outside the boundary by following a recorded link
+  (gitdir, superproject) or by letting each library complete its own walk. An
+  earlier draft forbade looking above the boundary at all, which would have made
+  0169's `nested-*` arms unimplementable.
+
+  **Consequence for query 1**: a bare repository has neither a `.jj` nor a
+  `.git` marker, so the marker walk returns `None` for it (confirmed
+  2026-08-03) while `gix::open` on the bare directory reports `is_bare = true`.
+  Bare detection therefore cannot take its start path from the boundary walk and
+  needs its own entry point. This matches today's behaviour, which
+  `cli/vcs-adapters/tests/detection.rs:250-277` pins as `facts(&bare) == None`.
 - **Avoid `jj_lib::workspace::Workspace::load`.** It needs a fully-populated
   `UserSettings` whose defaults are private to jj-lib, discovered one panic at a
   time. `DefaultWorkspaceLoaderFactory` is public and
@@ -174,17 +331,53 @@ These are shipped artefacts, not incidental test code, and are sized as such.
   crate-wide, deliberately wider than the detection paths strictly require, so
   the guard is a simple one.
 
+  **Confirmed 2026-08-03 (spike) — the crate-wide statement holds, and it is why
+  jj `revision` is out of scope.** A spike enumerated every route to the
+  working-copy commit id and found none that is both settings-free and
+  read-only: `LocalWorkingCopy::load` needs `&UserSettings` for
+  `TreeStateSettings`; `CheckoutState` (which holds the `operation_id` +
+  `workspace_name` pair) is private; and `SimpleWorkspaceStore::load`, though
+  settings-free, **creates `.jj/repo/workspace_store` and writes an `index`
+  file** — verified by removing the directory and observing it recreated. The op
+  stores themselves are settings-free (`SimpleOpHeadsStore::load(dir)`,
+  `SimpleOpStore::load(path, root_data)`), so the chain fails only at the
+  workspace-name link. The guard therefore costs nothing in scope, and does not
+  need narrowing.
+
+  **The loader does not walk** (verified 2026-08-03 against jj-lib 0.43
+  `src/workspace.rs:564-585`): `create(workspace_root)` demands a path whose
+  `.jj` is a directory and errors otherwise, so the caller must supply the
+  workspace root — see the `.jj`-only walk in the three-walk requirement above.
+  Note also that `repo_path()` comes back already canonicalised
+  (`dunce::canonicalize`) while `workspace_root()` is the path passed in, so both
+  sides need canonicalising before the secondary-vs-main comparison.
+
 ### Dependency policy
 
-- **`jj-lib` pinned exactly at `=0.43`.** The loader-internals design and every
+- **`jj-lib` pinned exactly at `=0.43.0`.** The loader-internals design and every
   feasibility measurement were validated against it, and the crate declares its
   API unstable. `mise.toml`'s `jj` CLI pin is held in lockstep at 0.43.0 so the
   CLI that writes fixtures and the library that reads them cannot skew. **The
   bump landed 2026-08-02**; what remains for this story is `mise install` in CI
   and a re-run of the jj-fixture shell suites.
-- **`gix` pinned to the version `jj-lib` 0.43 depends on when its `gix`
-  feature is enabled** — 0.85 (verified 2026-08-02: `jj-lib` 0.43.0 declares
+- **`gix` pinned to `~0.85.0`** — the version `jj-lib` 0.43 depends on when its
+  `gix` feature is enabled (verified 2026-08-02: `jj-lib` 0.43.0 declares
   `gix ^0.85.0`, optional). See the Assumption on feature-gating.
+
+  **Amended 2026-08-03 (plan review) — the two pins are deliberately asymmetric.**
+  `gix` takes a tilde range rather than `=`, permitting `0.85.x` patches so a
+  RustSec fix is a lock update instead of a pin edit. That matters because
+  `cli/deny.toml` sets `unmaintained = "all"` and `yanked = "deny"` over a
+  ~60-crate closure no repo code calls, and an exact pin would make an
+  `advisories.ignore` entry the cheapest response to an advisory. The
+  single-graph property is untouched: it comes from jj-lib's own `^0.85.0` plus
+  cargo's range unification, not from exactness, and `Cargo.lock` supplies the
+  exactness either way — `~0.85.0` is range-identical to `^0.85.0` for a 0.x
+  crate. `jj-lib` keeps `=` because the agility argument does not apply to the
+  crate whose declared-unstable internals this design depends on, and because a
+  transitive advisory inside *its* closure is adoptable with
+  `cargo update -p <crate>` without touching the pin. **The coupling is four-way,
+  not two-way**: jj-lib + gix + the Rust toolchain + the `mise.toml` jj CLI pin.
   Load-bearing: `gix`
   0.86.0 exists, and a caret range on a `0.x` crate will not cross it, so
   pinning 0.86 here would produce exactly the two graphs this forbids. The pin
@@ -224,15 +417,29 @@ field) is part of the mapping established in planning.
 
 - [ ] `detection.rs` runs every existing case through the injection seam against
       **the retained `MarkerWalkRoot`/`CommandProbe` pair and the single
-      library-backed type**, producing identical `RepoFacts`, with the suite's
-      existing **fixed expected values** retained — agreement between two
-      implementations is not on its own an oracle. The `.git`-as-file worktree
-      case keeps **today's** value (`classify_checkout` reports `main`, the git
-      side unseen); 0169 owns correcting that to `colocated`, so a
-      library-backed answer of `colocated` here is the deferred correction
-      arriving early, not a defect to chase. This dual comparison is
+      library-backed type**, with the suite's existing **fixed expected values**
+      retained — agreement between two implementations is not on its own an
+      oracle. The `.git`-as-file worktree case keeps **today's** value
+      (`classify_checkout` reports `main`, the git side unseen); 0169 owns
+      correcting that to `colocated`. This dual comparison is
       **transitional**: 0185 deletes `CommandProbe`, and collapsing the suite to
       the library-backed type alone is part of that deletion.
+
+      **Amended 2026-08-03 (spike) — parity is asserted per `VcsKind`.** Full
+      `RepoFacts` equality for `VcsKind::Git`; `root`/`name`/`kind` only for
+      `VcsKind::Jj`, where the library-backed `revision` is `None` by design
+      while `CommandProbe` returns a 40-hex id. The jj cases therefore assert the
+      `CommandProbe` arm against the suite's fixed values as today, and the
+      library-backed arm against the three fields it owns, so neither adapter's
+      coverage is dropped. Narrowing wholesale would also have discarded
+      achievable protection on the git revision path, which
+      `detection.rs:84-86` already pins.
+
+      Related, measured 2026-08-03: a **sha256** repository's `HEAD` is 64 hex
+      characters, so `is_full_revision_id`'s 40-hex assertion rejects it. Any
+      revision validation must accept both widths or record sha256 as
+      unsupported — a decision 0185 inherits, since its switch is what exposes
+      users to it.
 - [ ] All six queries are unit-tested against every **(fixture, start
       directory)** pair in the matrix — start directory included because every
       query is start-path-relative and the oracle is directory-parameterised, so
@@ -244,16 +451,35 @@ field) is part of the mapping established in planning.
 
       | Fixture | Start directories |
       | --- | --- |
-      | colocated | root |
+      | colocated, **real** (`jj git init --colocate`) | root |
+      | colocated, **hand-grafted** (jj secondary + git linked worktree at one path) | root |
       | jj secondary workspace | workspace root, and a subdirectory |
       | plain git | root, and a subdirectory |
       | nested-jj-in-git | inner jj workspace, and the outer git root |
       | nested-git-in-jj | inner git repo, and the outer jj root |
       | linked git worktree | the linked worktree, and the main worktree |
       | git submodule | the submodule, and the superproject root |
+      | git submodule, **nested** (depth 2) | the depth-2 submodule |
+      | git submodule, **old form** (nested `.git` directory) | the nested repo |
       | bare repository | the bare dir |
       | no repository at all | a dir with no marker at or above it |
       | pure-jj measurement fixture | root |
+
+      **Amended 2026-08-03 (measurement).** The row previously read "colocated |
+      root", which is ambiguous between two genuinely different shapes, and both
+      are now required. A real `jj git init --colocate` main repository has
+      `.jj/repo` as a *directory* and `gix` reports `Kind::Common`, so the shell
+      classifies it as **`main`** — the `colocated` arm requires
+      `jj_secondary && git_worktree` (`vcs-common.sh:242-247`). The shell suite's
+      hand-grafted fixture (`hooks/test-vcs-detect.sh:96-157`) is a jj secondary
+      workspace whose path is simultaneously a git linked worktree, reports
+      `Kind::LinkedWorkTree`, and is the only shape that classifies as
+      **`colocated`**. The two submodule rows are likewise split out: the
+      depth-2 shape is what proves the superproject derivation takes the
+      *nearest* `modules` component, and the old-form shape reports
+      `Kind::Common` — agreeing with git, which also reports no superproject —
+      so a `Kind::Submodule`-only implementation would silently miss it with no
+      oracle disagreement to reveal the omission.
 
 - [ ] The scrub invariant holds across that whole matrix: every query returns
       the same value with and without `GIT_DIR`/`GIT_COMMON_DIR` set — where
@@ -337,18 +563,72 @@ field) is part of the mapping established in planning.
       in-process cost, and cold per-process cost via the reference artefact.
       The last is required because an in-process microbenchmark yields
       microsecond figures that cannot be compared with 0169's millisecond
-      process-level baseline; it is the figure that corresponds to **G**, so the
-      reference artefact needs a single-query mode for it — timing a binary that
-      runs all six queries plus both port methods would inflate it by an unknown
-      factor. The `MarkerWalkRoot`/`CommandProbe` baseline is taken for the port
-      methods only (it has no queries and no library to initialise). Host and OS
-      recorded.
-- [ ] The reference artefact demonstrably links the dependency trees: its size
-      **built with the query calls live** is at least **2 MB larger** than the
-      same binary built with those calls replaced by stubs, both sizes recorded.
-      Without a floor this check cannot fail, and it is the one guarding the
-      story's headline false-pass — dead-code elimination letting the musl and
-      size checks succeed while linking almost none of `gix`/`jj-lib`.
+      process-level baseline; it is the figure that corresponds to **G**. The
+      reference artefact carries a single-query mode for it. The
+      `MarkerWalkRoot`/`CommandProbe` baseline is taken for the port methods only
+      (it has no queries and no library to initialise). Host and OS recorded,
+      and **darwin-arm64 is the required host** so the figures are comparable
+      with 0186's `B = 35.1 ms` — the ~97 ms probe delta is macOS-specific, so a
+      cross-host comparison would leave 0169's gate ill-posed.
+
+      **Amended 2026-08-03 (measurement), two corrections.**
+
+      *The single-query rationale was wrong.* This criterion previously said the
+      single-query mode was needed because "timing a binary that runs all six
+      queries plus both port methods would inflate it by an unknown factor."
+      Measured: `all` (six queries + both ports) **3.66 ms** against
+      `only <query>` **3.65 ms** on the pure-jj fixture, and 4.49 ms vs 3.65 ms
+      on plain git — process startup dominates, so the inflation is 0–23%, not
+      unknown. The mode is retained because 0169 will want a per-query figure,
+      not because the aggregate figure would be unusable.
+
+      *The fixture needs an explicit flag.* `jj git init` **colocates by default
+      at jj 0.43** — a bare `jj git init` in an empty directory produces both
+      `.jj` and `.git` — so "no `.git`" is not the default and cannot be assumed.
+      The builder must pass **`--no-colocate`** and assert `.git` is absent.
+      Consequence for the existing suites: `make_main_jj_workspace`
+      (`hooks/test-vcs-detect.sh:47-52`) has been producing *colocated*
+      repositories all along and is misnamed; several fixtures built on it are
+      not the pure-jj shapes their names suggest.
+- [ ] The reference artefact demonstrably links the dependency trees: **built
+      with the query calls live** it is at least **3× the size** of the same
+      artefact built with those calls replaced by stubs, **and** at least
+      **1,500,000 bytes larger** — measured on the **musl-static, stripped**
+      artefact, which is the one the release pipeline actually ships, with the
+      darwin figures recorded alongside. Both absolute sizes, the delta and the
+      ratio are recorded. Without a floor this check cannot fail, and it is the
+      one guarding the story's headline false-pass — dead-code elimination
+      letting the musl and size checks succeed while linking almost none of
+      `gix`/`jj-lib`.
+
+      **Amended 2026-08-03 (measurement).** This criterion previously demanded a
+      flat "at least 2 MB larger" and, as written, **would have failed on the
+      artefact it exists to guard**. Measured against a prototype linking
+      `gix` 0.85 + `jj-lib` 0.43: musl-static stripped delta **2,031,448 B**,
+      darwin stripped **1,639,872 B**, darwin unstripped 2,058,656 B. So the old
+      floor passed only on a decimal-MB reading of the musl build, by 1.6%, and
+      failed outright on the stripped darwin build and on every MiB reading —
+      while the trees were unambiguously linked (**ratio 6.19×** on musl, 5.42×
+      on darwin). A ratio floor is the robust discriminator; the absolute floor
+      is retained at a level with real headroom, with its unit stated, because
+      the ratio alone would lose the "these trees are large" signal.
+
+      **Amended again 2026-08-03 (plan review) — the floor needs a mechanism.**
+      Amendment 1 fixed the threshold but left it a number written into Validation
+      Results, which catches no later regression: a future edit that stops
+      printing a query result would let the linker drop the trees again with
+      nothing objecting. It is now a **committed assertion** in `tasks/build.py`'s
+      fixture staging, with a unit test over the comparison function using
+      synthetic sizes. Two scoping rules, because a heuristic threshold that first
+      executes in the release pipeline can abort a whole product release: the
+      **ratio** floor applies on every triple (wide margin — 5.42× darwin, 6.19×
+      musl), while the **absolute-byte** floor applies to **musl triples only**,
+      matching how `_assert_static_elf` is already guarded. The darwin stripped
+      delta clears 1,500,000 B by just 9.3%, and `[profile.release] strip = true`
+      means every triple is stripped, so gating darwin on it would put a
+      9%-margin heuristic on `prerelease:prepare`'s critical path. A host-native
+      ratio assertion also runs on the PR path, so the guard is not first
+      exercised during a release.
 - [ ] Dated notes are appended to three siblings, **raising** information
       without re-scoping them:
       - **0125** — the adapter dissolves its lexical-fallback rationale *for
@@ -400,10 +680,14 @@ field) is part of the mapping established in planning.
   - **Ongoing cost, not just one-off**: both transitive trees enter `cargo
     deny`'s `advisories` scope, so a future RustSec advisory anywhere in the
     `gix`/`jj-lib` closure fails the workspace-wide check for every unrelated
-    change. And because `gix` is pinned to whatever `jj-lib` depends on, any
-    future `jj-lib` bump is a **coordinated two-crate bump** — the single-
-    version criterion will otherwise fail it. Both pins carry inline comments
-    saying so.
+    change. And because `gix` tracks whatever `jj-lib` depends on, any future
+    `jj-lib` **minor** bump is a **coordinated four-pin change** — jj-lib, gix,
+    the Rust toolchain (jj-lib's MSRV moved 1.85 → 1.88 → 1.89 across eight
+    releases) and the `mise.toml` jj CLI pin, which writes the format jj-lib
+    reads. The single-version criterion will otherwise fail it. Both pins carry
+    inline comments saying so. *(Amended 2026-08-03: was "two-crate bump"; the
+    toolchain and CLI legs were unstated. `gix` patch releases within `~0.85.0`
+    are pre-authorised and need none of this ceremony.)*
 - **Upstream toolchain preconditions**:
   - **`jj` CLI ↔ `jj-lib` are now a lockstep pair.** The `bash-parity` fixtures
     are built by the installed `jj` CLI and read by `jj-lib`, so a skew between
@@ -504,13 +788,16 @@ record because their answers carry consequences.
   requirement forbids. `jj-lib` 0.43.0 also depends on `gix-ignore ^0.21.0`
   (non-optional), and carries no `git2`/`libgit2-sys` — confirming the
   2026-07-29 finding.
-- **`gix` is an *optional* dependency of `jj-lib` 0.43** (feature-gated). The
-  single-graph requirement is written as though `jj-lib` always pulls `gix`; if
-  the gating feature is off in our configuration, `jj-lib` may pull no `gix` at
-  all and this story's direct dependency is the only one. That changes the
-  *reasoning* behind the pin, not the pin itself — but the plan should state
-  which `jj-lib` features are enabled and re-check the single-version assertion
-  under that configuration.
+- **`gix` is an *optional* dependency of `jj-lib` 0.43** (feature-gated), but
+  **its gating feature is on under default features** — so the single-graph
+  reasoning behind the pin holds as written. **Resolved 2026-08-03** by resolving
+  the real graph: `jj-lib` 0.43.0 with default features pulls `gix` 0.85.0 and
+  enables `attributes`, `blob-diff`, `index`, `max-performance-safe`, `sha1` and
+  `zlib-rs` on it (plus a non-optional `gix-ignore ^0.21`). Two consequences:
+  the single-version assertion is **non-vacuous** under our configuration, and
+  the `attributes` feature that `Repository::submodules()` needs arrives from
+  `jj-lib` itself rather than from `gix`'s own defaults — so narrowing `gix`'s
+  features to shrink the binary would not remove it.
 - `jj-lib`'s loader API remains stable across **the pinned `jj-lib` version,
   0.43**, which the exact pin holds fixed. Verified against 0.43; unstable by
   the crate's own declaration.
@@ -561,6 +848,61 @@ record because their answers carry consequences.
   than the adapter would be what stops the walk and the criterion would pass
   vacuously.
 
+## Spike Outcome — gix 0.85 API surface (2026-08-03)
+
+Three of the six queries had **no recorded API evidence**: the 2026-07-29
+feasibility probe exercised exactly one gix entry point (`gix::discover`), and
+the word "submodule" appears nowhere in it. A throwaway prototype against real
+git fixtures (git 2.54.0, darwin-arm64, `gix` 0.85.0 with default features)
+settled them, together with two riders. Full evidence tables, including the
+verbatim per-fixture oracle comparison, are in
+`meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`.
+
+- **Query 1 (bare) — available.** `Repository::is_bare()`
+  (`gix-0.85.0/src/repository/worktree.rs:64`) agreed with
+  `git rev-parse --is-bare-repository`. It reads `core.bare`, falling back to
+  `workdir().is_none()`. See the reachability consequence in Library traps.
+- **Query 2 (worktree + common dir) — first-class, and cheaper than assumed.**
+  `Repository::kind()` returns a three-variant enum — `Common`, `Submodule`,
+  `LinkedWorkTree` (`src/repository/mod.rs:6-16`) — so "is this a linked
+  worktree" is a single enum read rather than a path comparison. `git_dir()`
+  (`src/repository/location.rs:11`), `common_dir()` (`:33`) and `main_repo()`
+  (`src/repository/worktree.rs`) matched `--git-dir`, `--git-common-dir` and the
+  main worktree root exactly, from both the linked worktree and the main one.
+  `worktrees()` enumerates linked worktrees by id.
+- **Query 3 (superproject) — NO library API exists; it must be hand-rolled.**
+  Verified by search across `gix` 0.85, `gix-discover` and `gix-submodule`, and
+  behaviourally: `main_repo()` on a submodule returns the *submodule*, not the
+  superproject. `Repository::submodules()`
+  (`src/repository/submodule.rs:93`) resolves only the opposite direction
+  (superproject → children) and requires the `attributes` feature. A ~15-line
+  derivation from `Kind::Submodule` plus the `git_dir()` path shape
+  (`<super-git-dir>/modules/<name>`, nesting as
+  `.git/modules/mid/modules/leaf`) matched
+  `--show-superproject-working-tree` at depth 1 **and** depth 2. **This is a
+  sizing correction**: query 3 is bespoke path logic with its own edge cases,
+  not a library call like the other five.
+  - Old-form submodules (a nested `.git` *directory*) report `Kind::Common`, and
+    git also reports no superproject for them — the two **agree**, so this is
+    not an adapter/oracle divergence. The fixture matrix should still carry the
+    shape, because `Kind::Submodule` alone would silently miss it.
+- **Rider — the boundary rule's mechanism changed.** See Library traps above:
+  the ceiling route is structurally incapable of enforcing the rule, and the
+  requirement has been rewritten to marker-walk-then-`gix::open`.
+- **Rider — the scrub invariant holds for free on the git side.** With
+  `GIT_DIR`, `GIT_COMMON_DIR` and `GIT_CONFIG_GLOBAL` (asserting
+  `core.bare = true`) all poisoned at another fixture's real `.git`, every gix
+  query — `kind()`, `is_bare()`, `git_dir()`, `common_dir()`, `workdir()`,
+  `main_repo()` — returned **identical** values, while
+  `git rev-parse --git-dir` diverged, proving the poisoning was live. Plain
+  `gix::discover`/`gix::open` do not consult the environment;
+  only `discover_with_environment_overrides` does, and it diverged as expected.
+  Consequences: no explicit scrub is needed for the git-side queries — the
+  invariant is a property to *verify*, not to implement — and
+  `discover_with_environment_overrides` is a ready-made non-vacuity control for
+  the "an unscrubbed control must diverge" clause. **The jj-lib side remains
+  untested.**
+
 ## Validation Results
 
 - **Platform the strong-form zero-spawn run held on** — _pending_; absolute
@@ -579,7 +921,38 @@ record because their answers carry consequences.
   _pending_.
 - **Installed `git` CLI version the fixtures were built with** — _recorded
   2026-08-02_: 2.54.0, against `gix` 0.85. Coherence unverified but low-risk;
-  no format-boundary concern was identified.
+  no format-boundary concern was identified. _Spike 2026-08-03_: gix 0.85.0 read
+  bare, linked-worktree, modern-submodule, nested-submodule and old-form-nested
+  repositories written by git 2.54.0 with no format-boundary problem observed,
+  on darwin-arm64.
+- **gix API coverage for the six queries** — _spiked 2026-08-03_: queries 1 and
+  2 are served by library calls; **query 3 has no gix API and requires a
+  hand-rolled derivation** (validated against the oracle at submodule depths 1
+  and 2). Queries 4-6 not covered by this spike. See Spike Outcome.
+- **`gix` boundary containment mechanism** — _resolved 2026-08-03_:
+  `ceiling_dirs` cannot enforce the rule at any anchor; `gix::open` performs no
+  walk and is the mechanism. A paired negative assertion is available:
+  unbounded `gix::discover` from a `.jj`-only directory nested in a git
+  repository escapes to the parent repository, reproducibly.
+- **`GIT_DIR` scrub invariant, git side** — _measured 2026-08-03_: all six
+  probed gix calls stable under poisoned `GIT_DIR` + `GIT_COMMON_DIR` +
+  `GIT_CONFIG_GLOBAL`; `git rev-parse --git-dir` diverged under the same
+  poisoning (live control).
+- **`GIT_DIR` scrub invariant, jj-lib side** — _measured 2026-08-03_: stable.
+  Every gix **and** jj-lib call returned identical values across **all 25
+  (fixture, start directory) pairs** with `GIT_DIR` and `GIT_COMMON_DIR` pointed
+  at another fixture's real `.git`. The invariant therefore needs no
+  implementation on either side — it is verified, not built. Non-vacuity control
+  confirmed in the same run: `gix::discover_with_environment_overrides` returned
+  the poison target while plain `gix::discover` and `gix::open` did not.
+- **Local toolchain skew** — _found 2026-08-03_: the development machine used
+  for the spike had `jj` **0.42.0** on `PATH` from Homebrew
+  (`/opt/homebrew/bin/jj`), not the pinned 0.43.0, because `mise.toml` is
+  untrusted there and mise was not activating. Reinforces the outstanding
+  `mise install` item above, and is a reminder that on a developer's macOS
+  machine `/opt/homebrew/bin/jj` **is** the real binary — the opposite of CI,
+  where no system `jj` exists at all (see the shadow-list note in the research
+  document).
 - **Adapter/shell divergences recorded** — the `GIT_DIR` scrub asymmetry in
   `classify_checkout` (`:206-215` unscrubbed vs `:130-135` scrubbed), which the
   adapter deliberately does not reproduce — _confirmed 2026-08-01_; any further

--- a/mise.toml
+++ b/mise.toml
@@ -409,6 +409,11 @@ description = "Keep atomic_write consolidated: no temp-and-rename outside cli/st
 depends = ["deps:install:python"]
 run = "invoke lint.store-duplication.check"
 
+[tasks."lint:vcs-settings:check"]
+description = "Keep jj UserSettings and Workspace::load out of cli/vcs-adapters (their defaults are private to jj-lib)"
+depends = ["deps:install:python"]
+run = "invoke lint.vcs-settings.check"
+
 [tasks."lint:skill-permissions:check"]
 description = "Guard every SKILL.md !-preprocessor invocation against its allowed-tools rules (coverage, --fail-safe, no metacharacters, no bare-launcher grant) plus the injection census"
 depends = ["deps:install:python"]
@@ -426,7 +431,7 @@ run = "invoke lint.claude-coupling.check"
 
 [tasks."cli:check"]
 description = "Run all cli/ workspace format and lint checks (workspace-wide rustfmt + clippy + vendored-shim drift guard; read-only, no tests)"
-depends = ["format:cli:check", "lint:cli:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check"]
+depends = ["format:cli:check", "lint:cli:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check", "lint:vcs-settings:check"]
 
 [tasks."deny:check"]
 description = "Check the cli/ workspace dependency graph with cargo-deny (advisories, licenses, bans, sources)"
@@ -468,7 +473,7 @@ depends = ["format:frontend:check", "lint:frontend:check", "types:frontend:check
 
 [tasks."lint:check"]
 description = "Run all lint checks"
-depends = ["lint:frontend:check", "lint:server:check", "lint:cli:check", "lint:build-system:check", "lint:scripts:check", "lint:skill-permissions:check", "lint:call-site-migration:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check", "lint:dispatch-coherence:check"]
+depends = ["lint:frontend:check", "lint:server:check", "lint:cli:check", "lint:build-system:check", "lint:scripts:check", "lint:skill-permissions:check", "lint:call-site-migration:check", "lint:vendor-shims:check", "lint:store-duplication:check", "lint:claude-coupling:check", "lint:dispatch-coherence:check", "lint:vcs-settings:check"]
 
 [tasks."lint:fix"]
 description = "Apply all safe lint fixes (shell has no autofixer — run `mise run scripts:check` for remaining shell findings)"

--- a/mise.toml
+++ b/mise.toml
@@ -210,6 +210,11 @@ description = "Prove the library-backed VCS adapter reads git and jj without spa
 depends = ["deps:install:python"]
 run = "invoke test.integration.zero-spawn"
 
+[tasks."test:integration:zero-spawn:strong"]
+description = "The strong form of the above: shadows the real git/jj with sudo for the duration, so absolute-path access cannot satisfy the adapter (CI only — gated behind ACCELERATOR_ZERO_SPAWN_SHADOW=yes)"
+depends = ["deps:install:python", "build:cli:fixture-size"]
+run = "invoke test.integration.zero-spawn-strong"
+
 [tasks."test:integration:pup"]
 description = "Run the cargo-pup architecture regression (needs the nightly lane; check-architecture only, not the test roll-up)"
 depends = ["deps:install:python", "deps:install:pup", "build:frontend:stub"]

--- a/mise.toml
+++ b/mise.toml
@@ -127,6 +127,11 @@ description = "Cross-compile the cli launcher + verify shim for all four release
 depends = ["deps:install:rust-targets"]
 run = "invoke build.cli-cross-compile"
 
+[tasks."build:cli:fixture-size"]
+description = "Assert the host-native VCS reference artefact links its gix/jj-lib trees (ratio floor; the absolute floor is musl-only and runs in the cross-compile)"
+depends = ["deps:install:python"]
+run = "invoke build.cli-fixture-size-check"
+
 [tasks."build:vendor-verify-shims"]
 description = "Copy the cross-compiled verify shims into the committed bin/ tree and record the drift marker"
 depends = ["build:cli:cross-compile"]
@@ -199,6 +204,11 @@ run = "invoke test.integration.config"
 description = "Run the cargo-deny native-tls/OpenSSL ban regression (offline fixtures)"
 depends = ["deps:install:python"]
 run = "invoke test.integration.deny"
+
+[tasks."test:integration:zero-spawn"]
+description = "Prove the library-backed VCS adapter reads git and jj without spawning them (its own CI job, not the test roll-up)"
+depends = ["deps:install:python"]
+run = "invoke test.integration.zero-spawn"
 
 [tasks."test:integration:pup"]
 description = "Run the cargo-pup architecture regression (needs the nightly lane; check-architecture only, not the test roll-up)"

--- a/mise.toml
+++ b/mise.toml
@@ -9,10 +9,9 @@ rust = { version = "1.90.0", components = "rustfmt,clippy" }
 node = "22.22.2"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
-# Kept in lockstep with the `jj-lib` crate pin in cli/ (0.43): the
-# library-backed VCS adapter reads repositories the CLI writes, so a version
-# skew between them is a format-coherence risk. Bump both together. See
-# meta/work/0188-library-backed-vcs-adapter.md.
+# Kept in lockstep with the `jj-lib` crate pin in cli/ (0.43): the adapter reads
+# repositories this CLI writes, so a skew between them is a format-coherence
+# risk. Bump both together.
 jj = "0.43.0"
 jq = "1.7.1"
 # Exact pin + explicit backend (aqua), matching the exact-pin discipline of the

--- a/tasks/CLAUDE.md
+++ b/tasks/CLAUDE.md
@@ -4,6 +4,10 @@
   their rule sets are version-sensitive. Shared helpers live in `tasks/shared/`.
 - Release/version logic enforces **version coherence**: `plugin.json`, the
   `cli/` workspace `Cargo.toml`, and any version-pinned member manifest must
-  agree.
+  agree. `cli/Cargo.lock` counts too — it carries a copy of the version per
+  workspace member, so `version.write` syncs it via `cargo metadata` (the
+  minimal update, never `generate-lockfile`). Clippy runs `--locked`, so drift
+  there surfaces as an unrelated-looking Rust failure;
+  `tests/unit/tasks/test_version.py` guards it by name instead.
 - Registering a new dispatched sub-binary is a thirteen-point surface — see
   `tasks/README.md#registering-a-dispatched-sub-binary` before adding one.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -111,8 +111,9 @@ is no longer enumerated.
 `cli/vcs-adapters` reads git through `gix` and jj through `jj-lib` in-process.
 Those two pins are **not independent**, and neither is bumped alone.
 
-**The coupling is four-way**: `jj-lib` (exact, `=0.43.0`), `gix`
-(tilde, `~0.85.0`), the Rust toolchain, and `mise.toml`'s `jj` CLI pin. The CLI
+**The coupling is six-way**: `jj-lib` (exact, `=0.43.0`), `gix`
+(tilde, `~0.85.0`), `prost` and `pollster` (jj-lib's own, adopted as direct
+edges), the Rust toolchain, and `mise.toml`'s `jj` CLI pin. The CLI
 writes the repository format the library reads, so a skew between them surfaces
 as an apparently wrong detection answer rather than as a version mismatch;
 `jj-lib`'s MSRV moved 1.85 → 1.88 → 1.89 across eight releases, so a bump drags
@@ -123,11 +124,23 @@ tilde so a RustSec fix is a lock update rather than a pin edit. `gix` also sets
 helpers spawn `git credential-*` programs — out of a module that exists to avoid
 spawning. Widening that feature list is how a consumer adds a capability.
 
+`prost` and `pollster` are the newest two, and they are **jj-lib's, not ours**.
+They exist so the jj working-copy commit id can be read without constructing a
+settings value: `prost` decodes `jj_lib::protos::local_working_copy::Checkout` (a
+public module, so this is API rather than a private wire format) and `pollster`
+drives the `OpStore` trait's async reads, which jj-lib itself drives with
+pollster. Both were already in the lock through jj-lib, so adopting them added
+two edges and no packages. They are pinned to the majors jj-lib requires, because
+the decoded type comes *from* jj-lib — a major mismatch would put two `prost`
+graphs in the lock and the generated code would stop matching the decoder. Move
+them when `jj-lib` moves, never on their own.
+
 Two committed checks hold this together:
 `tests/unit/tasks/test_vcs_pin_lockstep.py` (the declarations agree and keep
 their inline rationale) and `tests/integration/deny/test_vcs_library_graph.py`
-(versions, single gix graph, the enabled feature set, no TLS in the subtree on
-any of deny.toml's five targets, MSRV, and a build-script/proc-macro snapshot).
+(versions, single gix graph, a single `prost`/`pollster` version each, the
+enabled feature set, no TLS in the subtree on any of deny.toml's five targets,
+MSRV, and a build-script/proc-macro snapshot).
 That the *binary* building fixtures matches the pin is asserted by the fixture
 harness, not by these.
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -170,6 +170,59 @@ crate acquiring or replacing one is a hard failure needing either an `allow`
 addition (permissive) or a justified `[[licenses.exceptions]]` (copyleft), with
 the `uluru` MPL-2.0 entry as the template.
 
+### Zero-spawn strong form
+
+The library-backed VCS adapter reads git and jj **in-process**. Two mechanisms
+prove it, and they prove different things.
+
+`test:integration:zero-spawn` puts marker-writing `git`/`jj` stubs first on a
+synthetic `PATH`, drops every directory that could resolve a real one, runs the
+whole fixture matrix, and asserts **both** that no stub recorded a spawn **and**
+that every value matches an unrestricted run — an adapter degrading to absence
+also writes no marker. It is scoped to `git`/`jj` specifically, not "no
+subprocess at all": the clock spawns `date` unconditionally.
+
+That is the **weak** form: a caller reaching `/usr/bin/git` by absolute path
+never consults `PATH`. The **strong** form additionally shadows those absolute
+paths, and runs only in the `check-zero-spawn` CI job, which is in
+`prerelease.needs`. The harness and the workflow step have an explicit contract
+— `ACCELERATOR_ZERO_SPAWN_MODE` and `ACCELERATOR_ZERO_SPAWN_SHADOWED` — and the
+harness **fails closed** on a malformed mode or a path that is still executable,
+so a runner image that relocates `git` cannot turn the `sudo mv` into a silent
+no-op.
+
+`test:integration:zero-spawn` is deliberately **out of the `test:integration`
+roll-up**: membership would rebuild the ~34-fixture matrix a second time per
+run, on both OS legs and on every bare `mise run`, in a code path with a
+documented flake history under parallel CI load. It stays runnable on demand.
+
+**The harness never writes outside its own temp directories.** It resolves and
+*reports* absolute paths; it never moves, chmods or `sudo`s anything. All
+privileged mutation lives in the CI step. `/opt/homebrew/bin` is user-writable,
+so an "attempt and record the failure" design would succeed there and could
+leave a developer's machine without `git` or `jj` — and the suite is reachable
+from the bare `mise run` every contributor runs before pushing.
+
+**Containment assumes ephemeral runners.** Shadow, run and restore live in one
+step with a `trap restore EXIT` and a step-level `timeout-minutes` shorter than
+the job's, so the shell rather than the scheduler guarantees the restore; a
+trailing `if: always()` step asserts `git --version` and `jj --version` both
+succeed. The job sets `cache: false` on `mise-action` because the jj shadow
+target sits inside the tree the action saves on its post step, so a failed
+restore would otherwise persist a `jj`-less tool tree into the cache that every
+later run restores. A move to self-hosted, containerised or reusable runners
+turns a contained hazard into a persistently broken runner.
+
+`build:cli:fixture-size` is the third guard: the linked reference artefact must
+be at least 3× the stubbed twin, so a future edit that stops printing a query
+result — letting the linker drop `gix`/`jj-lib` — is caught on the PR path
+rather than first firing during a release. The cross-compile applies the same
+ratio on every triple plus an absolute byte floor on **musl only**; the darwin
+stripped delta clears that floor by ~9%, and every triple is stripped, so gating
+darwin would put a 9%-margin heuristic on `prerelease:prepare`'s critical path.
+When it fires: re-measure, then adjust the constants in `tasks/build.py` only if
+the drop is understood.
+
 ### Rust nightly lane (cargo-pup)
 
 Architecture enforcement (the ADR-0053 inward-dependency rule) runs via
@@ -380,3 +433,4 @@ locally with the mapped command:
 | `check-cli`                           | `mise run cli:check`                      |
 | `check-supply-chain`                  | `mise run deny:check`                     |
 | `check-architecture`                  | `mise run pup:check` (+ `test:integration:pup`) |
+| `check-zero-spawn`                    | `mise run test:integration:zero-spawn` (PATH-only locally; the strong form shadows absolute paths and runs only in CI) |

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -197,9 +197,22 @@ subprocess at all": the clock spawns `date` unconditionally.
 
 That is the **weak** form: a caller reaching `/usr/bin/git` by absolute path
 never consults `PATH`. The **strong** form additionally shadows those absolute
-paths, and runs only in the `check-zero-spawn` CI job, which is in
-`prerelease.needs`. The harness and the workflow step have an explicit contract
-— `ACCELERATOR_ZERO_SPAWN_MODE` and `ACCELERATOR_ZERO_SPAWN_SHADOWED` — and the
+paths. It is `test:integration:zero-spawn:strong`, and it owns the whole
+sequence: compile the artefacts and build the fixture matrix while the real
+binaries are still reachable, shadow them, run the prebuilt suite, restore in a
+`finally`. Only the `check-zero-spawn` CI job invokes it, and that job is in
+`prerelease.needs`.
+
+Targets are resolved at run time from **three** sources: every `PATH` hit (macOS
+ships `git` in two directories), `mise which git`/`mise which jj`, and the known
+system paths. `mise which` is the load-bearing one on CI — there is no system
+`jj` on the runner, the real binary lives under the mise install tree, and what
+sits on `PATH` may be a shim pointing at it. Shadowing only a shim would leave
+the real binary reachable by absolute path while the harness agreed the run was
+strong, because it is only told about the paths we shadowed.
+
+The harness and the task have an explicit contract —
+`ACCELERATOR_ZERO_SPAWN_MODE` and `ACCELERATOR_ZERO_SPAWN_SHADOWED` — and the
 harness **fails closed** on a malformed mode or a path that is still executable,
 so a runner image that relocates `git` cannot turn the `sudo mv` into a silent
 no-op.
@@ -209,18 +222,23 @@ roll-up**: membership would rebuild the ~34-fixture matrix a second time per
 run, on both OS legs and on every bare `mise run`, in a code path with a
 documented flake history under parallel CI load. It stays runnable on demand.
 
-**The harness never writes outside its own temp directories.** It resolves and
-*reports* absolute paths; it never moves, chmods or `sudo`s anything. All
-privileged mutation lives in the CI step. `/opt/homebrew/bin` is user-writable,
-so an "attempt and record the failure" design would succeed there and could
-leave a developer's machine without `git` or `jj` — and the suite is reachable
-from the bare `mise run` every contributor runs before pushing.
+**The Rust harness never writes outside its own temp directories.** It resolves
+and *reports* absolute paths; it never moves, chmods or `sudo`s anything. All
+privileged mutation lives in the strong-form task, which is **gated behind
+`ACCELERATOR_ZERO_SPAWN_SHADOW=yes`** and refuses to start without it.
+`/opt/homebrew/bin` is user-writable, so an ungated task would succeed there and
+could leave a developer's machine without `git` or `jj`. The gate is an
+environment variable rather than a flag precisely because a task name can be
+tab-completed by accident and an `env:` block cannot.
 
 **Containment assumes ephemeral runners.** Shadow, run and restore live in one
-step with a `trap restore EXIT` and a step-level `timeout-minutes` shorter than
-the job's, so the shell rather than the scheduler guarantees the restore; a
-trailing `if: always()` step asserts `git --version` and `jj --version` both
-succeed. The job sets `cache: false` on `mise-action` because the jj shadow
+task, with the restore in a `finally` and a step-level `timeout-minutes` shorter
+than the job's, so the process rather than the scheduler guarantees the restore.
+A trailing `if: always()` step then asserts `git --version` and `jj --version`
+both succeed — deliberately as bare commands, not `mise run`, because mise would
+reinstall the missing tool and turn the one check that catches a failed restore
+into one that quietly repairs it. For the same reason the task invokes cargo
+directly inside the window: mise is entered before it and never within. The job sets `cache: false` on `mise-action` because the jj shadow
 target sits inside the tree the action saves on its post step, so a failed
 restore would otherwise persist a `jj`-less tool tree into the cache that every
 later run restores. A move to self-hosted, containerised or reusable runners
@@ -446,4 +464,4 @@ locally with the mapped command:
 | `check-cli`                           | `mise run cli:check`                      |
 | `check-supply-chain`                  | `mise run deny:check`                     |
 | `check-architecture`                  | `mise run pup:check` (+ `test:integration:pup`) |
-| `check-zero-spawn`                    | `mise run test:integration:zero-spawn` (PATH-only locally; the strong form shadows absolute paths and runs only in CI) |
+| `check-zero-spawn`                    | `mise run test:integration:zero-spawn` (PATH-only; the CI job runs `test:integration:zero-spawn:strong`, which shadows absolute paths and needs `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`) |

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -44,7 +44,10 @@ too. Beyond `cli:check`, Rust
 enforcement also spans standalone entity tasks wired directly into the top-level
 `check` (they sit outside the `cli:` roll-up, mirroring `version:*` /
 `github:*`): `deny:check` (cargo-deny supply-chain) and `pup:check` (cargo-pup
-architecture, on an isolated nightly lane).
+architecture, on an isolated nightly lane). `pup.ron` carries one rule per
+domain boundary plus `vcs_adapters_library_reads_in_process`, which scopes the
+library-backed VCS adapter's imports to a permit list and denies `std::process`
+— see "Library-backed VCS dependency pins" below.
 
 ## Family aggregates
 
@@ -102,6 +105,63 @@ is no longer enumerated.
   mode and assumes an exec-bit-preserving filesystem — acceptable given the
   macOS + Linux target matrix (CI runs `check-scripts` on `ubuntu-latest`; local
   dev is macOS via jj workspaces).
+
+### Library-backed VCS dependency pins
+
+`cli/vcs-adapters` reads git through `gix` and jj through `jj-lib` in-process.
+Those two pins are **not independent**, and neither is bumped alone.
+
+**The coupling is four-way**: `jj-lib` (exact, `=0.43.0`), `gix`
+(tilde, `~0.85.0`), the Rust toolchain, and `mise.toml`'s `jj` CLI pin. The CLI
+writes the repository format the library reads, so a skew between them surfaces
+as an apparently wrong detection answer rather than as a version mismatch;
+`jj-lib`'s MSRV moved 1.85 → 1.88 → 1.89 across eight releases, so a bump drags
+the toolchain too. The asymmetry is deliberate: `jj-lib` is exact because the
+design leans on its declared-unstable loader internals, while `gix` takes a
+tilde so a RustSec fix is a lock update rather than a pin edit. `gix` also sets
+`default-features = false`, which is what keeps `gix-credentials` — whose
+helpers spawn `git credential-*` programs — out of a module that exists to avoid
+spawning. Widening that feature list is how a consumer adds a capability.
+
+Two committed checks hold this together:
+`tests/unit/tasks/test_vcs_pin_lockstep.py` (the declarations agree and keep
+their inline rationale) and `tests/integration/deny/test_vcs_library_graph.py`
+(versions, single gix graph, the enabled feature set, no TLS in the subtree on
+any of deny.toml's five targets, MSRV, and a build-script/proc-macro snapshot).
+That the *binary* building fixtures matches the pin is asserted by the fixture
+harness, not by these.
+
+**Two enforcement mechanisms, with a clean division of labour.** cargo-pup owns
+**import** prohibitions; the `tasks/` source guards own **usage** prohibitions
+imports cannot express — `RestrictImports` resolves `use` paths, so a
+fully-qualified `jj_lib::settings::UserSettings::from_config(…)` or a
+`Workspace::load` method call is invisible to it. That is the whole
+justification for the extra Python machinery over a one-line `denied` clause.
+
+**Break-glass for a supply-chain failure.** Both transitive trees enter
+cargo-deny's `advisories` scope under `unmaintained = "all"` with
+`yanked = "deny"`, over a ~60-crate closure no repo code calls, and the advisory
+DB is fetched fresh every run. One upstream advisory there turns
+`check-supply-chain` red for every unrelated PR — and that job is in
+`prerelease.needs`, so it also stops releases. Recovery is a scoped, dated
+`[advisories].ignore` entry following the existing `RUSTSEC-2026-0118/0119`
+precedent, with a `review-by: YYYY-MM-DD` in its `reason`;
+`tests/integration/deny/test_advisory_ignores.py` asserts every entry carries
+one and that none has lapsed.
+
+**The break-glass is scoped to the `unmaintained`, `yanked` and `notice`
+classes only.** A `vulnerability`-class advisory takes the escalation path —
+upgrade, patch or vendor — never an ignore, regardless of release pressure,
+because this closure reaches the publicly distributed signed
+`accelerator-visualiser` binary. cargo-deny's `ignore` list is flat with no
+class distinction, so the scoping has to be written down or the pre-authorised
+action silently covers every class.
+
+**The licence side has no `ignore` mechanism at all.** `[licenses].allow` is
+pruned to exactly the licences the current closure carries, so a transitive
+crate acquiring or replacing one is a hard failure needing either an `allow`
+addition (permissive) or a justified `[[licenses.exceptions]]` (copyleft), with
+the `uluru` MPL-2.0 entry as the template.
 
 ### Rust nightly lane (cargo-pup)
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -138,6 +138,13 @@ fully-qualified `jj_lib::settings::UserSettings::from_config(…)` or a
 `Workspace::load` method call is invisible to it. That is the whole
 justification for the extra Python machinery over a one-line `denied` clause.
 
+`lint:vcs-settings:check` (`tasks/lint/vcs_settings.py`) is that guard: no code
+in `cli/vcs-adapters` may construct a `UserSettings` or call `Workspace::load`,
+whose defaults are private to jj-lib and were discovered one panic at a time.
+It **strips comments before matching**, so the crate can document why it avoids
+them without flagging itself. It rides both `cli:check` and `lint:check`, for
+the same bare-`default` reason as the other `cli/`-scoped guards.
+
 **Break-glass for a supply-chain failure.** Both transitive trees enter
 cargo-deny's `advisories` scope under `unmaintained = "all"` with
 `yanked = "deny"`, over a ~60-crate closure no repo code calls, and the advisory

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -117,6 +117,9 @@ ns_lint.add_collection(
 ns_lint.add_collection(
     Collection.from_module(lint.dispatch_coherence)
 )  # lint.dispatch-coherence.check
+ns_lint.add_collection(
+    Collection.from_module(lint.vcs_settings)
+)  # lint.vcs-settings.check
 ns.add_collection(ns_lint)
 
 ns_types = Collection("types")

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -34,6 +34,33 @@ from tasks.shared.targets import TARGETS
 
 _CLI_RELEASE_BINARIES = ("accelerator", "accelerator-verify")
 
+# The linked/stubbed pair whose size delta proves the VCS dependency trees are
+# actually linked. Deliberately NOT in _CLI_RELEASE_BINARIES: that constant
+# means "binaries we ship" and drives staging into dist/release/, the tree the
+# signed manifest is assembled from and whose `accelerator-*` members are
+# provenance-attested. Nothing would be published today, but two unshipped
+# diagnostic binaries that print absolute repository paths would sit in the
+# release staging directory on every release run, one glob change away from
+# being product. The names avoid the `accelerator-` prefix for the same reason.
+_CLI_FIXTURE_BINARIES = (
+    "vcs-adapters-fixture",
+    "vcs-adapters-fixture-stub",
+)
+
+# The floor guarding this story's headline false pass: dead-code elimination
+# letting the musl and size checks succeed while linking almost none of
+# gix/jj-lib.
+#
+# Two scoping rules, because a heuristic threshold that first executes in the
+# release pipeline can abort a whole product release. The *ratio* has wide
+# margin (measured 5.42x darwin, 6.19x musl) and is asserted everywhere. The
+# *absolute* floor is musl-only, matching how _assert_static_elf is already
+# guarded: `[profile.release] strip = true` means every triple is stripped, and
+# the darwin stripped delta clears this by only ~9%, so gating darwin on it
+# would put a 9%-margin heuristic on prerelease:prepare's critical path.
+_FIXTURE_SIZE_RATIO_FLOOR = 3.0
+_FIXTURE_SIZE_DELTA_FLOOR = 1_500_000
+
 
 class VersionCoherenceError(Exception): ...
 
@@ -155,6 +182,54 @@ def _assert_static_elf(path: Path) -> None:
         raise RuntimeError(
             f"{path.name} is not statically linked: {result.stdout.strip()}"
         )
+
+
+def assert_fixture_size_floor(
+    linked: int,
+    stubbed: int,
+    *,
+    triple: str,
+) -> None:
+    """Fail unless the linked artefact is enough larger than the stubbed one.
+
+    Pure comparison over sizes so the thresholds are unit-testable without a
+    real cross-compile — the only path that otherwise exercises them is the
+    release pipeline.
+    """
+    if stubbed <= 0:
+        raise RuntimeError(
+            f"stubbed fixture for {triple} has size {stubbed}; cannot compare"
+        )
+    ratio = linked / stubbed
+    delta = linked - stubbed
+    if ratio < _FIXTURE_SIZE_RATIO_FLOOR:
+        raise RuntimeError(
+            f"the VCS reference artefact for {triple} is only {ratio:.2f}x the "
+            f"stubbed build ({linked} vs {stubbed} bytes), below the "
+            f"{_FIXTURE_SIZE_RATIO_FLOOR}x floor — the gix/jj-lib trees are "
+            "probably not linked. Re-measure, then adjust the floor in "
+            "tasks/build.py only if the drop is understood."
+        )
+    if "musl" in triple and delta < _FIXTURE_SIZE_DELTA_FLOOR:
+        raise RuntimeError(
+            f"the VCS reference artefact for {triple} is only {delta} bytes "
+            f"larger than the stubbed build, below the "
+            f"{_FIXTURE_SIZE_DELTA_FLOOR}-byte floor (decimal) — see above."
+        )
+
+
+def _assert_fixture_pair(directory: Path, triple: str) -> None:
+    """Assert both fixture binaries exist, are sound, and differ enough."""
+    linked, stubbed = (directory / name for name in _CLI_FIXTURE_BINARIES)
+    for path in (linked, stubbed):
+        if not path.is_file():
+            raise RuntimeError(f"fixture binary not built: {path}")
+        _assert_magic_bytes(path, triple)
+        if "musl" in triple:
+            _assert_static_elf(path)
+    assert_fixture_size_floor(
+        linked.stat().st_size, stubbed.stat().st_size, triple=triple
+    )
 
 
 def validate_version_coherence(
@@ -286,6 +361,38 @@ def server_cross_compile(context: Context) -> None:
 
 
 @task
+def cli_fixture_size_check(context: Context) -> None:
+    """Assert the host-native VCS reference artefact links its dependency trees.
+
+    The same ratio floor the cross-compile applies, on the PR path. Without it a
+    contributor who deletes a result print — letting the linker drop gix/jj-lib
+    again — sees green everywhere they look, and the guard first fires during a
+    release.
+    """
+    context.run(
+        "cargo build --release "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        + " ".join(f"--bin {name}" for name in _CLI_FIXTURE_BINARIES),
+        pty=True,
+    )
+    directory = CLI_DIR / "target" / "release"
+    linked, stubbed = (directory / name for name in _CLI_FIXTURE_BINARIES)
+    for path in (linked, stubbed):
+        if not path.is_file():
+            raise RuntimeError(f"fixture binary not built: {path}")
+    linked_size = linked.stat().st_size
+    stubbed_size = stubbed.stat().st_size
+    # Host-native, so the ratio only — the absolute floor is calibrated on the
+    # musl-static artefact the release pipeline ships.
+    assert_fixture_size_floor(linked_size, stubbed_size, triple="host")
+    print(
+        f"vcs reference artefact: linked {linked_size} B, "
+        f"stubbed {stubbed_size} B, "
+        f"ratio {linked_size / stubbed_size:.2f}x"
+    )
+
+
+@task
 def cli_cross_compile(context: Context) -> None:
     """Cross-compile the cli launcher + verify shim for all four targets.
 
@@ -305,6 +412,10 @@ def cli_cross_compile(context: Context) -> None:
             if "musl" in triple:
                 _assert_static_elf(src)
             shutil.copy2(src, cli_binary_path(name, platform))
+
+        # Asserted in place under cli/target/, never copied into dist/release/:
+        # these are diagnostics, not product.
+        _assert_fixture_pair(CLI_DIR / "target" / triple / "release", triple)
 
 
 def _minisign_verify_pin(cargo_toml_text: str) -> str:

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -47,17 +47,11 @@ _CLI_FIXTURE_BINARIES = (
     "vcs-adapters-fixture-stub",
 )
 
-# The floor guarding this story's headline false pass: dead-code elimination
-# letting the musl and size checks succeed while linking almost none of
-# gix/jj-lib.
-#
-# Two scoping rules, because a heuristic threshold that first executes in the
-# release pipeline can abort a whole product release. The *ratio* has wide
-# margin (measured 5.42x darwin, 6.19x musl) and is asserted everywhere. The
-# *absolute* floor is musl-only, matching how _assert_static_elf is already
-# guarded: `[profile.release] strip = true` means every triple is stripped, and
-# the darwin stripped delta clears this by only ~9%, so gating darwin on it
-# would put a 9%-margin heuristic on prerelease:prepare's critical path.
+# Catches dead-code elimination letting the musl and size checks pass while
+# linking almost none of gix/jj-lib. The ratio has wide margin and is asserted
+# everywhere; the absolute floor is musl-only, because a stripped darwin delta
+# clears it by ~9% and a 9%-margin heuristic does not belong on the release
+# path.
 _FIXTURE_SIZE_RATIO_FLOOR = 3.0
 _FIXTURE_SIZE_DELTA_FLOOR = 1_500_000
 

--- a/tasks/lint/__init__.py
+++ b/tasks/lint/__init__.py
@@ -9,6 +9,7 @@ from . import (
     server,
     skill_permissions,
     store_duplication,
+    vcs_settings,
     vendor_shims,
     workflows,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "server",
     "skill_permissions",
     "store_duplication",
+    "vcs_settings",
     "vendor_shims",
     "workflows",
 ]

--- a/tasks/lint/store_duplication.py
+++ b/tasks/lint/store_duplication.py
@@ -25,6 +25,11 @@ ALLOWLIST: frozenset[str] = frozenset(
         # is a read/index module and performs no atomic writes (those route
         # through the file driver onto store::atomic_write).
         "cli/visualiser/server/src/indexer.rs",
+        # Grafts a `.jj` *directory* into the colocated fixture, mirroring the
+        # shell suite's `mv`. Both `git worktree add` and `jj workspace add`
+        # refuse an existing non-empty target, so the workspace is built
+        # elsewhere and moved — a directory relocation, not a whole-file write.
+        "cli/vcs-test-support/src/fixtures.rs",
     }
 )
 

--- a/tasks/lint/vcs_settings.py
+++ b/tasks/lint/vcs_settings.py
@@ -1,0 +1,83 @@
+"""Guard: no code in cli/vcs-adapters constructs a jj ``UserSettings``.
+
+``jj_lib::workspace::Workspace::load`` needs a fully-populated ``UserSettings``
+whose defaults are private to jj-lib and were discovered one panic at a time —
+the attempt was abandoned after five successive panics with the chain never
+exhausted. ``DefaultWorkspaceLoaderFactory`` is public and
+``WorkspaceLoader::{workspace_root, repo_path}`` need no settings, so nothing in
+the detection paths requires it.
+
+The statement is crate-wide, deliberately wider than the detection paths
+strictly need, so the guard is a simple one. A spike established that jj-lib
+0.43 offers no read-only, settings-free route to the working-copy commit id
+either, which is why the jj half of ``revision`` is out of scope rather than a
+reason to narrow this.
+
+**Why this is not a cargo-pup ``denied`` clause.** ``RestrictImports`` resolves
+``use`` paths, so it cannot see a fully-qualified
+``jj_lib::settings::UserSettings::from_config(...)`` or a ``Workspace::load``
+method call. cargo-pup owns import prohibitions; this owns the usage
+prohibitions imports cannot express.
+
+Comments are stripped before matching. The model this copies matches a regex
+against every raw line, which would make it impossible to document *why*
+``UserSettings`` is avoided in the very crate the guard covers — and that reason
+is exactly the kind of extremely-non-obvious fact this repo's comment bar
+admits. Without the strip, an implementer hits the self-flagging problem
+immediately and works around it by mangling the word.
+"""
+
+import re
+from pathlib import Path
+
+from invoke import Context, Exit, task
+
+from tasks.shared.sources import repo_root
+
+CRATE = "cli/vcs-adapters"
+
+# The two constructs the work item forbids by name.
+_FORBIDDEN = re.compile(r"\bUserSettings\b|\bWorkspace::load\b")
+
+_LINE_COMMENT = re.compile(r"//.*$")
+_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def strip_comments(source: str) -> str:
+    """``source`` with block and line comments blanked, lines preserved.
+
+    Newlines survive so reported line numbers still point at the real line.
+    """
+    without_blocks = _BLOCK_COMMENT.sub(
+        lambda match: "\n" * match.group().count("\n"), source
+    )
+    return "\n".join(
+        _LINE_COMMENT.sub("", line) for line in without_blocks.splitlines()
+    )
+
+
+def violations(root: Path) -> list[str]:
+    """Repo-relative ``path:line`` for each forbidden construct in the crate."""
+    found: list[str] = []
+    for path in sorted((root / CRATE).rglob("*.rs")):
+        rel = path.relative_to(root).as_posix()
+        source = strip_comments(path.read_text())
+        for number, line in enumerate(source.splitlines(), start=1):
+            if _FORBIDDEN.search(line):
+                found.append(f"{rel}:{number}")
+    return found
+
+
+@task
+def check(context: Context) -> None:
+    """Fail if cli/vcs-adapters names UserSettings or Workspace::load."""
+    offenders = violations(repo_root())
+    if offenders:
+        raise Exit(
+            "cli/vcs-adapters must not construct a jj UserSettings or call "
+            "Workspace::load — its defaults are private to jj-lib and the "
+            "detection paths need neither. Use "
+            "DefaultWorkspaceLoaderFactory and WorkspaceLoader instead:\n  "
+            + "\n  ".join(offenders),
+            code=1,
+        )

--- a/tasks/lint/vcs_settings.py
+++ b/tasks/lint/vcs_settings.py
@@ -1,30 +1,17 @@
 """Guard: no code in cli/vcs-adapters constructs a jj ``UserSettings``.
 
-``jj_lib::workspace::Workspace::load`` needs a fully-populated ``UserSettings``
-whose defaults are private to jj-lib and were discovered one panic at a time —
-the attempt was abandoned after five successive panics with the chain never
-exhausted. ``DefaultWorkspaceLoaderFactory`` is public and
-``WorkspaceLoader::{workspace_root, repo_path}`` need no settings, so nothing in
-the detection paths requires it.
+``Workspace::load`` needs a fully-populated ``UserSettings`` whose defaults are
+private to jj-lib and were discovered one panic at a time. Nothing here needs
+it: ``DefaultWorkspaceLoaderFactory`` is public, and the checkout state and
+operation store are both reachable without settings.
 
-The statement is crate-wide, deliberately wider than the detection paths
-strictly need, so the guard is a simple one. A spike established that jj-lib
-0.43 offers no read-only, settings-free route to the working-copy commit id
-either, which is why the jj half of ``revision`` is out of scope rather than a
-reason to narrow this.
-
-**Why this is not a cargo-pup ``denied`` clause.** ``RestrictImports`` resolves
-``use`` paths, so it cannot see a fully-qualified
+Not a cargo-pup ``denied`` clause because ``RestrictImports`` resolves ``use``
+paths, so it cannot see a fully-qualified
 ``jj_lib::settings::UserSettings::from_config(...)`` or a ``Workspace::load``
-method call. cargo-pup owns import prohibitions; this owns the usage
-prohibitions imports cannot express.
+method call. cargo-pup owns import prohibitions; this owns usage prohibitions.
 
-Comments are stripped before matching. The model this copies matches a regex
-against every raw line, which would make it impossible to document *why*
-``UserSettings`` is avoided in the very crate the guard covers — and that reason
-is exactly the kind of extremely-non-obvious fact this repo's comment bar
-admits. Without the strip, an implementer hits the self-flagging problem
-immediately and works around it by mangling the word.
+Comments are stripped before matching, so the crate can document why it avoids
+these without flagging itself.
 """
 
 import re
@@ -36,7 +23,6 @@ from tasks.shared.sources import repo_root
 
 CRATE = "cli/vcs-adapters"
 
-# The two constructs the work item forbids by name.
 _FORBIDDEN = re.compile(r"\bUserSettings\b|\bWorkspace::load\b")
 
 _LINE_COMMENT = re.compile(r"//.*$")

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -9,15 +9,12 @@ from tasks.shared.paths import CARGO_TOML, CLI_WORKSPACE_CARGO_TOML
 
 from .helpers import accelerator_env, run_shell_suites
 
-# The strong-form zero-spawn run moves system binaries aside with sudo, so it
-# refuses to start without this. Not a `--yes` flag: the CI step sets it in
-# `env:`, and an env gate cannot be reached by tab-completing a task name.
+# An env gate rather than a `--yes` flag: a task name can be tab-completed by
+# accident, and the CI step sets this in `env:`.
 _SHADOW_OPT_IN = "ACCELERATOR_ZERO_SPAWN_SHADOW"
 
-# Checked in addition to every PATH hit and to `mise which`, because a probe
-# reaching for one of these by absolute path is exactly what the strong form has
-# to defeat. These are the system locations; on CI there is no system jj at all,
-# which is why `mise which` carries the jj side.
+# Checked alongside every PATH hit and `mise which`, because absolute-path
+# access is what the strong form has to defeat.
 _ABSOLUTE_VCS_PATHS = (
     "/usr/bin/git",
     "/usr/local/bin/git",
@@ -178,27 +175,22 @@ def zero_spawn(context: Context) -> None:
 
 @task
 def zero_spawn_strong(context: Context) -> None:
-    """Run the zero-spawn suite in its strong form, with git and jj shadowed.
+    """Run the zero-spawn suite with git and jj shadowed.
 
-    The strong form is what makes the property non-degradable: `PATH` stubs
-    alone leave the binaries reachable by absolute path, so this moves every
-    resolved `git`/`jj` aside for the duration of the run and hands the harness
-    the list, which hard-fails if any listed path is still executable.
+    `PATH` stubs alone leave the binaries reachable by absolute path, so this
+    moves every resolved `git`/`jj` aside and hands the harness the list, which
+    hard-fails if any listed path is still executable.
 
-    **This moves binaries out of system directories and needs `sudo`.** It is
-    gated behind `ACCELERATOR_ZERO_SPAWN_SHADOW=yes` and stays out of every
-    roll-up, because `/opt/homebrew/bin` is user-writable — a developer who ran
-    this unaware could be left without `git` or `jj`. Ephemeral CI runners are
-    the intended host; `tasks/README.md` records the containment assumption.
+    **Moves binaries out of system directories with `sudo`**, so it is gated
+    behind `ACCELERATOR_ZERO_SPAWN_SHADOW=yes` and stays out of every roll-up:
+    `/opt/homebrew/bin` is user-writable, and a developer running this unaware
+    could be left without `git` or `jj`. Ephemeral CI runners are the host.
 
-    Ordering is load-bearing. Everything needing a real binary happens *before*
-    the shadow window: `cli/launcher` carries a `vergen-gitcl` build dependency
-    that shells out to git, cargo may need git on a cold registry cache, and the
-    fixture matrix is built by invoking the real CLIs. The suite is therefore
-    compiled with `--no-run` first and only executed inside the window, and
-    cargo is invoked directly rather than through `mise run` — mise could
-    observe `jj` as missing inside the window and reinstall it, silently
-    restoring the binary and making the assertion vacuous.
+    Ordering is load-bearing. Compilation needs git (`vergen-gitcl`, and a cold
+    registry cache) and the fixture matrix needs both binaries, so both happen
+    before the window and the suite runs `--no-run` first. Cargo is invoked
+    directly rather than through `mise run`, which could see `jj` missing inside
+    the window and reinstall it, making the assertion vacuous.
     """
     if os.environ.get(_SHADOW_OPT_IN) != "yes":
         raise Exit(
@@ -241,10 +233,7 @@ def zero_spawn_strong(context: Context) -> None:
 
 
 def _compile_zero_spawn_targets(context: Context) -> None:
-    """Build the reference artefacts and compile the suite without running it.
-
-    Both need a real git, so both happen before the shadow window.
-    """
+    """Build the reference artefacts and compile the suite, without running."""
     context.run(
         "cargo build "
         f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
@@ -274,17 +263,11 @@ def _build_fixture_matrix(context: Context) -> None:
 def _resolve_vcs_binaries(context: Context) -> list[Path]:
     """Resolve every `git`/`jj` on `PATH`, plus the absolute paths to check.
 
-    Every `PATH` hit rather than the first: macOS ships `git` in two
-    directories, and the enumeration keeps this honest when a runner image
-    moves things. Deduplicated, order preserved, and only what exists.
-
-    `mise which` is asked as well, and it is the load-bearing one on CI. There
-    is no system `jj` on the runner at all — the real binary lives under the
-    mise install tree, and what sits on `PATH` may be a shim pointing at it.
-    Shadowing only the shim would leave the real binary reachable by absolute
-    path, which is precisely what the strong form exists to defeat, while the
-    harness would agree the run was strong because we only told it about the
-    shim.
+    Every `PATH` hit rather than the first, because macOS ships `git` in two
+    directories. `mise which` is load-bearing on CI: there is no system `jj`
+    there, and what sits on `PATH` may be a shim pointing into the mise install
+    tree. Shadowing only the shim would leave the real binary reachable by
+    absolute path while the harness agreed the run was strong.
     """
     found: list[Path] = []
 
@@ -311,10 +294,9 @@ def _restore_vcs_binaries(
 ) -> None:
     """Put every shadowed binary back, then prove it is runnable again.
 
-    Idempotent per path and it reports at the end rather than aborting on the
-    first failure, so a partial shadow does not leave the rest stranded. Raises
-    when anything is still missing: an unrestored `git` also breaks
-    `actions/checkout`'s post step, which runs git to strip its auth token.
+    Idempotent per path, reporting at the end rather than aborting on the first
+    failure, so a partial shadow does not strand the rest. An unrestored `git`
+    also breaks `actions/checkout`'s post step.
     """
     still_missing: list[Path] = []
     for target in shadowed:

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -1,6 +1,6 @@
 from invoke import Context, Exit, task
 
-from tasks.shared.paths import CARGO_TOML
+from tasks.shared.paths import CARGO_TOML, CLI_WORKSPACE_CARGO_TOML
 
 from .helpers import accelerator_env, run_shell_suites
 
@@ -129,6 +129,28 @@ def deny(context: Context) -> None:
 def pup(context: Context) -> None:
     """cargo-pup architecture regression (needs the nightly lane)."""
     context.run("uv run pytest tests/integration/pup -v")
+
+
+@task
+def zero_spawn(context: Context) -> None:
+    """Run the zero-spawn suite (its own CI job, not the test roll-up).
+
+    Builds the reference artefact first: the suite resolves it beside its own
+    test binary, and a bare `cargo nextest run -p corpus-adapters` does not
+    build another crate's bin target.
+    """
+    context.run(
+        "cargo build "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "-p vcs-adapters --bin vcs-adapters-fixture",
+        pty=True,
+    )
+    context.run(
+        "cargo nextest run "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "-p corpus-adapters --features bash-parity -E 'binary(zero_spawn)'",
+        pty=True,
+    )
 
 
 @task

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -13,6 +13,10 @@ from .helpers import accelerator_env, run_shell_suites
 # accident, and the CI step sets this in `env:`.
 _SHADOW_OPT_IN = "ACCELERATOR_ZERO_SPAWN_SHADOW"
 
+# Hands the prebuilt fixture matrix to the suite, which cannot build one once
+# the binaries are out of reach. Mirrors fixtures::MATRIX_ROOT_VARIABLE.
+_MATRIX_ROOT = "ACCELERATOR_ZERO_SPAWN_MATRIX"
+
 # Checked alongside every PATH hit and `mise which`, because absolute-path
 # access is what the strong form has to defeat.
 _ABSOLUTE_VCS_PATHS = (
@@ -188,7 +192,8 @@ def zero_spawn_strong(context: Context) -> None:
 
     Ordering is load-bearing. Compilation needs git (`vergen-gitcl`, and a cold
     registry cache) and the fixture matrix needs both binaries, so both happen
-    before the window and the suite runs `--no-run` first. Cargo is invoked
+    before the window, the suite runs `--no-run` first, and the matrix is handed
+    over by path for the suite to adopt. Cargo is invoked
     directly rather than through `mise run`, which could see `jj` missing inside
     the window and reinstall it, making the assertion vacuous.
     """
@@ -202,7 +207,8 @@ def zero_spawn_strong(context: Context) -> None:
         )
 
     _compile_zero_spawn_targets(context)
-    _build_fixture_matrix(context)
+    matrix_root = Path(tempfile.mkdtemp(prefix="accelerator-vcs-matrix-"))
+    _build_fixture_matrix(context, matrix_root)
 
     targets = _resolve_vcs_binaries(context)
     if not targets:
@@ -226,6 +232,8 @@ def zero_spawn_strong(context: Context) -> None:
                 "ACCELERATOR_ZERO_SPAWN_SHADOWED": ":".join(
                     str(path) for path in shadowed
                 ),
+                # Adopted, not rebuilt: there is no git or jj to build with now.
+                _MATRIX_ROOT: str(matrix_root),
             },
         )
     finally:
@@ -250,13 +258,20 @@ def _compile_zero_spawn_targets(context: Context) -> None:
     )
 
 
-def _build_fixture_matrix(context: Context) -> None:
-    """Exercise the matrix builders while the real CLIs are still reachable."""
+def _build_fixture_matrix(context: Context, root: Path) -> None:
+    """Build the matrix at `root` while the real CLIs are still reachable.
+
+    One test rather than the whole binary: with a shared root, tests building
+    concurrently would race to populate it. The rest of the matrix suite runs in
+    `test:unit:cli` against its own temp roots.
+    """
     context.run(
         "cargo nextest run "
         f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
-        "-p vcs-test-support -E 'binary(matrix)'",
+        "-p vcs-test-support "
+        "-E 'binary(matrix) and test(every_recorded_fixture_key_is_built)'",
         pty=True,
+        env={_MATRIX_ROOT: str(root)},
     )
 
 
@@ -270,10 +285,19 @@ def _resolve_vcs_binaries(context: Context) -> list[Path]:
     absolute path while the harness agreed the run was strong.
     """
     found: list[Path] = []
+    seen: set[Path] = set()
 
     def remember(candidate: Path) -> None:
-        if os.access(candidate, os.X_OK) and candidate not in found:
-            found.append(candidate)
+        # Deduplicated by RESOLVED path: on a usrmerge Linux /bin is a symlink
+        # to /usr/bin, so both spellings name one file and moving it under the
+        # first name makes the second fail to stat.
+        if not os.access(candidate, os.X_OK):
+            return
+        identity = candidate.resolve()
+        if identity in seen:
+            return
+        seen.add(identity)
+        found.append(candidate)
 
     for name in ("git", "jj"):
         for directory in os.environ.get("PATH", "").split(os.pathsep):

--- a/tasks/test/integration.py
+++ b/tasks/test/integration.py
@@ -1,8 +1,31 @@
+import os
+import shlex
+import tempfile
+from pathlib import Path
+
 from invoke import Context, Exit, task
 
 from tasks.shared.paths import CARGO_TOML, CLI_WORKSPACE_CARGO_TOML
 
 from .helpers import accelerator_env, run_shell_suites
+
+# The strong-form zero-spawn run moves system binaries aside with sudo, so it
+# refuses to start without this. Not a `--yes` flag: the CI step sets it in
+# `env:`, and an env gate cannot be reached by tab-completing a task name.
+_SHADOW_OPT_IN = "ACCELERATOR_ZERO_SPAWN_SHADOW"
+
+# Checked in addition to every PATH hit and to `mise which`, because a probe
+# reaching for one of these by absolute path is exactly what the strong form has
+# to defeat. These are the system locations; on CI there is no system jj at all,
+# which is why `mise which` carries the jj side.
+_ABSOLUTE_VCS_PATHS = (
+    "/usr/bin/git",
+    "/usr/local/bin/git",
+    "/opt/homebrew/bin/git",
+    "/usr/bin/jj",
+    "/usr/local/bin/jj",
+    "/opt/homebrew/bin/jj",
+)
 
 # The migrate subtree ships exactly these shell suites. The count is asserted in
 # `migrate` below so a dropped exec bit (e.g. on an exec-bit-lossy filesystem)
@@ -151,6 +174,163 @@ def zero_spawn(context: Context) -> None:
         "-p corpus-adapters --features bash-parity -E 'binary(zero_spawn)'",
         pty=True,
     )
+
+
+@task
+def zero_spawn_strong(context: Context) -> None:
+    """Run the zero-spawn suite in its strong form, with git and jj shadowed.
+
+    The strong form is what makes the property non-degradable: `PATH` stubs
+    alone leave the binaries reachable by absolute path, so this moves every
+    resolved `git`/`jj` aside for the duration of the run and hands the harness
+    the list, which hard-fails if any listed path is still executable.
+
+    **This moves binaries out of system directories and needs `sudo`.** It is
+    gated behind `ACCELERATOR_ZERO_SPAWN_SHADOW=yes` and stays out of every
+    roll-up, because `/opt/homebrew/bin` is user-writable — a developer who ran
+    this unaware could be left without `git` or `jj`. Ephemeral CI runners are
+    the intended host; `tasks/README.md` records the containment assumption.
+
+    Ordering is load-bearing. Everything needing a real binary happens *before*
+    the shadow window: `cli/launcher` carries a `vergen-gitcl` build dependency
+    that shells out to git, cargo may need git on a cold registry cache, and the
+    fixture matrix is built by invoking the real CLIs. The suite is therefore
+    compiled with `--no-run` first and only executed inside the window, and
+    cargo is invoked directly rather than through `mise run` — mise could
+    observe `jj` as missing inside the window and reinstall it, silently
+    restoring the binary and making the assertion vacuous.
+    """
+    if os.environ.get(_SHADOW_OPT_IN) != "yes":
+        raise Exit(
+            f"refusing to shadow the real git/jj: set {_SHADOW_OPT_IN}=yes to "
+            "confirm. This moves binaries out of system directories with sudo "
+            "and is meant for ephemeral CI runners, not a developer machine. "
+            "For the local property, run test:integration:zero-spawn instead.",
+            code=1,
+        )
+
+    _compile_zero_spawn_targets(context)
+    _build_fixture_matrix(context)
+
+    targets = _resolve_vcs_binaries(context)
+    if not targets:
+        raise Exit("found no git or jj to shadow — nothing to prove", code=1)
+
+    shadow_dir = Path(tempfile.mkdtemp(prefix="accelerator-shadowed-"))
+    shadowed: list[Path] = []
+    try:
+        for target in targets:
+            stashed = shadow_dir / str(target).replace(os.sep, "_")
+            context.run(f"sudo mv {shlex.quote(str(target))} {stashed}")
+            shadowed.append(target)
+        context.run(
+            "cargo nextest run "
+            f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+            "-p corpus-adapters --features bash-parity "
+            "-E 'binary(zero_spawn)' --no-fail-fast",
+            pty=True,
+            env={
+                "ACCELERATOR_ZERO_SPAWN_MODE": "strong",
+                "ACCELERATOR_ZERO_SPAWN_SHADOWED": ":".join(
+                    str(path) for path in shadowed
+                ),
+            },
+        )
+    finally:
+        _restore_vcs_binaries(context, shadow_dir, shadowed)
+
+
+def _compile_zero_spawn_targets(context: Context) -> None:
+    """Build the reference artefacts and compile the suite without running it.
+
+    Both need a real git, so both happen before the shadow window.
+    """
+    context.run(
+        "cargo build "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "-p vcs-adapters --bin vcs-adapters-fixture "
+        "--bin vcs-adapters-fixture-stub",
+        pty=True,
+    )
+    context.run(
+        "cargo nextest run "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "-p corpus-adapters --features bash-parity "
+        "-E 'binary(zero_spawn)' --no-run",
+        pty=True,
+    )
+
+
+def _build_fixture_matrix(context: Context) -> None:
+    """Exercise the matrix builders while the real CLIs are still reachable."""
+    context.run(
+        "cargo nextest run "
+        f"--manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "-p vcs-test-support -E 'binary(matrix)'",
+        pty=True,
+    )
+
+
+def _resolve_vcs_binaries(context: Context) -> list[Path]:
+    """Resolve every `git`/`jj` on `PATH`, plus the absolute paths to check.
+
+    Every `PATH` hit rather than the first: macOS ships `git` in two
+    directories, and the enumeration keeps this honest when a runner image
+    moves things. Deduplicated, order preserved, and only what exists.
+
+    `mise which` is asked as well, and it is the load-bearing one on CI. There
+    is no system `jj` on the runner at all — the real binary lives under the
+    mise install tree, and what sits on `PATH` may be a shim pointing at it.
+    Shadowing only the shim would leave the real binary reachable by absolute
+    path, which is precisely what the strong form exists to defeat, while the
+    harness would agree the run was strong because we only told it about the
+    shim.
+    """
+    found: list[Path] = []
+
+    def remember(candidate: Path) -> None:
+        if os.access(candidate, os.X_OK) and candidate not in found:
+            found.append(candidate)
+
+    for name in ("git", "jj"):
+        for directory in os.environ.get("PATH", "").split(os.pathsep):
+            if directory:
+                remember(Path(directory) / name)
+        resolved = context.run(f"mise which {name}", warn=True, hide=True)
+        if resolved is not None and resolved.exited == 0:
+            target = resolved.stdout.strip()
+            if target:
+                remember(Path(target))
+    for absolute in _ABSOLUTE_VCS_PATHS:
+        remember(Path(absolute))
+    return found
+
+
+def _restore_vcs_binaries(
+    context: Context, shadow_dir: Path, shadowed: list[Path]
+) -> None:
+    """Put every shadowed binary back, then prove it is runnable again.
+
+    Idempotent per path and it reports at the end rather than aborting on the
+    first failure, so a partial shadow does not leave the rest stranded. Raises
+    when anything is still missing: an unrestored `git` also breaks
+    `actions/checkout`'s post step, which runs git to strip its auth token.
+    """
+    still_missing: list[Path] = []
+    for target in shadowed:
+        stashed = shadow_dir / str(target).replace(os.sep, "_")
+        if stashed.exists():
+            context.run(
+                f"sudo mv -f {stashed} {shlex.quote(str(target))}", warn=True
+            )
+        if not os.access(target, os.X_OK):
+            still_missing.append(target)
+    if still_missing:
+        raise Exit(
+            "failed to restore: "
+            + ", ".join(str(path) for path in still_missing),
+            code=1,
+        )
 
 
 @task

--- a/tasks/version.py
+++ b/tasks/version.py
@@ -51,30 +51,54 @@ def read(_context: Context, print_to_stdout: bool = True) -> semver.Version:
     return semver.Version.parse(current_version)
 
 
+def _sync_cargo_lock(context: Context) -> None:
+    """Fold the new version into `cli/Cargo.lock`.
+
+    The lock records a version for **every** workspace member, so rewriting the
+    manifest alone leaves the two disagreeing — and clippy runs `--locked`,
+    which fails on exactly that. The failure surfaces as a Rust job complaining
+    the lock needs updating, nowhere near the bump that caused it.
+
+    `cargo metadata` performs the *minimal* update: only the entries whose
+    version moved. `cargo generate-lockfile` would re-resolve the whole
+    ~360-package closure and float every caret-bounded dependency, which is
+    never what a version bump wants.
+    """
+    context.run(
+        f"cargo metadata --manifest-path {CLI_WORKSPACE_CARGO_TOML} "
+        "--format-version 1",
+        hide=True,
+    )
+
+
 @task
-def write(_context: Context, version: str) -> None:
+def write(context: Context, version: str) -> None:
     """Write plugin version to plugin.json and the cli/ workspace manifest.
 
     The visualiser server inherits its version from
     [workspace.package].version, so bumping the cli/ workspace manifest covers
     it; writing the member manifest would clobber that inheritance.
+
+    The lock is synced too, because it carries a copy of the version per member
+    and would otherwise be left behind — see `_sync_cargo_lock`.
     """
     rendered_plugin_json = _render_plugin_json(version)
     rendered_workspace_cargo_toml = _render_workspace_cargo_toml(version)
 
     atomic_write_text(PLUGIN_JSON, rendered_plugin_json)
     atomic_write_text(CLI_WORKSPACE_CARGO_TOML, rendered_workspace_cargo_toml)
+    _sync_cargo_lock(context)
 
 
 @task(iterable=["bump_type"])
 def bump(
-    _context: Context, bump_type: list[BumpType] | None = None
+    context: Context, bump_type: list[BumpType] | None = None
 ) -> semver.Version:
     """Bump plugin version."""
     # "pre" is the semver pre-release token (e.g. 1.2.3-pre.4), not a secret —
     # S105's "token"-named-string heuristic is a false positive here.
     prerelease_token = "pre"  # noqa: S105
-    current_version = read(_context, print_to_stdout=False)
+    current_version = read(context, print_to_stdout=False)
     new_version = current_version
 
     bump_types = bump_type or (BumpType.PRE,)
@@ -107,6 +131,6 @@ def bump(
                     part="minor", prerelease_token=prerelease_token
                 )
 
-    write(_context, str(new_version))
+    write(context, str(new_version))
 
     return new_version

--- a/tests/integration/deny/test_advisory_ignores.py
+++ b/tests/integration/deny/test_advisory_ignores.py
@@ -1,0 +1,77 @@
+"""Every advisory suppression in cli/deny.toml carries a live review-by date.
+
+cargo-deny enforces no expiry of its own: the ignore list is flat, and an entry
+added under release pressure outlives its justification silently. That matters
+more now the gix/jj-lib closure is in advisories scope under
+unmaintained = "all" with yanked = "deny" — one upstream advisory in ~60 crates
+no repo code calls turns check-supply-chain red for every unrelated PR, and that
+job is in prerelease.needs, so a documented five-minute suppression is exactly
+what gets applied reflexively.
+
+A lapsed date is a prompt to re-check upstream and re-date or remove, not to
+bump the date blindly. The break-glass procedure in tasks/README.md is scoped to
+the unmaintained, yanked and notice classes only.
+"""
+
+import datetime as dt
+import re
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DENY = _REPO_ROOT / "cli/deny.toml"
+
+_REVIEW_BY = re.compile(r"review-by:\s*(\d{4}-\d{2}-\d{2})")
+
+
+def _ignores() -> list[dict | str]:
+    return tomllib.loads(_DENY.read_text())["advisories"]["ignore"]
+
+
+def test_every_ignore_entry_is_a_table_with_a_reason() -> None:
+    # A bare "RUSTSEC-…" string carries nowhere to put the date.
+    bare = [entry for entry in _ignores() if not isinstance(entry, dict)]
+    assert not bare, (
+        f"advisory ignores must be tables with a reason, found bare ids: {bare}"
+    )
+    missing = [
+        entry["id"]
+        for entry in _ignores()
+        if not entry.get("reason", "").strip()
+    ]
+    assert not missing, f"advisory ignores with no reason: {missing}"
+
+
+def test_every_ignore_entry_carries_a_review_by_date() -> None:
+    undated = [
+        entry["id"]
+        for entry in _ignores()
+        if not _REVIEW_BY.search(entry.get("reason", ""))
+    ]
+    assert not undated, (
+        "advisory ignores with no machine-readable `review-by: YYYY-MM-DD` in "
+        f"their reason: {undated}"
+    )
+
+
+def test_no_ignore_entry_is_past_its_review_by_date() -> None:
+    today = dt.datetime.now(tz=dt.UTC).date()
+    lapsed = []
+    for entry in _ignores():
+        match = _REVIEW_BY.search(entry.get("reason", ""))
+        if match is None:
+            continue
+        review_by = dt.date.fromisoformat(match.group(1))
+        if review_by < today:
+            lapsed.append((entry["id"], match.group(1)))
+    assert not lapsed, (
+        "advisory suppressions past their review-by date — re-check whether "
+        "upstream now offers a fix, then remove the entry or re-date it with "
+        f"the current reason: {lapsed}"
+    )
+
+
+def test_the_review_by_assertion_is_not_vacuous() -> None:
+    # An empty ignore list would pass all three checks above while proving
+    # nothing about the mechanism.
+    assert _ignores(), "no advisory ignores to check — has the list moved?"

--- a/tests/integration/deny/test_vcs_library_graph.py
+++ b/tests/integration/deny/test_vcs_library_graph.py
@@ -74,9 +74,8 @@ _FEATURES_ABSENT = (
 )
 _FEATURE_PREFIXES_ABSENT = ("blocking-http-transport",)
 
-# The work item's criterion is that the vcs-adapters *subtree* carries no TLS
-# stack — narrower than deny.toml's whole-graph bans, which cannot say this:
-# rustls is a first-party workspace dependency the launcher consumes directly.
+# Subtree-scoped, which is narrower than deny.toml's whole-graph bans and cannot
+# be expressed there: rustls is a first-party dependency the launcher consumes.
 _TLS_CRATES = ("rustls", "openssl", "openssl-sys", "native-tls", "curl-sys")
 
 # deny.toml's [graph].targets, which [bans] is evaluated against.

--- a/tests/integration/deny/test_vcs_library_graph.py
+++ b/tests/integration/deny/test_vcs_library_graph.py
@@ -265,6 +265,17 @@ def test_no_gix_package_is_present_at_more_than_one_version() -> None:
     assert not duplicated, f"duplicate gix-family versions: {duplicated}"
 
 
+@pytest.mark.parametrize("crate", ["prost", "pollster"])
+def test_the_jj_helper_crates_resolve_to_one_version(crate: str) -> None:
+    # vcs-adapters depends on both directly, to decode jj's checkout state and
+    # to drive the OpStore trait's async reads. The decoded type comes FROM
+    # jj-lib, so a second prost graph would mean the generated code and the
+    # decoder in use were different crates — the failure the pin comment in
+    # cli/Cargo.toml names. Both must stay single-version.
+    versions = _lock_packages().get(crate, set())
+    assert len(versions) == 1, f"{crate} resolved to {sorted(versions)}"
+
+
 # --- Features ---
 
 

--- a/tests/integration/deny/test_vcs_library_graph.py
+++ b/tests/integration/deny/test_vcs_library_graph.py
@@ -1,0 +1,371 @@
+"""Regression: the library-backed VCS adapter's resolved graph stays pinned.
+
+deny.toml bans by crate name; this asserts what names cannot express. gix and
+jj-lib take *ranges* (~0.85.0 / =0.43.0) and gix republishes its feature set
+with every patch, so the effective surface is upstream-controlled within the
+permitted range — the same reasoning that made test_launcher_feature_graph.py
+exist alongside deny.toml's bans.
+
+Four invariants, each guarding a distinct failure:
+
+* Versions and single-graph. gix at 0.85.x specifically, not merely at one
+  version: gix is optional in jj-lib, so a bare single-version assertion would
+  hold vacuously if that feature were ever off. Duplicate detection reads
+  Cargo.lock directly because the repo's multiple-versions policy is warn-level
+  and would not fail on its own.
+* Features. The six the adapter's calls need must be on; the network client and
+  credentials families must be off. Feature absence — not crate absence — is
+  what keeps gix-transport and gix-protocol inert: both ARE in the graph via
+  jj-lib's defaults, so banning them by name would fail deny:check outright.
+* MSRV. Asserted directly rather than trusting resolver 3's
+  incompatible-rust-versions = "fallback", which is a *preference*, not a hard
+  constraint — without the gix/jj-lib trees the graph selects kstring 2.0.4,
+  which needs Rust 1.96 and will not build on the pinned toolchain. The value
+  comes from cargo metadata: Cargo.lock does not record rust-version at all, so
+  a lock-parsing implementation would pass vacuously on exactly the mechanism
+  this backstops.
+* Build-script and proc-macro snapshot. These trees execute ~48 crates' build
+  scripts and proc macros on every developer machine and on the release runner,
+  which already documents build-script trust as a live concern. A lock
+  regeneration could otherwise grow that set silently.
+"""
+
+import json
+import re
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parents[2]
+_CLI = _REPO_ROOT / "cli"
+_CLI_CARGO = _CLI / "Cargo.toml"
+_CLI_LOCK = _CLI / "Cargo.lock"
+
+_CARGO = shutil.which("cargo")
+
+_PACKAGE = "vcs-adapters"
+
+# The gix release line jj-lib 0.43 requires, and the exact jj-lib pin.
+_GIX_VERSION = re.compile(r"^0\.85\.\d+$")
+_JJ_LIB_VERSION = re.compile(r"^0\.43\.\d+$")
+
+# What the adapter's calls need. attributes/blob-diff/index/sha1/zlib-rs and
+# max-performance-safe arrive from jj-lib's own selection, not from gix's
+# defaults, which the pin turns off.
+_FEATURES_PRESENT = (
+    "attributes",
+    "blob-diff",
+    "index",
+    "max-performance-safe",
+    "sha1",
+    "zlib-rs",
+)
+# credentials is load-bearing here: it pulls gix-credentials, which spawns
+# `git credential-*` helper programs, against a module whose whole point is
+# reading git without a subprocess.
+_FEATURES_ABSENT = (
+    "blocking-network-client",
+    "async-network-client",
+    "credentials",
+)
+_FEATURE_PREFIXES_ABSENT = ("blocking-http-transport",)
+
+# The work item's criterion is that the vcs-adapters *subtree* carries no TLS
+# stack — narrower than deny.toml's whole-graph bans, which cannot say this:
+# rustls is a first-party workspace dependency the launcher consumes directly.
+_TLS_CRATES = ("rustls", "openssl", "openssl-sys", "native-tls", "curl-sys")
+
+# deny.toml's [graph].targets, which [bans] is evaluated against.
+_TARGETS = (
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+    "x86_64-unknown-linux-gnu",
+)
+
+_BUILD_SCRIPT_CRATES = frozenset(
+    {
+        "anyhow",
+        "crc32fast",
+        "crossbeam-deque",
+        "crossbeam-epoch",
+        "crossbeam-utils",
+        "defmt",
+        "defmt-macros",
+        "generic-array",
+        "getrandom",
+        "heapless",
+        "iana-time-zone-haiku",
+        "libc",
+        "logos-codegen",
+        "num-traits",
+        "parking_lot_core",
+        "portable-atomic",
+        "portable-atomic-util",
+        "proc-macro2",
+        "quote",
+        "rayon-core",
+        "ref-cast",
+        "rustix",
+        "rustversion",
+        "serde",
+        "serde_core",
+        "thiserror",
+        "valuable",
+        "wasm-bindgen",
+        "wasm-bindgen-shared",
+        "zerocopy",
+    }
+)
+
+_PROC_MACRO_CRATES = frozenset(
+    {
+        "async-trait",
+        "defmt-macros",
+        "futures-macro",
+        "jiff-static",
+        "jj-lib-proc-macros",
+        "logos-derive",
+        "maybe-async",
+        "pest_derive",
+        "prost-derive",
+        "ref-cast-impl",
+        "rustversion",
+        "serde_derive",
+        "thiserror-impl",
+        "tracing-attributes",
+        "wasm-bindgen-macro",
+        "windows-implement",
+        "windows-interface",
+        "zerocopy-derive",
+    }
+)
+
+
+def _require_cargo() -> None:
+    if _CARGO is None:
+        pytest.skip("cargo not on PATH")
+
+
+def _feature_tree(target: str | None = None) -> str:
+    _require_cargo()
+    command = ["cargo", "tree", "-e", "features", "-p", _PACKAGE]
+    if target is not None:
+        command += ["--target", target]
+    result = subprocess.run(
+        command, cwd=_CLI, capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result.stdout
+
+
+def _metadata() -> dict:
+    _require_cargo()
+    result = subprocess.run(
+        ["cargo", "metadata", "--locked", "--format-version", "1"],
+        cwd=_CLI,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def _lock_packages() -> dict[str, set[str]]:
+    packages: dict[str, set[str]] = {}
+    pattern = re.compile(
+        r'\[\[package\]\]\nname = "([^"]+)"\nversion = "([^"]+)"'
+    )
+    for name, version in pattern.findall(_CLI_LOCK.read_text()):
+        packages.setdefault(name, set()).add(version)
+    return packages
+
+
+def _node_present(tree: str, crate: str) -> bool:
+    # A node renders as "<crate> v<version>"; the lookbehind stops `openssl`
+    # matching `openssl-probe` and `gix` matching `gix-odb`.
+    return re.search(rf"(?<![\w-]){re.escape(crate)} v\d", tree) is not None
+
+
+def _gix_features(tree: str) -> set[str]:
+    return set(re.findall(r'(?<![\w-])gix feature "([^"]+)"', tree))
+
+
+def _subtree_packages() -> dict[str, dict]:
+    """Every package reachable from vcs-adapters by normal and build edges.
+
+    Dev edges are excluded deliberately: they do not reach a shipped binary, and
+    including them would make the snapshot churn on test-only dependencies.
+    """
+    metadata = _metadata()
+    nodes = {node["id"]: node for node in metadata["resolve"]["nodes"]}
+    packages = {package["id"]: package for package in metadata["packages"]}
+
+    roots = [
+        identifier
+        for identifier, package in packages.items()
+        if package["name"] == _PACKAGE
+    ]
+    assert roots, f"{_PACKAGE} is not in the workspace metadata"
+
+    seen: set[str] = set()
+    stack = list(roots)
+    while stack:
+        identifier = stack.pop()
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        for dependency in nodes[identifier]["deps"]:
+            kinds = {kind["kind"] for kind in dependency["dep_kinds"]}
+            if kinds & {None, "build"}:
+                stack.append(dependency["pkg"])
+    return {identifier: packages[identifier] for identifier in seen}
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(
+        int(part) for part in version.split("-", maxsplit=1)[0].split(".")[:3]
+    )
+
+
+def _workspace_msrv() -> str:
+    data = tomllib.loads(_CLI_CARGO.read_text())
+    return data["workspace"]["package"]["rust-version"]
+
+
+# --- Versions and the single graph ---
+
+
+def test_gix_resolves_to_the_pinned_release_line() -> None:
+    versions = _lock_packages().get("gix", set())
+    assert len(versions) == 1, f"expected exactly one gix, found {versions}"
+    (version,) = versions
+    assert _GIX_VERSION.match(version), f"gix resolved to {version}, not 0.85.x"
+
+
+def test_jj_lib_resolves_to_the_pinned_version() -> None:
+    versions = _lock_packages().get("jj-lib", set())
+    assert len(versions) == 1, f"expected exactly one jj-lib, found {versions}"
+    (version,) = versions
+    assert _JJ_LIB_VERSION.match(version), f"jj-lib resolved to {version}"
+
+
+def test_no_gix_package_is_present_at_more_than_one_version() -> None:
+    duplicated = {
+        name: versions
+        for name, versions in _lock_packages().items()
+        if (name == "gix" or name.startswith("gix-")) and len(versions) > 1
+    }
+    assert not duplicated, f"duplicate gix-family versions: {duplicated}"
+
+
+# --- Features ---
+
+
+@pytest.mark.parametrize("feature", _FEATURES_PRESENT)
+def test_required_gix_feature_is_enabled(feature: str) -> None:
+    enabled = _gix_features(_feature_tree())
+    assert feature in enabled, (
+        f"gix feature {feature!r} is off; enabled: {sorted(enabled)}"
+    )
+
+
+@pytest.mark.parametrize("feature", _FEATURES_ABSENT)
+def test_prohibited_gix_feature_is_disabled(feature: str) -> None:
+    enabled = _gix_features(_feature_tree())
+    assert feature not in enabled, f"gix feature {feature!r} is unexpectedly on"
+
+
+def test_no_http_transport_feature_is_enabled() -> None:
+    offenders = sorted(
+        feature
+        for feature in _gix_features(_feature_tree())
+        if feature.startswith(_FEATURE_PREFIXES_ABSENT)
+    )
+    assert not offenders, f"http transport features enabled: {offenders}"
+
+
+def test_the_feature_assertion_is_not_vacuous() -> None:
+    # A tree that parsed to nothing would pass every absence assertion above.
+    assert len(_gix_features(_feature_tree())) >= len(_FEATURES_PRESENT)
+
+
+# --- No TLS stack in the subtree, on every target deny.toml evaluates ---
+
+
+@pytest.mark.parametrize("target", _TARGETS)
+@pytest.mark.parametrize("crate", _TLS_CRATES)
+def test_no_tls_stack_in_the_vcs_subtree(crate: str, target: str) -> None:
+    tree = _feature_tree(target)
+    assert not _node_present(tree, crate), (
+        f"{crate} unexpectedly present in the {_PACKAGE} subtree for {target}"
+    )
+
+
+# --- MSRV ---
+
+
+def test_no_package_requires_a_newer_rust_than_the_pinned_toolchain() -> None:
+    pinned = _workspace_msrv()
+    ceiling = _version_key(pinned)
+    offenders = sorted(
+        (package["name"], package["version"], package["rust_version"])
+        for package in _metadata()["packages"]
+        if package.get("rust_version")
+        and _version_key(package["rust_version"]) > ceiling
+    )
+    assert not offenders, (
+        f"packages requiring Rust newer than the pinned {pinned}: {offenders}"
+    )
+
+
+def test_the_msrv_assertion_is_not_vacuous() -> None:
+    # A graph where nothing declared rust_version would pass the check above
+    # while proving nothing — the exact failure a lock-parsing implementation
+    # would have, since Cargo.lock does not carry the field at all.
+    declaring = [
+        package
+        for package in _metadata()["packages"]
+        if package.get("rust_version")
+    ]
+    assert len(declaring) > 100, (
+        f"only {len(declaring)} packages declare rust_version — the MSRV "
+        "check has lost its subject"
+    )
+
+
+# --- Build-script and proc-macro snapshot ---
+
+
+def test_build_script_crates_in_the_subtree_are_the_snapshot() -> None:
+    found = {
+        package["name"]
+        for package in _subtree_packages().values()
+        if any(
+            target["kind"] == ["custom-build"] for target in package["targets"]
+        )
+    }
+    assert found == set(_BUILD_SCRIPT_CRATES), (
+        "the build-script set changed — review the additions, then update the "
+        f"snapshot. added={sorted(found - _BUILD_SCRIPT_CRATES)} "
+        f"removed={sorted(_BUILD_SCRIPT_CRATES - found)}"
+    )
+
+
+def test_proc_macro_crates_in_the_subtree_are_the_snapshot() -> None:
+    found = {
+        package["name"]
+        for package in _subtree_packages().values()
+        if any("proc-macro" in target["kind"] for target in package["targets"])
+    }
+    assert found == set(_PROC_MACRO_CRATES), (
+        "the proc-macro set changed — review the additions, then update the "
+        f"snapshot. added={sorted(found - _PROC_MACRO_CRATES)} "
+        f"removed={sorted(_PROC_MACRO_CRATES - found)}"
+    )

--- a/tests/integration/pup/test_import_rule.py
+++ b/tests/integration/pup/test_import_rule.py
@@ -506,3 +506,95 @@ def test_config_command_rule_passes_a_compliant_module(
     _write_config_command_probe(tmp_path, _CONFIG_COMMAND_COMPLIANT)
     result = _pup("--pup-config", str(CLI_PUP_RON), cwd=tmp_path)
     assert result.returncode == 0, _ANSI.sub("", result.stdout + result.stderr)
+
+
+# --- The library-backed VCS adapter's two-clause rule ---
+#
+# The only shipped rule pairing `allowed_only` with `denied`, because the thing
+# it prohibits (std::process) sits *inside* the permitted std. Driven against a
+# crate literally named `vcs-adapters` with a `library` module, under the
+# shipped cli/pup.ron, so a rename of the real module makes these fail.
+#
+# The grouped-import case pins behaviour rather than asserting a preference:
+# cargo-pup resolves `use a::{b, c}` to an empty module name, which an
+# allowed_only list rejects. That is why the real module writes one single-item
+# `use` per import, and this test is what would notice the constraint lifting.
+
+_VCS_WORKSPACE = """\
+[workspace]
+resolver = "2"
+members = ["vcs-adapters"]
+"""
+
+_VCS_ADAPTERS_MANIFEST = """\
+[package]
+name = "vcs-adapters"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+
+[lib]
+path = "src/lib.rs"
+"""
+
+_VCS_ADAPTERS_LIB = "pub mod library;\n"
+
+# The prohibition the deny clause exists for: std::process is inside the
+# permitted std, so the permit list alone would admit it.
+_LIBRARY_SPAWNS = (
+    "use std::process::Command;\n\npub fn make() -> Command {\n"
+    '    Command::new("git")\n}\n'
+)
+# Single-item imports from the permit list — compliant (positive control).
+_LIBRARY_COMPLIANT = (
+    "use std::path::Path;\nuse std::path::PathBuf;\n\n"
+    "pub fn make(p: &Path) -> PathBuf {\n    p.to_path_buf()\n}\n"
+)
+# A grouped import of two permitted items, which cargo-pup resolves to an empty
+# module name and the permit list therefore rejects.
+_LIBRARY_GROUPED = (
+    "use std::path::{Path, PathBuf};\n\n"
+    "pub fn make(p: &Path) -> PathBuf {\n    p.to_path_buf()\n}\n"
+)
+
+
+def _write_vcs_library_probe(root: Path, library_body: str) -> None:
+    (root / "Cargo.toml").write_text(_VCS_WORKSPACE)
+    src = root / "vcs-adapters/src"
+    src.mkdir(parents=True, exist_ok=True)
+    (root / "vcs-adapters/Cargo.toml").write_text(_VCS_ADAPTERS_MANIFEST)
+    (src / "lib.rs").write_text(_VCS_ADAPTERS_LIB)
+    (src / "library.rs").write_text(library_body)
+
+
+def test_vcs_library_rule_rejects_importing_std_process(
+    tmp_path: Path,
+) -> None:
+    _require_tools()
+    _write_vcs_library_probe(tmp_path, _LIBRARY_SPAWNS)
+    result = _pup("--pup-config", str(CLI_PUP_RON), cwd=tmp_path)
+    output = _ANSI.sub("", result.stdout + result.stderr)
+    assert result.returncode != 0, output
+    # "is denied" rather than "is not allowed": the deny clause is what fires,
+    # proving it wins over the permit list on overlap.
+    assert "is denied" in output, output
+    assert "vcs_adapters_library_reads_in_process" in output, output
+
+
+def test_vcs_library_rule_passes_single_item_imports(tmp_path: Path) -> None:
+    # Positive control: a green run means "evaluated and allowed", not a rule
+    # whose module scope silently matched nothing.
+    _require_tools()
+    _write_vcs_library_probe(tmp_path, _LIBRARY_COMPLIANT)
+    result = _pup("--pup-config", str(CLI_PUP_RON), cwd=tmp_path)
+    assert result.returncode == 0, _ANSI.sub("", result.stdout + result.stderr)
+
+
+def test_vcs_library_rule_rejects_a_grouped_import(tmp_path: Path) -> None:
+    _require_tools()
+    _write_vcs_library_probe(tmp_path, _LIBRARY_GROUPED)
+    result = _pup("--pup-config", str(CLI_PUP_RON), cwd=tmp_path)
+    output = _ANSI.sub("", result.stdout + result.stderr)
+    assert result.returncode != 0, output
+    assert "is not allowed" in output, output
+    assert "vcs_adapters_library_reads_in_process" in output, output

--- a/tests/unit/tasks/test_build.py
+++ b/tests/unit/tasks/test_build.py
@@ -417,3 +417,69 @@ class TestCliWorkspaceCoherence:
         with pytest.raises(VersionCoherenceError) as exc_info:
             validate_version_coherence("1.20.0", repo_root=fake_repo_tree)
         assert "cli/launcher/Cargo.toml" in str(exc_info.value)
+
+
+class TestFixtureSizeFloor:
+    """The guard against this story's headline false pass: dead-code
+    elimination letting the musl and size checks succeed while linking almost
+    none of gix/jj-lib.
+
+    Threshold logic only — no real tb. The cross-compile that otherwise
+    exercises it runs solely in the release pipeline, which is exactly why the
+    comparison is a pure function.
+    """
+
+    MUSL = "aarch64-unknown-linux-musl"
+    DARWIN = "aarch64-apple-darwin"
+
+    def test_the_measured_musl_figures_pass(self) -> None:
+        # 2,422,864 vs 391,416 — the delivered two-binary shape.
+        tb.assert_fixture_size_floor(2_422_864, 391_416, triple=self.MUSL)
+
+    def test_the_measured_darwin_figures_pass(self) -> None:
+        tb.assert_fixture_size_floor(2_031_288, 391_416, triple=self.DARWIN)
+
+    def test_a_collapsed_ratio_fails_on_every_triple(self) -> None:
+        for triple in (self.MUSL, self.DARWIN):
+            with pytest.raises(RuntimeError, match=r"below the .* floor"):
+                tb.assert_fixture_size_floor(1_000_000, 400_000, triple=triple)
+
+    def test_the_absolute_floor_is_musl_only(self) -> None:
+        # A wide ratio but a small delta: musl rejects, darwin accepts. This is
+        # the scoping rule — `[profile.release] strip = true` means every triple
+        # is stripped and the darwin delta clears the floor by only ~9%, so
+        # gating darwin would put a 9%-margin heuristic on the release path.
+        with pytest.raises(RuntimeError, match="bytes larger"):
+            tb.assert_fixture_size_floor(1_600_000, 400_000, triple=self.MUSL)
+        tb.assert_fixture_size_floor(1_600_000, 400_000, triple=self.DARWIN)
+
+    def test_a_zero_sized_stub_is_rejected_rather_than_dividing_by_zero(
+        self,
+    ) -> None:
+        with pytest.raises(RuntimeError, match="cannot compare"):
+            tb.assert_fixture_size_floor(2_000_000, 0, triple=self.MUSL)
+
+    def test_the_fixture_binaries_are_never_release_artefacts(self) -> None:
+        # They print absolute repository paths and are not product. Keeping them
+        # out of _CLI_RELEASE_BINARIES is what keeps them out of dist/release/,
+        # the tree the signed manifest is assembled from.
+        overlap = set(tb._CLI_FIXTURE_BINARIES) & set(tb._CLI_RELEASE_BINARIES)
+        assert not overlap, f"fixture binaries staged as product: {overlap}"
+
+    def test_no_fixture_binary_carries_the_attested_prefix(self) -> None:
+        # dist/release/accelerator-* is provenance-attested by a glob.
+        for name in tb._CLI_FIXTURE_BINARIES:
+            assert not name.startswith("accelerator-"), name
+
+    def test_no_fixture_binary_is_a_release_upload(self) -> None:
+        # The direct assertion, not just the constants: _release_uploads()
+        # enumerates assets explicitly rather than globbing, so nothing would be
+        # published today — but these binaries print absolute repository paths
+        # and must stay one deliberate decision away from being product.
+        from tasks.github import _release_uploads
+
+        names = {path.name for path in _release_uploads()}
+        for fixture in tb._CLI_FIXTURE_BINARIES:
+            assert not any(fixture in name for name in names), (
+                f"{fixture} is enumerated as a release upload"
+            )

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -61,6 +61,8 @@ _NO_LAUNCHER_NEEDED = {
     "test:integration:hooks": "shell suites run with no accelerator_env",
     "test:integration:github": "shell suites run with no accelerator_env",
     "test:integration:zero-spawn": "cargo nextest over the vcs fixture matrix",
+    "test:integration:zero-spawn:strong": "the same suite, with the real "
+    "git/jj shadowed",
 }
 
 
@@ -150,6 +152,12 @@ _NOT_IN_INTEGRATION_ROLLUP = {
     # demand.
     "test:integration:zero-spawn": "owned by its own CI job; rebuilds the "
     "whole fixture matrix",
+    # Strictly worse to put in a roll-up than its PATH-only sibling: it moves
+    # system binaries aside with sudo. Gated behind an env opt-in as well, so
+    # a stray invocation fails closed rather than leaving a developer without
+    # git. Owned by check-zero-spawn.
+    "test:integration:zero-spawn:strong": "shadows the real git/jj with "
+    "sudo; CI-only by design",
 }
 
 

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -60,6 +60,7 @@ _NO_LAUNCHER_NEEDED = {
     "test:integration:pup": "cargo-pup, built through build:frontend:stub",
     "test:integration:hooks": "shell suites run with no accelerator_env",
     "test:integration:github": "shell suites run with no accelerator_env",
+    "test:integration:zero-spawn": "cargo nextest over the vcs fixture matrix",
 }
 
 
@@ -141,6 +142,14 @@ def test_the_two_launcher_sets_are_disjoint():
 # runs. Each exclusion carries its reason.
 _NOT_IN_INTEGRATION_ROLLUP = {
     "test:integration:pup": "needs the isolated nightly toolchain lane",
+    # Membership would build the ~34-fixture matrix a second time per run — on
+    # both legs of test-integration and on every bare `mise run` — on top of
+    # queries.rs, in the code path with a documented flake history under
+    # parallel CI load. It also keeps the harness that reads the shadow
+    # contract off the local path. Owned by check-zero-spawn; runnable on
+    # demand.
+    "test:integration:zero-spawn": "owned by its own CI job; rebuilds the "
+    "whole fixture matrix",
 }
 
 

--- a/tests/unit/tasks/test_mise.py
+++ b/tests/unit/tasks/test_mise.py
@@ -26,6 +26,7 @@ _CLI_CHECK_GATES = [
     "lint:vendor-shims:check",
     "lint:store-duplication:check",
     "lint:claude-coupling:check",
+    "lint:vcs-settings:check",
 ]
 
 # The dispatch guard is a skills-tree guard, so it cannot join _CLI_CHECK_GATES

--- a/tests/unit/tasks/test_vcs_pin_lockstep.py
+++ b/tests/unit/tasks/test_vcs_pin_lockstep.py
@@ -121,6 +121,20 @@ def test_the_gix_pin_comment_records_why_defaults_are_off() -> None:
     )
 
 
+def test_the_jj_helper_pins_record_that_they_move_with_jj_lib() -> None:
+    # prost and pollster are jj-lib's own dependencies, adopted as direct edges
+    # to read the working-copy commit id. The non-obvious part is that they are
+    # not independent choices: the decoded protobuf type comes from jj-lib, so a
+    # prost major mismatch breaks the decode and splits the graph. A contributor
+    # regenerating this file has to be able to see that from the file.
+    comment = _comment_above(_CLI_CARGO.read_text(), "prost = ")
+    assert comment, "the prost/pollster pins have lost their comment"
+    for required in ("jj-lib", "prost", "pollster"):
+        assert required in comment, (
+            f"the helper pin comment no longer mentions {required}: {comment}"
+        )
+
+
 def test_the_uluru_licence_exception_keeps_its_comment() -> None:
     comment = _comment_above(_DENY.read_text(), "[[licenses.exceptions]]")
     assert comment, "the uluru licence exception has lost its comment"

--- a/tests/unit/tasks/test_vcs_pin_lockstep.py
+++ b/tests/unit/tasks/test_vcs_pin_lockstep.py
@@ -1,0 +1,129 @@
+"""The jj CLI and the jj-lib crate are a lockstep pair, and both VCS pins carry
+their inline rationale.
+
+The CLI writes the repository format the library reads, so a skew between
+mise.toml's `jj` pin and cli/Cargo.toml's `jj-lib` pin fails in a way that reads
+as an adapter defect rather than a pin mismatch — this repo has already hit
+exactly that, with a local jj 0.42.0 against a jj-lib 0.43 design.
+
+This checks *declarations in files*. That the binary actually building fixtures
+matches the pin is asserted by the fixture harness, not here.
+
+The comment assertions are not style policing: the work item requires both, and
+comments are the first thing lost when a contributor regenerates a manifest on a
+merge conflict — which the plan's lock-contention notes anticipate happening.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MISE = _REPO_ROOT / "mise.toml"
+_CLI_CARGO = _REPO_ROOT / "cli/Cargo.toml"
+_DENY = _REPO_ROOT / "cli/deny.toml"
+
+
+def _minor(version: str) -> tuple[int, int]:
+    parts = version.lstrip("=~^").split(".")
+    return int(parts[0]), int(parts[1])
+
+
+def _mise_jj() -> str:
+    jj = tomllib.loads(_MISE.read_text())["tools"]["jj"]
+    return jj["version"] if isinstance(jj, dict) else jj
+
+
+def _workspace_dependency(name: str) -> str | dict:
+    data = tomllib.loads(_CLI_CARGO.read_text())
+    return data["workspace"]["dependencies"][name]
+
+
+def _requirement(name: str) -> str:
+    declared = _workspace_dependency(name)
+    return declared if isinstance(declared, str) else declared["version"]
+
+
+def _comment_above(text: str, needle: str) -> str:
+    """The contiguous run of `#` lines immediately above the line matching."""
+    lines = text.splitlines()
+    index = next(
+        position
+        for position, line in enumerate(lines)
+        if line.strip().startswith(needle)
+    )
+    comment = []
+    cursor = index - 1
+    while cursor >= 0 and lines[cursor].lstrip().startswith("#"):
+        comment.append(lines[cursor].lstrip().lstrip("#").strip())
+        cursor -= 1
+    return "\n".join(reversed(comment)).strip()
+
+
+def test_the_jj_cli_pin_and_the_jj_lib_pin_share_a_minor_version() -> None:
+    cli = _mise_jj()
+    crate = _requirement("jj-lib")
+    assert _minor(cli) == _minor(crate), (
+        f"jj CLI pin {cli} and jj-lib pin {crate} have drifted apart — the CLI "
+        "writes the format the library reads, so bump both together"
+    )
+
+
+def test_the_jj_lib_pin_is_exact() -> None:
+    # The crate declares its API unstable and the adapter leans on its
+    # workspace-loader internals, so adopting a version is a deliberate act
+    # rather than a resolution outcome.
+    assert _requirement("jj-lib").startswith("="), (
+        "jj-lib must stay exactly pinned"
+    )
+
+
+def test_the_gix_pin_permits_only_its_patch_line() -> None:
+    # A tilde so a RustSec fix is a lock update rather than a pin edit, and
+    # never a caret, which on a 0.x crate would still not cross 0.86 but says
+    # something weaker than intended.
+    requirement = _requirement("gix")
+    assert requirement.startswith("~"), (
+        f"gix should be tilde-pinned, found {requirement!r}"
+    )
+
+
+def test_the_mise_jj_pin_keeps_its_lockstep_comment() -> None:
+    comment = _comment_above(_MISE.read_text(), "jj = ")
+    assert comment, "the mise.toml jj pin has lost its comment"
+    assert re.search(r"jj-lib", comment), (
+        f"the mise.toml jj pin's comment no longer ties it to jj-lib: {comment}"
+    )
+
+
+def test_the_vcs_pins_keep_their_shared_comment() -> None:
+    # The two pins are a matched pair introduced by one block, so the rationale
+    # sits above the first of them rather than above each.
+    comment = _comment_above(_CLI_CARGO.read_text(), "jj-lib = ")
+    assert comment, "the cli/Cargo.toml VCS pins have lost their comment"
+    for required in ("gix", "jj-lib"):
+        assert required in comment, (
+            f"the VCS pin comment no longer mentions {required}: {comment}"
+        )
+
+
+def test_the_gix_pin_comment_records_why_defaults_are_off() -> None:
+    # default-features = false is the non-obvious half of the pin: it is what
+    # keeps gix-credentials, whose helpers spawn subprocesses, out of a module
+    # that exists to avoid spawning.
+    declared = _workspace_dependency("gix")
+    assert (
+        isinstance(declared, dict) and declared.get("default-features") is False
+    ), "the gix pin must disable default features"
+    comment = _comment_above(_CLI_CARGO.read_text(), "jj-lib = ")
+    assert "default-features" in comment, (
+        f"the VCS pin comment no longer explains default-features: {comment}"
+    )
+
+
+def test_the_uluru_licence_exception_keeps_its_comment() -> None:
+    comment = _comment_above(_DENY.read_text(), "[[licenses.exceptions]]")
+    assert comment, "the uluru licence exception has lost its comment"
+    assert "0188" in comment, (
+        f"the uluru exception's comment must cite its work item: {comment}"
+    )

--- a/tests/unit/tasks/test_vcs_pin_lockstep.py
+++ b/tests/unit/tasks/test_vcs_pin_lockstep.py
@@ -1,17 +1,14 @@
-"""The jj CLI and the jj-lib crate are a lockstep pair, and both VCS pins carry
-their inline rationale.
+"""The jj CLI and the jj-lib crate are a lockstep pair.
 
 The CLI writes the repository format the library reads, so a skew between
 mise.toml's `jj` pin and cli/Cargo.toml's `jj-lib` pin fails in a way that reads
-as an adapter defect rather than a pin mismatch — this repo has already hit
-exactly that, with a local jj 0.42.0 against a jj-lib 0.43 design.
+as an adapter defect rather than a pin mismatch.
 
 This checks *declarations in files*. That the binary actually building fixtures
 matches the pin is asserted by the fixture harness, not here.
 
-The comment assertions are not style policing: the work item requires both, and
-comments are the first thing lost when a contributor regenerates a manifest on a
-merge conflict — which the plan's lock-contention notes anticipate happening.
+The comment assertions guard rationale that cannot be recovered from the pins
+themselves, and that a manifest regenerated on a merge conflict silently drops.
 """
 
 import re
@@ -136,8 +133,12 @@ def test_the_jj_helper_pins_record_that_they_move_with_jj_lib() -> None:
 
 
 def test_the_uluru_licence_exception_keeps_its_comment() -> None:
+    # The exception rests on a dead-code-elimination finding that has a re-check
+    # trigger. Losing the comment loses the only record of both.
     comment = _comment_above(_DENY.read_text(), "[[licenses.exceptions]]")
     assert comment, "the uluru licence exception has lost its comment"
-    assert "0188" in comment, (
-        f"the uluru exception's comment must cite its work item: {comment}"
-    )
+    for required in ("MPL-2.0", "Re-check"):
+        assert required in comment, (
+            f"the uluru exception's comment no longer records {required}: "
+            f"{comment}"
+        )

--- a/tests/unit/tasks/test_vcs_settings.py
+++ b/tests/unit/tasks/test_vcs_settings.py
@@ -1,0 +1,135 @@
+"""Tests for the UserSettings guard in ``tasks/lint/vcs_settings.py``.
+
+The guard keeps ``jj_lib``'s ``UserSettings`` and ``Workspace::load`` out of
+``cli/vcs-adapters``: their defaults are private to jj-lib and were discovered
+one panic at a time, and the detection paths need neither.
+
+Two layers, mirroring ``test_store_duplication.py``:
+
+* synthetic ``tmp_path`` trees exercising every branch of the scan, including
+  the comment-stripping that lets the crate *document* the prohibition, and
+* a real-tree assertion that the shipped crate is clean — so a green run means
+  "scanned and found nothing" rather than "scanned nothing".
+"""
+
+from pathlib import Path
+
+from tasks.lint import vcs_settings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+
+
+def test_flags_a_user_settings_construction(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "let settings = UserSettings::from_config(config)?;\n",
+    )
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/src/library.rs:1"
+    ]
+
+
+def test_flags_a_workspace_load_call(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/other.rs",
+        "\nWorkspace::load(&settings, root)?;\n",
+    )
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/src/other.rs:2"
+    ]
+
+
+def test_flags_a_fully_qualified_path(tmp_path: Path) -> None:
+    # The whole reason this exists rather than a cargo-pup `denied` clause:
+    # RestrictImports resolves `use` paths and cannot see this.
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "jj_lib::settings::UserSettings::from_config(c);\n",
+    )
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/src/library.rs:1"
+    ]
+
+
+def test_scans_tests_and_fixtures_too(tmp_path: Path) -> None:
+    _write(tmp_path, "cli/vcs-adapters/tests/x.rs", "UserSettings::default()\n")
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/tests/x.rs:1"
+    ]
+
+
+def test_ignores_other_crates(tmp_path: Path) -> None:
+    _write(tmp_path, "cli/corpus-adapters/src/a.rs", "UserSettings::new()\n")
+    assert vcs_settings.violations(tmp_path) == []
+
+
+def test_a_line_comment_may_name_the_prohibition(tmp_path: Path) -> None:
+    # Without the strip it is impossible to document *why* UserSettings is
+    # avoided in the very crate the guard covers, and an implementer works
+    # around the self-flagging by mangling the word.
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "// Deliberately avoids UserSettings: its defaults are private.\n"
+        "let loader = factory.create(root)?;\n",
+    )
+    assert vcs_settings.violations(tmp_path) == []
+
+
+def test_a_block_comment_may_name_the_prohibition(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "/* Workspace::load needs a UserSettings,\n"
+        "   so the loader is used. */\n"
+        "let loader = factory.create(root)?;\n",
+    )
+    assert vcs_settings.violations(tmp_path) == []
+
+
+def test_a_block_comment_preserves_line_numbers(tmp_path: Path) -> None:
+    # A reported line must still point at the real line after stripping.
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "/* one\n   two\n   three */\nUserSettings::new()\n",
+    )
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/src/library.rs:4"
+    ]
+
+
+def test_code_after_a_block_comment_on_one_line_is_still_scanned(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path,
+        "cli/vcs-adapters/src/library.rs",
+        "/* fine */ UserSettings::new()\n",
+    )
+    assert vcs_settings.violations(tmp_path) == [
+        "cli/vcs-adapters/src/library.rs:1"
+    ]
+
+
+def test_the_shipped_crate_is_clean() -> None:
+    assert vcs_settings.violations(REPO_ROOT) == []
+
+
+def test_the_real_tree_scan_is_not_vacuous() -> None:
+    # A guard over a directory that does not exist, or whose files it never
+    # opens, would pass the assertion above while proving nothing.
+    sources = list((REPO_ROOT / vcs_settings.CRATE).rglob("*.rs"))
+    assert len(sources) > 3, (
+        f"only {len(sources)} Rust sources found under {vcs_settings.CRATE} — "
+        "has the crate moved?"
+    )

--- a/tests/unit/tasks/test_version.py
+++ b/tests/unit/tasks/test_version.py
@@ -72,6 +72,105 @@ class TestWrite:
         )
         assert workspace["workspace"]["package"]["version"] == "1.21.0"
 
+    def test_syncs_the_cargo_lock(self, ctx, mocker, fake_repo_tree):
+        # The lock carries a copy of the version per workspace member, so a
+        # manifest-only write leaves them disagreeing — and clippy runs
+        # `--locked`. `cargo metadata` is the minimal update; generate-lockfile
+        # would re-resolve the whole closure.
+        _patch_paths(mocker, fake_repo_tree)
+        tv.write(ctx, "1.21.0")
+
+        commands = [call.args[0] for call in ctx.run.call_args_list]
+        assert any(
+            "cargo metadata" in command and "cli/Cargo.toml" in command
+            for command in commands
+        ), f"write() did not sync the lock: {commands}"
+        assert not any("generate-lockfile" in c for c in commands), commands
+
+
+class TestLockVersionCoherence:
+    """The lock's workspace-member versions must match the manifest.
+
+    This is the guard for the drift the sync above prevents. It reads the real
+    files and needs no cargo, so it fails in `test:unit:tasks` with a named
+    diagnostic rather than as a clippy `--locked` complaint in a Rust job, far
+    from the bump that caused it.
+    """
+
+    @staticmethod
+    def _member_package_names() -> set[str]:
+        # From each member's own [package].name, not its directory: three of
+        # them differ (launcher -> accelerator, verify -> accelerator-verify,
+        # visualiser/server -> accelerator-visualiser), and the lock keys on the
+        # package name.
+        cargo = tomllib.loads((CLI_DIR / "Cargo.toml").read_text())
+        return {
+            tomllib.loads((CLI_DIR / member / "Cargo.toml").read_text())[
+                "package"
+            ]["name"]
+            for member in cargo["workspace"]["members"]
+        }
+
+    @staticmethod
+    def _locked_path_packages() -> dict[str, str]:
+        # Workspace members are the lock entries with no `source` — registry and
+        # git packages both carry one.
+        lock = tomllib.loads((CLI_DIR / "Cargo.lock").read_text())
+        return {
+            package["name"]: package["version"]
+            for package in lock["package"]
+            if "source" not in package
+        }
+
+    def test_every_member_entry_matches_the_workspace_version(self):
+        cargo = tomllib.loads((CLI_DIR / "Cargo.toml").read_text())
+        expected = cargo["workspace"]["package"]["version"]
+
+        # Every member inherits `version.workspace = true`, with no exceptions,
+        # so all of them must read alike — including accelerator-visualiser.
+        stale = {
+            name: version
+            for name, version in self._locked_path_packages().items()
+            if version != expected
+        }
+        assert not stale, (
+            f"cli/Cargo.lock disagrees with the workspace version {expected}: "
+            f"{stale}. Run `cargo metadata --manifest-path cli/Cargo.toml` to "
+            "sync it (the minimal update), never `cargo generate-lockfile`."
+        )
+
+    def test_the_assertion_covers_every_member(self):
+        # Non-vacuity: a lock that stopped listing members, or a member renamed
+        # out of it, would leave the assertion above passing over a smaller set
+        # than it claims. Equality both ways, so a member added to the workspace
+        # without reaching the lock fails here too.
+        assert self._locked_path_packages().keys() == (
+            self._member_package_names()
+        )
+
+    def test_every_member_inherits_the_workspace_version(self):
+        # The premise of the exact comparison above. A member that pinned its
+        # own version would legitimately differ, and would have to be excluded
+        # rather than silently failing.
+        # `version.workspace = true` parses to {"workspace": True}; a member
+        # that pins its own writes a plain string. That is the discriminator —
+        # not presence, which every member satisfies either way.
+        cargo = tomllib.loads((CLI_DIR / "Cargo.toml").read_text())
+        pinned = [
+            member
+            for member in cargo["workspace"]["members"]
+            if isinstance(
+                tomllib.loads((CLI_DIR / member / "Cargo.toml").read_text())[
+                    "package"
+                ].get("version"),
+                str,
+            )
+        ]
+        assert not pinned, (
+            f"these members pin their own version: {pinned}. The lock "
+            "coherence assertion assumes workspace inheritance throughout."
+        )
+
 
 # ── cli/ workspace manifest render ────────────────────────────────────
 


### PR DESCRIPTION
# Add a library-backed VCS adapter over gix and jj-lib

## Summary

Adds `InProcessProbe` — an implementation of `cli/vcs`'s `RepoRoot` and `VcsProbe` ports that reads git through `gix` and jj through `jj-lib` in the calling process rather than by spawning the VCS binaries — plus six taxonomy queries the subprocess pair has no equivalent for, and the test apparatus that proves both idioms are read without a subprocess.

**Nothing is wired.** `vcs_adapters::facts` still names the subprocess pair, so no runtime behaviour changes. The value delivered is risk isolation: two dependency trees, the workspace's first copyleft licence exception and a pre-1.0 API bet land where they can be reviewed and reverted on their own.

## Changes

### The adapter (`cli/vcs-adapters`)

- **`library.rs`** — `InProcessProbe`, both port implementations, and six inherent queries returning `Result<Option<T>, Error>` so failure is distinguishable from absence: `is_bare`, `worktree`, `superproject`, `jj_workspace_root`, `jj_repository`, and `dual_roots` (infallible, with a per-side `Result` so a one-sided failure can't read as "jj only").
- **Three distinct walks, not one.** The combined `.jj`-or-`.git` boundary walk answers `RepoRoot::discover` only; a **`.jj`-only** walk answers the jj queries, because jj-lib's loader performs no walk of its own and feeding it the combined boundary reports absence on a git checkout nested inside a jj workspace — where `jj workspace root` reports a root; `gix::discover` performs the third.
- **`subprocess.rs`** — the retained `MarkerWalkRoot`/`CommandProbe` pair, moved out of the crate root so each file holds one shape. `lib.rs` drops from 315 lines to 59: module declarations, `facts`, one test.
- **`markers.rs`** — the ancestor walk and marker reading both adapters share. Each delegates *to* it, so retiring either strands nothing.
- Every returned path is canonicalised at one choke point, and `start` is absolutised before any walk — without it a relative start makes a colocated checkout report a git root and no jj root, which is the wrong classifier arm.

### Dependency policy and enforcement

- `jj-lib = "=0.43.0"` (exact — declared-unstable internals) and `gix = { version = "~0.85.0", default-features = false }`. Defaults are off because gix's `default` reaches `gix-credentials`, the one gix subsystem that spawns `git credential-*` helpers.
- `prost` and `pollster` as direct edges for the jj revision route. Both were already in the lock through jj-lib, so this adds **two edges and no packages**.
- The workspace's first `[[licenses.exceptions]]` — `uluru`, MPL-2.0, reached from `gix-pack` and not feature-gatable out.
- A cargo-pup rule scoping `vcs_adapters::library`'s imports to a permit list and denying `std::process`, with probe cases for the rule.
- A source guard (`lint:vcs-settings:check`) forbidding jj settings construction crate-wide — cargo-pup resolves `use` paths and cannot see a fully-qualified call.
- Graph invariants: single gix/prost/pollster versions, the enabled gix feature set, no TLS in the subtree on all five targets, and no package requiring a Rust newer than the pin.

### Test apparatus (`cli/vcs-test-support`, new crate)

- A 34-pair fixture matrix covering colocated, secondary-workspace, nested, submodule (depths 1 and 2, plus three awkward shapes), worktree, bare, reftable, sha256, hostile-config and three degenerate shapes.
- The hermetic environment, the marker-writing stubs, and a platform-aware report of the absolute paths it cannot shadow. The Rust harness never writes outside its own temp directories.
- Zero-spawn proven **across a crate boundary** from `cli/corpus-adapters`, the crate that will converge onto the adapter.

### Build system and CI

- `test:integration:zero-spawn` (PATH-only) and `test:integration:zero-spawn:strong` (shadows the real binaries; gated behind `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`), plus a `check-zero-spawn` Linux job.
- A committed size floor on the reference artefact — linked ≥ 3× stubbed everywhere, plus an absolute byte floor on musl — guarding this story's headline false pass, where dead-code elimination lets the musl and size checks succeed while linking almost none of the trees.
- `version.write` now syncs `cli/Cargo.lock`, which carries a copy of the version per workspace member and was being left behind.

## Context

- Work item: `meta/work/0188-library-backed-vcs-adapter.md`
- Plan: `meta/plans/2026-08-03-0188-library-backed-vcs-adapter.md`, carrying the full oracle mapping — every query against every fixture, with the shell implementation in `scripts/vcs-common.sh` as the behavioural oracle
- Research: `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`
- Plan review: `meta/reviews/plans/2026-08-03-0188-library-backed-vcs-adapter-review-1.md`
- Validation: `meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md`
- Dated hand-off notes are appended to **0125**, **0169** and **0185**; ADR-0053 (thin CLI over a hexagonal core) is the governing decision

## Testing

- [x] `mise run` green end to end (601s, zero task failures, no formatter drift)
- [x] `test:unit:cli` — 625 tests. Includes the six queries against all 34 (fixture, start directory) pairs, every expected value traceable to a cell in the recorded oracle mapping
- [x] The scrub invariant across the whole matrix, with a live-poison control (`gix::discover_with_environment_overrides` resolving the poison target) so the assertion can't hold vacuously
- [x] `detection.rs` runs every pre-existing case through an injection seam against **both** implementations, asserting identical `RepoFacts` for both idioms while keeping its own fixed expected values — agreement between two implementations is not on its own an oracle
- [x] `test:integration:deny` (65), `test:unit:tasks` (660), `test:integration:pup`, `lint:vcs-settings:check`
- [x] Non-vacuity committed rather than demonstrated by hand: a `std::process` import fails cargo-pup naming the rule, a deliberate settings construction fails the source guard, and a compliant module passes as the positive control
- [x] `test:integration:zero-spawn` in PATH-only mode
- [x] All four release triples cross-compile; both musl builds pass the static-ELF assertion; size ratios 6.86×–7.37× against a 3× floor
- [x] The jj-fixture shell suites (`hooks/test-vcs-detect.sh`, `scripts/test-metadata-helpers.sh`) green under the jj 0.43 pin
- [x] The strong-form task refuses to run without its opt-in, and touches nothing
- [ ] **The strong-form zero-spawn run itself — see Notes.** It has never executed and will not pass as written
- [ ] Cold-cache CI timings against `test-visual-regression`'s 20-minute cap. Measured locally: the two new trees cost 16.92s wall / 65.8s CPU cold, so roughly a minute or two on a 4-vCPU runner. No budget raise expected — worth confirming on the first run

## Notes for Reviewers

**Start with the dependency policy.** `cli/Cargo.toml`, `cli/deny.toml` and `cli/pup.ron` are the reviewable core; the adapter is replaceable, a licence exception and a pre-1.0 pin are not. The trees enter the build graph of the shipped `accelerator-visualiser`, though dead-code elimination removes them from the binary — verified, and the basis for the MPL-2.0 finding below.

**The MPL-2.0 §3.2 question is closed by measurement, conditionally.** `uluru` reaches exactly one shipped binary, and an unstripped release build of it carries zero symbols from `gix`, `gix-pack`, `gix-odb`, `jj_lib`, `clru` or `uluru` against 26,247 total, and none of the distinctive literals the linked reference artefact does carry. So the notice obligation does not bind and no attribution artefact is needed. The finding is **contingent** on nothing in the visualiser reaching `vcs-adapters`, so its re-check trigger is recorded in the `deny.toml` comment and on 0185.

**A spike conclusion was reversed during review.** The plan descoped the jj half of `revision` to 0185, on a finding that jj-lib 0.43 offers no read-only, settings-free route to the working-copy commit id. That was wrong — `jj_lib::protos` is a **public** module, so the workspace's checkout state decodes through published API rather than a private wire format. The route is delivered here and matches the CLI exactly across pure-jj, colocated, commitless, secondary-workspace and multi-workspace shapes, writing nothing. Amendment 8 is withdrawn by amendment 10.

**One deliberate behavioural divergence, and it is the read-only direction.** Asking the `jj` binary snapshots the working copy first, so with unsnapshotted edits present it reports — and *writes* — a new commit. The in-process route reports the commit as of the last recorded operation and writes nothing. After 0185's switch, deriving metadata therefore stops mutating the user's repository. Pinned by `an_unsnapshotted_edit_is_the_one_documented_divergence`.

**Known defect, not fixed here.** The strong-form zero-spawn suite builds its own fixture matrix, which needs the real binaries — so on CI that build lands inside the shadow window with no `git` or `jj` to run it. The job has never executed, so this is latent rather than a regression. Fixing it needs a Rust-side handoff (build the matrix outside the window, pass its root in), which is scoped separately rather than smuggled into this branch.

**Pre-existing flake worth knowing about.** `test:integration:entrypoint` failed in two of five full local runs, always because `tests/integration/support/installation.py:125-141` builds into the shared `cli/target/debug` and asserts the artefact's presence with no tolerance for a concurrent rebuild. CI is structurally immune — `test-unit` and `test-integration` are separate jobs — so the exposure is to the local `mise run` gate. Deserves its own item; this branch enlarges the Rust build and so widens the window.

**What this deliberately does not do:** wire anything (`facts` stays hard-wired, 0185 owns the switch), build `classify_checkout`'s arm cascade or `vcs status` / `vcs log` (0169), define a domain port over the six queries (0169), gate on cost, or migrate the ~26 shell call sites. `cli/vcs/src/**` is byte-for-byte unmodified.

**Sizing:** 16 commits, +14,268/−528 across 51 files. Roughly 6,700 lines are `meta/` documents (plan, research, review, validation, work-item amendments) and 1,447 are `cli/Cargo.lock`, whose delta is worth reading only for the `vcs-adapters` dependency edges. That leaves about 4,200 lines of Rust — two thirds of it fixtures and tests — and about 1,400 of Python task and guard code.

**Two commits are housekeeping over this branch's own additions**, not delivered capability: one extracts the retained subprocess pair out of the crate root into `subprocess.rs` so each file holds one adapter, and one cuts the comments back to this repo's bar — 900 comment lines down to 635, with every reference to work items, ADRs, ACs and plan documents removed, since those go stale across work item boundaries. Neither changes behaviour, and both are worth skipping when reading the diff for correctness.
