### PR TITLE
Split 0170/0194 tracker crate and remote sync engine work items

### DIFF
--- a/meta/prs/50-description.md
+++ b/meta/prs/50-description.md
@@ -1,0 +1,50 @@
+---
+type: pr-description
+id: "50"
+title: "Split 0170/0194 tracker crate and remote sync engine work items"
+date: "2026-08-06T00:31:44+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+parent: "work-item:0136"
+relates_to: ["work-item:0170", "work-item:0194", "work-item:0171"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/50"
+pr_number: 50
+tags: []
+revision: "08de11b010aee84301b90f03b63ad26e5a6b653e"
+repository: "accelerator"
+last_updated: "2026-08-06T00:31:44+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Split 0170/0194 tracker crate and remote sync engine work items
+
+## Summary
+
+Splits work item 0170 (Work-Item Subdomain and Sync Engine) into a lean lifecycle-CRUD story (0170) and a new tracker-crate-and-sync-engine story (0194), then reviews and refines 0194 through all five work item lenses, then moves `--push` support out of 0170 and into 0194 so the two stories carry no dependency on each other beyond one narrow slice. Net effect: 0170 and 0194 can now be implemented fully in parallel, with only 0194's `--push`-wiring acceptance criteria waiting on 0170's `create`/`update` commands existing.
+
+## Changes
+
+- Splits 0170 into 0170 (lifecycle CRUD: create/show/update/resolve/diff) and a new 0194 (the `tracker` crate's `RemoteTracker` port, the sync state machine, and the `accelerator work sync` command), following work item review 1 of 0170, which found the combined story epic-scale and the two halves independently deliverable.
+- Updates the 0136 epic's decomposition list and 0171's dependency/relates_to references to point at 0194 for the `RemoteTracker` port instead of 0170.
+- Reviews 0194 through all five work item lenses (clarity, completeness, dependency, scope, testability); the only major finding (AC1's resumability contract had no concrete verification procedure) and several minor/clarity gaps are addressed directly in the item, then verified resolved on re-review — verdict APPROVE.
+- Decouples 0170 from 0194 entirely: moves `--push` support for `create`/`update` (and the `work-item-create-remote.sh`, `work-item-update-remote.sh`, and `work-item-push-decide.sh` scripts that implement it) out of 0170's scope and into 0194's. 0170 now ships as pure local-only CRUD with zero remaining blockers; 0194 gains two new acceptance criteria for the `--push` wiring and becomes `blocked_by: 0170` for that one slice only — the `tracker` crate and `sync` command remain independently deliverable.
+- Adds two new review artifacts (`meta/reviews/work/0170-...-review-1.md`, `meta/reviews/work/0194-...-review-1.md`) documenting both review passes, findings, and resolutions.
+
+## Context
+
+Parent epic: 0136 (Migrate Shell Scripts into a Rust CLI). Directly restructures work items 0170, 0194, and touches 0171 and 0136 for cross-references. No source code changes — this PR is entirely `meta/work/` and `meta/reviews/work/` planning documents.
+
+## Testing
+
+- [x] All six changed files are markdown planning documents (work items and work item reviews) under `meta/`; there is no code change, so the standard `mise run check`/`mise run test:*` suites don't apply.
+- [x] Cross-checked frontmatter typed-linkage fields (`blocks`/`blocked_by`/`relates_to`) for consistency across all four touched work items (0136, 0170, 0171, 0194) — the blocking relationship between 0170 and 0194 correctly reverses for the `--push`-wiring slice while the rest of each item's dependency graph stays accurate.
+- [x] Grepped for stale cross-references to the removed `0170 --push`/`RemoteTracker` coupling across all four files after the decoupling edit; none found.
+- [ ] No manual/UI verification applicable (documentation-only change).
+
+## Notes for Reviewers
+
+- The three commits read as a sequence: split → review-and-approve 0194 → decouple 0170 from 0194. Each is independently reviewable.
+- The most consequential judgment call is in the third commit: moving `--push` support (and its three source bash scripts) from 0170 into 0194 reverses part of the dependency direction established in the first commit. Worth double-checking that 0194's new Acceptance Criteria for `create --push`/`update --push` (mirroring the old 0170 ones) and the updated Dependencies sections on both items still read coherently together.
+- 0170's Acceptance Criteria for `create`/`update` are now considerably simpler (local-only, no remote-call/retry semantics) — the removed complexity moved to 0194's two new ACs, not lost.

--- a/meta/reviews/work/0170-work-item-subdomain-and-sync-engine-review-1.md
+++ b/meta/reviews/work/0170-work-item-subdomain-and-sync-engine-review-1.md
@@ -1,0 +1,605 @@
+---
+type: work-item-review
+id: "0170-work-item-subdomain-and-sync-engine-review-1"
+title: "Work Item Review: Work-Item Subdomain and Sync Engine"
+date: "2026-08-05T18:07:37+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0170"
+work_item_id: "0170"
+reviewer: Toby Clemson
+verdict: "APPROVE"
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-05T19:12:57+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Work-Item Subdomain and Sync Engine
+
+**Verdict:** REVISE
+
+0170 is a mature, detailed draft — its Acceptance Criteria are unusually
+thorough for a story and its Technical Notes fully work through a resolved
+design decision. However, it bundles two independently-deliverable efforts
+(lifecycle CRUD and the sync engine/tracker crate) into one story, leaves the
+0171 relationship under-specified in the formal Dependencies/frontmatter
+fields despite describing real coupling in prose, and contains several
+referent and enumeration gaps (an undefined "the dispatcher," an
+inconsistently-listed ~14-script set, missing Acceptance Criteria for half
+the committed subcommand surface) that would need resolving before
+implementation.
+
+### Cross-Cutting Themes
+
+- **The ~14 untested-script set is never authoritatively enumerated**
+  (flagged by: clarity, testability) — Context/Requirements say "~14," AC5
+  names eight scripts plus "etc.," and the Technical Notes' internal-only
+  list names a different seven. Both lenses independently concluded this
+  can't be verified as written — clarity because the referent is ambiguous,
+  testability because the acceptance criterion has no fixed roster to check
+  against.
+- **The 0170/0171 boundary and the sync/lifecycle bundling are
+  under-specified together** (flagged by: dependency, scope) — dependency
+  found that 0171's consumption of the `RemoteTracker` port isn't captured
+  as a `Blocks` relationship despite being a real ordering constraint, while
+  scope found the sync engine and lifecycle CRUD are bundled into one story
+  despite being separately deliverable. Splitting the story (per scope's
+  recommendation) would also clarify the 0171 wiring question, since the
+  in-process real-provider wiring described in the Summary would move with
+  the sync half.
+
+### Findings
+
+#### Major
+
+- 🟡 **Scope**: Story bundles lifecycle CRUD and the sync engine as two
+  independently deliverable concerns
+  **Location**: Summary
+  The Summary itself signals this ("lifecycle operations plus the remote
+  sync engine"); the CRUD surface and the tracker crate's port/state machine
+  are not mutually dependent for delivery, making this read as epic-scale
+  work filed as a single story.
+
+- 🟡 **Scope**: Declared "story" kind looks undersized for the described
+  scope
+  **Location**: Frontmatter: kind
+  Two new crates, a provider-agnostic port verified by dependency-graph
+  inspection, a five-state sync pipeline, and a 14-script characterization
+  backlog together exceed what the kind-specific guidance treats as
+  story-sized.
+
+- 🟡 **Dependency**: 0171 is a downstream consumer of the tracker port but
+  is not captured as a Blocks entry
+  **Location**: Dependencies
+  Context states 0171's clients implement the `RemoteTracker` port this
+  story defines, but Dependencies lists 0171 only as "Relates to," and
+  frontmatter has no `blocks` field — the ordering constraint is invisible
+  to anyone scheduling from Dependencies alone.
+
+- 🟡 **Dependency**: In-process wiring of 0171's client adapters is
+  described as in-scope while 0171 is still draft, but this coupling isn't
+  captured as a blocker
+  **Location**: Summary
+  The Summary and Context describe `accelerator-work` linking 0171's
+  provider adapters in-process; if that wiring is genuinely required for
+  completion (not just the faked-port ACs), 0171 is an unstated upstream
+  blocker.
+
+- 🔴 **Completeness**: Open Questions declares "None" while Drafting Notes
+  admits an unresolved design risk
+  **Location**: Open Questions
+  Drafting Notes flags the subcommand-vocabulary grouping as "a judgment
+  call, not confirmed against an actual implementation spike," which is a
+  live open question not surfaced where readers expect to find one.
+
+- 🔴 **Testability**: Characterization-test criterion has no fixed,
+  enumerable scope
+  **Location**: Acceptance Criteria
+  The same ~14-script ambiguity noted under Clarity means a verifier cannot
+  produce a definitive pass/fail — there is no complete list to check "all
+  of them" against.
+
+- 🟡 **Testability**: No Acceptance Criteria for three of the six
+  user-facing subcommands
+  **Location**: Acceptance Criteria
+  Technical Notes commits to six subcommands (`create`, `update`, `sync`,
+  `show`, `resolve`, `diff`); only the first three have Given/When/Then
+  criteria, leaving `show`/`resolve`/`diff` without a defined verification
+  procedure.
+
+- 🟡 **Clarity**: "the dispatcher" in AC1 has no defined referent
+  **Location**: Acceptance Criteria
+  "Dispatcher" is a term of art elsewhere in the epic (launcher-level
+  sub-binary dispatch, ADR-0054) but AC1 appears to mean the remote
+  create call succeeding — as written it risks an incorrect no-partial-file
+  guard condition.
+
+- 🟡 **Clarity**: The "~14 previously-untested work-item-* scripts" set is
+  enumerated inconsistently
+  **Location**: Acceptance Criteria / Technical Notes
+  Context/Requirements say "~14," AC5 names eight scripts plus "etc.," and
+  the Technical Notes' internal-only list names a different, non-identical
+  seven — no section gives one authoritative, closed enumeration.
+
+- 🟡 **Clarity**: Dispatch-token naming example appears to contradict the
+  resolved subcommand vocabulary
+  **Location**: Technical Notes
+  The 2026-08-01 note implies a `work-item` dispatch token, while the rest
+  of the document (including the 2026-08-05 resolution) establishes `work`
+  as the subcommand namespace — unclear whether this is stale or signals a
+  genuinely different registered token.
+
+#### Minor
+
+- 🔵 **Clarity**: Bare "resolved Q2"/"resolved Q7" references require
+  chasing an external document's numbering
+  **Location**: Summary, Requirements, Assumptions
+  Neither question is restated inline, so a reader relying on this work
+  item alone can't verify what was resolved without opening and counting
+  through the source research document.
+
+- 🔵 **Completeness**: Story does not identify who or what benefits from
+  the work
+  **Location**: Context
+  The Summary/Context describe technical scope but no beneficiary (e.g.,
+  skill authors, future maintainers) is named, as the Story kind calls for.
+
+- 🔵 **Completeness**: Status remains "draft" despite content that reads
+  as implementation-ready
+  **Location**: Frontmatter: status
+  Both named blockers are done, the sole open question is resolved, and
+  Acceptance Criteria/Technical Notes are implementation-level detailed —
+  more typical of `ready` than `draft`.
+
+- 🔵 **Dependency**: 0187's blocker-resolved status rests on informal
+  confirmation the work item itself flags as unconfirmed
+  **Location**: Dependencies
+  Dependencies asserts 0187 is "done," but Drafting Notes notes 0187's own
+  frontmatter still shows `status: ready` and that updating it was left
+  out of scope — the blocker-cleared claim rests on informal confirmation
+  rather than the authoritative field.
+
+- 🔵 **Scope**: Legacy-script characterization work is a distinct
+  engineering activity bundled into the feature story
+  **Location**: Requirements
+  Writing characterization tests for ~14 untested bash scripts is
+  test-debt closure ahead of a port, a different kind of work from
+  building the new CRUD/sync capability, even though it's a reasonable
+  precondition for a safe port.
+
+- 🔵 **Testability**: "A characterization test captures its pre-port
+  behaviour" sets no coverage bar
+  **Location**: Acceptance Criteria
+  No minimum bar (flags covered, error paths, etc.) is specified, so a
+  single trivial test would technically satisfy the letter of the
+  criterion.
+
+- 🔵 **Testability**: "fully populated frontmatter" lacks an in-document
+  definition
+  **Location**: Acceptance Criteria
+  The `create` criterion doesn't state which fields constitute "fully
+  populated," nor reference a schema, leaving a verifier unable to
+  determine a failing case from this document alone.
+
+#### Suggestions
+
+- 🔵 **Clarity**: Lowercase "the remote tracker" risks conflation with the
+  capitalised `RemoteTracker` port
+  **Location**: Context
+  The generic external-system phrasing sits close to the capitalised
+  trait name introduced in the same document, inviting a quick
+  misreading.
+
+- 🔵 **Clarity**: "commit sequence" in AC3 could be misread as a VCS
+  operation
+  **Location**: Acceptance Criteria
+  In a codebase where jj/git commits are a heavily-discussed concept,
+  "the per-item commit sequence" could briefly read as a VCS commit rather
+  than the sync pipeline's own write sequencing.
+
+- 🔵 **Testability**: "explicitly-tagged contract/integration suite"
+  doesn't name the tag or mechanism
+  **Location**: Acceptance Criteria
+  The parity-suite criterion doesn't name the specific tagging convention
+  (e.g., a nextest filter or cargo feature) a verifier would check network
+  isolation against.
+
+### Strengths
+
+- ✅ Acceptance Criteria are unusually thorough for a story, using
+  consistent Given/When/Then framing and anchoring several criteria to
+  concrete pre-existing parity fixtures (e.g., `work-item-sync-classify.sh`,
+  `work-item-sync-decide.sh`).
+- ✅ Dependencies is fully worked and consistently referenced: prior
+  blockers (0166, 0187) are marked done with dates, and crate/binary naming
+  (`accelerator-work`, `tracker`) is used consistently throughout.
+- ✅ Technical Notes captures a complete, dated resolution of the
+  subcommand-vocabulary open question, including a concrete naming gotcha
+  (dispatch-token underscore restriction) and a mapping of each legacy
+  script to its new home.
+- ✅ The Drafting Notes proactively acknowledge that the tracker/
+  accelerator-work split is "tightly related but separable," showing
+  self-awareness of the decomposition question the scope lens later raises
+  independently.
+- ✅ The tracker crate's public-API purity criterion ("no `reqwest` or
+  provider-crate types in public signatures") is a strong example of a
+  testable, mechanically-checkable design constraint.
+
+### Recommended Changes
+
+1. **Split the story into a lifecycle-CRUD story and a tracker+sync story**
+   (addresses: "Story bundles lifecycle CRUD and the sync engine," "story
+   kind looks undersized," "in-process wiring of 0171's client adapters")
+   Separate `accelerator-work`'s CRUD surface (`create`/`update`/`show`/
+   `resolve`/`diff`/`next-number`/`normalise`/`section-diff`) from the
+   `tracker` crate and `sync` command; sequence sync after CRUD since it
+   depends on local file operations, and let each land independently.
+
+2. **Consolidate the ~14-script list into one authoritative enumeration**
+   (addresses: "the ~14 ... enumerated inconsistently," "characterization-
+   test criterion has no fixed, enumerable scope")
+   Give a single exact list referenced consistently by Requirements, AC5,
+   and the Technical Notes' internal-only list, rather than three
+   overlapping partial subsets.
+
+3. **Add an explicit Blocks relationship from 0170 to 0171 and clarify
+   real-provider wiring timing** (addresses: "0171 ... not captured as a
+   Blocks entry," "in-process wiring of 0171's client adapters")
+   Add `blocks: ["work-item:0171"]` to frontmatter and a Dependencies
+   bullet naming the `RemoteTracker`-port coupling; state explicitly
+   whether this story's own completion requires real-provider wiring or
+   only the faked port.
+
+4. **Replace "the dispatcher succeeds" with a concrete named condition**
+   (addresses: "'the dispatcher' in AC1 has no defined referent")
+   Name the actual gate, e.g. "the remote create call via the wired
+   `RemoteTracker` client succeeds," to avoid confusion with launcher-level
+   dispatch.
+
+5. **Reconcile the Technical Notes' dispatch-token example with the
+   resolved subcommand vocabulary** (addresses: "Dispatch-token naming
+   example appears to contradict the resolved subcommand vocabulary")
+   Confirm the registered token is `work` (dropping the now-irrelevant
+   hyphen/underscore example) or explain why a different token applies.
+
+6. **Add Acceptance Criteria for `show`, `resolve`, and `diff`**
+   (addresses: "No Acceptance Criteria for three of the six user-facing
+   subcommands")
+   Give each a Given/When/Then criterion, ideally anchored to the bash
+   scripts they replace (`work-item-read-field.sh`/`work-item-read-status.sh`,
+   `work-item-resolve-id.sh`, `work-item-section-diff.sh`).
+
+7. **Move the subcommand-grouping caveat from Drafting Notes into Open
+   Questions** (addresses: "Open Questions declares 'None' while Drafting
+   Notes admits an unresolved design risk")
+   Surface it as a live, lower-priority question to validate once
+   `accelerator-work` scaffolding starts.
+
+8. **Reconcile status fields with actual readiness** (addresses: "Status
+   remains 'draft' despite content that reads as implementation-ready,"
+   "0187's blocker-resolved status rests on informal confirmation")
+   Update 0170's `status` to `ready` if intended, and update 0187's
+   frontmatter `status` field to `done` rather than relying on informal
+   confirmation.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: 0170 is a mature, well-structured draft: consistent naming of
+the accelerator-work binary, the tracker crate, and the sync pipeline stages
+keeps most referents unambiguous, and the Given/When/Then Acceptance
+Criteria are largely self-contained. The main clarity gaps are a handful of
+undefined or inconsistent terms — an unexplained "the dispatcher" in AC1, a
+dispatch-token example in Technical Notes that appears to contradict the
+resolved subcommand vocabulary, an inconsistently enumerated "~14 scripts"
+set across three sections, and bare "resolved Q2/Q7" cross-references that
+require the reader to chase an external document's numbering.
+
+**Strengths**:
+- Crate and binary naming (accelerator-work, tracker, "the work binary") is
+  used consistently throughout, so the reader never has to guess which
+  component a reference points to.
+- The five-state sync classification (unsynced / local-ahead / remote-ahead
+  / in-sync / conflict) is spelled out explicitly in AC3 rather than left
+  implicit.
+- The Open Questions section explicitly states "None" and points to
+  exactly where the one resolved question is documented (Technical Notes),
+  rather than leaving a stale placeholder.
+
+**Findings**:
+- 🟡 major/high — "the dispatcher" in AC1 has no defined referent.
+  **Location**: Acceptance Criteria. AC1 gates the no-partial-file
+  substitution on "the dispatcher" succeeding, but that term is a term of
+  art elsewhere in the epic (launcher dispatch) and never defined here.
+- 🟡 major/medium — The "~14 previously-untested work-item-* scripts" set
+  is enumerated inconsistently. **Location**: Acceptance Criteria /
+  Technical Notes. Three sections give three different partial lists with
+  no single closed enumeration.
+- 🟡 major/medium — Dispatch-token naming example appears to contradict the
+  resolved subcommand vocabulary. **Location**: Technical Notes. The
+  2026-08-01 note implies token `work-item`; the rest of the document
+  establishes `work`.
+- 🔵 minor/medium — Bare "resolved Q2"/"resolved Q7" references require
+  chasing an external document's numbering. **Location**: Summary,
+  Requirements, Assumptions.
+- 🔵 suggestion/low — Lowercase "the remote tracker" risks conflation with
+  the capitalised `RemoteTracker` port. **Location**: Context.
+- 🔵 suggestion/low — "commit sequence" in AC3 could be misread as a VCS
+  operation. **Location**: Acceptance Criteria.
+
+### Completeness
+
+**Summary**: The work item is structurally strong: every expected section
+is present and most are unusually well populated, especially Acceptance
+Criteria (eight specific Given/When/Then criteria) and Technical Notes (a
+fully worked subcommand-vocabulary resolution). The main completeness gaps
+are a status field that appears to lag the content's actual readiness, an
+acknowledged design uncertainty that lives only in Drafting Notes rather
+than being surfaced in Open Questions, and the absence of an explicit
+statement of who benefits from this story, which the Story kind calls for.
+
+**Strengths**:
+- Acceptance Criteria are exceptionally thorough for a story — eight
+  Given/When/Then criteria covering create, update, sync classification/
+  decision tables, characterization testing of untested scripts, parity-
+  suite passage, the tracker crate's dependency-graph purity, and script/
+  suite removal.
+- Dependencies is fully worked: prior blockers (0166, 0187) are explicitly
+  marked done with a date, the 0171 relationship is characterized, and the
+  parent epic is named.
+- Technical Notes captures a complete, dated resolution of the subcommand-
+  vocabulary open question, including the mapping of each legacy script to
+  its new home (subcommand vs. private function) and a concrete naming
+  gotcha (dispatch token underscore restriction).
+- Requirements and Context together give an implementer enough
+  architectural grounding to begin work without further clarification on
+  scope.
+
+**Findings**:
+- 🔴 major/high — Open Questions declares "None" while Drafting Notes
+  admits an unresolved design risk. **Location**: Open Questions.
+- 🔵 minor/medium — Story does not identify who or what benefits from the
+  work. **Location**: Context.
+- 🔵 minor/medium — Status remains "draft" despite content that reads as
+  implementation-ready. **Location**: Frontmatter: status.
+
+### Dependency
+
+**Summary**: 0170 does a good job resolving its two named upstream
+blockers (0166, 0187) with dated confirmation, but the downstream/lateral
+coupling with 0171 is inconsistently captured: the Context and Assumptions
+describe 0170's binary as linking 0171's client adapters in-process, yet
+Dependencies only lists 0171 as "Relates to... still draft" rather than as
+a blocker or a Blocks entry, and there is no frontmatter `blocks` field
+pointing at 0171. There is also an unresolved internal inconsistency about
+whether 0187 is genuinely "done" as claimed.
+
+**Strengths**:
+- Dependencies section names both prior blockers (0166, 0187) explicitly
+  and dates their resolution (2026-08-05), rather than leaving them as
+  vague prose.
+- Technical Notes proactively surfaces the no-underscore dispatch-token
+  constraint inherited from 0187, preventing a foreseeable registration
+  mistake.
+- Context and Requirements are explicit about which crate (`tracker`) is
+  shared with 0171 and what contract it exposes, giving a concrete basis
+  for coordinating the two stories even where the formal Dependencies
+  fields fall short.
+
+**Findings**:
+- 🟡 major/high — 0171 is a downstream consumer of the tracker port but is
+  not captured as a Blocks entry. **Location**: Dependencies.
+- 🟡 major/medium — In-process wiring of 0171's client adapters is
+  described as in-scope while 0171 is still draft, but this coupling isn't
+  captured as a blocker. **Location**: Summary.
+- 🔵 minor/medium — 0187's blocker-resolved status rests on informal
+  confirmation the work item itself flags as unconfirmed in the
+  authoritative record. **Location**: Dependencies.
+
+### Scope
+
+**Summary**: This story bundles two substantial, architecturally distinct
+efforts — a CRUD-style work-item lifecycle subdomain and a five-stage
+remote sync engine backed by a brand-new `tracker` crate — under a single
+story declaration, a bundling the Summary itself flags with "plus." The
+eight acceptance criteria, two new crates, a provider-agnostic port/state-
+machine, and a 14-script characterization backlog together describe multi-
+week, multi-capability scope more consistent with an epic-level unit than a
+single story. The item is otherwise well-bounded in its detail (resolved
+open questions, explicit dependency state), but the unit of delivery itself
+looks too large and too internally heterogeneous.
+
+**Strengths**:
+- The Drafting Notes explicitly acknowledge the tracker/accelerator-work
+  split is "tightly related but separable," showing the author already
+  recognises the decomposition question rather than glossing over it.
+- The resolved subcommand-vocabulary section gives a concrete, bounded
+  shape to what would otherwise be an open-ended 22-script consolidation,
+  meaningfully narrowing the scope of the CRUD side of the story.
+- Dependencies are cleanly resolved (0166, 0187 done) and the relationship
+  to the sibling 0171 story is named explicitly rather than left implicit.
+
+**Findings**:
+- 🔴 major/high — Story bundles lifecycle CRUD and the sync engine as two
+  independently deliverable concerns. **Location**: Summary.
+- 🟡 major/medium — Declared "story" kind looks undersized for the
+  described scope. **Location**: Frontmatter: kind.
+- 🔵 minor/medium — Legacy-script characterization work is a distinct
+  engineering activity bundled into the feature story. **Location**:
+  Requirements.
+
+### Testability
+
+**Summary**: Most Acceptance Criteria are strongly testable: they use
+Given/When/Then framing, tie to existing bash parity fixtures, and one
+criterion (the tracker crate's dependency-graph purity check) is a model of
+a concrete, mechanically-verifiable design constraint. The two significant
+gaps are an incompletely-enumerated criterion for the ~14 characterization
+tests (using an approximate count plus "etc.") that cannot be conclusively
+checked off, and the absence of any Acceptance Criteria for three of the
+six user-facing subcommands described in the Technical Notes (`show`,
+`resolve`, `diff`).
+
+**Strengths**:
+- Acceptance Criteria consistently use Given/When/Then framing appropriate
+  for a story, with explicit preconditions and observable outcomes rather
+  than implementation instructions.
+- Several criteria anchor verification to concrete, pre-existing artefacts
+  (e.g., "work-item-sync-classify.sh parity fixtures," "work-item-sync-
+  decide.sh's forbidden-write cells"), giving a tester an unambiguous
+  oracle to compare against.
+- The tracker crate's public-API purity criterion is an excellent example
+  of a testable, mechanically-checkable design constraint rather than a
+  subjective quality statement.
+
+**Findings**:
+- 🔴 major/high — Characterization-test criterion has no fixed, enumerable
+  scope. **Location**: Acceptance Criteria.
+- 🟡 major/medium — No Acceptance Criteria for three of the six user-facing
+  subcommands (`show`, `resolve`, `diff`). **Location**: Acceptance
+  Criteria.
+- 🔵 minor/medium — "A characterization test captures its pre-port
+  behaviour" sets no coverage bar. **Location**: Acceptance Criteria.
+- 🔵 minor/low — "fully populated frontmatter" lacks an in-document
+  definition. **Location**: Acceptance Criteria.
+- 🔵 suggestion/low — "explicitly-tagged contract/integration suite"
+  doesn't name the tag or mechanism. **Location**: Acceptance Criteria.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-05T18:18:52+00:00
+
+**Verdict:** APPROVE *(overridden from the suggested COMMENT verdict by Toby
+Clemson on 2026-08-05T19:12:57+00:00 — the two remaining items are an
+explicitly by-design status-field deferral and an accepted scope
+trade-off, neither a quality gap in the work item itself.)*
+
+All eight recommended changes were addressed, most substantially via a
+story split: 0170 (Work-Item Subdomain and Sync Engine) split into 0170
+(Work-Item Lifecycle Subdomain) and a new sibling, 0194 (Tracker Crate and
+Remote Sync Engine). 0171 and the parent epic 0136 were updated in lockstep
+to keep the dependency graph coherent. All five lenses were re-run against
+the updated 0170; the split resolved every major finding from Pass 1, and
+the re-review surfaced a small number of new issues — mostly artefacts of
+the split itself — all of which were fixed in this same pass.
+
+### Previously Identified Issues
+
+- 🟡 **Scope**: Story bundles lifecycle CRUD and the sync engine — Resolved
+  (split into 0170 + 0194).
+- 🟡 **Scope**: Declared "story" kind undersized — Resolved (each split
+  item is story-sized; confirmed by the scope re-review).
+- 🟡 **Dependency**: 0171 not captured as a Blocks entry — Resolved (0194
+  now `blocks: ["work-item:0170", "work-item:0171"]`).
+- 🟡 **Dependency**: In-process wiring of 0171's client adapters not
+  captured as a blocker — Resolved (dependency direction clarified: 0194's
+  `RemoteTracker` port blocks both 0170's `--push` flows and 0171).
+- 🔴 **Completeness**: Open Questions declares "None" while Drafting Notes
+  admits an unresolved risk — Resolved (the subcommand-grouping caveat now
+  lives in Open Questions on both 0170 and 0194).
+- 🔴 **Testability**: Characterization-test criterion has no fixed,
+  enumerable scope — Resolved (verified against the actual
+  `skills/work/scripts/` inventory: 11 lifecycle-side scripts in 0170, 4
+  sync-side scripts in 0194, cross-checked against which already have a
+  dedicated `test-work-item-*.sh` suite).
+- 🟡 **Testability**: No Acceptance Criteria for `show`/`resolve`/`diff` —
+  Resolved (three new Given/When/Then criteria added).
+- 🟡 **Clarity**: "the dispatcher" in AC1 has no defined referent —
+  Resolved (reworded to name the `RemoteTracker` port explicitly).
+- 🟡 **Clarity**: The ~14-script set enumerated inconsistently — Resolved
+  (same fix as the testability finding above).
+- 🟡 **Clarity**: Dispatch-token example contradicts the resolved
+  vocabulary — Resolved (Technical Notes reconciled to confirm the token is
+  `work`).
+- 🔵 **Clarity**: Bare "resolved Q2"/"resolved Q7" references — Resolved,
+  then further tightened in this pass after the re-review found the
+  "Resolved QN" labels themselves had become orphaned once the original
+  numbered Open Questions list no longer existed in the document; both
+  items now state the decisions as plain prose with no dangling Q-number.
+- 🔵 **Completeness**: No beneficiary named for a story-kind item —
+  Resolved (Context now names plugin maintainers as the beneficiary).
+- 🔵 **Completeness**: Status remains "draft" despite ready-looking content
+  — Still present, by design: status transitions are a separate workflow
+  decision, not made during work item editing.
+- 🔵 **Dependency**: 0187's "done" status rests on informal confirmation —
+  Still present, by design (same reason).
+- 🔵 **Scope**: Characterization-test debt bundled with feature delivery —
+  Still present; re-confirmed as a defensible, explicitly-accepted
+  trade-off rather than fixed.
+- 🔵 **Testability**: "captures its pre-port behaviour" sets no coverage
+  bar — Resolved (both items' characterization ACs now require covering
+  each flag/argument combination and at least one error path).
+- 🔵 **Testability**: "fully populated frontmatter" undefined — Resolved
+  (AC1 now references the `create-work-item` template schema).
+- 🔵 **Clarity**: Lowercase "the remote tracker" risked conflation with the
+  port — Resolved as a side effect of the split (the phrase no longer
+  appears in 0170's rewritten Context).
+- 🔵 **Clarity**: "commit sequence" could be misread as a VCS operation —
+  Resolved as a side effect of the split (0194's classify/decide AC now
+  says "write sequence").
+- 🔵 **Testability**: Contract/integration suite tag unnamed — Partially
+  resolved (both items now name the mechanism — a cargo-nextest filter
+  excluded from the default `cargo test`/`cargo nextest run` invocation —
+  though not a specific filter name).
+
+### New Issues Introduced
+
+- 🔴 **Clarity**: "Resolved Q2"/"Resolved Q7" labels became orphaned
+  references once the original numbered Open Questions list no longer
+  existed in the document — Resolved (both items restate the decisions as
+  plain prose).
+- 🟡 **Clarity**: Dependencies' "no remaining blockers of its own" read as
+  self-contradictory next to the following "Blocked by: 0194" bullet —
+  Resolved (reworded to scope the claim to the pre-split blockers
+  explicitly).
+- 🟡 **Clarity**: "the existing push state machine" was undefined and
+  risked conflation with 0194's distinct sync state machine — Resolved
+  (AC1 now names `work-item-create-remote.sh`'s existing outcome table
+  instead of an invented "state machine" term).
+- 🔴 **Testability** / 🔵 **Scope**: `work-item-fetch-remote.sh`'s test
+  suite was named in 0170's parity gate and removal criterion, but no
+  command in either split item actually absorbs its behaviour — it is a
+  dependency of `work-item-sync-apply.sh`, not of any lifecycle command —
+  Resolved (moved to 0194's scope; 0170's parity/removal criteria no
+  longer reference it).
+- 🔵 **Clarity**: "RemoteTracker client" (AC1) vs. "RemoteTracker port"
+  (Requirements/Assumptions) — inconsistent terminology — Resolved
+  (AC1 now says "port" throughout).
+- 🔵 **Completeness**: The known stale `external_id` (still reflecting the
+  pre-split scope) was recorded only in Drafting Notes, not as a trackable
+  follow-up — Resolved (added to Open Questions).
+- 🔵 **Dependency**: 0171 named in Assumptions as part of the real-wiring
+  path but absent from Dependencies/`relates_to` — Resolved (added a
+  `relates_to` entry and a Dependencies bullet).
+- 🔵 **Testability**: Push-failure branches for `create`/`update --push`
+  were only implied, not stated as their own observable outcome —
+  Resolved (both criteria now verified against the actual documented
+  failure behaviour — `create`'s outcome table, `update`'s
+  retryable/terminal exit taxonomy — rather than an invented claim).
+- 🔵 **Clarity**: The filename `0170-work-item-subdomain-and-sync-engine.md`
+  still names the pre-split scope even though the title and body now read
+  "Work-Item Lifecycle Subdomain" — Not resolved; accepted as a low-cost
+  cosmetic trade-off (renaming would require updating an inbound reference
+  in 0179) rather than a substantive gap.
+
+### Assessment
+
+0170 and its new sibling 0194 are both in good shape for planning. The
+story-scope, dependency-graph, and enumeration issues that drove the
+original REVISE verdict are resolved through the split; the issues the
+split itself introduced (mostly terminology drift and one script
+mis-assigned to the wrong item) were caught by the re-review and fixed in
+this same pass. What remains is two by-design deferrals (status-field
+transitions, left to a separate workflow) and one accepted scope trade-off
+(characterization-test debt bundled with feature work) — neither blocks
+implementation. Recommended next step: `/update-work-item` to reconcile
+0170's and 0187's `status` fields, and a future `/sync-work-items` pass to
+push 0170's narrowed scope to its existing remote issue (PP-191) and create
+a new remote issue for 0194.

--- a/meta/reviews/work/0194-tracker-crate-and-remote-sync-engine-review-1.md
+++ b/meta/reviews/work/0194-tracker-crate-and-remote-sync-engine-review-1.md
@@ -1,0 +1,402 @@
+---
+type: work-item-review
+id: "0194-tracker-crate-and-remote-sync-engine-review-1"
+title: "Work Item Review: Tracker Crate and Remote Sync Engine"
+date: "2026-08-05T19:37:49+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0194"
+work_item_id: "0194"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-05T19:56:06+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Tracker Crate and Remote Sync Engine
+
+**Verdict:** COMMENT
+
+0194 is a well-formed, clearly-scoped split-off from 0170 with strong
+Acceptance Criteria (concrete Given/When/Then statements anchored to existing
+bash parity fixtures) and a thorough Context/Drafting Notes trail explaining
+the split rationale and the reversed sequencing it introduced. The findings
+below are mostly minor polish and one major gap: the "side effect first,
+baseline write last" resumability contract — the highest-risk property in a
+sync engine — is asserted in Acceptance Criteria without a verification
+procedure, and two lenses independently flag consequences of the sequencing
+reversal that the document doesn't fully carry through.
+
+### Cross-Cutting Themes
+
+- **Underspecified resumability contract** (flagged by: testability, clarity)
+  — the "side effect first, baseline write last" resumability contract named
+  in AC1 is never defined or given a verification method anywhere in the
+  document, and clarity independently flags it as a term used without a
+  citation or inline gloss (alongside "the decision table" and
+  `work.integration`).
+- **Reversed sequencing has loose ends** (flagged by: scope, dependency) — the
+  split now has 0194 precede 0170 rather than depend on it, but two
+  consequences of that reversal aren't fully worked through: the Dependencies
+  section frames 0170/0171's blocking need narrower ("the port is stable")
+  than the item's actual Acceptance Criteria gate (the full sync command,
+  test suites, and script removal), and 0194 doesn't carry the 0187
+  sub-binary registration checklist that its sibling 0170 references, even
+  though 0194 may now be the first story to exercise it.
+
+### Findings
+
+#### Major
+
+- 🟡 **Testability**: Resumability contract in AC1 names a property without a
+  verification procedure
+  **Location**: Acceptance Criteria
+  AC1 requires the write sequence to honour the "side effect first, baseline
+  write last" resumability contract but doesn't specify how that would be
+  checked — e.g. via write-order assertions on a recording fake, or a
+  crash-injection test.
+
+#### Minor
+
+- 🟡 **Scope**: Blocking dependency is framed narrower than the item's own
+  Acceptance Criteria gate
+  **Location**: Dependencies
+  Dependencies says 0170/0171 are blocked only until "the port is stable,"
+  but this item's Acceptance Criteria bundle the port together with the full
+  sync command, four characterization suites, and script removal — none of
+  which the blocked siblings actually need.
+
+- 🟡 **Dependency**: Sub-binary registration coupling (0187 checklist)
+  referenced by 0170 but not by 0194
+  **Location**: Technical Notes / Dependencies
+  0170 cites the 0187 registration checklist for wiring the dispatch token;
+  0194, which may now land first and first exercise the work binary's
+  composition root, doesn't mention it.
+
+- 🔵 **Completeness**: Requirements section omits scope that only appears in
+  Acceptance Criteria
+  **Location**: Requirements
+  AC4's nextest-filter partitioning and AC6's script-removal/floor-decrement
+  work are introduced only in Acceptance Criteria, with no mirroring
+  Requirements bullet.
+
+- 🔵 **Clarity**: Several domain terms/config keys are used without inline
+  definition or link
+  **Location**: Requirements; Acceptance Criteria
+  `work.integration`, "the decision table," and the "side effect first,
+  baseline write last" resumability contract are each used with a definite
+  article but never defined or cited within the document.
+
+- 🔵 **Clarity**: The sync-stage internal-function boundary is presented as
+  both settled and open
+  **Location**: Technical Notes; Open Questions
+  Technical Notes states unconditionally that the five stages stay internal
+  functions; Open Questions immediately asks whether that same boundary
+  "holds" — leaving unclear whether it's fixed or provisional.
+
+- 🔵 **Dependency**: Assumption about workspace-wide `reqwest` implicitly
+  depends on the launcher (0164) without naming it in Dependencies
+  **Location**: Assumptions
+  The Assumptions section relies on 0164 having landed workspace-wide
+  `reqwest`, but 0164 isn't listed in Dependencies alongside 0166/0187.
+
+#### Suggestions
+
+- 🔵 **Testability**: AC5 conflates two distinct verification mechanisms
+  **Location**: Acceptance Criteria
+  A dependency-graph check and a public-signature check are different
+  procedures with different failure modes; AC5 reads as if one inspection
+  covers both.
+
+- 🔵 **Testability**: Composition-root provider wiring has no corresponding
+  Acceptance Criterion
+  **Location**: Requirements
+  The Requirements' claim that provider selection is wired per
+  `work.integration` has no Acceptance Criterion verifying the selection
+  logic itself.
+
+- 🔵 **Testability**: No criterion verifies the fake `RemoteTracker` conforms
+  to the same contract as future real implementations
+  **Location**: Assumptions
+  Nothing establishes that the fake and 0171's eventual real implementation
+  must satisfy an identical shared contract test.
+
+- 🔵 **Scope**: Item combines novel port/design work with command build-out
+  and script retirement
+  **Location**: Requirements
+  A wide set of distinct engineering activities for one story, mirroring its
+  sibling's granularity but with schedule risk concentrated in the
+  not-yet-finalized port design (see Open Questions).
+
+- 🔵 **Clarity**: Bare "(resolved Q2)" citation has no inline referent
+  **Location**: Assumptions
+  The `reqwest` assumption cites "Q2" without naming what it refers to;
+  confirming it requires opening the linked research document.
+
+### Strengths
+
+- ✅ Acceptance Criteria are consistently phrased as concrete Given/When/Then
+  statements anchored to existing bash parity fixtures and named scripts,
+  giving an unambiguous, externally-verifiable definition of done.
+- ✅ Context and Drafting Notes give a well-evidenced rationale for the split
+  from 0170 (tracker crate depends only on already-built shared crates) and
+  are cross-checked as consistent with 0170's own Context, Dependencies, and
+  Drafting Notes.
+- ✅ Both downstream consumers of the shared `RemoteTracker` port (0170,
+  0171) are named as Blocks with the specific coupling mechanism, and
+  provider-specific concerns are deliberately kept out of scope — even
+  verified by an Acceptance Criterion checking the crate's public API for
+  provider/HTTP types.
+- ✅ Technical Notes enumerates the exact source-bash inventory being
+  ported/retired and pre-empts an obvious implementer question about
+  `work-item-fetch-remote.sh`'s existing test coverage.
+
+### Recommended Changes
+
+1. **Specify a verification procedure for the resumability contract**
+   (addresses: "Resumability contract in AC1 names a property without a
+   verification procedure") — add a concrete mechanism to AC1, e.g. a
+   write-order assertion against a recording fake store, or a
+   crash-injection test that interrupts between the side-effect write and
+   the baseline write and confirms a resumed run reaches the same terminal
+   state.
+
+2. **Reconcile the Dependencies blocking claim with the AC gate, or split
+   the port-stabilization milestone out** (addresses: "Blocking dependency
+   is framed narrower than the item's own Acceptance Criteria gate") —
+   clarify whether 0170/0171 can proceed once the port trait compiles, or
+   accept that they wait for the full bundle.
+
+3. **Add a 0187 registration-checklist cross-reference to Technical Notes**
+   (addresses: "Sub-binary registration coupling referenced by 0170 but not
+   by 0194") — mirror 0170's note now that 0194 may exercise the
+   composition root first.
+
+4. **Mirror AC4/AC6 scope in Requirements** (addresses: "Requirements
+   section omits scope that only appears in Acceptance Criteria") — add
+   bullets covering the nextest-filter partitioning and script
+   removal/floor decrement.
+
+5. **Gloss or cite undefined terms** (addresses: "Several domain terms/config
+   keys are used without inline definition or link", "Bare '(resolved Q2)'
+   citation has no inline referent") — add short parentheticals or citations
+   for `work.integration`, "the decision table," the resumability contract,
+   and the Q2 reference.
+
+6. **Resolve the settled-vs-open tension on the internal-function boundary**
+   (addresses: "The sync-stage internal-function boundary is presented as
+   both settled and open") — either soften the Technical Notes statement as
+   provisional or narrow the Open Question.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: 0194 is largely clear and internally consistent: the tracker
+crate, the RemoteTracker port, and the five-stage sync pipeline are named
+once and then referred to consistently across Summary, Context,
+Requirements, and Acceptance Criteria, and its account of the split from
+0170 matches 0170's own text almost exactly. A small number of domain terms
+and cross-references are asserted with a definite article or a bare
+citation but never defined or linked within the document itself, and one
+Technical Notes statement reads as settled while the adjacent Open Question
+treats the same point as still unresolved.
+
+**Strengths**:
+- Terminology for the crate, the port, and the pipeline stages is used
+  consistently throughout.
+- The item's narrative of the 0170 split is cross-checked against and
+  matches 0170's own Context, Dependencies, and Drafting Notes.
+- Acceptance criteria consistently name the actor and trigger and tie each
+  expected outcome to a specific named existing script for comparison.
+
+**Findings**:
+- 🔵 Suggestion (medium confidence) — Bare "(resolved Q2)" citation has no
+  inline referent. Location: Assumptions.
+- 🔵 Minor (medium confidence) — Several domain terms/config keys are used
+  without inline definition or link. Location: Requirements; Acceptance
+  Criteria.
+- 🔵 Minor (medium confidence) — The sync-stage internal-function boundary
+  is presented as both settled and open. Location: Technical Notes; Open
+  Questions.
+
+### Completeness
+
+**Summary**: 0194 is an unusually complete work item for a freshly-split
+story: every expected section is present and substantively populated, the
+Acceptance Criteria are expressed as detailed Given/When/Then statements,
+and Context/Drafting Notes trace the split rationale and dependency
+reversal in full. Frontmatter is intact and kind-appropriate. The only gap
+found is a minor asymmetry between the Requirements section and the
+Acceptance Criteria.
+
+**Strengths**:
+- Acceptance Criteria are all phrased as specific Given/When/Then statements
+  referencing concrete artefacts.
+- Context section explains both the mechanical and process motivation for
+  the item's existence.
+- Dependencies section explicitly confirms both pre-split blockers are
+  resolved and states the direction and reason for outbound blocking
+  relationships.
+- Technical Notes enumerates the exact source-bash inventory being
+  ported/retired and pre-empts an obvious implementer question.
+
+**Findings**:
+- 🔵 Minor (medium confidence) — Requirements section omits scope that only
+  appears in Acceptance Criteria. Location: Requirements.
+
+### Dependency
+
+**Summary**: 0194 captures its primary couplings well: upstream blockers
+(0166, 0187) are named and correctly marked resolved, and the two
+downstream consumers of the RemoteTracker port (0170, 0171) are both
+explicit Blocks entries with a clear rationale. The main gap is a
+second-order ordering question the split introduced: since 0194 now
+precedes 0170, it may be the first story to scaffold the accelerator-work
+binary, but it doesn't carry the sub-binary registration coupling that
+0170's own Technical Notes reference.
+
+**Strengths**:
+- Dependencies section explicitly names both prior blockers, states they
+  are done, and gives the precise reason the story is unblocked.
+- Both downstream consumers of the shared RemoteTracker port artefact are
+  listed as Blocks with the specific coupling mechanism named, verified
+  consistent with 0170's own frontmatter.
+- The story deliberately keeps provider-specific/external-system coupling
+  out of its own scope, correctly deferring that coupling to 0171.
+
+**Findings**:
+- 🟡 Minor (medium confidence) — Sub-binary registration coupling (0187
+  checklist) referenced by 0170 but not by 0194, despite 0194 now preceding
+  it. Location: Technical Notes / Dependencies.
+- 🔵 Minor (low confidence) — Assumption about workspace-wide reqwest
+  implicitly depends on the launcher (0164) without naming it in
+  Dependencies. Location: Assumptions.
+
+### Scope
+
+**Summary**: 0194 is a well-formed split-off from 0170's originally
+epic-scale story: the tracker crate and the sync command form one
+coherent, service-boundary-respecting unit, and the Summary/Requirements/
+Acceptance Criteria stay in alignment throughout. The one scope-relevant
+wrinkle is that the item's own Dependencies section distinguishes between
+"the port being stable" and the item's full Acceptance Criteria gate,
+bundling these as a single indivisible deliverable.
+
+**Strengths**:
+- Context and Drafting Notes document a concrete, evidence-based rationale
+  for the split, rather than an arbitrary halving of a large story.
+- Summary, Requirements, and Acceptance Criteria describe the same scope
+  throughout, with no mismatched or bolted-on capability.
+- The item explicitly keeps provider-specific concerns out of scope,
+  cleanly respecting the service boundary with 0171.
+
+**Findings**:
+- 🟡 Minor (medium confidence) — Blocking dependency is framed narrower
+  than the item's own Acceptance Criteria gate. Location: Dependencies.
+- 🔵 Suggestion (low confidence) — Item combines novel port/state-machine
+  design with command build-out and script retirement. Location:
+  Requirements.
+
+### Testability
+
+**Summary**: Most Acceptance Criteria are strong: they anchor verification
+to concrete external oracles and bound the characterization-test criterion
+to documented flag/argument combinations plus at least one error path. The
+main weaknesses are AC1's resumability-contract clause, which names a
+property without specifying how compliance is checked, and AC5's
+verification method, which conflates a dependency-graph check with a
+public-API-signature check as if they were one procedure.
+
+**Strengths**:
+- AC1 and AC2 anchor verification to existing, named external oracles,
+  giving a definitive pass/fail procedure.
+- AC3 bounds the characterization-test obligation concretely.
+- AC4 gives a clear, mechanically checkable separation between the default
+  no-network test run and a separately tagged contract/integration suite.
+- AC6 is a concrete, binary check rather than a vague "cleanup is done"
+  claim.
+
+**Findings**:
+- 🟡 Major (medium confidence) — Resumability contract in AC1 names a
+  property without a verification procedure. Location: Acceptance
+  Criteria.
+- 🔵 Minor (medium confidence) — AC5 conflates two distinct verification
+  mechanisms. Location: Acceptance Criteria.
+- 🔵 Suggestion (low confidence) — Composition-root provider wiring has no
+  corresponding Acceptance Criterion. Location: Requirements.
+- 🔵 Suggestion (low confidence) — No criterion verifies the fake
+  RemoteTracker conforms to the same contract as future real
+  implementations. Location: Assumptions.
+
+
+## Re-Review (Pass 2) — 2026-08-05T19:56:06+00:00
+
+**Verdict:** APPROVE (verdict overridden by reviewer from COMMENT)
+
+### Previously Identified Issues
+
+- 🟡 **Testability**: Resumability contract in AC1 names a property without a
+  verification procedure — Resolved. AC1 now specifies a concrete two-part
+  verification mechanism: a write-order assertion via a fake store, plus a
+  crash-then-rerun determinism check.
+- 🟡 **Scope**: Blocking dependency is framed narrower than the item's own
+  Acceptance Criteria gate — Resolved. Both Blocks entries now explicitly
+  state the blocking milestone is the `RemoteTracker` port signature
+  compiling, not the full AC gate.
+- 🟡 **Dependency**: Sub-binary registration coupling (0187 checklist)
+  referenced by 0170 but not by 0194 — Resolved. Technical Notes now cites
+  the same 0187 registration checklist that 0170 references, tied to the
+  reversed-sequencing rationale.
+- 🔵 **Completeness**: Requirements section omits scope that only appears in
+  Acceptance Criteria — Resolved. Requirements now has bullets mirroring
+  AC4's test-partitioning and AC6's removal/floor-decrement scope.
+- 🔵 **Clarity**: Several domain terms/config keys used without inline
+  definition or link — Resolved. `work.integration`, "the decision table,"
+  and the resumability contract all carry inline glosses at first use.
+- 🔵 **Clarity**: The sync-stage internal-function boundary presented as
+  both settled and open — Resolved. Technical Notes now hedges the claim as
+  provisional and cross-references Open Questions.
+- 🔵 **Clarity**: Bare "(resolved Q2)" citation has no inline referent —
+  Resolved. The Assumptions bullet now names the research document and
+  Open Question 2 explicitly.
+- 🔵 **Dependency**: Assumption about workspace-wide `reqwest` implicitly
+  depends on the launcher (0164) without naming it in Dependencies — Still
+  present. Not selected for fixing; low-confidence, non-blocking per the
+  dependency lens.
+- 🔵 **Testability**: AC5 conflates two distinct verification mechanisms —
+  Still present. Not selected for fixing.
+- 🔵 **Testability**: Composition-root provider wiring has no corresponding
+  Acceptance Criterion — Still present. Not selected for fixing.
+- 🔵 **Testability**: No criterion verifies the fake `RemoteTracker`
+  conforms to the same contract as future real implementations — Still
+  present. Not selected for fixing.
+
+### New Issues Introduced
+
+- 🔵 **Clarity**: Hedge scope ("the five stages") and the Open Question it
+  cites (naming only `work-item-sync-decide.sh`) don't match — the
+  Technical Notes hedge now points to an Open Question that only names one
+  of the five stages, leaving unclear whether the other four are settled.
+- 🔵 **Clarity**: "The reversed sequencing" is used in Technical Notes before
+  its rationale is spelled out in Drafting Notes, several sections later.
+
+### Assessment
+
+The work item is ready for implementation. The major finding (the
+resumability contract's missing verification procedure) is resolved, and
+all four selected minor/suggestion fixes landed cleanly with no regressions
+in the areas they touched. The two new clarity wrinkles are minor polish
+introduced by the hedge itself, not correctness gaps, and the four
+remaining still-present items were explicitly deferred by the user's
+choice rather than missed. No further re-review is required unless the
+remaining open items are picked up later.
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
+++ b/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
@@ -11,7 +11,7 @@ priority: medium
 source: "note:2026-06-22-ideas-backlog"
 relates_to: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture", "codebase-research:2026-06-23-0136-shell-scripts-rust-cli-migration-surface"]
 tags: [rust, cli, migration, epic]
-last_updated: "2026-08-01T16:57:37+00:00"
+last_updated: "2026-08-05T18:18:52+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: PP-157
@@ -77,7 +77,9 @@ tracked on the items themselves.
 - 0168 — Fold the Visualiser into the cli/ Workspace
 - 0188 — Library-Backed VCS Adapter over gix and jj-lib *(precedes 0169)*
 - 0169 — VCS Subdomain and Hooks Migration
-- 0170 — Work-Item Subdomain and Sync Engine
+- 0194 — Tracker Crate and Remote Sync Engine *(split from 0170 on
+  2026-08-05; precedes 0170's `--push` flows and 0171's client adapters)*
+- 0170 — Work-Item Lifecycle Subdomain
 - 0171 — Jira and Linear Integrations
 - 0172 — Migration Engine Subdomain
 - 0173 — Remaining Subdomains: corpus, design, collaboration
@@ -97,7 +99,8 @@ ADR-0045/0046/0047/0051/0052/0053/0054.
       regressing skill behaviour, with the migration sequenced so the plugin
       stays functional at each step.
 - [ ] All child work items are completed: 0162–0174, plus 0185–0188 added by the
-      2026-07-31 split of 0169.
+      2026-07-31 split of 0169, plus 0194 added by the 2026-08-05 split of
+      0170.
 
 ## Open Questions
 

--- a/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
+++ b/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
@@ -11,7 +11,7 @@ priority: medium
 source: "note:2026-06-22-ideas-backlog"
 relates_to: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture", "codebase-research:2026-06-23-0136-shell-scripts-rust-cli-migration-surface"]
 tags: [rust, cli, migration, epic]
-last_updated: "2026-08-05T18:18:52+00:00"
+last_updated: "2026-08-05T22:11:33+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: PP-157
@@ -78,7 +78,8 @@ tracked on the items themselves.
 - 0188 — Library-Backed VCS Adapter over gix and jj-lib *(precedes 0169)*
 - 0169 — VCS Subdomain and Hooks Migration
 - 0194 — Tracker Crate and Remote Sync Engine *(split from 0170 on
-  2026-08-05; precedes 0170's `--push` flows and 0171's client adapters)*
+  2026-08-05; also wires `--push` onto 0170's `create`/`update` commands,
+  and precedes 0171's client adapters)*
 - 0170 — Work-Item Lifecycle Subdomain
 - 0171 — Jira and Linear Integrations
 - 0172 — Migration Engine Subdomain

--- a/meta/work/0170-work-item-subdomain-and-sync-engine.md
+++ b/meta/work/0170-work-item-subdomain-and-sync-engine.md
@@ -1,117 +1,246 @@
 ---
 type: work-item
 id: "0170"
-title: "Work-Item Subdomain and Sync Engine"
+title: "Work-Item Lifecycle Subdomain"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
+status: ready
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0187"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
-relates_to: ["work-item:0171"]
-tags: [rust, work-items, sync, tracker]
-last_updated: "2026-08-01T16:57:37+00:00"
+relates_to: ["work-item:0194", "work-item:0171"]
+blocked_by: ["work-item:0194"]
+tags: [rust, work-items]
+last_updated: "2026-08-05T18:18:52+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-191"
 ---
 
-# 0170: Work-Item Subdomain and Sync Engine
+# 0170: Work-Item Lifecycle Subdomain
 
 **Kind**: Story
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
-Build the `accelerator-work` subdomain — work-item lifecycle operations plus the
-remote sync engine — and the shared `tracker` crate (the `RemoteTracker` port and
-sync state machine), wiring the active integration client in-process at the work
-binary's composition root (resolved Q2).
+Build the `accelerator-work` subdomain's work-item lifecycle operations —
+create, show, update, resolve, diff — over the shared `corpus`/`config`/
+`store` crates, absorbing ID allocation, remote create/update, and
+tag-mutation flows from the legacy bash scripts. `create`/`update --push`
+call through 0194's `RemoteTracker` port (faked in this story's own unit
+tests); the sync engine itself is 0194's scope.
 
 ## Context
 
-`skills/work/scripts/` (22 prod scripts) covers create/fetch/update/sync/normalise/
-next-number/section-diff/read-field. Sync is a transactional state machine
-(classify → decide → apply → baseline → label) that orchestrates the remote tracker.
-Resolved Q2: the `RemoteTracker` port and the sync state machine live in their own
-`tracker` crate, and `accelerator-work` links the per-provider client adapters
-(0171) in-process and fakes the port in tests. ~14 `work-item-*` scripts have no
-dedicated test suite — a coverage gap to close.
+`skills/work/scripts/` (22 prod scripts) covers create/fetch/update/sync/
+normalise/next-number/section-diff/read-field. This story covers the
+lifecycle-CRUD half of that surface — create, update, show, resolve, diff —
+absorbing the ID-allocation and tag-mutation flows, so plugin maintainers
+inherit a typed, bash-3.2-independent, characterization-tested CLI in place
+of the current untested shell scripts backing the work-item skills. The sync engine and the
+`tracker` crate split off into 0194 on 2026-08-05 (see Drafting Notes)
+following a work item review that found the two efforts independently
+deliverable and the combined story epic-scale. The `RemoteTracker` port and
+the sync state machine live in their own `tracker` crate (0194), not inside
+`accelerator-work`; this story's `--push` flows call through that port,
+faking it in unit tests. The coverage gap for the previously-untested
+lifecycle scripts is closed via characterize-then-port — write a
+characterization test capturing each script's pre-port behaviour before
+replacing it (see Acceptance Criteria). 11 lifecycle-side `work-item-*`
+scripts have no dedicated test suite today; 0194 covers the 4 sync-side
+ones separately.
 
 ## Requirements
 
-- Implement `accelerator-work` over the shared `corpus`/`config`/`store` crates:
-  lifecycle ops (create, read-field, update, update-tags, next-number, normalise,
-  section-diff) and the sync flow (classify/decide/apply/baseline/label).
-- Implement the `tracker` crate: the `RemoteTracker` port (issue/transition/sync
-  verdict vocabulary) and the sync state machine in pure domain terms; the work
-  binary wires the active provider per `work.integration` at its composition root,
-  faking the port in unit tests.
-- Preserve the `external_id`-as-remote-key convention and the JSONL/atomic-write
-  semantics (via `store`).
-- Close the coverage gap: characterize-then-port the ~14 untested `work-item-*`
-  scripts (resolved Q7).
+- Implement `accelerator-work` over the shared `corpus`/`config`/`store`
+  crates: lifecycle ops `create`, `show` (read-field/read-status), `update`
+  (including tag mutations), `resolve`, `diff` (section-diff), plus the
+  internal helpers `next-number`, `normalise`, `pattern`,
+  `template-field-hints`, `file-dirty`, `project-remote`, and
+  `push-decide`.
+- `create --push` and `update --push` call through 0194's `RemoteTracker`
+  port (faked in this story's unit tests) to create or whole-content-replace
+  the remote issue.
+- Preserve the `external_id`-as-remote-key convention and the JSONL/
+  atomic-write semantics (via `store`).
+- Close the coverage gap: characterize-then-port the 11 previously-untested
+  lifecycle scripts — `work-item-file-dirty.sh`, `work-item-next-number.sh`,
+  `work-item-normalise.sh`, `work-item-project-remote.sh`,
+  `work-item-push-decide.sh`, `work-item-read-field.sh`,
+  `work-item-read-status.sh`, `work-item-resolve-id.sh`,
+  `work-item-section-diff.sh`, `work-item-template-field-hints.sh`,
+  `work-item-update-tags.sh` (none has a dedicated `test-work-item-*.sh`
+  suite today; `work-item-pattern.sh` already does and is out of scope
+  here).
 
 ## Acceptance Criteria
 
-- [ ] `accelerator work …` reproduces the lifecycle and sync behaviours, verified
-      against the repointed `skills/work/scripts/test-*.sh` parity gates where they
-      exist, and against characterization tests for the previously untested scripts.
-- [ ] The sync state machine is unit-tested in-process against a fake
-      `RemoteTracker`, with no live network in unit tests.
-- [ ] The `tracker` port carries no provider-specific or HTTP types; provider
-      clients (0171) implement it.
-- [ ] The migrated `work-item-*` scripts are removed and the work suite floor
-      decremented in the same change.
+- [ ] Given a fresh work item directory, when `accelerator work create`
+      runs, then it allocates the next ID per the configured pattern and
+      writes the local file with fully populated frontmatter (every field
+      the item's `kind` requires, per the `create-work-item` template
+      schema); when invoked with `--push` and the remote create call via
+      the wired (or, in unit tests, faked) `RemoteTracker` port succeeds,
+      `external_id` is substituted before the single write — no file exists
+      until success, decline, or confirmed-local-fallback resolves, per
+      `work-item-create-remote.sh`'s existing outcome table; when the
+      remote call fails, the file is still written but without
+      `external_id` (saved unsynced), with guidance matching that table's
+      retryable/terminal rows — the command never silently duplicates a
+      create on retry.
+- [ ] Given a work item file, when `accelerator work update` runs with
+      field or tag mutations, then the local file is rewritten atomically
+      and, when `--push` targets a synced item, the remote issue is
+      replaced via the same whole-content contract as
+      `work-item-update-remote.sh`; when the remote replace call fails, the
+      command surfaces that script's existing retryable-vs-terminal exit
+      distinction (`E_DISPATCH_RETRYABLE` = provably no mutation, safe to
+      retry; `E_DISPATCH_TERMINAL` = mutation state uncertain, never
+      auto-retried) and this story defines the corresponding local-file
+      outcome for each case as part of its implementation — it must not
+      leave the local file silently diverged from a replace that may have
+      actually applied.
+- [ ] Given a work item file, when `accelerator work show <path>` runs,
+      then it prints the full rendered item; when run with `--field NAME`
+      (including the `--field status` shorthand), it prints only that
+      field's value, matching `work-item-read-field.sh`/
+      `work-item-read-status.sh`'s output.
+- [ ] Given a path, full ID, or bare number, when `accelerator work resolve
+      <input>` runs, then it resolves to the same absolute path (or the
+      same exit codes for unrecognised/ambiguous/no-match input) as
+      `work-item-resolve-id.sh`.
+- [ ] Given a local and a remote work item representation, when
+      `accelerator work diff <local> <remote>` runs, then it reports the
+      same per-section differences as `work-item-section-diff.sh`.
+- [ ] Given each of the 11 previously-untested lifecycle scripts named in
+      Requirements, a characterization test captures its pre-port
+      behaviour — covering each documented flag/argument combination and
+      at least one error path — before the Rust port replaces it.
+- [ ] The lifecycle parity suite (`accelerator work create`/`update`/
+      `show`/`resolve`/`diff` against the repointed
+      `skills/work/scripts/test-work-item-{create-remote,pattern,
+      update-remote}.sh` gates and the new characterization suites) passes
+      with no live network calls in unit tests — remote calls are
+      exercised only by a separate, explicitly-tagged contract/integration
+      suite, gated behind a cargo-nextest filter excluded from the default
+      `cargo test`/`cargo nextest run` invocation.
+- [ ] The migrated lifecycle `work-item-*.sh` scripts (every script named
+      in Requirements, plus `work-item-create-remote.sh`,
+      `work-item-update-remote.sh`, and `work-item-pattern.sh`) and their
+      `test-*.sh` suites are removed and the work suite floor is
+      decremented in the same change; `work-item-fetch-remote.sh` and the
+      sync-stage scripts stay until 0194 removes them (fetch-remote is a
+      dependency of `work-item-sync-apply.sh`, not of any lifecycle
+      command).
 
 ## Open Questions
 
-- Exact `accelerator work` subcommand vocabulary (which shell scripts collapse into
-  one subcommand with flags vs stay distinct) — decided during implementation per
-  the Q7 interface-redesign principle.
+- Whether the internal-function boundary for `work-item-pattern.sh`,
+  `work-item-template-field-hints.sh`, `work-item-file-dirty.sh`,
+  `work-item-project-remote.sh`, `work-item-push-decide.sh`, and
+  `work-item-normalise.sh` (kept as private functions per Technical Notes,
+  not separate subcommands) holds once `accelerator-work` scaffolding
+  starts — a bash-era boundary may turn out to matter for a reason not
+  visible from a script's header comment alone.
+- Follow-up: this item's remote counterpart (`external_id: PP-191`) still
+  reflects the pre-split title/scope and needs reconciling — via
+  `accelerator work update --push` or an equivalent sync — on the next
+  push after this split.
 
 ## Dependencies
 
-- Blocked by: 0166 (shared crates).
-- Blocked by: 0187 (generalises the sub-binary registration surface). This story
-  adds a dispatch token; it does not generalise the surface. Registration
-  follows the checklist 0187 adds at
-  `tasks/README.md#registering-a-dispatched-sub-binary`. Note the token
-  constraint that bites here specifically: the dispatch token may not contain
-  `_`, because it derives `ACCELERATOR_<TOKEN>_BIN` — so `work-item`, not
-  `work_item`. (2026-08-01)
-- Relates to: 0171 (provides the `jira-client`/`linear-client` adapters the sync
-  engine wires in).
+- The pre-split blockers are both done as of 2026-08-05: 0166 (shared
+  crates) and 0187 (generalises the sub-binary registration surface).
+- Blocked by: 0194 (tracker crate and remote sync engine) — the split
+  introduced this new blocker: `create`/`update --push` call through the
+  `RemoteTracker` port 0194 defines, so only 0194's port (not its full
+  `sync` command) needs to land first; this story fakes the port in its
+  own unit tests.
+- Relates to: 0194 (split sibling — carries the sync engine and `tracker`
+  crate that this story was originally bundled with).
+- Relates to: 0171 (Jira and Linear Integrations) — this story's own
+  Acceptance Criteria only require the faked port, but end-to-end `--push`
+  against a real tracker is gated on 0171 landing (via 0194).
 - Parent: epic 0136.
 
 ## Assumptions
 
-- `reqwest` in the work binary (via the client adapters) is acceptable — it is
-  already workspace-wide via the launcher (resolved Q2).
+- 0194's `RemoteTracker` port trait is sufficient for this story's
+  `--push` behaviour; concrete provider wiring (real Jira/Linear clients)
+  happens via 0194/0171, not directly in this story.
 
 ## Technical Notes
 
-- Source bash: `skills/work/scripts/work-item-common.sh`, `work-item-sync-*.sh`,
-  `work-item-create-remote.sh`, `work-item-fetch-remote.sh`,
-  `work-item-next-number.sh`, `work-item-pattern.sh`, etc.
-- The sync flow depends on config + JSONL/store + the integration clients.
+- Source bash: `skills/work/scripts/work-item-common.sh`,
+  `work-item-create-remote.sh`,
+  `work-item-next-number.sh`, `work-item-normalise.sh`,
+  `work-item-pattern.sh`, `work-item-read-field.sh`,
+  `work-item-read-status.sh`, `work-item-resolve-id.sh`,
+  `work-item-section-diff.sh`, `work-item-update-remote.sh`,
+  `work-item-update-tags.sh`, `work-item-file-dirty.sh`,
+  `work-item-project-remote.sh`, `work-item-push-decide.sh`,
+  `work-item-template-field-hints.sh`.
+- Registration follows the checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary`. The dispatch token
+  for the `accelerator work <verb>` subcommand namespace is `work` — a
+  single word with no separator, so the constraint that a dispatch token
+  may not contain `_` (it derives `ACCELERATOR_<TOKEN>_BIN`) doesn't bite
+  here; it would only matter if the token were ever renamed to something
+  hyphenated or underscored. (2026-08-01, reconciled 2026-08-05)
+- **Subcommand vocabulary (resolved 2026-08-05)**: `accelerator work`
+  exposes six user-facing subcommands; five are this story's scope, and
+  `sync` is 0194's. The remaining scripts become private functions inside
+  the `accelerator-work`/`tracker` crates rather than separate
+  subcommands, since bash needed subprocess boundaries for testability
+  that Rust doesn't:
+  - `work create` — absorbs `work-item-next-number.sh` (ID allocation) and
+    `work-item-create-remote.sh` (`--push` flag triggers the remote
+    create).
+  - `work update` — absorbs `work-item-update-tags.sh` (`--add-tag`/
+    `--remove-tag` flags) and `work-item-update-remote.sh` (`--push`).
+  - `work show <path> [--field NAME]` — absorbs `work-item-read-field.sh`
+    and `work-item-read-status.sh` (`--field status` shorthand).
+  - `work resolve <input>` — direct port of `work-item-resolve-id.sh`.
+  - `work diff <local> <remote>` — direct port of
+    `work-item-section-diff.sh`.
+  - `work sync [--push-only|--pull-only]` — 0194's scope, not this story's.
+  - Internal-only (no CLI subcommand), this story's scope:
+    `work-item-pattern.sh`, `work-item-template-field-hints.sh`,
+    `work-item-file-dirty.sh`, `work-item-project-remote.sh`,
+    `work-item-push-decide.sh`, `work-item-normalise.sh` — each becomes a
+    private function called by `create`/`update`, still unit-tested
+    directly at the function level (satisfies the characterization-test
+    acceptance criterion without needing a CLI surface).
 
 ## Drafting Notes
 
-- Treated as the Phase 7 story; introduces the `tracker` crate that 0171's clients
-  implement, so the two are tightly related but separable.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+- Split on 2026-08-05 into this item (lifecycle CRUD) and 0194 (tracker
+  crate and remote sync engine) following work item review 1
+  (`meta/reviews/work/0170-work-item-subdomain-and-sync-engine-review-1.md`),
+  which found the two efforts independently deliverable and the combined
+  story epic-scale for a `kind: story` item. This item keeps the original
+  title's scope narrowed to lifecycle ops; 0194 carries the `tracker` crate
+  and `sync` command. This item's remote counterpart (`external_id:
+  PP-191`) still reflects the pre-split title/scope until the next push.
+- Refined interactively on 2026-08-05, prior to the split: resolved the
+  subcommand-vocabulary open question (six user-facing verbs; internal
+  helpers stay as private functions rather than 1:1 script ports — see
+  Technical Notes), tightened Acceptance Criteria to Given/When/Then, and
+  cleared both blockers (0166, 0187) from Dependencies/frontmatter.
+- The internal-vs-subcommand grouping is a judgment call, not confirmed
+  against an actual implementation spike — see Open Questions.
+- Note: 0187's own frontmatter still shows `status: ready`, not `done`, as
+  of this edit — Toby confirmed it's actually done; someone should update
+  0187's status field separately (out of scope for this edit).
 
 ## References
 
 - Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
 - Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Split into: `meta/work/0194-tracker-crate-and-remote-sync-engine.md`
 - ADRs: ADR-0045, ADR-0052, ADR-0053

--- a/meta/work/0170-work-item-subdomain-and-sync-engine.md
+++ b/meta/work/0170-work-item-subdomain-and-sync-engine.md
@@ -10,10 +10,10 @@ kind: story
 priority: medium
 parent: "work-item:0136"
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
-relates_to: ["work-item:0194", "work-item:0171"]
-blocked_by: ["work-item:0194"]
+relates_to: ["work-item:0194"]
+blocks: ["work-item:0194"]
 tags: [rust, work-items]
-last_updated: "2026-08-05T18:18:52+00:00"
+last_updated: "2026-08-05T22:11:33+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-191"
@@ -30,10 +30,11 @@ external_id: "PP-191"
 
 Build the `accelerator-work` subdomain's work-item lifecycle operations —
 create, show, update, resolve, diff — over the shared `corpus`/`config`/
-`store` crates, absorbing ID allocation, remote create/update, and
-tag-mutation flows from the legacy bash scripts. `create`/`update --push`
-call through 0194's `RemoteTracker` port (faked in this story's own unit
-tests); the sync engine itself is 0194's scope.
+`store` crates, absorbing ID allocation and tag-mutation flows from the
+legacy bash scripts. These commands are local-only, with no dependency on
+the remote tracker: `--push` support for `create`/`update` and the sync
+engine itself are both 0194's scope — 0194 wires `--push` onto these
+commands once they exist, calling through its own `RemoteTracker` port.
 
 ## Context
 
@@ -42,18 +43,21 @@ normalise/next-number/section-diff/read-field. This story covers the
 lifecycle-CRUD half of that surface — create, update, show, resolve, diff —
 absorbing the ID-allocation and tag-mutation flows, so plugin maintainers
 inherit a typed, bash-3.2-independent, characterization-tested CLI in place
-of the current untested shell scripts backing the work-item skills. The sync engine and the
-`tracker` crate split off into 0194 on 2026-08-05 (see Drafting Notes)
-following a work item review that found the two efforts independently
-deliverable and the combined story epic-scale. The `RemoteTracker` port and
-the sync state machine live in their own `tracker` crate (0194), not inside
-`accelerator-work`; this story's `--push` flows call through that port,
-faking it in unit tests. The coverage gap for the previously-untested
-lifecycle scripts is closed via characterize-then-port — write a
-characterization test capturing each script's pre-port behaviour before
-replacing it (see Acceptance Criteria). 11 lifecycle-side `work-item-*`
-scripts have no dedicated test suite today; 0194 covers the 4 sync-side
-ones separately.
+of the current untested shell scripts backing the work-item skills. The sync
+engine and the `tracker` crate split off into 0194 on 2026-08-05 (see
+Drafting Notes) following a work item review that found the two efforts
+independently deliverable and the combined story epic-scale. `--push`
+support for `create`/`update` was originally scoped here too, but moved to
+0194 on a follow-up pass (see Drafting Notes): 0194 wires the flag onto
+these commands once both they and its own `RemoteTracker` port exist, so
+this story carries no remote-tracker dependency at all — every command here
+is local-only. The coverage gap for the previously-untested lifecycle
+scripts is closed via characterize-then-port — write a characterization
+test capturing each script's pre-port behaviour before replacing it (see
+Acceptance Criteria). 10 lifecycle-side `work-item-*` scripts have no
+dedicated test suite today; `work-item-push-decide.sh` moved to 0194
+alongside the push-wiring it decides for, and 0194 covers the 4 sync-side
+scripts separately.
 
 ## Requirements
 
@@ -61,22 +65,20 @@ ones separately.
   crates: lifecycle ops `create`, `show` (read-field/read-status), `update`
   (including tag mutations), `resolve`, `diff` (section-diff), plus the
   internal helpers `next-number`, `normalise`, `pattern`,
-  `template-field-hints`, `file-dirty`, `project-remote`, and
-  `push-decide`.
-- `create --push` and `update --push` call through 0194's `RemoteTracker`
-  port (faked in this story's unit tests) to create or whole-content-replace
-  the remote issue.
+  `template-field-hints`, `file-dirty`, and `project-remote`. These
+  commands are local-only — no remote calls, no `RemoteTracker` dependency;
+  `--push` support is 0194's scope (see Dependencies).
 - Preserve the `external_id`-as-remote-key convention and the JSONL/
   atomic-write semantics (via `store`).
-- Close the coverage gap: characterize-then-port the 11 previously-untested
+- Close the coverage gap: characterize-then-port the 10 previously-untested
   lifecycle scripts — `work-item-file-dirty.sh`, `work-item-next-number.sh`,
   `work-item-normalise.sh`, `work-item-project-remote.sh`,
-  `work-item-push-decide.sh`, `work-item-read-field.sh`,
-  `work-item-read-status.sh`, `work-item-resolve-id.sh`,
-  `work-item-section-diff.sh`, `work-item-template-field-hints.sh`,
-  `work-item-update-tags.sh` (none has a dedicated `test-work-item-*.sh`
-  suite today; `work-item-pattern.sh` already does and is out of scope
-  here).
+  `work-item-read-field.sh`, `work-item-read-status.sh`,
+  `work-item-resolve-id.sh`, `work-item-section-diff.sh`,
+  `work-item-template-field-hints.sh`, `work-item-update-tags.sh` (none has
+  a dedicated `test-work-item-*.sh` suite today; `work-item-pattern.sh`
+  already does and is out of scope here; `work-item-push-decide.sh` moved
+  to 0194 alongside the push-wiring it decides for).
 
 ## Acceptance Criteria
 
@@ -84,27 +86,11 @@ ones separately.
       runs, then it allocates the next ID per the configured pattern and
       writes the local file with fully populated frontmatter (every field
       the item's `kind` requires, per the `create-work-item` template
-      schema); when invoked with `--push` and the remote create call via
-      the wired (or, in unit tests, faked) `RemoteTracker` port succeeds,
-      `external_id` is substituted before the single write — no file exists
-      until success, decline, or confirmed-local-fallback resolves, per
-      `work-item-create-remote.sh`'s existing outcome table; when the
-      remote call fails, the file is still written but without
-      `external_id` (saved unsynced), with guidance matching that table's
-      retryable/terminal rows — the command never silently duplicates a
-      create on retry.
+      schema).
 - [ ] Given a work item file, when `accelerator work update` runs with
       field or tag mutations, then the local file is rewritten atomically
-      and, when `--push` targets a synced item, the remote issue is
-      replaced via the same whole-content contract as
-      `work-item-update-remote.sh`; when the remote replace call fails, the
-      command surfaces that script's existing retryable-vs-terminal exit
-      distinction (`E_DISPATCH_RETRYABLE` = provably no mutation, safe to
-      retry; `E_DISPATCH_TERMINAL` = mutation state uncertain, never
-      auto-retried) and this story defines the corresponding local-file
-      outcome for each case as part of its implementation — it must not
-      leave the local file silently diverged from a replace that may have
-      actually applied.
+      via the same whole-file replace contract as `work-item-update-tags.sh`
+      for tag mutations, with all other fields left unchanged.
 - [ ] Given a work item file, when `accelerator work show <path>` runs,
       then it prints the full rendered item; when run with `--field NAME`
       (including the `--field status` shorthand), it prints only that
@@ -117,74 +103,73 @@ ones separately.
 - [ ] Given a local and a remote work item representation, when
       `accelerator work diff <local> <remote>` runs, then it reports the
       same per-section differences as `work-item-section-diff.sh`.
-- [ ] Given each of the 11 previously-untested lifecycle scripts named in
+- [ ] Given each of the 10 previously-untested lifecycle scripts named in
       Requirements, a characterization test captures its pre-port
       behaviour — covering each documented flag/argument combination and
       at least one error path — before the Rust port replaces it.
 - [ ] The lifecycle parity suite (`accelerator work create`/`update`/
       `show`/`resolve`/`diff` against the repointed
-      `skills/work/scripts/test-work-item-{create-remote,pattern,
-      update-remote}.sh` gates and the new characterization suites) passes
-      with no live network calls in unit tests — remote calls are
-      exercised only by a separate, explicitly-tagged contract/integration
-      suite, gated behind a cargo-nextest filter excluded from the default
-      `cargo test`/`cargo nextest run` invocation.
+      `skills/work/scripts/test-work-item-pattern.sh` gate and the new
+      characterization suites) passes; this crate makes no network calls
+      at all, so no separate contract/integration suite is needed for it
+      (0194 carries that gate for the push-wiring it adds on top).
 - [ ] The migrated lifecycle `work-item-*.sh` scripts (every script named
-      in Requirements, plus `work-item-create-remote.sh`,
-      `work-item-update-remote.sh`, and `work-item-pattern.sh`) and their
-      `test-*.sh` suites are removed and the work suite floor is
-      decremented in the same change; `work-item-fetch-remote.sh` and the
-      sync-stage scripts stay until 0194 removes them (fetch-remote is a
-      dependency of `work-item-sync-apply.sh`, not of any lifecycle
-      command).
+      in Requirements, plus `work-item-pattern.sh`) and their `test-*.sh`
+      suites are removed and the work suite floor is decremented in the
+      same change; `work-item-create-remote.sh`, `work-item-update-remote.sh`,
+      `work-item-push-decide.sh`, `work-item-fetch-remote.sh`, and the
+      sync-stage scripts stay until 0194 removes them (they're 0194's
+      porting/removal responsibility now, not this story's).
 
 ## Open Questions
 
 - Whether the internal-function boundary for `work-item-pattern.sh`,
   `work-item-template-field-hints.sh`, `work-item-file-dirty.sh`,
-  `work-item-project-remote.sh`, `work-item-push-decide.sh`, and
-  `work-item-normalise.sh` (kept as private functions per Technical Notes,
-  not separate subcommands) holds once `accelerator-work` scaffolding
-  starts — a bash-era boundary may turn out to matter for a reason not
-  visible from a script's header comment alone.
+  `work-item-project-remote.sh`, and `work-item-normalise.sh` (kept as
+  private functions per Technical Notes, not separate subcommands) holds
+  once `accelerator-work` scaffolding starts — a bash-era boundary may
+  turn out to matter for a reason not visible from a script's header
+  comment alone.
 - Follow-up: this item's remote counterpart (`external_id: PP-191`) still
   reflects the pre-split title/scope and needs reconciling — via
-  `accelerator work update --push` or an equivalent sync — on the next
-  push after this split.
+  `accelerator work update --push` (once 0194 wires it onto this story's
+  `update` command) or an equivalent sync — on the next push after this
+  split.
 
 ## Dependencies
 
 - The pre-split blockers are both done as of 2026-08-05: 0166 (shared
   crates) and 0187 (generalises the sub-binary registration surface).
-- Blocked by: 0194 (tracker crate and remote sync engine) — the split
-  introduced this new blocker: `create`/`update --push` call through the
-  `RemoteTracker` port 0194 defines, so only 0194's port (not its full
-  `sync` command) needs to land first; this story fakes the port in its
-  own unit tests.
-- Relates to: 0194 (split sibling — carries the sync engine and `tracker`
-  crate that this story was originally bundled with).
-- Relates to: 0171 (Jira and Linear Integrations) — this story's own
-  Acceptance Criteria only require the faked port, but end-to-end `--push`
-  against a real tracker is gated on 0171 landing (via 0194).
+- No remaining blockers: `--push` support (the one thing that needed
+  0194's `RemoteTracker` port) moved to 0194's own scope on 2026-08-05
+  (see Drafting Notes), so this story now has zero dependency on 0194 or
+  0171 — every command here is local-only and can proceed immediately.
+- Blocks: 0194 — 0194 wires `--push` onto this story's `create`/`update`
+  commands once they exist, so that one slice of 0194's scope needs this
+  story's commands to land first; the rest of 0194 (the `tracker` crate,
+  the `sync` command, its characterization tests) doesn't depend on this
+  story at all.
+- Relates to: 0194 (split sibling — carries the sync engine, the `tracker`
+  crate, and now the `--push` wiring for this story's commands too).
 - Parent: epic 0136.
 
 ## Assumptions
 
-- 0194's `RemoteTracker` port trait is sufficient for this story's
-  `--push` behaviour; concrete provider wiring (real Jira/Linear clients)
-  happens via 0194/0171, not directly in this story.
+- This story's `create`/`update` CLI signatures (flags and arguments) are
+  stable once implemented; 0194 extends them with a `--push` flag
+  afterwards without needing this story's further involvement.
 
 ## Technical Notes
 
 - Source bash: `skills/work/scripts/work-item-common.sh`,
-  `work-item-create-remote.sh`,
   `work-item-next-number.sh`, `work-item-normalise.sh`,
   `work-item-pattern.sh`, `work-item-read-field.sh`,
   `work-item-read-status.sh`, `work-item-resolve-id.sh`,
-  `work-item-section-diff.sh`, `work-item-update-remote.sh`,
-  `work-item-update-tags.sh`, `work-item-file-dirty.sh`,
-  `work-item-project-remote.sh`, `work-item-push-decide.sh`,
-  `work-item-template-field-hints.sh`.
+  `work-item-section-diff.sh`, `work-item-update-tags.sh`,
+  `work-item-file-dirty.sh`, `work-item-project-remote.sh`,
+  `work-item-template-field-hints.sh`. `work-item-create-remote.sh`,
+  `work-item-update-remote.sh`, and `work-item-push-decide.sh` moved to
+  0194 alongside the `--push` wiring they implement (see Drafting Notes).
 - Registration follows the checklist 0187 adds at
   `tasks/README.md#registering-a-dispatched-sub-binary`. The dispatch token
   for the `accelerator work <verb>` subcommand namespace is `work` — a
@@ -192,17 +177,18 @@ ones separately.
   may not contain `_` (it derives `ACCELERATOR_<TOKEN>_BIN`) doesn't bite
   here; it would only matter if the token were ever renamed to something
   hyphenated or underscored. (2026-08-01, reconciled 2026-08-05)
-- **Subcommand vocabulary (resolved 2026-08-05)**: `accelerator work`
-  exposes six user-facing subcommands; five are this story's scope, and
-  `sync` is 0194's. The remaining scripts become private functions inside
-  the `accelerator-work`/`tracker` crates rather than separate
-  subcommands, since bash needed subprocess boundaries for testability
-  that Rust doesn't:
-  - `work create` — absorbs `work-item-next-number.sh` (ID allocation) and
-    `work-item-create-remote.sh` (`--push` flag triggers the remote
-    create).
+- **Subcommand vocabulary (resolved 2026-08-05, revised 2026-08-05)**:
+  `accelerator work` exposes six user-facing subcommands; five are this
+  story's scope, and `sync` is 0194's. The remaining scripts become
+  private functions inside the `accelerator-work`/`tracker` crates rather
+  than separate subcommands, since bash needed subprocess boundaries for
+  testability that Rust doesn't:
+  - `work create` — absorbs `work-item-next-number.sh` (ID allocation);
+    local-only in this story. 0194 later adds the `--push` flag, absorbing
+    `work-item-create-remote.sh`.
   - `work update` — absorbs `work-item-update-tags.sh` (`--add-tag`/
-    `--remove-tag` flags) and `work-item-update-remote.sh` (`--push`).
+    `--remove-tag` flags); local-only in this story. 0194 later adds the
+    `--push` flag, absorbing `work-item-update-remote.sh`.
   - `work show <path> [--field NAME]` — absorbs `work-item-read-field.sh`
     and `work-item-read-status.sh` (`--field status` shorthand).
   - `work resolve <input>` — direct port of `work-item-resolve-id.sh`.
@@ -212,10 +198,11 @@ ones separately.
   - Internal-only (no CLI subcommand), this story's scope:
     `work-item-pattern.sh`, `work-item-template-field-hints.sh`,
     `work-item-file-dirty.sh`, `work-item-project-remote.sh`,
-    `work-item-push-decide.sh`, `work-item-normalise.sh` — each becomes a
-    private function called by `create`/`update`, still unit-tested
-    directly at the function level (satisfies the characterization-test
-    acceptance criterion without needing a CLI surface).
+    `work-item-normalise.sh` — each becomes a private function called by
+    `create`/`update`, still unit-tested directly at the function level
+    (satisfies the characterization-test acceptance criterion without
+    needing a CLI surface). `work-item-push-decide.sh` moved to 0194
+    alongside the `--push` wiring it decides for.
 
 ## Drafting Notes
 
@@ -237,6 +224,16 @@ ones separately.
 - Note: 0187's own frontmatter still shows `status: ready`, not `done`, as
   of this edit — Toby confirmed it's actually done; someone should update
   0187's status field separately (out of scope for this edit).
+- Revised 2026-08-05, following a review discussion: moved `--push`
+  support for `create`/`update` (and the `work-item-create-remote.sh`,
+  `work-item-update-remote.sh`, and `work-item-push-decide.sh` scripts
+  that implement it) out of this story and into 0194, to remove this
+  story's dependency on 0194's `RemoteTracker` port entirely. This story
+  is now fully local-only and unblocked; 0194 wires `--push` onto these
+  commands once they exist, so the dependency direction flips for that one
+  slice of 0194's scope (0194 blocked by 0170), while the rest of 0194
+  (the `tracker` crate, the `sync` command) remains independent of this
+  story, as before.
 
 ## References
 

--- a/meta/work/0171-jira-and-linear-integrations.md
+++ b/meta/work/0171-jira-and-linear-integrations.md
@@ -13,7 +13,7 @@ blocked_by: ["work-item:0187", "work-item:0194"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 relates_to: ["work-item:0170", "work-item:0194"]
 tags: [rust, jira, linear, integrations, reqwest]
-last_updated: "2026-08-05T18:18:52+00:00"
+last_updated: "2026-08-05T22:11:33+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-192"
@@ -82,8 +82,10 @@ granularity is wanted.
   adds a dispatch token; it does not generalise the surface. Registration
   follows the checklist 0187 adds at
   `tasks/README.md#registering-a-dispatched-sub-binary`. (2026-08-01)
-- Relates to: 0170 (the work-item lifecycle subdomain — also consumes these
-  clients' shared `RemoteTracker` port via 0194).
+- Relates to: 0170 (the work-item lifecycle subdomain — no direct
+  dependency on these clients or the `RemoteTracker` port itself; 0194
+  wires `--push` onto its `create`/`update` commands separately, using
+  0194's own port).
 - Relates to: 0194 (the sync engine consumes these clients).
 - Parent: epic 0136.
 

--- a/meta/work/0171-jira-and-linear-integrations.md
+++ b/meta/work/0171-jira-and-linear-integrations.md
@@ -9,11 +9,11 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0187"]
+blocked_by: ["work-item:0187", "work-item:0194"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
-relates_to: ["work-item:0170"]
+relates_to: ["work-item:0170", "work-item:0194"]
 tags: [rust, jira, linear, integrations, reqwest]
-last_updated: "2026-08-01T16:57:37+00:00"
+last_updated: "2026-08-05T18:18:52+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-192"
@@ -40,14 +40,16 @@ provider.
 implement create/update/comment/transition/search/show/attach/init flows, ADF↔markdown
 conversion, JQL/GraphQL, and auth, shelling out to `jq`/`curl`. Both have Python
 mock HTTP servers for tests. Resolved Q2: provider clients are shared crates reused
-by both the standalone binaries and the `tracker` sync engine (0170). May be split
-into separate Jira and Linear stories if finer granularity is wanted.
+by both the standalone binaries and the `tracker` sync engine (0194 — split off
+from 0170 on 2026-08-05; the `tracker` crate and `RemoteTracker` port now live
+there, not in 0170). May be split into separate Jira and Linear stories if finer
+granularity is wanted.
 
 ## Requirements
 
 - Implement `jira-client` (Jira REST + ADF↔markdown + auth) and `linear-client`
   (Linear GraphQL + auth) as adapter crates over `reqwest` + rustls + serde, each
-  `impl RemoteTracker` (the port from 0170's `tracker` crate).
+  `impl RemoteTracker` (the port from 0194's `tracker` crate).
 - Implement `accelerator-jira` and `accelerator-linear` as thin inbound CLI adapters
   exposing the user-facing flows (create/update/comment/transition/search/show/
   attach/init).
@@ -61,7 +63,7 @@ into separate Jira and Linear stories if finer granularity is wanted.
 - [ ] `accelerator jira …` and `accelerator linear …` reproduce the standalone flows,
       verified against the repointed integration suites and the mock servers.
 - [ ] Both client crates implement `RemoteTracker` and are consumable by
-      `accelerator-work`'s sync engine (0170) with no duplication of API logic.
+      `accelerator-work`'s sync engine (0194) with no duplication of API logic.
 - [ ] No production `jq`/`curl` dependency remains for the migrated integration
       skills; their `allowed-tools` entries are removed.
 - [ ] The integration suite floor is decremented in lockstep as the shell scripts
@@ -74,12 +76,15 @@ into separate Jira and Linear stories if finer granularity is wanted.
 
 ## Dependencies
 
-- Blocked by: 0166 (shared crates), and the `tracker` port from 0170.
+- Blocked by: 0166 (shared crates), and the `tracker` port from 0194
+  (split off from 0170 on 2026-08-05).
 - Blocked by: 0187 (generalises the sub-binary registration surface). This story
   adds a dispatch token; it does not generalise the surface. Registration
   follows the checklist 0187 adds at
   `tasks/README.md#registering-a-dispatched-sub-binary`. (2026-08-01)
-- Relates to: 0170 (the sync engine consumes these clients).
+- Relates to: 0170 (the work-item lifecycle subdomain — also consumes these
+  clients' shared `RemoteTracker` port via 0194).
+- Relates to: 0194 (the sync engine consumes these clients).
 - Parent: epic 0136.
 
 ## Assumptions
@@ -99,6 +104,10 @@ into separate Jira and Linear stories if finer granularity is wanted.
 
 - Treated as the Phase 8 story; kept as one grouped item per the user's selection,
   with a noted split option.
+- Updated 2026-08-05: 0170 split into 0170 (lifecycle CRUD) and 0194
+  (`tracker` crate and remote sync engine) following a work item review. All
+  references to "the tracker port from 0170" now point at 0194, which is
+  where the `RemoteTracker` port actually lives.
 
 > Extracted from source documents without interactive enrichment.
 > Acceptance criteria, dependencies, and kind may need refinement before

--- a/meta/work/0194-tracker-crate-and-remote-sync-engine.md
+++ b/meta/work/0194-tracker-crate-and-remote-sync-engine.md
@@ -1,0 +1,214 @@
+---
+type: work-item
+id: "0194"
+title: "Tracker Crate and Remote Sync Engine"
+date: "2026-08-05T18:18:52+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0136"
+derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
+relates_to: ["work-item:0170"]
+blocks: ["work-item:0170", "work-item:0171"]
+tags: [rust, work-items, sync, tracker]
+last_updated: "2026-08-05T19:37:49+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0194: Tracker Crate and Remote Sync Engine
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Build the shared `tracker` crate (the `RemoteTracker` port and sync state
+machine, in pure domain terms) and the `accelerator work sync` command that
+orchestrates it against the local work-item store, so both 0170's `create`/
+`update --push` flows and 0171's per-provider client adapters have a stable
+port to build against, and the sync flow can be unit-tested against a fake
+`RemoteTracker`.
+
+## Context
+
+`skills/work/scripts/work-item-sync-*.sh` implements a transactional state
+machine (classify → decide → apply → baseline → label) that orchestrates the
+remote tracker. This story split off from 0170 (the work-item lifecycle
+subdomain — see that item's Drafting Notes) on 2026-08-05 following a work
+item review that found the two efforts independently deliverable: the
+`tracker` crate depends only on the already-built shared `corpus`/`config`/
+`store` crates (0166), not on 0170's own CRUD implementation, whereas 0170's
+`create`/`update --push` flows and 0171's client adapters both need this
+crate's `RemoteTracker` port to exist first. The `RemoteTracker` port and
+the sync state machine live in their own `tracker` crate;
+`accelerator-work` links the per-provider client adapters (0171) in-process
+at its composition root and fakes the port in tests.
+
+## Requirements
+
+- Implement the `tracker` crate: the `RemoteTracker` port (issue/transition/
+  sync verdict vocabulary) and the sync state machine in pure domain terms,
+  with no provider-specific or HTTP types in its public API.
+- Implement `accelerator work sync [--push-only|--pull-only]` in
+  `accelerator-work`, orchestrating the tracker crate's classify → decide →
+  apply → baseline → label pipeline against the local work-item store (via
+  the shared `corpus`/`store` crates from 0166) and the active provider
+  client, wired at the work binary's composition root per `work.integration`
+  (the config key selecting the active remote tracker provider, e.g. `jira`
+  or `linear`).
+- Preserve the JSONL/atomic-write semantics for baseline writes (via
+  `store`).
+- Close the coverage gap: characterize-then-port the sync-side previously
+  untested scripts — `work-item-sync-baseline.sh`, `work-item-sync-classify.sh`,
+  `work-item-sync-decide.sh`, `work-item-sync-label.sh` (none has a dedicated
+  `test-work-item-*.sh` suite today; `work-item-sync-apply.sh` already does
+  and is out of scope here).
+- Partition tests so the default `cargo test`/`cargo nextest run` invocation
+  exercises the parity/characterization suite only (no live network calls);
+  gate the contract/integration suite exercising real remote calls behind a
+  separate, explicitly-tagged cargo-nextest filter excluded from that
+  default invocation.
+- Remove the migrated `work-item-sync-*.sh` scripts, `work-item-fetch-remote.sh`,
+  and their `test-*.sh` suites, and decrement the work suite floor in the
+  same change.
+
+## Acceptance Criteria
+
+- [ ] Given a local item and a fake `RemoteTracker` record, when
+      `accelerator work sync` runs its classify → decide → apply → baseline →
+      label pipeline, then the five-state classification (unsynced /
+      local-ahead / remote-ahead / in-sync / conflict) matches the bash
+      `work-item-sync-classify.sh` parity fixtures, and the per-item write
+      sequence honours the "side effect first, baseline write last"
+      resumability contract (the remote/local side effect for a given item is
+      written before that item's baseline record, so a baseline write can be
+      treated as confirmation the side effect already completed) — verified
+      by a test harness that captures write-call order via a fake store and
+      asserts the baseline write occurs strictly after the corresponding side
+      effect for every classified state, and by simulating a crash after the
+      side effect but before the baseline write and asserting a re-run
+      produces the same terminal state as an uninterrupted run.
+- [ ] Given `accelerator work sync --push-only` or `--pull-only`, then the
+      decision table (the classification-state × sync-mode matrix the
+      `decide` stage consults to choose push, pull, or no-op per item)
+      forbids writes in the disallowed direction, matching
+      `work-item-sync-decide.sh`'s forbidden-write cells.
+- [ ] Given each of the four previously-untested sync scripts
+      (`sync-baseline`, `sync-classify`, `sync-decide`, `sync-label`), a
+      characterization test captures its pre-port behaviour — covering each
+      documented flag/argument combination and at least one error path —
+      before the Rust port replaces it.
+- [ ] The `sync` parity suite (`accelerator work sync` against the
+      repointed `skills/work/scripts/test-work-item-sync-*.sh` gates and the
+      classify/decide fixtures) passes with no live network calls; remote
+      calls are exercised only by a separate, explicitly-tagged contract/
+      integration suite (gated behind a cargo-nextest filter excluded from
+      the default `cargo test`/`cargo nextest run` invocation).
+- [ ] The `tracker` crate's public API contains no provider-specific or HTTP
+      types (verified by its dependency graph carrying no `reqwest` or
+      provider-crate types in public signatures) — 0171's clients implement
+      the port instead.
+- [ ] The migrated `work-item-sync-*.sh` scripts, `work-item-fetch-remote.sh`,
+      and their `test-*.sh` suites are removed and the work suite floor is
+      decremented in the same change.
+
+## Open Questions
+
+- Whether `work-item-sync-decide.sh`'s internal-function boundary (kept as
+  a private function inside `sync` per 0170's Technical Notes, not a
+  separate subcommand) holds once the `tracker` crate scaffolding starts —
+  a bash-era boundary may turn out to matter for a reason not visible from
+  the script's header comment alone. Carried over from 0170's Drafting
+  Notes as the sync-specific half of that judgment call.
+
+## Dependencies
+
+- No remaining blockers: 0166 (shared crates) and 0187 (generalises the
+  sub-binary registration surface) are both done as of 2026-08-05. The
+  `tracker` crate's own build only needs these two, not 0170's CRUD
+  implementation.
+- Blocks: 0170 (the work-item lifecycle subdomain) — `create`/`update
+  --push` call through the `RemoteTracker` port this story defines, so
+  0170 cannot implement `--push` (though it can implement the rest of its
+  CRUD surface) until this crate's port is stable. This blocking milestone
+  is narrower than this item's full Acceptance Criteria gate: 0170 only
+  needs the `RemoteTracker` trait signature to compile, not the finished
+  `accelerator work sync` command, its characterization-test suites, or the
+  legacy-script removal — those can land after 0170 unblocks.
+- Blocks: 0171 (Jira and Linear Integrations) — its client adapters
+  implement the `RemoteTracker` port this story defines; 0171 cannot
+  complete its `impl RemoteTracker` work until this crate's port is
+  stable. As with 0170, only the port signature is the actual blocking
+  milestone, not this item's full acceptance gate.
+- Parent: epic 0136.
+
+## Assumptions
+
+- `reqwest` in the work binary (via the client adapters 0171 provides) is
+  acceptable — it is already workspace-wide via the launcher, resolved by
+  the work↔integrations coupling decision (research doc
+  `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`,
+  Open Question 2).
+- The active provider client is faked at the `RemoteTracker` port boundary
+  for this story's own unit tests; real Jira/Linear wiring is exercised
+  once 0171 lands, via the separate contract/integration suite.
+
+## Technical Notes
+
+- Source bash: `skills/work/scripts/work-item-sync-*.sh` and
+  `work-item-fetch-remote.sh` (the sync engine's read counterpart to
+  `work-item-create-remote.sh`; `work-item-sync-apply.sh` calls it directly
+  — it is not a 0170 lifecycle concern despite appearing in that item's
+  original source-bash list before the split. It already has a dedicated
+  `test-work-item-fetch-remote.sh` suite, so it needs no new
+  characterization test, only porting and removal alongside the other
+  sync-stage scripts).
+- The sync flow depends on config + JSONL/store + the integration clients
+  (0171); this story only requires the port to exist, not a concrete
+  provider implementation.
+- `work sync [--push-only|--pull-only]` runs the classify → decide → apply →
+  baseline → label pipeline as one command; the current plan is for the five
+  stages to stay internal functions, not separate subcommands, unit-tested
+  directly at the function level — pending confirmation once the `tracker`
+  crate scaffolding starts (see Open Questions).
+- Because the reversed sequencing means this story, not 0170, may be the
+  first to scaffold/extend the `accelerator-work` binary and its composition
+  root, registration follows the same checklist 0187 adds at
+  `tasks/README.md#registering-a-dispatched-sub-binary` that 0170's
+  Technical Notes also references.
+
+## Drafting Notes
+
+- Split from 0170 on 2026-08-05 following work item review 1
+  (`meta/reviews/work/0170-work-item-subdomain-and-sync-engine-review-1.md`),
+  which found the lifecycle CRUD and sync engine independently deliverable.
+  This item carries the `tracker` crate and `sync` command; 0170 keeps the
+  CRUD lifecycle ops. Because 0170's `--push` flows and 0171's clients both
+  build against this crate's port, this item precedes both rather than
+  depending on either — the reverse of the sequencing first assumed during
+  the split discussion.
+- The four-script untested-scripts list here was verified against the
+  actual `skills/work/scripts/` inventory at split time: scripts with a
+  dedicated `test-work-item-<name>.sh` file (`sync-apply`) are excluded;
+  the remaining sync-stage scripts without one are listed above.
+- Revised following work item review 1
+  (`meta/reviews/work/0194-tracker-crate-and-remote-sync-engine-review-1.md`):
+  added a concrete verification mechanism for AC1's resumability contract,
+  clarified that Dependencies' blocking milestone is the port signature
+  compiling rather than this item's full Acceptance Criteria gate, added a
+  Technical Notes cross-reference to the 0187 registration checklist, added
+  Requirements bullets mirroring AC4's test-partitioning and AC6's
+  removal/floor-decrement scope, and glossed several previously-undefined
+  terms (`work.integration`, the decision table, the Q2 reference).
+
+## References
+
+- Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Split from: `meta/work/0170-work-item-subdomain-and-sync-engine.md`
+- ADRs: ADR-0045, ADR-0052, ADR-0053

--- a/meta/work/0194-tracker-crate-and-remote-sync-engine.md
+++ b/meta/work/0194-tracker-crate-and-remote-sync-engine.md
@@ -11,9 +11,10 @@ priority: medium
 parent: "work-item:0136"
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 relates_to: ["work-item:0170"]
-blocks: ["work-item:0170", "work-item:0171"]
+blocks: ["work-item:0171"]
+blocked_by: ["work-item:0170"]
 tags: [rust, work-items, sync, tracker]
-last_updated: "2026-08-05T19:37:49+00:00"
+last_updated: "2026-08-05T22:11:33+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -28,11 +29,12 @@ schema_version: 1
 ## Summary
 
 Build the shared `tracker` crate (the `RemoteTracker` port and sync state
-machine, in pure domain terms) and the `accelerator work sync` command that
-orchestrates it against the local work-item store, so both 0170's `create`/
-`update --push` flows and 0171's per-provider client adapters have a stable
-port to build against, and the sync flow can be unit-tested against a fake
-`RemoteTracker`.
+machine, in pure domain terms), the `accelerator work sync` command that
+orchestrates it against the local work-item store, and the `--push` wiring
+onto 0170's `create`/`update` commands — so 0171's per-provider client
+adapters have a stable port to build against, the sync flow (and the
+`--push` flows) can be unit-tested against a fake `RemoteTracker`, and 0170
+ships its lifecycle CRUD with zero dependency on this crate.
 
 ## Context
 
@@ -42,12 +44,20 @@ remote tracker. This story split off from 0170 (the work-item lifecycle
 subdomain — see that item's Drafting Notes) on 2026-08-05 following a work
 item review that found the two efforts independently deliverable: the
 `tracker` crate depends only on the already-built shared `corpus`/`config`/
-`store` crates (0166), not on 0170's own CRUD implementation, whereas 0170's
-`create`/`update --push` flows and 0171's client adapters both need this
-crate's `RemoteTracker` port to exist first. The `RemoteTracker` port and
-the sync state machine live in their own `tracker` crate;
-`accelerator-work` links the per-provider client adapters (0171) in-process
-at its composition root and fakes the port in tests.
+`store` crates (0166), not on 0170's own CRUD implementation, whereas
+0171's client adapters need this crate's `RemoteTracker` port to exist
+first. `create`/`update --push` were originally scoped to 0170 too, calling
+through this crate's port; a follow-up review found that made 0170
+dependent on this crate for no good reason, since only the `--push` flag
+needed the port, not the rest of 0170's CRUD surface. `--push` support (and
+the `work-item-create-remote.sh`/`work-item-update-remote.sh`/
+`work-item-push-decide.sh` scripts that implement it) moved here instead:
+this story now wires `--push` onto 0170's `create`/`update` commands once
+they exist, so 0170 itself carries no dependency on the `RemoteTracker`
+port at all. The `RemoteTracker` port and the sync state machine live in
+their own `tracker` crate; `accelerator-work` links the per-provider client
+adapters (0171) in-process at its composition root and fakes the port in
+tests.
 
 ## Requirements
 
@@ -61,21 +71,42 @@ at its composition root and fakes the port in tests.
   client, wired at the work binary's composition root per `work.integration`
   (the config key selecting the active remote tracker provider, e.g. `jira`
   or `linear`).
+- Wire `--push` onto 0170's `accelerator work create`/`update` commands,
+  calling through this crate's `RemoteTracker` port: on `create --push`,
+  create the remote issue and substitute `external_id` before the single
+  write — no file exists until success, decline, or confirmed-local-
+  fallback resolves, per `work-item-create-remote.sh`'s existing outcome
+  table; when the remote call fails, the file is still written but without
+  `external_id` (saved unsynced), with guidance matching that table's
+  retryable/terminal rows — never silently duplicates a create on retry.
+  On `update --push` targeting a synced item, replace the remote issue via
+  the same whole-content contract as `work-item-update-remote.sh`; when
+  the remote replace call fails, surface that script's existing
+  retryable-vs-terminal exit distinction (`E_DISPATCH_RETRYABLE` =
+  provably no mutation, safe to retry; `E_DISPATCH_TERMINAL` = mutation
+  state uncertain, never auto-retried) and define the corresponding
+  local-file outcome for each case — must not leave the local file
+  silently diverged from a replace that may have actually applied.
 - Preserve the JSONL/atomic-write semantics for baseline writes (via
   `store`).
 - Close the coverage gap: characterize-then-port the sync-side previously
   untested scripts — `work-item-sync-baseline.sh`, `work-item-sync-classify.sh`,
-  `work-item-sync-decide.sh`, `work-item-sync-label.sh` (none has a dedicated
-  `test-work-item-*.sh` suite today; `work-item-sync-apply.sh` already does
-  and is out of scope here).
+  `work-item-sync-decide.sh`, `work-item-sync-label.sh` — plus
+  `work-item-push-decide.sh`, which moved here from 0170 alongside the
+  `--push` wiring it decides for and also has no dedicated
+  `test-work-item-*.sh` suite today (`work-item-sync-apply.sh`,
+  `work-item-create-remote.sh`, and `work-item-update-remote.sh` all
+  already have dedicated `test-work-item-*.sh` suites, so they need
+  porting and removal only, not new characterization tests).
 - Partition tests so the default `cargo test`/`cargo nextest run` invocation
   exercises the parity/characterization suite only (no live network calls);
   gate the contract/integration suite exercising real remote calls behind a
   separate, explicitly-tagged cargo-nextest filter excluded from that
   default invocation.
 - Remove the migrated `work-item-sync-*.sh` scripts, `work-item-fetch-remote.sh`,
-  and their `test-*.sh` suites, and decrement the work suite floor in the
-  same change.
+  `work-item-create-remote.sh`, `work-item-update-remote.sh`,
+  `work-item-push-decide.sh`, and their `test-*.sh` suites, and decrement
+  the work suite floor in the same change.
 
 ## Acceptance Criteria
 
@@ -98,11 +129,32 @@ at its composition root and fakes the port in tests.
       `decide` stage consults to choose push, pull, or no-op per item)
       forbids writes in the disallowed direction, matching
       `work-item-sync-decide.sh`'s forbidden-write cells.
-- [ ] Given each of the four previously-untested sync scripts
-      (`sync-baseline`, `sync-classify`, `sync-decide`, `sync-label`), a
-      characterization test captures its pre-port behaviour — covering each
-      documented flag/argument combination and at least one error path —
-      before the Rust port replaces it.
+- [ ] Given a fresh work item directory, when `accelerator work create
+      --push` runs, then it allocates the next ID per the configured
+      pattern and, when the remote create call via the wired (or, in unit
+      tests, faked) `RemoteTracker` port succeeds, writes the local file
+      with `external_id` already substituted — no file exists until
+      success, decline, or confirmed-local-fallback resolves, per
+      `work-item-create-remote.sh`'s existing outcome table; when the
+      remote call fails, the file is still written but without
+      `external_id` (saved unsynced), with guidance matching that table's
+      retryable/terminal rows — the command never silently duplicates a
+      create on retry.
+- [ ] Given a work item file, when `accelerator work update --push`
+      targets a synced item, then the remote issue is replaced via the
+      same whole-content contract as `work-item-update-remote.sh`; when
+      the remote replace call fails, the command surfaces that script's
+      existing retryable-vs-terminal exit distinction
+      (`E_DISPATCH_RETRYABLE` = provably no mutation, safe to retry;
+      `E_DISPATCH_TERMINAL` = mutation state uncertain, never
+      auto-retried) with the corresponding local-file outcome for each
+      case — it must not leave the local file silently diverged from a
+      replace that may have actually applied.
+- [ ] Given each of the five previously-untested sync-side scripts
+      (`sync-baseline`, `sync-classify`, `sync-decide`, `sync-label`,
+      `push-decide`), a characterization test captures its pre-port
+      behaviour — covering each documented flag/argument combination and
+      at least one error path — before the Rust port replaces it.
 - [ ] The `sync` parity suite (`accelerator work sync` against the
       repointed `skills/work/scripts/test-work-item-sync-*.sh` gates and the
       classify/decide fixtures) passes with no live network calls; remote
@@ -114,37 +166,37 @@ at its composition root and fakes the port in tests.
       provider-crate types in public signatures) — 0171's clients implement
       the port instead.
 - [ ] The migrated `work-item-sync-*.sh` scripts, `work-item-fetch-remote.sh`,
-      and their `test-*.sh` suites are removed and the work suite floor is
-      decremented in the same change.
+      `work-item-create-remote.sh`, `work-item-update-remote.sh`,
+      `work-item-push-decide.sh`, and their `test-*.sh` suites are removed
+      and the work suite floor is decremented in the same change.
 
 ## Open Questions
 
-- Whether `work-item-sync-decide.sh`'s internal-function boundary (kept as
-  a private function inside `sync` per 0170's Technical Notes, not a
-  separate subcommand) holds once the `tracker` crate scaffolding starts —
+- Whether `work-item-sync-decide.sh`'s and `work-item-push-decide.sh`'s
+  internal-function boundaries (both kept as private functions, not
+  separate subcommands) hold once the `tracker` crate scaffolding starts —
   a bash-era boundary may turn out to matter for a reason not visible from
-  the script's header comment alone. Carried over from 0170's Drafting
-  Notes as the sync-specific half of that judgment call.
+  either script's header comment alone. Carried over from 0170's Drafting
+  Notes as the sync-specific half of that judgment call, plus
+  `push-decide`'s share of it following the 2026-08-05 `--push`-wiring
+  move.
 
 ## Dependencies
 
-- No remaining blockers: 0166 (shared crates) and 0187 (generalises the
-  sub-binary registration surface) are both done as of 2026-08-05. The
-  `tracker` crate's own build only needs these two, not 0170's CRUD
-  implementation.
-- Blocks: 0170 (the work-item lifecycle subdomain) — `create`/`update
-  --push` call through the `RemoteTracker` port this story defines, so
-  0170 cannot implement `--push` (though it can implement the rest of its
-  CRUD surface) until this crate's port is stable. This blocking milestone
-  is narrower than this item's full Acceptance Criteria gate: 0170 only
-  needs the `RemoteTracker` trait signature to compile, not the finished
-  `accelerator work sync` command, its characterization-test suites, or the
-  legacy-script removal — those can land after 0170 unblocks.
+- The `tracker` crate, the `sync` command, and their characterization
+  tests have no remaining blockers: 0166 (shared crates) and 0187
+  (generalises the sub-binary registration surface) are both done as of
+  2026-08-05, and none of that work needs 0170's CRUD implementation — it
+  can proceed in parallel with 0170 from the start.
+- Blocked by: 0170 (the work-item lifecycle subdomain) — but only for the
+  `--push`-wiring slice of this story's own scope: wiring `--push` onto
+  `accelerator work create`/`update` needs those commands to exist first.
+  The rest of this story is unblocked and can start immediately.
 - Blocks: 0171 (Jira and Linear Integrations) — its client adapters
   implement the `RemoteTracker` port this story defines; 0171 cannot
   complete its `impl RemoteTracker` work until this crate's port is
-  stable. As with 0170, only the port signature is the actual blocking
-  milestone, not this item's full acceptance gate.
+  stable. Only the port signature is the actual blocking milestone, not
+  this item's full acceptance gate.
 - Parent: epic 0136.
 
 ## Assumptions
@@ -157,30 +209,45 @@ at its composition root and fakes the port in tests.
 - The active provider client is faked at the `RemoteTracker` port boundary
   for this story's own unit tests; real Jira/Linear wiring is exercised
   once 0171 lands, via the separate contract/integration suite.
+- 0170's `create`/`update` CLI signatures (flags and arguments) are stable
+  once implemented, so this story's `--push` wiring doesn't need to
+  renegotiate them; if 0170's signatures change after landing, that wiring
+  may need rework.
 
 ## Technical Notes
 
-- Source bash: `skills/work/scripts/work-item-sync-*.sh` and
+- Source bash: `skills/work/scripts/work-item-sync-*.sh`,
   `work-item-fetch-remote.sh` (the sync engine's read counterpart to
-  `work-item-create-remote.sh`; `work-item-sync-apply.sh` calls it directly
-  — it is not a 0170 lifecycle concern despite appearing in that item's
-  original source-bash list before the split. It already has a dedicated
-  `test-work-item-fetch-remote.sh` suite, so it needs no new
-  characterization test, only porting and removal alongside the other
-  sync-stage scripts).
+  `work-item-create-remote.sh`; `work-item-sync-apply.sh` calls it
+  directly. It already has a dedicated `test-work-item-fetch-remote.sh`
+  suite, so it needs no new characterization test, only porting and
+  removal alongside the other sync-stage scripts), and — moved from 0170
+  alongside the `--push` wiring they implement —
+  `work-item-create-remote.sh`, `work-item-update-remote.sh` (both already
+  have dedicated `test-work-item-{create-remote,update-remote}.sh` suites,
+  so they need porting and removal only) and `work-item-push-decide.sh`
+  (no dedicated suite; needs a new characterization test, see Acceptance
+  Criteria).
 - The sync flow depends on config + JSONL/store + the integration clients
   (0171); this story only requires the port to exist, not a concrete
   provider implementation.
+- The `--push` wiring onto `create`/`update` extends 0170's
+  already-implemented command definitions in `accelerator-work` with a
+  `--push` flag that calls through this crate's port — it's a follow-on
+  change to 0170's code, not a rewrite of it.
 - `work sync [--push-only|--pull-only]` runs the classify → decide → apply →
   baseline → label pipeline as one command; the current plan is for the five
   stages to stay internal functions, not separate subcommands, unit-tested
   directly at the function level — pending confirmation once the `tracker`
   crate scaffolding starts (see Open Questions).
-- Because the reversed sequencing means this story, not 0170, may be the
-  first to scaffold/extend the `accelerator-work` binary and its composition
-  root, registration follows the same checklist 0187 adds at
+- Both this story and 0170 are now fully independent for their own
+  respective scopes (the tracker crate/sync command here, the CRUD
+  commands there), so either could scaffold/extend the `accelerator-work`
+  binary and its composition root first. Registration follows the same
+  checklist 0187 adds at
   `tasks/README.md#registering-a-dispatched-sub-binary` that 0170's
-  Technical Notes also references.
+  Technical Notes also references — whichever story lands first does the
+  actual registration; the other just finds it already done.
 
 ## Drafting Notes
 
@@ -205,6 +272,13 @@ at its composition root and fakes the port in tests.
   Requirements bullets mirroring AC4's test-partitioning and AC6's
   removal/floor-decrement scope, and glossed several previously-undefined
   terms (`work.integration`, the decision table, the Q2 reference).
+- Revised 2026-08-05, following a review discussion: absorbed `--push`
+  support for 0170's `create`/`update` commands (and the
+  `work-item-create-remote.sh`/`work-item-update-remote.sh`/
+  `work-item-push-decide.sh` scripts that implement it) from 0170, to
+  remove 0170's dependency on this crate entirely. This story now depends
+  on 0170 instead, but only for the new `--push`-wiring ACs; the `tracker`
+  crate and `sync` command remain independent of 0170, as before.
 
 ## References
 


### PR DESCRIPTION

# Split 0170/0194 tracker crate and remote sync engine work items

## Summary

Splits work item 0170 (Work-Item Subdomain and Sync Engine) into a lean lifecycle-CRUD story (0170) and a new tracker-crate-and-sync-engine story (0194), then reviews and refines 0194 through all five work item lenses, then moves `--push` support out of 0170 and into 0194 so the two stories carry no dependency on each other beyond one narrow slice. Net effect: 0170 and 0194 can now be implemented fully in parallel, with only 0194's `--push`-wiring acceptance criteria waiting on 0170's `create`/`update` commands existing.

## Changes

- Splits 0170 into 0170 (lifecycle CRUD: create/show/update/resolve/diff) and a new 0194 (the `tracker` crate's `RemoteTracker` port, the sync state machine, and the `accelerator work sync` command), following work item review 1 of 0170, which found the combined story epic-scale and the two halves independently deliverable.
- Updates the 0136 epic's decomposition list and 0171's dependency/relates_to references to point at 0194 for the `RemoteTracker` port instead of 0170.
- Reviews 0194 through all five work item lenses (clarity, completeness, dependency, scope, testability); the only major finding (AC1's resumability contract had no concrete verification procedure) and several minor/clarity gaps are addressed directly in the item, then verified resolved on re-review — verdict APPROVE.
- Decouples 0170 from 0194 entirely: moves `--push` support for `create`/`update` (and the `work-item-create-remote.sh`, `work-item-update-remote.sh`, and `work-item-push-decide.sh` scripts that implement it) out of 0170's scope and into 0194's. 0170 now ships as pure local-only CRUD with zero remaining blockers; 0194 gains two new acceptance criteria for the `--push` wiring and becomes `blocked_by: 0170` for that one slice only — the `tracker` crate and `sync` command remain independently deliverable.
- Adds two new review artifacts (`meta/reviews/work/0170-...-review-1.md`, `meta/reviews/work/0194-...-review-1.md`) documenting both review passes, findings, and resolutions.

## Context

Parent epic: 0136 (Migrate Shell Scripts into a Rust CLI). Directly restructures work items 0170, 0194, and touches 0171 and 0136 for cross-references. No source code changes — this PR is entirely `meta/work/` and `meta/reviews/work/` planning documents.

## Testing

- [x] All six changed files are markdown planning documents (work items and work item reviews) under `meta/`; there is no code change, so the standard `mise run check`/`mise run test:*` suites don't apply.
- [x] Cross-checked frontmatter typed-linkage fields (`blocks`/`blocked_by`/`relates_to`) for consistency across all four touched work items (0136, 0170, 0171, 0194) — the blocking relationship between 0170 and 0194 correctly reverses for the `--push`-wiring slice while the rest of each item's dependency graph stays accurate.
- [x] Grepped for stale cross-references to the removed `0170 --push`/`RemoteTracker` coupling across all four files after the decoupling edit; none found.
- [ ] No manual/UI verification applicable (documentation-only change).

## Notes for Reviewers

- The three commits read as a sequence: split → review-and-approve 0194 → decouple 0170 from 0194. Each is independently reviewable.
- The most consequential judgment call is in the third commit: moving `--push` support (and its three source bash scripts) from 0170 into 0194 reverses part of the dependency direction established in the first commit. Worth double-checking that 0194's new Acceptance Criteria for `create --push`/`update --push` (mirroring the old 0170 ones) and the updated Dependencies sections on both items still read coherently together.
- 0170's Acceptance Criteria for `create`/`update` are now considerably simpler (local-only, no remote-call/retry semantics) — the removed complexity moved to 0194's two new ACs, not lost.
