### PR TITLE
Update VCS CLI rewrite and documentation stories

### DIFF
--- a/meta/plans/2026-07-10-0193-make-the-docs-amazing.md
+++ b/meta/plans/2026-07-10-0193-make-the-docs-amazing.md
@@ -1,16 +1,16 @@
 ---
 type: plan
-id: "2026-07-10-0179-make-the-docs-amazing"
+id: "2026-07-10-0193-make-the-docs-amazing"
 title: "Make the Docs Amazing Implementation Plan"
 date: "2026-07-10T20:08:08+00:00"
 author: Phil Helm
 producer: create-plan
 status: ready
-work_item_id: "work-item:0179"
-parent: "work-item:0179"
+work_item_id: "work-item:0193"
+parent: "work-item:0193"
 derived_from:
   [
-    "codebase-research:2026-07-10-0179-make-the-docs-amazing",
+    "codebase-research:2026-07-10-0193-make-the-docs-amazing",
     "codebase-research:2026-07-13-docs-site-visualiser-design-alignment",
   ]
 tags: [docs, docs-site, starlight, generation, ci, design-tokens, theming]
@@ -27,7 +27,7 @@ schema_version: 1
 ## Overview
 
 Overhaul the Astro Starlight docs site (`docs-site/`) per the audiences
-in epic 0178: generated per-skill reference pages (69) built by a
+in epic 0192: generated per-skill reference pages (69) built by a
 prebuild script in the `tasks/` invoke toolchain, a CI drift guard, new
 tutorial/how-to/FAQ content, a splash landing page, a restructured
 sidebar, richer explanation pages, and Starlight polish.
@@ -81,7 +81,7 @@ A site where each audience self-serves:
 
 Verify: `mise run check` green, `docs:build` (strict, incl. link
 validation) green locally and in CI, Pages deploy succeeds, all
-acceptance criteria in work item 0179 ticked.
+acceptance criteria in work item 0193 ticked.
 
 ### Key Discoveries
 
@@ -120,7 +120,7 @@ acceptance criteria in work item 0179 ticked.
 ## What We're NOT Doing
 
 - AI-generated explanatory diagrams / hero artwork (possible follow-up).
-- A changelog page or contributor-docs overhaul (separate 0178 children).
+- A changelog page or contributor-docs overhaul (separate 0192 children).
 - Visualiser feature changes.
 - Committing generated pages — they are build-time only, gitignored.
 - Deleting the eight family pages — they become curated overviews.
@@ -1009,8 +1009,8 @@ treatment.
 
 ## References
 
-- Original work item: `meta/work/0179-make-the-docs-amazing.md`
-- Research: `meta/research/codebase/2026-07-10-0179-make-the-docs-amazing.md`
+- Original work item: `meta/work/0193-make-the-docs-amazing.md`
+- Research: `meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md`
 - Theming research: `meta/research/codebase/2026-07-13-docs-site-visualiser-design-alignment.md`
 - Canonical token sheet: `skills/visualisation/visualise/frontend/src/styles/global.css`
 - Token fixture: `skills/visualisation/visualise/frontend/src/styles/fixtures/prototype-tokens.json`

--- a/meta/prs/49-description.md
+++ b/meta/prs/49-description.md
@@ -1,0 +1,68 @@
+---
+type: pr-description
+id: "49"
+title: "Update VCS CLI rewrite and documentation stories"
+date: "2026-08-05T19:08:29+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+relates_to:
+  [
+    "work-item:0187",
+    "work-item:0188",
+    "work-item:0192",
+    "work-item:0193",
+    "work-item:0136",
+  ]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/49"
+pr_number: 49
+tags: [meta, work-items, housekeeping]
+revision: "6e3f9ed5f3d767c7bb0be4072599d948636d5cc3"
+repository: "accelerator"
+last_updated: "2026-08-05T19:14:12+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Update VCS CLI rewrite and documentation stories
+
+## Summary
+
+Two independent pieces of `meta/` corpus housekeeping. First, it resolves a genuine work-item ID collision: `0178` and `0179` were each claimed by two different work items — the Rust CLI crate stories and the documentation epic/story — so the documentation pair is renumbered to the next free IDs, `0192` and `0193`. Second, it marks `0187` and `0188` done now that both have landed, which clears the last two blockers gating the VCS subdomain migration.
+
+No product code changes — every file is Markdown under `meta/`.
+
+## Changes
+
+**Renumber the documentation work items (`0178` → `0192`, `0179` → `0193`)**
+
+- Renamed `meta/work/0178-documentation.md` → `0192-documentation.md` and `meta/work/0179-make-the-docs-amazing.md` → `0193-make-the-docs-amazing.md`, updating each file's `id:` and body H1 to match.
+- Renamed the derived artifacts to keep the filename/ID convention intact: `meta/plans/2026-07-10-0179-make-the-docs-amazing.md` and `meta/research/codebase/2026-07-10-0179-make-the-docs-amazing.md` both move to the `-0193-` form, with their `id:`, `work_item_id:`, `parent:`, and `derived_from:` slots repointed.
+- Repointed the inbound `parent:` links on the two children of the docs epic — `0145-documentation-improvements.md` and `0177-documentation-site-for-docs-tree.md` — from `work-item:0178` to `work-item:0192`.
+- Updated the prose references throughout the plan and both research documents (`2026-07-10-…-make-the-docs-amazing`, `2026-07-13-docs-site-visualiser-design-alignment`) so narrative mentions of "epic 0178" / "work item 0179" now read 0192 / 0193.
+
+**Mark `0187` and `0188` done**
+
+- `0187` (Generalise the Sub-Binary Registration Surface) and `0188` (Library-Backed VCS Adapter over gix and jj-lib) both move `status: ready` → `done`, with the body `**Status**:` label synced and `last_updated` bumped.
+
+## Context
+
+- Epic `meta/work/0136-migrate-shell-scripts-to-rust-cli.md` — owns `0187` and `0188`. With both done, the dependency graph opens up: `0169` (VCS Subdomain and Hooks Migration) has all seven of its blockers satisfied and is the only newly-unblocked item already at `ready`. `0170`, `0171`, `0173`, and `0185` also clear, though all four are still `draft` and need refinement before they are workable. `0172` and `0174` remain blocked behind `0169`.
+- Epic `meta/work/0192-documentation.md` — the renumbered documentation umbrella, with children `0145`, `0177`, and `0193`.
+- Plan `meta/plans/2026-07-10-0193-make-the-docs-amazing.md` and research `meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md` — the active docs-site work that the renumber keeps addressable.
+
+## Testing
+
+- [x] Confirmed the collision was real: on `main`, `meta/work/` contained both `0178-config-crates-native-yaml-reader.md` and `0178-documentation.md`, and both `0179-corpus-crates-parsing-conventions.md` and `0179-make-the-docs-amazing.md`.
+- [x] Confirmed `0192`/`0193` were the next free IDs — the highest previously allocated work item is `0191`.
+- [x] Grepped the repo for stale references to the old docs IDs (`0178-documentation`, `0179-make-the-docs-amazing`). The only surviving hits are the two `docs/0179-docs-polish` branch-name mentions in `2026-07-13-docs-site-visualiser-design-alignment.md`, which are a historical VCS branch name and correctly left alone.
+- [x] Verified every remaining `"work-item:0178"` / `"work-item:0179"` typed reference in `meta/` now unambiguously resolves to the crate work items (plans, research, reviews, and PR descriptions for `0178`/`0179`/`0180`, plus `blocked_by` slots on `0167`, `0180`, `0185`, and `0188`).
+- [x] `mise run check` passes (exit 0, 78.8s) — format, lint, and type-checks across frontend, server, cli, build-system, and scripts. It exercises none of the changed files, since every one of them is Markdown under `meta/`, but it confirms the branch is clean.
+
+## Notes for Reviewers
+
+- **Two unrelated changes in one PR.** The documentation renumber and the `0187`/`0188` status flips share no files and no rationale; they are simply co-resident on this branch. Each commit is self-contained, so they can be split if you would rather review them separately.
+- **The renumber is the part worth reading carefully.** It is a rename-plus-rewrite across seven files, and the failure mode is a dangling reference rather than a broken build — nothing in CI validates work-item linkage, and `mise run check` never reads `meta/`, so the grep evidence above is the only guard.
+- **`last_updated` was deliberately not bumped on the renumbered files.** `0192` and `0193` keep their original 2026-07-10 timestamps on the grounds that renumbering fixes identity rather than changing content. Worth a second opinion if you read that field as "last touched".
+- **The `docs/0179-docs-polish` branch name is intentionally stale.** It names a real branch and would be wrong to rewrite.
+- **Follow-up.** With `0169` now genuinely unblocked, it is the natural next item off this epic.

--- a/meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md
+++ b/meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md
@@ -1,13 +1,13 @@
 ---
 type: codebase-research
-id: "2026-07-10-0179-make-the-docs-amazing"
-title: "Research: Make the Docs Amazing (0179) — docs site overhaul groundwork"
+id: "2026-07-10-0193-make-the-docs-amazing"
+title: "Research: Make the Docs Amazing (0193) — docs site overhaul groundwork"
 date: "2026-07-10T19:55:16+00:00"
 author: Phil Helm
 producer: research-codebase
 status: complete
-work_item_id: "0179"
-parent: "work-item:0179"
+work_item_id: "0193"
+parent: "work-item:0193"
 relates_to: ["codebase-research:2026-07-10-0177-documentation-site-for-docs-tree"]
 topic: "Docs site overhaul: generated per-skill reference, tutorials, splash landing, sidebar restructure, drift guards"
 tags: [research, codebase, docs-site, starlight, skills, tasks, ci]
@@ -18,7 +18,7 @@ last_updated_by: Phil Helm
 schema_version: 1
 ---
 
-# Research: Make the Docs Amazing (0179) — docs site overhaul groundwork
+# Research: Make the Docs Amazing (0193) — docs site overhaul groundwork
 
 **Date**: 2026-07-10T19:55:16+00:00 (UTC)
 **Author**: Phil Helm
@@ -28,7 +28,7 @@ schema_version: 1
 
 ## Research Question
 
-What does the codebase look like today for implementing work item 0179 —
+What does the codebase look like today for implementing work item 0193 —
 overhauling the Astro Starlight docs site with generated per-skill
 reference pages, new tutorial/how-to content, a splash landing page, a
 restructured sidebar, Starlight polish, and CI drift guards?
@@ -76,7 +76,7 @@ shell-only, so a YAML dependency (or minimal parser) is needed.
   collectionBase: false }` (lines 14–17).
 - **Sidebar** — fully manual (lines 25–51): eight top-level slugs plus a
   "Skills Reference" group of nine pages; label overrides at lines 28 and
-  38–41 disambiguate the two "Development Loop" pages. 0179's Start Here
+  38–41 disambiguate the two "Development Loop" pages. 0193's Start Here
   / Guides / Reference restructure means rewriting this array; per-page
   `sidebar.*` frontmatter is used nowhere yet.
 - **Pages** — 18 files. Top level: `index.md` (39 lines, doc template,
@@ -214,7 +214,7 @@ shell-only, so a YAML dependency (or minimal parser) is needed.
   determinism check (regenerate + diff) or a coverage check modelled on
   `validate_version_coherence`.
 - **The family pages decision reverses 0176.** 0176 deliberately chose
-  "no standalone per-skill pages"; 0179 keeps the eight family pages as
+  "no standalone per-skill pages"; 0193 keeps the eight family pages as
   curated overviews linking into generated pages — expect to rework the
   `skills/index.md` "All Skills" relationship, not just add pages.
 - **Base-path discipline**: markdown links are handled by
@@ -228,7 +228,7 @@ shell-only, so a YAML dependency (or minimal parser) is needed.
   to conflict with.
 - **Non-invokable skills need a policy**: 23 of 69 skills are
   `user-invocable: false` internals (lenses, output-formats,
-  browser-executor, paths). The 0178 epic AC says "every skill in
+  browser-executor, paths). The 0192 epic AC says "every skill in
   plugin.json has a page" — badge them (e.g. `sidebar.badge:
   Internal`) or group them separately rather than omitting them.
 - **Starlight is pre-1.0** — minor releases can break; the site is on
@@ -239,21 +239,21 @@ shell-only, so a YAML dependency (or minimal parser) is needed.
 - `meta/decisions/ADR-0056-astro-starlight-for-documentation-site.md` —
   Starlight rationale and rejected alternatives (don't relitigate).
 - `meta/plans/2026-07-10-0177-documentation-site-for-docs-tree.md` — what
-  0177 built; its "What We're NOT Doing" list is effectively 0179's
+  0177 built; its "What We're NOT Doing" list is effectively 0193's
   menu (no content rewrites, no theming, no MDX, no CI caching).
 - `meta/research/codebase/2026-07-10-0177-documentation-site-for-docs-tree.md`
   — anchor fragility in headings with raw `<img>`, Chromium ~150MB per
   CI run uncached (optimisation candidate as builds grow).
 - `meta/work/0176-per-skill-family-reference-docs.md` — the family-pages
-  model 0179 supersedes; its deferred open question (generate the index
-  from frontmatter with a CI consistency check) is 0179's drift-guard
+  model 0193 supersedes; its deferred open question (generate the index
+  from frontmatter with a CI consistency check) is 0193's drift-guard
   mandate.
-- `meta/work/0178-documentation.md` — the audience framing; Diátaxis is
+- `meta/work/0192-documentation.md` — the audience framing; Diátaxis is
   an influence, not a mandate; prefers generation + drift guards over
   hand-maintained duplication. Unresolved: whether 0145's in-progress
-  content is absorbed into 0178's children.
+  content is absorbed into 0192's children.
 - `meta/work/0145-documentation-improvements.md` — earlier docs epic;
-  its IA questions are effectively superseded by 0178/0179.
+  its IA questions are effectively superseded by 0192/0193.
 
 ## Related Research
 
@@ -262,7 +262,7 @@ shell-only, so a YAML dependency (or minimal parser) is needed.
 
 ## Open Questions
 
-All resolved with the user on 2026-07-10 (recorded in work item 0179's
+All resolved with the user on 2026-07-10 (recorded in work item 0193's
 Assumptions):
 
 - **Generated pages are build-time only** (gitignored output in the

--- a/meta/research/codebase/2026-07-13-docs-site-visualiser-design-alignment.md
+++ b/meta/research/codebase/2026-07-13-docs-site-visualiser-design-alignment.md
@@ -44,7 +44,7 @@ layers, and user `customCss` is injected first and unlayered, so plain
 `:root` re-declarations win. Alignment is therefore mostly a **token
 mapping exercise** (`--atomic-*`/`--ac-*` values → `--sl-*` properties)
 plus self-hosting the three font families. No prior decision blocks
-this — 0177 explicitly deferred theming and the active 0179 plan covers
+this — 0177 explicitly deferred theming and the active 0193 plan covers
 config polish only — so it is **new, additive scope**, and per
 ADR-0026/0035 conventions it should get its own supplementary ADR and a
 drift guard for any duplicated token values.
@@ -157,7 +157,7 @@ theming — the one area needing more than variable overrides.
   `--atomic-*`; tints via `color-mix` at locked 8/18/30%; spacing
   snapped to `--sp-*` within ±2px; new `:root`-only token families
   require a supplementary ADR. Both accepted and immutable (ADR-0031).
-- **0177** explicitly listed theming as out of scope; **0179** (active
+- **0177** explicitly listed theming as out of scope; **0193** (active
   plan, this branch) covers Starlight config polish + splash page only.
   So this work is additive scope, not a reversal.
 - Repo pattern for sharing values across builds is **duplication with a
@@ -204,8 +204,8 @@ theming — the one area needing more than variable overrides.
 - `meta/decisions/ADR-0026-css-design-token-application-conventions.md`
   (+ `ADR-0035-brand-layer-indirection-supplement-to-adr-0026.md`)
 - `meta/research/codebase/2026-05-23-0073-atomic-brand-layer-palette.md`
-- `meta/research/codebase/2026-07-10-0179-make-the-docs-amazing.md` and
-  `meta/plans/2026-07-10-0179-make-the-docs-amazing.md` — active docs
+- `meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md` and
+  `meta/plans/2026-07-10-0193-make-the-docs-amazing.md` — active docs
   polish work; theming deliberately not included
 - `meta/research/codebase/2026-05-06-0033-design-token-system.md`,
   `2026-05-08-0034-theme-and-font-mode-toggles.md`,
@@ -240,8 +240,8 @@ The five open questions were reviewed with the user and resolved:
   brand hex values in docs custom CSS against
   `frontend/src/styles/fixtures/prototype-tokens.json`; skip the
   supplementary ADR for now.
-- **Work item — new phase in the 0179 plan**
-  (`meta/plans/2026-07-10-0179-make-the-docs-amazing.md`), continuing
+- **Work item — new phase in the 0193 plan**
+  (`meta/plans/2026-07-10-0193-make-the-docs-amazing.md`), continuing
   on the current `docs/0179-docs-polish` branch.
 - **Fonts — trimmed set.** Self-host Inter 400/600/700, Sora 600/700,
   Fira Code 400 as woff2 in `docs-site/public/fonts/` (copied from the

--- a/meta/work/0145-documentation-improvements.md
+++ b/meta/work/0145-documentation-improvements.md
@@ -14,7 +14,7 @@ last_updated: "2026-06-29T13:04:00+00:00"
 last_updated_by: Phil Helm
 schema_version: 1
 external_id: PP-166
-parent: "work-item:0178"
+parent: "work-item:0192"
 ---
 
 # 0145: Documentation Improvements

--- a/meta/work/0177-documentation-site-for-docs-tree.md
+++ b/meta/work/0177-documentation-site-for-docs-tree.md
@@ -8,7 +8,7 @@ producer: refine-work-item
 status: done
 kind: story
 priority: medium
-parent: "work-item:0178"
+parent: "work-item:0192"
 tags: []
 last_updated: "2026-07-23T00:00:00+00:00"
 last_updated_by: Phil Helm

--- a/meta/work/0187-generalise-sub-binary-registration-surface.md
+++ b/meta/work/0187-generalise-sub-binary-registration-surface.md
@@ -5,7 +5,7 @@ title: "Generalise the Sub-Binary Registration Surface"
 date: "2026-07-31T10:41:51+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: ready
+status: done
 kind: task
 priority: high
 parent: "work-item:0136"
@@ -13,7 +13,7 @@ blocked_by: ["work-item:0168"]
 blocks: ["work-item:0169", "work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173"]
 relates_to: ["work-item:0165", "work-item:0182"]
 tags: [build-system, distribution, rust]
-last_updated: "2026-08-01T17:29:06+00:00"
+last_updated: "2026-08-05T17:36:44+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -21,7 +21,7 @@ schema_version: 1
 # 0187: Generalise the Sub-Binary Registration Surface
 
 **Kind**: Task
-**Status**: Ready
+**Status**: Done
 **Priority**: High
 **Author**: Toby Clemson
 

--- a/meta/work/0188-library-backed-vcs-adapter.md
+++ b/meta/work/0188-library-backed-vcs-adapter.md
@@ -5,7 +5,7 @@ title: "Library-Backed VCS Adapter over gix and jj-lib"
 date: "2026-07-31T10:41:51+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: ready
+status: done
 kind: story
 priority: high
 parent: "work-item:0136"
@@ -15,7 +15,7 @@ relates_to: ["work-item:0125", "work-item:0168", "work-item:0187",
   "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["work-item:0169"]
 tags: [rust, vcs, dependencies]
-last_updated: "2026-08-03T16:37:02+00:00"
+last_updated: "2026-08-05T17:36:44+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -23,7 +23,7 @@ schema_version: 1
 # 0188: Library-Backed VCS Adapter over gix and jj-lib
 
 **Kind**: Story
-**Status**: Ready
+**Status**: Done
 **Priority**: High
 **Author**: Toby Clemson
 

--- a/meta/work/0192-documentation.md
+++ b/meta/work/0192-documentation.md
@@ -1,6 +1,6 @@
 ---
 type: work-item
-id: "0178"
+id: "0192"
 title: "Documentation"
 date: "2026-07-10T19:41:21+00:00"
 author: Phil Helm
@@ -15,7 +15,7 @@ last_updated_by: Phil Helm
 schema_version: 1
 ---
 
-# 0178: Documentation
+# 0192: Documentation
 
 **Kind**: Epic
 **Status**: Draft

--- a/meta/work/0193-make-the-docs-amazing.md
+++ b/meta/work/0193-make-the-docs-amazing.md
@@ -1,6 +1,6 @@
 ---
 type: work-item
-id: "0179"
+id: "0193"
 title: "Make the Docs Amazing"
 date: "2026-07-10T19:47:43+00:00"
 author: Phil Helm
@@ -8,7 +8,7 @@ producer: create-work-item
 status: draft
 kind: story
 priority: medium
-parent: "work-item:0178"
+parent: "work-item:0192"
 relates_to: ["work-item:0177", "work-item:0145"]
 tags: [docs]
 last_updated: "2026-07-10T19:55:16+00:00"
@@ -17,7 +17,7 @@ last_updated_note: "Corrected skill count to 69; recorded generation decisions f
 schema_version: 1
 ---
 
-# 0179: Make the Docs Amazing
+# 0193: Make the Docs Amazing
 
 **Kind**: Story
 **Status**: Draft
@@ -28,7 +28,7 @@ schema_version: 1
 
 As a reader of the Accelerator docs site, I want the content, structure,
 reference coverage, and presentation overhauled, so that whichever
-audience I belong to (per epic 0178), the site gets me to my goal
+audience I belong to (per epic 0192), the site gets me to my goal
 without the authors present.
 
 Overhaul of the Astro Starlight docs site: new tutorial and how-to
@@ -55,7 +55,7 @@ the content collection.
 
 ## Requirements
 
-Organised by the audiences defined in epic 0178:
+Organised by the audiences defined in epic 0192:
 
 **Newcomers (tutorial)**
 
@@ -178,17 +178,17 @@ Organised by the audiences defined in epic 0178:
 
 ## Drafting Notes
 
-- Scoped as one story under epic 0178 rather than several items, per the
+- Scoped as one story under epic 0192 rather than several items, per the
   user's preference to break it down later if needed.
 - Out of scope by drafting decision: AI-generated explanatory diagrams
   (hero art may be a follow-up), a changelog page, contributor docs
-  overhaul (a separate child of 0178), and visualiser feature changes.
+  overhaul (a separate child of 0192), and visualiser feature changes.
 - "Amazing" is interpreted as audience outcomes (install, find, look up,
   understand) rather than visual polish alone.
 
 ## References
 
-- Parent: 0178 (Documentation epic)
+- Parent: 0192 (Documentation epic)
 - Related: 0177, 0176 (done), 0145
 - Diátaxis framework: https://diataxis.fr/
 - Starlight sidebar guide: https://starlight.astro.build/guides/sidebar/


### PR DESCRIPTION
# Update VCS CLI rewrite and documentation stories

## Summary

Two independent pieces of `meta/` corpus housekeeping. First, it resolves a genuine work-item ID collision: `0178` and `0179` were each claimed by two different work items — the Rust CLI crate stories and the documentation epic/story — so the documentation pair is renumbered to the next free IDs, `0192` and `0193`. Second, it marks `0187` and `0188` done now that both have landed, which clears the last two blockers gating the VCS subdomain migration.

No product code changes — every file is Markdown under `meta/`.

## Changes

**Renumber the documentation work items (`0178` → `0192`, `0179` → `0193`)**

- Renamed `meta/work/0178-documentation.md` → `0192-documentation.md` and `meta/work/0179-make-the-docs-amazing.md` → `0193-make-the-docs-amazing.md`, updating each file's `id:` and body H1 to match.
- Renamed the derived artifacts to keep the filename/ID convention intact: `meta/plans/2026-07-10-0179-make-the-docs-amazing.md` and `meta/research/codebase/2026-07-10-0179-make-the-docs-amazing.md` both move to the `-0193-` form, with their `id:`, `work_item_id:`, `parent:`, and `derived_from:` slots repointed.
- Repointed the inbound `parent:` links on the two children of the docs epic — `0145-documentation-improvements.md` and `0177-documentation-site-for-docs-tree.md` — from `work-item:0178` to `work-item:0192`.
- Updated the prose references throughout the plan and both research documents (`2026-07-10-…-make-the-docs-amazing`, `2026-07-13-docs-site-visualiser-design-alignment`) so narrative mentions of "epic 0178" / "work item 0179" now read 0192 / 0193.

**Mark `0187` and `0188` done**

- `0187` (Generalise the Sub-Binary Registration Surface) and `0188` (Library-Backed VCS Adapter over gix and jj-lib) both move `status: ready` → `done`, with the body `**Status**:` label synced and `last_updated` bumped.

## Context

- Epic `meta/work/0136-migrate-shell-scripts-to-rust-cli.md` — owns `0187` and `0188`. With both done, the dependency graph opens up: `0169` (VCS Subdomain and Hooks Migration) has all seven of its blockers satisfied and is the only newly-unblocked item already at `ready`. `0170`, `0171`, `0173`, and `0185` also clear, though all four are still `draft` and need refinement before they are workable. `0172` and `0174` remain blocked behind `0169`.
- Epic `meta/work/0192-documentation.md` — the renumbered documentation umbrella, with children `0145`, `0177`, and `0193`.
- Plan `meta/plans/2026-07-10-0193-make-the-docs-amazing.md` and research `meta/research/codebase/2026-07-10-0193-make-the-docs-amazing.md` — the active docs-site work that the renumber keeps addressable.

## Testing

- [x] Confirmed the collision was real: on `main`, `meta/work/` contained both `0178-config-crates-native-yaml-reader.md` and `0178-documentation.md`, and both `0179-corpus-crates-parsing-conventions.md` and `0179-make-the-docs-amazing.md`.
- [x] Confirmed `0192`/`0193` were the next free IDs — the highest previously allocated work item is `0191`.
- [x] Grepped the repo for stale references to the old docs IDs (`0178-documentation`, `0179-make-the-docs-amazing`). The only surviving hits are the two `docs/0179-docs-polish` branch-name mentions in `2026-07-13-docs-site-visualiser-design-alignment.md`, which are a historical VCS branch name and correctly left alone.
- [x] Verified every remaining `"work-item:0178"` / `"work-item:0179"` typed reference in `meta/` now unambiguously resolves to the crate work items (plans, research, reviews, and PR descriptions for `0178`/`0179`/`0180`, plus `blocked_by` slots on `0167`, `0180`, `0185`, and `0188`).
- [x] `mise run check` passes (exit 0, 78.8s) — format, lint, and type-checks across frontend, server, cli, build-system, and scripts. It exercises none of the changed files, since every one of them is Markdown under `meta/`, but it confirms the branch is clean.

## Notes for Reviewers

- **Two unrelated changes in one PR.** The documentation renumber and the `0187`/`0188` status flips share no files and no rationale; they are simply co-resident on this branch. Each commit is self-contained, so they can be split if you would rather review them separately.
- **The renumber is the part worth reading carefully.** It is a rename-plus-rewrite across seven files, and the failure mode is a dangling reference rather than a broken build — nothing in CI validates work-item linkage, and `mise run check` never reads `meta/`, so the grep evidence above is the only guard.
- **`last_updated` was deliberately not bumped on the renumbered files.** `0192` and `0193` keep their original 2026-07-10 timestamps on the grounds that renumbering fixes identity rather than changing content. Worth a second opinion if you read that field as "last touched".
- **The `docs/0179-docs-polish` branch name is intentionally stale.** It names a real branch and would be wrong to rewrite.
- **Follow-up.** With `0169` now genuinely unblocked, it is the natural next item off this epic.
