### PR TITLE
Split work-item 0173 into 0195/0196/0197, review each, and mark 0197 ready

### DIFF
--- a/meta/prs/52-description.md
+++ b/meta/prs/52-description.md
@@ -1,0 +1,48 @@
+---
+type: pr-description
+id: "52"
+title: "Split work-item 0173 into 0195/0196/0197, review each, and mark 0197 ready"
+date: "2026-08-06T01:34:44+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+parent: "work-item:0136"
+relates_to: ["work-item:0173", "work-item:0195", "work-item:0196", "work-item:0197"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/52"
+pr_number: 52
+tags: []
+revision: "da56e1204b087db48d4da7e48193cae002465c1b"
+repository: "accelerator"
+last_updated: "2026-08-06T01:34:44+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Split work-item 0173 into 0195/0196/0197, review each, and mark 0197 ready
+
+## Summary
+
+Work-item 0173 bundled three functionally independent efforts — `accelerator-corpus`, `accelerator-design`, and `accelerator-collaboration` — into a single oversized story, and its review-1 pass flagged this as a scope violation. This PR abandons 0173 and splits it into three new stories (0195, 0196, 0197) parented directly under the 0136 epic, reviews each of the three through all five work-item lenses, addresses the findings from 0197's review, and marks all three items `ready` for planning. It touches only `meta/work/` and `meta/reviews/work/` — no source code changes.
+
+## Changes
+
+- Abandon work-item:0173 (`status: abandoned`), record the split rationale in its Drafting Notes, and link forward to its three successors via `relates_to` and a new "Superseded by" reference.
+- Add work-item:0195 (`accelerator-corpus`: ADR, metadata, frontmatter validation, and linkage CLI), work-item:0196 (`accelerator-design`: design inventory and gap tooling CLI), and work-item:0197 (`accelerator-collaboration`: PR helper CLI), each carrying forward its slice of 0173's Requirements/Acceptance Criteria/Dependencies with that review's gaps fixed, and each set to `status: ready`.
+- Review 0173, 0195, 0196, and 0197 through the clarity, completeness, dependency, scope, and testability lenses; record each review under `meta/reviews/work/`. 0173's review-1 (verdict REVISE) is the scope finding that motivated the split. 0195 and 0196 land at verdict APPROVE. 0197 goes through two review passes: pass 1 (verdict COMMENT) surfaces a cross-cutting finding that 0197 inconsistently characterised work-item:0150's completion status across its Summary, Context, and Dependencies sections, plus several precision gaps (glob-shaped scope language, Requirements missing two AC-gated obligations, an ambiguous AC1 verification method); pass 2, after those edits, surfaces one new major finding — 0197 didn't reciprocate a sibling-coordination note that 0196 already carries about concurrent sub-binary registration touching shared state — which is then also addressed, bringing 0197 to verdict APPROVE.
+- Update work-item:0136 (the epic)'s phase list and Drafting Notes to reflect the split, and update work-item:0174's `blocked_by` and work-item:0179's `blocks`/cross-references to point at 0195/0196/0197 instead of the now-abandoned 0173.
+
+## Context
+
+Part of the ongoing shell-to-Rust CLI migration epic (work-item:0136). 0173 was originally extracted from `codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture` as a single grouped story for the three remaining sub-binary domains; its review-1 found the grouping risked partial-completion ambiguity and an oversized PR, since the three sub-binaries share no functional relationship beyond the sub-binary registration pattern (work-item:0187).
+
+## Testing
+
+- [x] Confirmed every changed file's YAML frontmatter parses as valid YAML with the expected keys (ran a standalone parse check across all 11 touched files).
+- [x] Confirmed 0173/0174/0179's cross-references to the split items are reciprocal (e.g. 0174's `blocked_by` lists 0195/0196/0197; 0196's Dependencies names 0195 and 0197 in its coordination note, which 0197 now reciprocates).
+- [ ] No source code changed by this PR, so `mise run check`/`mise run` were not run — there is nothing in `cli/`, `server/`, `frontend/`, or `tasks/` for them to exercise.
+
+## Notes for Reviewers
+
+This is a documentation/work-item-management PR only; it reshapes planning artifacts ahead of implementation, not application behaviour. Actual implementation of 0195/0196/0197 (the three Rust sub-binaries themselves) is follow-up work, not part of this PR.
+
+One known gap, left out of scope deliberately rather than fixed here: five already-completed/merged items (work-item:0166, 0167, 0169, 0172, 0187) still carry a `blocks: [..., "work-item:0173"]` frontmatter edge from before the split. Since 0173 is now abandoned rather than progressing, those edges are stale — they should arguably be retargeted at 0195/0196/0197 (mirroring what this PR already did for 0174 and 0179), but touching five unrelated, already-shipped items felt like scope creep for a PR whose job is the split itself. Flagging for a reviewer call on whether that cleanup belongs here, in a quick follow-up, or is fine left as historical record.

--- a/meta/reviews/work/0173-remaining-subdomains-corpus-design-collaboration-review-1.md
+++ b/meta/reviews/work/0173-remaining-subdomains-corpus-design-collaboration-review-1.md
@@ -1,0 +1,412 @@
+---
+type: work-item-review
+id: "0173-remaining-subdomains-corpus-design-collaboration-review-1"
+title: "Work Item Review: Remaining Subdomains: corpus, design, collaboration"
+date: "2026-08-05T18:55:14+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0173"
+work_item_id: "0173"
+reviewer: Toby Clemson
+verdict: REVISE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 1
+tags: []
+last_updated: "2026-08-05T18:55:14+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Remaining Subdomains: corpus, design, collaboration
+
+**Verdict:** REVISE
+
+The item is internally consistent and unusually well-maintained for its Dependencies
+section (concrete resolved-blocker evidence, a reusable registration-checklist
+pointer), but two structural problems recur across lenses: it bundles three
+functionally independent migration efforts (`accelerator-corpus`,
+`accelerator-design`, `accelerator-collaboration`) into a single `story`, and its
+Acceptance Criteria leave a stated Requirement (the skill call-site/`allowed-tools`
+rewrite) unverified while two other criteria rely on subjective baselines
+("launches correctly", "shells to `gh` as before"). The item's own Drafting Notes
+already flag that Acceptance Criteria, Requirements, and `kind` were not reviewed
+in the last enrichment pass — this review's findings confirm that pass is still
+needed.
+
+### Cross-Cutting Themes
+
+- **Skill call-site/`allowed-tools` rewrite is unverifiable** (flagged by:
+  completeness, testability) — Requirements' fourth bullet (apply the Q7
+  interface-redesign principle; rewrite call sites + `allowed-tools`) has no
+  matching Acceptance Criterion, so this requirement could be left undone while
+  every stated AC still passes.
+- **Story bundles three independently deliverable efforts** (flagged by: scope,
+  echoed by dependency and completeness) — `accelerator-corpus`,
+  `accelerator-design`, and `accelerator-collaboration` share no functional
+  relationship beyond the shared registration pattern; each has its own source
+  scripts, target crate(s), skill domain, and test suite. The Context section's
+  own "may be split into three separate work items" line, and the Open
+  Questions/Requirements duplication over the Playwright executor's fate, are
+  symptoms of this same unresolved granularity question.
+- **Acceptance Criteria lean on undefined baselines** (flagged by: testability) —
+  "launches correctly" and "shells to `gh` as before" give a verifier no
+  observable pass/fail threshold, compounding the risk that the bundled scope
+  above makes partial completion hard to assess cleanly.
+
+### Findings
+
+#### Major
+
+- 🟡 **Completeness/Testability**: No acceptance criterion covers the skill
+  call-site / `allowed-tools` rewrite requirement
+  **Location**: Requirements; Acceptance Criteria
+  Requirements' fourth bullet mandates rewriting affected skills' call sites and
+  `allowed-tools` frontmatter per the Q7/0167 contract, but none of the four
+  Acceptance Criteria checks this — an implementer could satisfy every stated AC
+  while leaving skill call sites unrewritten or `allowed-tools` stale.
+
+- 🟡 **Scope**: Three independent bounded contexts bundled into a single story
+  **Location**: Summary; Requirements
+  `accelerator-corpus`, `accelerator-design`, and `accelerator-collaboration` are
+  functionally unrelated efforts, each with its own source scripts, target
+  crate(s), skill domain, and characterization/repointed test suite. They could
+  be implemented, reviewed, and merged independently, risking an oversized PR or
+  unclear partial-completion semantics if one binary blocks while the others are
+  ready.
+
+- 🟡 **Testability**: "Launches correctly" has no defined pass/fail threshold
+  **Location**: Acceptance Criteria
+  The design-binary criterion — "the Playwright executor still launches
+  correctly" — doesn't define "correctly" (exit code, absence of errors, a
+  specific artefact, parity with a prior invocation), so a verifier cannot
+  conclusively determine pass/fail.
+
+- 🟡 **Testability**: "Shells to gh as before" relies on an undefined baseline
+  **Location**: Acceptance Criteria
+  The collaboration-binary criterion offers no enumerated `gh` sub-commands,
+  flags, or expected outputs, and "before" is only recoverable by reading the
+  source bash scripts — not itself named as the verification mechanism.
+
+- 🟡 **Scope**: Story kind likely undersized for the combined scope
+  **Location**: Frontmatter: kind
+  The combined scope requires three separate sub-binary registrations (each
+  following a 13-point checklist), skill/`allowed-tools` rewrites across three
+  domains, and characterization suites per binary — materially larger than the
+  single-binary stories seen elsewhere in the same epic (e.g., 0179, 0169).
+
+#### Minor
+
+- 🔵 **Dependency**: 0179 (the crate-delivering work item) is not named alongside
+  its parent 0166
+  **Location**: Dependencies
+  The item's own References cite 0179 as the source of the crates this binary
+  sits on, and 0179 explicitly lists 0173 as a consumer it blocks — yet
+  Dependencies names only the coarser parent 0166 as the resolved blocker.
+
+- 🔵 **Dependency**: Downstream consumer 0174 not named as a Blocks entry
+  **Location**: Dependencies
+  Work-item 0174 lists 0173 in its own `blocked_by` and keys its floor-decrement
+  work directly to this story's shell removal, but this item's Dependencies
+  section has no reciprocal "Blocks" entry — the coupling is visible only from
+  0174's side.
+
+- 🔵 **Clarity**: "Q5"/"Q7" shorthand collides with the work item's own Open
+  Questions section
+  **Location**: Context; Requirements; Assumptions; Technical Notes
+  These labels refer to numbered questions in an external research document, but
+  this item has its own differently-numbered "Open Questions" section, so a
+  reader unfamiliar with the epic-level document may conflate the two or fail to
+  resolve the shorthand at all.
+
+- 🔵 **Clarity**: "Open" github→collaboration rename reads as undecided, but
+  Requirements state it as settled
+  **Location**: Summary; Context; Requirements
+  Summary/Context call it "the open github→collaboration rename" while
+  Requirements states flatly "Domain named `collaboration`, not `github`" with no
+  hedge — the two registers could read as describing different things.
+
+- 🔵 **Clarity**: Playwright executor's fate stated as either/or in Requirements,
+  then separately flagged as unresolved in Open Questions
+  **Location**: Requirements; Open Questions
+  The same undecided point (thin-wrapper vs. folded into the binary) appears
+  twice in different registers, risking a reader treating it as already settled
+  since it appears in Requirements rather than only as an Open Question.
+
+- 🟡 **Completeness**: Item's own notes flag acceptance criteria, requirements,
+  and kind as not yet reviewed
+  **Location**: Drafting Notes
+  The Drafting Notes explicitly state these sections "were not reviewed this
+  round — status intentionally left at draft pending that pass," meaning the
+  content just evaluated is self-flagged as provisional.
+
+- 🔵 **Scope**: Split-or-keep decision left open without criteria
+  **Location**: Context
+  The item states it "may be split into three separate work items if finer
+  granularity is wanted" but doesn't commit to a decision or state what would
+  trigger a split, leaving the question to resurface mid-implementation when
+  splitting is more disruptive.
+
+- 🔵 **Testability**: "Characterization tests where none exist" has no defined
+  coverage bar
+  **Location**: Acceptance Criteria
+  No minimum coverage is specified (e.g., happy path plus one failure path per
+  sub-command), so a single trivial test per gap could technically satisfy the
+  criterion.
+
+- 🔵 **Testability**: Registration-checklist compliance is stated as a dependency
+  but not as a verifiable criterion
+  **Location**: Dependencies
+  No Acceptance Criterion asserts the 13-point registration checklist was
+  actually applied and verified for all three binaries, so incomplete
+  registration could pass under the stated ACs.
+
+- 🔵 **Completeness**: No identification of the beneficiary whose need is met by
+  this migration
+  **Location**: Context
+  As a `story`, the item is expected to name who benefits; this is left implicit
+  and inherited from the parent epic.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "The relevant skills" is less specific than the named paths
+  given in Acceptance Criteria
+  **Location**: Requirements
+  Requirements' fourth bullet doesn't name which skills are relevant, though
+  Acceptance Criteria later enumerates the specific paths.
+
+- 🔵 **Dependency**: `gh` CLI external-tool coupling not named in Dependencies
+  **Location**: Requirements
+  `accelerator-collaboration` shells to `gh`, a runtime availability precondition
+  that isn't recorded in the Dependencies section.
+
+- 🔵 **Clarity**: "Dependency-bleed rationale" and "typed-linkage" used without an
+  in-document link
+  **Location**: Context
+  Both are terms of art from the epic's crate-split design, defined elsewhere
+  (e.g., ADR-0034), which isn't listed in this item's References.
+
+- 🔵 **Dependency**: Playwright executor runtime dependency not named in
+  Dependencies
+  **Location**: Requirements
+  The design binary implies a Node/Playwright runtime precondition, pre-existing
+  but unrecorded in Dependencies.
+
+### Strengths
+
+- ✅ The Dependencies section is unusually well-maintained: resolved blockers cite
+  concrete evidence (e.g., "work-item:0187 ... merged via PR #42") rather than an
+  unqualified "done", and the registration dependency is anchored to a specific,
+  reusable checklist location rather than a vague ask.
+- ✅ The three binary names and their constituent scripts/skills are stated
+  identically across Summary, Requirements, and Acceptance Criteria, with no
+  scope drift between sections, and each binary is given a clearly delineated
+  boundary (specific source scripts, crates, skill directories).
+- ✅ Acceptance Criteria are specific per sub-binary, naming concrete existing
+  sub-commands and behaviours (ADR numbering/status, artifact metadata,
+  frontmatter validation, linkage queries; inventory/gap tooling) rather than
+  gesturing vaguely at "migrate the functionality".
+- ✅ The removal/cleanup criterion is concretely verifiable — specific
+  files/directories are named for deletion with an explicit suite-floor
+  decrement requirement, giving a before/after comparison a verifier can run.
+- ✅ Technical Notes names the exact source bash files being migrated, and the
+  Drafting Notes transparently record the 2026-08-05 dependency-refresh pass and
+  what changed, giving a clear audit trail.
+
+### Recommended Changes
+
+1. **Add an Acceptance Criterion for the skill call-site/`allowed-tools` rewrite**
+   (addresses: "No acceptance criterion covers the skill call-site /
+   `allowed-tools` rewrite requirement"). E.g., "All skills invoking the migrated
+   scripts are repointed to the new `accelerator <subdomain>` sub-commands, with
+   `allowed-tools` updated per the 0167 contract" — ideally naming the specific
+   skills to check.
+
+2. **Replace subjective Acceptance Criteria with observable outcomes**
+   (addresses: "Launches correctly" and "Shells to gh as before" findings). State
+   an exit code/artefact/parity check for the Playwright executor, and either
+   enumerate the specific `gh` invocations each PR helper must issue or require
+   passing characterization tests capturing the current `gh` call shape.
+
+3. **Resolve the split-vs-single-story scope question before implementation**
+   (addresses: both scope major findings and the "split-or-keep decision left
+   open" minor). Either split into three stories (corpus, design, collaboration)
+   mirroring the granularity used elsewhere in epic 0136, or re-kind as an epic
+   with three child stories; commit to a rationale either way rather than
+   leaving it as an implicit option.
+
+4. **Add the missing Dependencies entries** (addresses: 0179/0174 findings, and
+   the `gh`/Playwright external-tool suggestions). Name work-item:0179
+   specifically alongside 0166, add a "Blocks: work-item:0174" entry, and
+   optionally note the `gh` CLI and Playwright/Node runtime preconditions.
+
+5. **Disambiguate the Q5/Q7 shorthand and the Playwright executor's status**
+   (addresses: the three clarity minor findings). Either spell out what each
+   resolved question decided inline every time it's referenced, or drop the
+   labels in favour of stating the resolved rule directly; state the Playwright
+   executor's open/closed status once, in one section, with the other
+   cross-referencing it.
+
+6. **Tighten the remaining testability gaps** (addresses: characterization
+   coverage bar, registration-checklist criterion). Define a minimum
+   characterization-test coverage expectation per sub-command, and add a
+   criterion that each binary passes every item of the registration checklist.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: 0173 is largely internally consistent — the three binaries named in
+the Summary recur unchanged through Requirements and Acceptance Criteria, and the
+Dependencies section is concrete about what has and hasn't resolved. The main
+clarity gaps are shorthand references to decisions logged in an external document
+("Q5", "Q7") that collide in name with this item's own Open Questions section, a
+status word ("open") applied to the github→collaboration rename that sits
+awkwardly next to a Requirements bullet that treats the rename as settled, and one
+place where the Requirements text hedges between two outcomes that the Open
+Questions section separately (and more explicitly) flags as undecided.
+
+**Strengths**:
+- The three binary names and their constituent script/skill groupings are stated
+  identically in Summary, Requirements, and Acceptance Criteria, with no scope
+  drift between sections.
+- The Dependencies section names each prior blocker by ID, states its resolution
+  explicitly (including a PR number), and gives a concrete pointer
+  (tasks/README.md#registering-a-dispatched-sub-binary) for the registration
+  step rather than a vague instruction.
+- The Technical Notes section names the exact source bash files being migrated,
+  leaving no ambiguity about what "the remaining script clusters" in the Summary
+  actually refers to.
+
+**Findings**:
+- 🔵 minor/medium — "Q5"/"Q7" shorthand collides with the work item's own Open
+  Questions section (Context, Requirements, Assumptions, Technical Notes)
+- 🔵 minor/medium — "Open" github→collaboration rename reads as undecided, but
+  Requirements state it as settled (Summary, Context, Requirements)
+- 🔵 minor/medium — Playwright executor's fate is stated as an either/or in
+  Requirements, then separately flagged as unresolved in Open Questions
+  (Requirements, Open Questions)
+- 🔵 suggestion/medium — "The relevant skills" is less specific than the named
+  paths given in Acceptance Criteria (Requirements)
+- 🔵 suggestion/low — "Dependency-bleed rationale" and "typed-linkage" used
+  without an in-document link (Context)
+
+### Completeness
+
+**Summary**: The work item is structurally well-formed for a story: every
+standard section is present and substantively populated, and the frontmatter is
+fully specified with a recognised kind and status. The main gap is that one
+Requirements bullet (the Q7 interface-redesign / skill call-site rewrite) has no
+corresponding Acceptance Criterion, so "done" for that part of the work is left
+undefined; a secondary observation is that the item's own Drafting Notes flag
+that acceptance criteria, requirements, and kind have not yet been reviewed this
+round.
+
+**Strengths**:
+- Every expected section for a story is present and substantively populated —
+  no placeholder or empty sections.
+- Acceptance Criteria are specific per sub-binary and include an explicit
+  cleanup criterion (legacy script removal with suite-floor decrement).
+- The Dependencies section is current and precise — it explicitly states which
+  prior blockers are now resolved rather than leaving stale `blocked_by`
+  references, and points to the concrete registration checklist to apply three
+  times.
+
+**Findings**:
+- 🟡 major/high — No acceptance criterion covers the interface-redesign / skill
+  call-site rewrite requirement (Acceptance Criteria)
+- 🟡 minor/medium — Item's own notes flag acceptance criteria, requirements, and
+  kind as not yet reviewed (Drafting Notes)
+- 🔵 minor/low — No identification of the beneficiary whose need is met by this
+  migration (Context)
+
+### Dependency
+
+**Summary**: The Dependencies section is unusually well-maintained for a draft
+item — it names three specific resolved blockers with evidence (a merged PR
+number) rather than vague status claims, and anchors the registration-surface
+dependency to a concrete document location. The main gaps are precision issues:
+References cite 0179 as the crate source but Dependencies names only the coarser
+parent (0166); sibling item 0174 explicitly lists this story as a blocker but the
+reverse Blocks entry is absent; and two runtime external-tool couplings (`gh`,
+the Playwright executor) go unmentioned in Dependencies.
+
+**Strengths**:
+- The resolved-blocker list cites concrete evidence ("work-item:0187 merged via
+  PR #42") rather than an unqualified "done".
+- The sub-binary registration dependency is anchored to a specific, reusable
+  location and explicitly notes it applies three times over.
+- The Drafting Notes transparently record when this dependency refresh
+  happened and what changed, giving a clear audit trail.
+
+**Findings**:
+- 🔵 minor/high — 0179 (the crate-delivering work item) is not named alongside
+  its parent 0166 (Dependencies)
+- 🔵 minor/high — Downstream consumer 0174 not named as a Blocks entry
+  (Dependencies)
+- 🔵 suggestion/medium — gh CLI external-tool coupling not named in Dependencies
+  (Requirements)
+- 🔵 suggestion/low — Playwright executor runtime dependency not named in
+  Dependencies (Requirements)
+
+### Scope
+
+**Summary**: This story bundles three functionally independent migration efforts
+— the accelerator-corpus, accelerator-design, and accelerator-collaboration
+sub-binaries — each with its own source scripts, skill domain, registration
+checklist, and test suite, with the item's own Context section acknowledging it
+"may be split into three separate work items." The internal sections are
+mutually consistent, but that consistency is achieved by uniformly describing
+three parallel efforts rather than one coherent increment, and the declared
+"story" kind understates the combined breadth of the work.
+
+**Strengths**:
+- Summary, Requirements, and Acceptance Criteria are internally consistent with
+  each other — all three consistently scope the work to the same three
+  binaries.
+- Each of the three binaries is given a clearly delineated boundary, which would
+  make a future split into three work items straightforward if pursued.
+- The Dependencies section explicitly surfaces that the registration checklist
+  must be applied three times, showing the author is aware of the multiplicity.
+
+**Findings**:
+- 🟡 major/high — Three independent bounded contexts bundled into a single
+  story (Summary, Requirements)
+- 🟡 major/medium — Story kind likely undersized for the combined scope
+  (Frontmatter: kind)
+- 🔵 minor/medium — Split-or-keep decision left open without criteria (Context)
+
+### Testability
+
+**Summary**: The Acceptance Criteria are unusually well-grounded for a story —
+they name concrete existing scripts, sub-commands, and a specific
+removal/floor-decrement mechanism. However, two criteria fall back on subjective
+or undefined baselines ("launches correctly", "as before"), a substantive
+requirement (rewriting skills' call sites and allowed-tools) has no
+corresponding criterion at all, and the characterization-test criterion has no
+defined coverage bar.
+
+**Strengths**:
+- Acceptance Criteria for the corpus and design binaries enumerate the exact
+  sub-commands/behaviours to reproduce rather than gesturing vaguely at
+  "migrate the functionality".
+- The removal criterion is concretely verifiable: specific files/directories
+  are named for deletion and suite floors must be decremented in lockstep.
+- Grounding verification in "repointed suites" gives a defined verification
+  mechanism rather than relying on manual judgement of behavioural equivalence.
+
+**Findings**:
+- 🔴 major/high — "Launches correctly" has no defined pass/fail threshold
+  (Acceptance Criteria)
+- 🔴 major/high — "Shells to gh as before" relies on an undefined baseline
+  (Acceptance Criteria)
+- 🟡 major/medium — Skill call-site / allowed-tools rewrite has no corresponding
+  Acceptance Criterion (Requirements)
+- 🔵 minor/medium — "Characterization tests where none exist" has no defined
+  coverage bar (Acceptance Criteria)
+- 🔵 minor/medium — Registration-checklist compliance is stated as a dependency
+  but not as a verifiable criterion (Dependencies)
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/reviews/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli-review-1.md
+++ b/meta/reviews/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli-review-1.md
@@ -1,0 +1,416 @@
+---
+type: work-item-review
+id: "0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli-review-1"
+title: "Work Item Review: accelerator-corpus: ADR, Metadata, Frontmatter Validation, and Linkage CLI"
+date: "2026-08-05T19:24:34+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0136"
+target: "work-item:0195"
+work_item_id: "0195"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-06T00:06:12+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: accelerator-corpus: ADR, Metadata, Frontmatter Validation, and Linkage CLI
+
+**Verdict:** REVISE
+
+0195 is a well-formed split from the abandoned 0173 — its Dependencies section
+resolves every prior blocker with provenance, its Acceptance Criteria are
+mostly concrete and enumerable, and it carries forward the resolved Q5
+grouping rationale transparently. The dominant problem is a single unreconciled
+loose end inherited from the split: a Technical Notes aside about an
+"interface-redesign rewrite" for `artifact-derive-metadata`'s output contract
+contradicts the parity/"reproduces" framing used everywhere else, and three
+lenses independently flagged it as leaving the actual pass/fail baseline for
+that subcommand ambiguous. A second, unrelated gap is a runtime dependency —
+how the compiled work-item-id regex reaches the standalone binary — that isn't
+named.
+
+### Cross-Cutting Themes
+
+- **The "interface-redesign rewrite" aside is unreconciled with the
+  "reproduces" framing used everywhere else** (flagged by: clarity,
+  completeness, testability) — Technical Notes says to "treat its output
+  contract carefully under the interface-redesign rewrite" for
+  `artifact-derive-metadata`, implying the contract may change, while Summary,
+  Requirements, and Acceptance Criteria all describe the CLI's job as
+  reproducing existing behaviour. Since this subcommand is "invoked by many
+  skills," the ambiguity is correctness-critical, not cosmetic — three
+  independent lenses reached the same conclusion from different angles
+  (undefined jargon, missing requirement, unverifiable acceptance criterion).
+- **"Reproduces" has no defined equivalence bar** (flagged by: testability,
+  echoed by clarity's "per subcommand" ambiguity) — none of byte-identical
+  output, exit-code parity, or "behaviour documented elsewhere" is stated as
+  the comparison method, for any of the four subcommand groups, not only the
+  flagged one.
+
+### Findings
+
+#### Major
+
+- 🔴 **Clarity/Completeness/Testability**: "Interface-redesign rewrite" is
+  undefined and contradicts the parity framing used elsewhere
+  **Location**: Technical Notes; Acceptance Criteria
+  Technical Notes states `artifact-derive-metadata`'s output contract should
+  be treated carefully "under the interface-redesign rewrite," but no
+  Requirement or Acceptance Criterion defines what this redesign entails, and
+  every other section frames the CLI as reproducing existing behaviour
+  byte-for-byte. An implementer cannot tell whether the output contract is
+  expected to change or must be preserved, risking either broken downstream
+  consumers or a missed intended improvement.
+
+- 🔴 **Testability**: "Reproduces" lacks a defined equivalence bar
+  **Location**: Acceptance Criteria
+  AC1 requires the CLI to "reproduce" ADR numbering/status, artifact metadata,
+  frontmatter validation, and linkage queries, but never states the comparison
+  method (byte-identical stdout, exit-code parity, JSON-shape equivalence, or
+  behaviour-only equivalence) — two implementers could disagree on whether a
+  subtly different output still "reproduces" the original.
+
+- 🟡 **Dependency**: Runtime source of the compiled work-item-id scan regex is
+  not named as a dependency
+  **Location**: Dependencies
+  The sibling library item (0179) injects the work-item-id scan regex from an
+  existing bash compiler at *test* time only, and explicitly defers the
+  regex-producing DSL compiler to 0170/0167. Neither 0179 nor this item states
+  what supplies the compiled regex at CLI *runtime* once `accelerator-corpus`
+  is a standalone binary with no bash library to shell out to — if that
+  source is 0170's not-yet-built compiler, this is an unnamed upstream
+  blocker.
+
+#### Minor
+
+- 🔵 **Clarity**: "Resolved Q5" label is untraceable to a primary source
+  within this item's own References
+  **Location**: Context
+  The resolution text is given inline and is clear on its own, but the "Q5"
+  label implies a numbered question from an original source document that
+  this item never names or links directly — only the abandoned 0173 traces
+  back further.
+
+- 🔵 **Scope**: Four subcommand groups bundled with asymmetric risk profiles
+  **Location**: Requirements
+  Technical Notes singles out `artifact-derive-metadata` as high fan-out and
+  high-risk, while the other three subcommand groups appear narrower. Bundling
+  a high-risk, high-fan-out piece with three lower-risk ones means the whole
+  story's completion gates on the riskiest piece — a milder version of the
+  concern that caused 0173 to be split.
+
+- 🔵 **Testability**: "Per subcommand" is ambiguous against four listed
+  clusters vs. five actual subcommands
+  **Location**: Acceptance Criteria
+  AC1's coverage floor is stated "per subcommand," but Requirements names five
+  concrete subcommands while AC1 groups them into four categories ("ADR
+  numbering/status" spans two) — it's unclear whether the floor applies per
+  category or per individual subcommand.
+
+- 🔵 **Testability**: AC2's skill call-site set is not enumerated
+  **Location**: Acceptance Criteria
+  AC2 requires "all skills previously invoking" the four named scripts to
+  migrate, but no call-site list or discovery method is given, leaving the
+  closed set to be independently rediscovered at verification time.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "Typed-linkage" is used without linking to its defining ADR
+  **Location**: References
+  "Typed-linkage queries" is a core capability named in Summary, Requirements,
+  and Acceptance Criteria, but ADR-0034 (its defining decision, per sibling
+  0179) is absent from this item's ADR list.
+
+- 🔵 **Completeness**: Context covers the split/grouping rationale but not the
+  substantive case for migrating this cluster
+  **Location**: Context
+  The administrative history (why 0195 exists, why corpus ops are grouped) is
+  clear, but the epic-level driver (bash 3.2 floor removal, cross-surface
+  duplication) is not restated, so the item doesn't fully stand alone.
+
+- 🔵 **Scope**: Total migration footprint may push this story toward
+  epic-scale
+  **Location**: Summary
+  The combined footprint (four subcommand implementations, call-site rewrites
+  across every consuming skill, removal, floor decrements, registration
+  checklist) is substantial; if call-site counts turn out large, consider
+  noting whether delivery will be phased across multiple PRs within the story.
+
+- 🔵 **Clarity**: Ambiguous referent for "each" in the coverage clause
+  **Location**: Acceptance Criteria
+  AC1's "verified against repointed suites and characterization tests where
+  none exist — each covering..." leaves unclear whether "each" binds to
+  subcommand, test, or verification approach.
+
+### Strengths
+
+- ✅ The Dependencies section resolves every prior blocker individually with
+  provenance (done status, what it supplies, PR numbers) rather than a bare
+  list, and captures the one real downstream coupling (Blocks: 0174) with its
+  specific causal mechanism.
+- ✅ The five corpus subcommands are named identically and consistently across
+  Summary, Requirements, and Acceptance Criteria, with no scope drift between
+  sections.
+- ✅ Acceptance Criteria are concrete and largely enumerable: a bounded minimum
+  test-coverage floor (not unbounded exhaustiveness), grep-auditable script/
+  skill references, and an anchor to a named, existing registration checklist.
+- ✅ Context and Drafting Notes transparently carry forward the resolved Q5
+  scope decision from the abandoned parent item, including its rationale —
+  good scope hygiene showing the boundary was deliberated, not assumed.
+
+### Recommended Changes
+
+1. **Resolve the interface-redesign ambiguity for `artifact-derive-metadata`**
+   (addresses: the merged clarity/completeness/testability finding). State
+   explicitly in Requirements/Acceptance Criteria whether the output contract
+   changes during this work or is preserved as-is; if it's preserved, replace
+   or remove the Technical Notes phrase so it no longer conflicts with the
+   "reproduces" framing.
+
+2. **Define the equivalence bar for "reproduces"** (addresses: the
+   "reproduces lacks a defined equivalence bar" finding). State the
+   comparison technique — e.g. stdout/exit-code parity via characterization
+   tests snapshotting the bash script's output as the golden baseline.
+
+3. **Name how `accelerator-corpus` obtains the compiled work-item-id regex at
+   runtime** (addresses: the dependency finding). Either state the dependency
+   on 0170's DSL compiler explicitly, or confirm the regex is available
+   another way (e.g. via the config crate) with no dependency on 0170.
+
+4. **Disambiguate "per subcommand" in AC1** (addresses: the four-vs-five
+   subcommand testability minor). Name the five subcommands explicitly, or
+   state the coverage floor applies to each of the five listed in
+   Requirements.
+
+5. **Consider the asymmetric-risk bundling in Requirements** (addresses: the
+   scope minor). If `artifact-derive-metadata`'s migration proves harder than
+   expected during implementation, sequence it as a distinguishable sub-phase
+   so the lower-risk subcommands aren't blocked by it.
+
+6. **Tighten remaining minor/suggestion items**: add ADR-0034 to References;
+   either drop the "Q5" label or cite its originating document; enumerate (or
+   state the discovery method for) AC2's skill call-site set.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is largely internally consistent — the five corpus
+subcommands are named identically across Summary, Requirements, and
+Acceptance Criteria, and the Dependencies section explicitly resolves each
+prior blocker's status. However, a Technical Notes reference to an undefined
+"interface-redesign rewrite" contradicts the parity language used everywhere
+else ("reproduces"), and several cross-references (Q5, typed-linkage/
+ADR-0034) require chasing an abandoned sibling work item to fully resolve.
+
+**Strengths**:
+- The five corpus subcommands are named identically and consistently across
+  the Summary, Requirements, and Acceptance Criteria sections.
+- The Dependencies section states the current resolution status of every
+  prior blocker rather than leaving them as open questions.
+- The Context section states the split rationale from 0173 and reproduces the
+  "Resolved Q5" grouping decision inline.
+
+**Findings**:
+- 🔴 major/high — "Interface-redesign rewrite" is undefined and contradicts
+  the parity framing used elsewhere (Technical Notes)
+- 🔵 minor/medium — "Resolved Q5" label is untraceable to a primary source
+  within this item's own References (Context)
+- 🔵 suggestion/medium — "Typed-linkage" is used without linking to its
+  defining ADR (References)
+- 🔵 suggestion/low — Ambiguous referent for "each" in the coverage clause
+  (Acceptance Criteria)
+
+### Completeness
+
+**Summary**: 0195 is a well-structured story: every expected section is
+present and substantively populated, frontmatter is complete and internally
+consistent, and the Acceptance Criteria and Dependencies sections are more
+thorough than the abandoned parent item. The one notable gap is that a
+requirement present in the predecessor item — an "interface-redesign"
+principle for the artifact-metadata output contract — survives only as an
+unexplained aside in Technical Notes.
+
+**Strengths**:
+- Acceptance Criteria are concrete and enumerable, an explicit improvement
+  over the predecessor item per the Drafting Notes.
+- Dependencies section resolves every prior blocker individually with status
+  and rationale.
+- Context clearly states the resolved grouping rationale (Q5) carried forward
+  from the split.
+- Frontmatter is complete and consistent with the body's header block.
+
+**Findings**:
+- 🔴 major/medium — Interface-redesign principle for artifact-metadata output
+  is referenced but never specified as a requirement (Technical Notes)
+- 🔵 suggestion/low — Context covers the split/grouping rationale but not the
+  substantive case for migrating this cluster (Context)
+
+### Dependency
+
+**Summary**: The Dependencies section is unusually well-maintained: it
+explicitly resolves each prior blocker with provenance and names the one real
+downstream coupling (0174's floor-decrement lockstep) with its mechanism. The
+main gap is a non-obvious upstream coupling inherited from the sibling
+library item (0179): the runtime source of the compiled work-item-id scan
+regex is never named.
+
+**Strengths**:
+- Each formerly-blocking work item is named individually with its resolution
+  status and what it supplies.
+- The single downstream coupling (Blocks: 0174) is captured with the specific
+  causal mechanism.
+- The skill call-site/allowed-tools rewrite is folded into this item's own
+  scope rather than left as an implicit, uncaptured coupling.
+
+**Findings**:
+- 🟡 major/medium — Runtime source of the compiled work-item-id scan regex is
+  not named as a dependency (Dependencies)
+
+### Scope
+
+**Summary**: This story is well-bounded relative to its declared purpose —
+Summary, Requirements, Acceptance Criteria, Dependencies, and Assumptions all
+consistently describe one binary built over one bounded context, and Context
+documents a deliberate, resolved scope decision inherited from 0173. The four
+subcommand groups share a plausible bounded-context rationale, but they carry
+asymmetric risk profiles and a large total migration surface worth
+re-checking against the same oversized-PR concern that triggered the original
+split.
+
+**Strengths**:
+- Context and Drafting Notes explicitly carry forward a resolved scope
+  decision (Q5) from the abandoned parent item, including its rationale.
+- Summary, Requirements, and Acceptance Criteria are fully aligned around the
+  same four subcommand areas with no drift between sections.
+- Dependencies section cleanly delineates this item's boundary against
+  sibling work items.
+
+**Findings**:
+- 🔵 minor/medium — Four subcommand groups bundled with asymmetric risk
+  profiles (Requirements)
+- 🔵 suggestion/low — Total migration footprint may push this story toward
+  epic-scale (Summary)
+
+### Testability
+
+**Summary**: The acceptance criteria are largely verifiable: AC1 sets a
+concrete minimum test-coverage floor, AC2/AC3 are grep-auditable, and AC4
+anchors to a bounded, named external checklist. The main gaps are that
+"reproduces" is never given a fidelity bar, and the "interface-redesign
+rewrite" hint is never reconciled with AC1's parity-based framing, leaving the
+pass/fail baseline for that subcommand ambiguous.
+
+**Strengths**:
+- AC1 defines a concrete minimum test-coverage floor rather than demanding
+  unbounded or exhaustive coverage.
+- AC2 and AC3 reference specific, named scripts and a specific migration
+  contract, making them auditable by direct inspection.
+- AC4 anchors verification to a concrete, existing checklist document.
+- The Dependencies section grounds "blocked by: none" in concrete evidence.
+
+**Findings**:
+- 🔴 major/medium — "Reproduces" lacks a defined equivalence bar (Acceptance
+  Criteria)
+- 🔴 major/medium — Interface-redesign note is unreconciled with the
+  "reproduces" framing (Technical Notes / Acceptance Criteria)
+- 🔵 minor/medium — "Per subcommand" is ambiguous against the four listed
+  clusters vs. five actual subcommands (Acceptance Criteria)
+- 🔵 minor/low — AC2's skill call-site set is not enumerated (Acceptance
+  Criteria)
+
+
+## Re-Review (Pass 2) — 2026-08-06
+
+**Verdict:** APPROVE
+
+### Previously Identified Issues
+
+- 🟡 **Clarity/Completeness/Testability**: Interface-redesign rewrite undefined
+  — Resolved (Technical Notes now states the output contract is preserved
+  as-is; the "interface-redesign" language only ever referred to the
+  call-site rewrite)
+- 🟡 **Testability**: "Reproduces" lacks a defined equivalence bar — Resolved
+  (AC1 now specifies characterization tests snapshotting stdout, exit code,
+  and stderr against the bash script's own output as the golden baseline)
+- 🟡 **Dependency**: Runtime source of the compiled work-item-id regex not
+  named — Resolved with a caveat. Direct source inspection
+  (`cli/corpus-adapters/src/work_item_pattern.rs`) confirmed
+  `compile_scan_regex` and `RegexScanner` already ship in `corpus-adapters`
+  (0179), so 0195's Dependencies note is factually correct — but this
+  surfaced that 0179's own document text still disclaims building the
+  compiler (stale relative to what shipped). Left 0179's document untouched
+  per reviewer decision; 0195's note stands as verified.
+- 🔵 **Clarity**: "Resolved Q5" label untraceable — Resolved (dropped; inline
+  resolution text stands alone)
+- 🔵 **Scope**: Four subcommand groups bundled with asymmetric risk profiles
+  — Still present (reviewer decision: accepted as intentional, no change)
+- 🔵 **Testability**: "Per subcommand" ambiguous (4 categories vs. 5
+  subcommands) — Resolved (Requirements/AC now use an explicit noun/verb
+  structure naming all five subcommands: `adr next-number`, `adr read-status`,
+  `metadata derive`, `frontmatter validate`, `linkage extract`)
+- 🔵 **Testability**: AC2's skill call-site set not enumerated — Resolved
+  (added an explicit discovery method, later tightened further in this pass)
+- 🔵 **Clarity**: Typed-linkage missing ADR-0034 — Resolved (added ADR-0034
+  and ADR-0038)
+- 🔵 **Completeness**: Context missing epic-level motivation — Resolved
+  (added bash-3.2-floor/ADR-0045 sentence)
+- 🔵 **Scope**: Epic-scale footprint / phasing — Resolved (added phasing note,
+  later extended with an explicit interim-state policy)
+- 🔵 **Clarity**: Ambiguous "each" referent in AC1 — Resolved (superseded by
+  the full AC1 rewrite)
+
+### New Issues Introduced
+
+This pass's edits (particularly the AC1 and AC2 rewrites) surfaced further
+issues, all discussed and resolved in this same session:
+
+- 🟡 **Clarity**: AC1's "none" referent and failure-path scope were ambiguous
+  — Resolved (split into explicit repointed-suite vs. new-test clauses)
+- 🟡 **Dependency**: AC2 (skills-only search) vs. AC3 (unconditional script
+  removal) left non-skill callers unaddressed — Resolved (broadened to all
+  callers, with an explicit exception carve-out)
+- 🟡 **Testability**: The repo-wide search "closed set" would false-positive
+  on documentation mentions of the script names — Resolved (scoped to
+  executable invocations: `Bash(...)` calls, `allowed-tools` entries, shell
+  `source`/exec sites)
+- 🔵 **Clarity**: Summary said "typed-linkage queries", Requirements/subcommand
+  name said "extraction"/`extract` — Resolved (aligned to "extraction")
+- 🔵 **Completeness**: No beneficiary named — Resolved (added skill
+  maintainers and the 0174 shell-retirement effort)
+- 🔵 **Dependency**: Context's "migration framework" duplication claim implied
+  an uncaptured 0172 coupling — Resolved (narrowed to bash library/visualiser,
+  which is what this item actually touches)
+- 🔵 **Scope**: Multi-PR phasing note didn't state the interim-state policy —
+  Resolved (noun groups ship independently; mixed bash/Rust state mid-migration
+  is acceptable)
+- 🔵 **Testability**: "Golden baseline" was undefined — Resolved (defined
+  inline as part of the AC1 rewrite)
+- 🔵 **Clarity**: ADR-0053 has no gloss, unlike ADR-0034/ADR-0038 — Declined
+  (reviewer decision: not worth the lookup)
+- 🔵 **Testability**: "One failure path" doesn't name a specific condition per
+  subcommand — Declined (reviewer decision: left to implementation)
+- 🔵 **Scope**: No re-open trigger stated if call-site counts turn out large —
+  Declined (reviewer decision: the phasing note already gives enough
+  flexibility)
+
+### Assessment
+
+The work item is now ready for implementation. All major and critical-adjacent
+findings across both review passes have been resolved through direct edits;
+the handful of remaining minor/suggestion items were explicitly discussed and
+accepted as intentional trade-offs rather than left as oversights. The one
+open thread — 0179's document text disclaiming a compiler that its own shipped
+code contains — was investigated, confirmed via direct source inspection not
+to affect 0195's correctness, and deliberately left unaddressed in 0179 by
+reviewer decision.
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/reviews/work/0196-accelerator-design-inventory-gap-tooling-cli-review-1.md
+++ b/meta/reviews/work/0196-accelerator-design-inventory-gap-tooling-cli-review-1.md
@@ -1,0 +1,449 @@
+---
+type: work-item-review
+id: "0196-accelerator-design-inventory-gap-tooling-cli-review-1"
+title: "Work Item Review: accelerator-design: Design Inventory and Gap Tooling CLI"
+date: "2026-08-06T00:35:37+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0196"
+work_item_id: "0196"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-06T00:46:19+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: accelerator-design: Design Inventory and Gap Tooling CLI
+
+**Verdict:** REVISE
+
+This is a well-formed split-out story with a strong Dependencies section,
+concrete Acceptance Criteria, and disciplined naming — but it undermines
+its own stated purpose. The item's Context explicitly says it exists to fix
+a clarity finding from its predecessor (0173): the Playwright-executor's
+fate stated inconsistently as a hedged either/or in one place and an
+unresolved Open Question in another. Three lenses (clarity, completeness,
+scope) independently found the same inconsistency has recurred within 0196
+itself — the Summary states the decision as settled while Requirements,
+Open Questions, and Acceptance Criteria all still hedge it. Scope also
+flags that the two possible outcomes are not equivalent-effort, so the
+story's size is not actually bounded until that decision is made.
+
+### Cross-Cutting Themes
+
+- **Playwright-executor decision stated as settled in Summary but open
+  everywhere else** (flagged by: clarity, completeness, scope) — the
+  Summary asserts run.sh definitely stays a thin wrapper
+  ("keeping the Playwright executor (`run.sh`) available per the ADR-0048
+  thin-wrapper exception"), while Requirements ("either stays a thin
+  wrapper ... or is folded into the binary ... see Open Questions for the
+  decision"), Open Questions, and Acceptance Criteria bullets 2 and 4 (which
+  hedge with "or its folded equivalent" / "if the thin-wrapper exception is
+  exercised") all treat it as unresolved. This is the exact class of
+  inconsistency the item's own Context says it was carved out of 0173 to
+  fix, and the Drafting Notes' claim that the choice "appears once, in Open
+  Questions" is itself inaccurate since Requirements restates it.
+
+### Findings
+
+#### Major
+
+- 🟡 **Clarity / Completeness / Scope**: Summary states the
+  Playwright-executor decision as settled, contradicting Requirements,
+  Open Questions, and Acceptance Criteria
+  **Location**: Summary
+  The Summary reads as a settled fact ("keeping the Playwright executor
+  (`run.sh`) available"), but every other section that touches the same
+  question hedges it as an open either/or to be decided during
+  implementation. A reader relying on the Summary alone would conclude the
+  opposite of what an implementer reading Requirements or Open Questions
+  would conclude.
+
+- 🟡 **Scope**: Playwright-executor either/or leaves the story's size
+  unbounded at authoring time
+  **Location**: Requirements / Open Questions
+  Thin-wrapper-vs-fold-in are not equivalent-effort alternatives — keeping
+  `run.sh` as a thin wrapper is near-zero additional work, while folding
+  Playwright-driving logic into the Rust binary is a substantial rewrite.
+  The parent epic's own resolved Open Questions (0136) describe a "thin
+  residual shell surface (launcher bootstrap, hook wrapper, Playwright
+  executor)" as the expected end state, suggesting the thin-wrapper outcome
+  was already the epic-level expectation, yet 0196 reopens it as a live
+  implementation-time choice with no default and no decision gate before
+  work starts.
+
+#### Minor
+
+- 🔵 **Testability**: "Same report artefact" has no defined equivalence
+  criterion
+  **Location**: Acceptance Criteria
+  AC2 requires the Playwright-driven subcommand to produce "the same report
+  artefact the current shell invocation produces" without defining what
+  counts as "the same" (byte-identical, schema-equivalent, or something
+  looser), leaving no defined procedure for a verifier to conclusively pass
+  or fail this comparison.
+
+- 🔵 **Testability**: "Per subcommand" coverage floor is uncountable without
+  an enumerated subcommand list
+  **Location**: Acceptance Criteria
+  AC1's minimum coverage floor (success path + one failure path per
+  subcommand) is a good concrete target in principle, but the work item
+  never enumerates the design binary's subcommands, so the denominator
+  needed to verify the floor is undefined from this document alone.
+
+- 🔵 **Clarity**: "The design binary's Playwright-driven subcommand" does not
+  name which subcommand it refers to
+  **Location**: Acceptance Criteria
+  AC2 refers to "the Playwright-driven subcommand" without stating whether
+  this is `inventory-design`, `analyse-design-gaps`, or both, forcing a
+  verifier to infer it rather than being told directly.
+
+- 🔵 **Completeness**: No explicit statement of who/what the migration
+  serves
+  **Location**: Requirements
+  As a Story, the item is expected to name the stakeholder whose need is
+  being met. Requirements and Context describe the migration mechanics but
+  never state the beneficiary beyond what's implicit in the parent epic.
+
+- 🔵 **Dependency**: Foundational launcher/dispatch infrastructure not named
+  among resolved prior blockers
+  **Location**: Dependencies
+  The item is otherwise scrupulous about naming resolved blockers
+  explicitly (0166, 0167, 0187) but omits the earlier foundational items
+  (0163 scaffold, 0164 launcher/dispatch) those depend on. Low impact —
+  these are very likely already covered transitively by 0167.
+
+- 🔵 **Dependency**: No coordination note for siblings sharing the same
+  registration pattern
+  **Location**: Dependencies
+  If the sub-binary registration checklist (AC5) touches shared state (a
+  central dispatch manifest or CI floor config), siblings 0195 and 0197
+  registering around the same time could produce merge contention not
+  visible from any single item's Dependencies section. Speculative —
+  only relevant if the checklist isn't purely additive per-binary.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "Repointed suites" used without a gloss
+  **Location**: Acceptance Criteria
+  AC1's "repointed suites" is inferable (existing tests redirected to the
+  new binary) but never stated explicitly.
+
+- 🔵 **Completeness**: No Assumptions section despite implicit assumptions
+  underpinning the Acceptance Criteria
+  **Location**: Dependencies
+  Predecessor item 0173 carried an explicit Assumptions section; 0196 has
+  none, though its AC rest on premises (e.g. that repointed suites plus
+  characterization tests establish sufficient behavioural parity) that
+  could be made explicit.
+
+### Strengths
+
+- ✅ Cleanly carries forward only the design-domain slice of the abandoned
+  0173, matching the granularity of siblings 0195 and 0197 — a concrete
+  example of right-sizing a previously bundled story.
+- ✅ Acceptance Criteria are concrete and checkable: an explicit minimum
+  test-coverage floor, a reference to a specific external registration
+  checklist (AC5), and a lockstep floor-decrement coupling to 0174 (AC4)
+  that avoids a dangling "suites are updated" claim.
+- ✅ Dependencies is unusually thorough — it names all three prior blockers
+  as explicitly resolved rather than leaving them silently absent, states
+  the specific coupling mechanism to the downstream blocked item (0174),
+  and correctly distinguishes the pre-existing external Node/Playwright
+  coupling from anything newly introduced.
+- ✅ Consistent naming discipline throughout: `accelerator-design` (binary
+  name) versus `accelerator design ...` (subcommand invocation) is never
+  conflated.
+- ✅ Context clearly states the motivating 0173 review-1 finding, giving
+  the reader provenance for why the item is structured the way it is.
+
+### Recommended Changes
+
+1. **Resolve the Summary/Requirements contradiction** (addresses: Summary
+   states the Playwright-executor decision as settled, contradicting
+   Requirements, Open Questions, and Acceptance Criteria) — Rewrite the
+   Summary to hedge consistently with Requirements and Acceptance Criteria
+   (e.g., "migrate ... while resolving whether the Playwright executor
+   `run.sh` stays a thin wrapper or is folded into the binary, per
+   ADR-0048"). Also remove the either/or restatement from either
+   Requirements or Open Questions so the decision genuinely appears once,
+   matching what the Drafting Notes already claim.
+
+2. **Decide or gate the Playwright-executor choice before implementation
+   starts** (addresses: Playwright-executor either/or leaves the story's
+   size unbounded at authoring time) — Either state a default outcome
+   (thin wrapper, consistent with the parent epic's resolved Open
+   Questions) with fold-in treated as an explicit re-scope trigger, or
+   require the decision to be confirmed before implementation begins
+   rather than during it.
+
+3. **Define the AC2 equivalence check** (addresses: "Same report artefact"
+   has no defined equivalence criterion) — State the comparison method,
+   e.g. byte-identical output for a fixed fixture input, or schema
+   validation plus equivalent findings.
+
+4. **Enumerate or reference the subcommand set** (addresses: "Per
+   subcommand" coverage floor is uncountable; "The design binary's
+   Playwright-driven subcommand" does not name which subcommand) — List
+   the expected subcommands in Requirements or Technical Notes (or state
+   explicitly that the set is whatever `inventory-design/scripts/*` and
+   `analyse-design-gaps/scripts/*` resolve to), and name which one is
+   Playwright-driven.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: This work item is largely precise and internally disciplined
+— it correctly distinguishes the `accelerator-design` binary name from the
+`accelerator design` subcommand invocation throughout, and cross-references
+sibling work items unambiguously. However, it undermines its own stated
+purpose (resolving 0173's Playwright-executor ambiguity) by having the
+Summary assert a settled outcome that contradicts the hedged either/or
+preserved verbatim in Requirements, Open Questions, and Acceptance
+Criteria, and the Drafting Notes' claim that the choice now "appears once,
+in Open Questions" does not match the item's own content. A secondary,
+lower-impact ambiguity leaves unclear which of the two migrated
+subcommands is the "Playwright-driven" one referenced in Acceptance
+Criteria bullet 2.
+
+**Strengths**:
+- Consistent naming discipline throughout: `accelerator-design` (sub-binary
+  name) versus `accelerator design ...` (subcommand invocation) is never
+  conflated across Summary, Requirements, and Acceptance Criteria.
+- Cross-references to sibling and predecessor work items (0136, 0166,
+  0167, 0173, 0174, 0187) are consistently identified and their relevance
+  stated.
+- Context is explicit about exactly which 0173 review-1 finding motivated
+  this item's structure.
+
+**Findings**:
+- 🟡 Major (high confidence) — Summary states the Playwright-executor
+  decision as settled, contradicting the hedge in Requirements/Open
+  Questions/AC. Location: Summary.
+- 🔵 Minor (medium confidence) — "The design binary's Playwright-driven
+  subcommand" does not name which subcommand it refers to. Location:
+  Acceptance Criteria.
+- 🔵 Suggestion (low confidence) — "Repointed suites" used without a gloss.
+  Location: Acceptance Criteria.
+
+### Completeness
+
+**Summary**: 0196 is a well-populated story: Context justifies the split
+from 0173, Requirements are specific, Acceptance Criteria enumerate five
+concrete checkable outcomes, and Dependencies is unusually thorough. The
+main gap is a self-contradiction the item explicitly claims to have fixed:
+the Summary asserts the Playwright-executor question is resolved while the
+Requirements and Open Questions sections state it is still undecided. Two
+smaller, lower-severity gaps round out the review: no explicit framing of
+who/what needs the migration, and no Assumptions section.
+
+**Strengths**:
+- Acceptance Criteria contains five specific, checkable items, including
+  exact test-coverage expectations and a reference to a concrete
+  registration checklist.
+- Dependencies distinguishes blocked-by (with each prior blocker's
+  resolution stated), blocks (with the concrete lockstep coupling to 0174
+  named), an external runtime coupling, and the parent epic.
+- Context clearly explains the motivating force rather than merely
+  restating the Summary.
+- Frontmatter is fully populated and internally consistent with the
+  referenced parent and split-from items.
+
+**Findings**:
+- 🔴 Major (high confidence) — Summary states the Playwright-executor
+  decision as settled while Requirements and Open Questions state it is
+  still undecided. Location: Summary.
+- 🔵 Minor (medium confidence) — No explicit statement of who/what the
+  migration serves. Location: Requirements.
+- 🔵 Suggestion (low confidence) — No Assumptions section despite implicit
+  assumptions underpinning the Acceptance Criteria. Location: Dependencies.
+
+### Dependency
+
+**Summary**: 0196's Dependencies section is unusually disciplined for a
+split-out story: it explicitly resolves what could have been ambiguous
+(naming three prior blockers as done), names the downstream consumer
+(0174) with the reason it is blocked, and captures the pre-existing
+Node/Playwright external coupling. The remaining observations are
+low-confidence completeness nuances rather than missing hard blockers.
+
+**Strengths**:
+- Dependencies explicitly lists the three prior blockers as resolved
+  (0166, 0167, 0187) rather than leaving Blocked-by empty.
+- The Blocks entry for 0174 names the specific mechanism of coupling, and
+  it is cross-referenced consistently in the Acceptance Criteria.
+- The Node/Playwright external runtime coupling is correctly distinguished
+  as pre-existing, carried forward from the bash scripts.
+- Context and Drafting Notes explicitly state that this item and its
+  siblings (0195, 0197) are functionally independent with no ordering
+  constraint.
+
+**Findings**:
+- 🔵 Minor (low confidence) — Foundational launcher/dispatch infrastructure
+  (0163, 0164) not named among resolved prior blockers. Location:
+  Dependencies.
+- 🔵 Minor (low confidence) — No coordination note for siblings sharing the
+  same registration pattern, in case the checklist touches shared state.
+  Location: Dependencies.
+
+### Scope
+
+**Summary**: This is a well-executed split: it carries forward exactly the
+design-domain slice of the abandoned 0173, matches the granularity of its
+siblings (0195, 0197), and its Requirements/Acceptance Criteria are tightly
+coupled around one coherent deliverable. The one real scope concern is that
+the Playwright-executor's fate is left as a decision to be made during
+implementation, and those two outcomes represent materially different
+amounts of work, so the story's actual size is not fully bounded at
+authoring time.
+
+**Strengths**:
+- Cleanly carries forward only the design-domain slice of 0173, matching
+  the granularity of siblings 0195 (corpus) and 0197 (collaboration).
+- Requirements, Acceptance Criteria, and Dependencies all describe the
+  same single unit of work with no unrelated capabilities smuggled in.
+- The "story" kind fits the scope: a single team-owned subdomain migration
+  deliverable and verifiable as one increment.
+
+**Findings**:
+- 🔴 Major (medium confidence) — Playwright-executor fate is an unresolved
+  either/or with materially different scope outcomes; the parent epic's
+  own resolved Open Questions suggest the thin-wrapper outcome was already
+  expected. Location: Requirements / Open Questions.
+- 🔵 Minor (low confidence) — Summary states the Playwright-executor
+  outcome as settled, contradicting Open Questions. Location: Summary.
+
+### Testability
+
+**Summary**: The Acceptance Criteria are largely well-specified for a
+migration story: AC5 anchors to a concrete, enumerable external checklist,
+AC1 sets an explicit minimum test-coverage floor, and AC4 ties script
+removal to a lockstep floor decrement tracked in a sibling work item. Two
+gaps reduce measurability: the equivalence criterion for "the same report
+artefact" in AC2 is undefined, and AC1's "per subcommand" coverage floor
+cannot be counted from this document because the subcommand set is never
+enumerated.
+
+**Strengths**:
+- AC5 anchors verification to a concrete, enumerable external artefact
+  rather than a vague "is properly registered" claim.
+- AC1 sets an explicit minimum floor (success path plus one failure path
+  per subcommand) — a concrete, countable target rather than unbounded
+  language.
+- AC4's floor-decrement requirement is made verifiable by explicit
+  cross-reference to work-item:0174.
+- The Open Question is scoped so it doesn't undermine testability of AC2,
+  which already covers both outcomes ("run.sh or its folded equivalent").
+
+**Findings**:
+- 🔵 Minor (medium confidence) — "Same report artefact" has no defined
+  equivalence criterion. Location: Acceptance Criteria.
+- 🔵 Minor (medium confidence) — "Per subcommand" coverage floor is
+  uncountable without an enumerated subcommand list. Location: Acceptance
+  Criteria.
+
+---
+
+## Re-Review (Pass 2) — 2026-08-06
+
+**Verdict:** COMMENT
+
+### Previously Identified Issues
+
+- 🟡 **Clarity / Completeness / Scope**: Summary states the
+  Playwright-executor decision as settled, contradicting Requirements, Open
+  Questions, and Acceptance Criteria — Resolved
+- 🟡 **Scope**: Playwright-executor either/or leaves the story's size
+  unbounded at authoring time — Resolved
+- 🔵 **Testability**: "Same report artefact" has no defined equivalence
+  criterion — Resolved
+- 🔵 **Testability**: "Per subcommand" coverage floor is uncountable
+  without an enumerated subcommand list — Partially resolved (the
+  deferral is now explicit, but a new finding below notes the recorded
+  mapping isn't cross-checked against delivered tests)
+- 🔵 **Clarity**: "The design binary's Playwright-driven subcommand" does
+  not name which subcommand it refers to — Resolved
+- 🔵 **Completeness**: No explicit statement of who/what the migration
+  serves — Resolved
+- 🔵 **Dependency**: Foundational launcher/dispatch infrastructure not
+  named among resolved prior blockers — Resolved (a new suggestion below
+  notes the subsumed item IDs could still be spelled out)
+- 🔵 **Dependency**: No coordination note for siblings sharing the same
+  registration pattern — Resolved
+- 🔵 **Clarity**: "Repointed suites" used without a gloss — Resolved
+- 🔵 **Completeness**: No Assumptions section despite implicit assumptions
+  underpinning the Acceptance Criteria — Resolved
+
+### New Issues Introduced
+
+- 🔴 **Testability** (major, medium confidence): The restructured-format
+  branch of AC2 ("schema-valid and equivalent in findings") has no defined
+  verification procedure — no schema is named and "equivalent in findings"
+  is undefined, so this branch has no pass/fail test if the format is
+  ever restructured. Location: Acceptance Criteria.
+- 🔵 **Clarity** (minor, high confidence): AC1's "the enumerated set (see
+  Requirements)" points to a Requirements bullet that explicitly disclaims
+  having an enumeration yet — the pointer resolves to the wrong section.
+  Location: Acceptance Criteria.
+- 🔵 **Testability** (minor, medium confidence): The Playwright-executor
+  decision resolution has no corresponding Acceptance Criterion — nothing
+  in the AC checklist would catch an unresolved or unrecorded decision.
+  Location: Open Questions.
+- 🔵 **Completeness** (minor, high confidence): Context explains the
+  item's split provenance but not the underlying migration motivation
+  (bash 3.2 floor removal, who benefits), unlike sibling work-item:0195.
+  Location: Context.
+- 🔵 **Scope** (minor, medium confidence): The fold-in alternative for the
+  Playwright executor has no stated re-scoping trigger — if confirmed, it's
+  unclear whether the rewrite stays in this item or is split out. Location:
+  Open Questions.
+- 🔵 **Testability** (suggestion, low confidence): The per-subcommand
+  coverage bar depends on a mapping deferred to implementation time, with
+  no AC step cross-checking the recorded mapping against delivered tests.
+  Location: Acceptance Criteria.
+- 🔵 **Dependency** (suggestion, low confidence): The launcher/dispatch
+  scaffold reference could name work-item:0163/0164 explicitly, matching
+  the naming discipline used for the other resolved blockers. Location:
+  Dependencies.
+- 🔵 **Clarity** (suggestion, medium confidence): Context/Drafting Notes'
+  claim that the choice "appears once, in Open Questions" is no longer
+  quite accurate, since the Summary also states the either/or (now
+  consistently hedged rather than settled). Location: Context.
+
+### Assessment
+
+Every finding that drove the original REVISE verdict is resolved — the
+structural contradiction between Summary and Requirements/Open
+Questions/AC is gone, and the story's size is now bounded by a stated
+default and a pre-implementation confirmation gate. The edit pass
+introduced one new major finding: the "restructured format" branch added
+to AC2's equivalence check is itself underspecified. That, plus the
+AC1 cross-reference pointing to the wrong section, are worth one more
+quick tightening pass before implementation begins; the remaining minor
+and suggestion items are polish rather than blockers. The item is
+acceptable but could be improved — see the major finding above.
+
+### Manual Verdict Update — 2026-08-06
+
+**Verdict:** APPROVE (updated from COMMENT by reviewer, no new lens pass)
+
+After Pass 2, the sole major finding (AC2's underspecified
+restructured-format branch) was fixed directly: AC2 now commits to
+byte-identical output only, deferring format restructuring to a future
+follow-up item, and AC1's cross-reference was corrected to point at
+Drafting Notes rather than Requirements. The reviewer accepted the item
+in this state; the remaining Pass 2 minor/suggestion findings (Context's
+missing migration motivation, the fold-in re-scoping trigger, explicit
+0163/0164 naming, the per-subcommand mapping cross-check, and the
+Drafting Notes "appears once" phrasing) were left unaddressed as
+non-blocking polish.
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/reviews/work/0197-accelerator-collaboration-pr-helper-cli-review-1.md
+++ b/meta/reviews/work/0197-accelerator-collaboration-pr-helper-cli-review-1.md
@@ -1,0 +1,451 @@
+---
+type: work-item-review
+id: "0197-accelerator-collaboration-pr-helper-cli-review-1"
+title: "Work Item Review: accelerator-collaboration: PR Helper CLI"
+date: "2026-08-06T00:51:57+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0197"
+work_item_id: "0197"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-06T01:13:07+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: accelerator-collaboration: PR Helper CLI
+
+**Verdict:** COMMENT
+
+Work item is acceptable but could be improved — see the major finding below.
+0197 is a well-bounded, well-documented split of a single sub-binary
+migration: Dependencies are unusually thorough, Acceptance Criteria are
+mostly concrete and verifiable, and the item is appropriately sized as a
+single-team story. The dominant issue, raised independently by three lenses,
+is an unresolved contradiction over whether work-item:0150 (the
+github→collaboration directory rename) is actually complete — the item's own
+Summary and Dependencies sections disagree with its Context section on this
+point. A handful of minor precision gaps (glob-shaped AC scoping, Requirements
+missing two AC-gated obligations, an underspecified verification method)
+round out the findings.
+
+### Cross-Cutting Themes
+
+- **work-item:0150's completion status is inconsistently characterised**
+  (flagged by: clarity, dependency, scope) — Dependencies lists 0150 among
+  "resolved" prior blockers, but 0150's own frontmatter is `status: draft`
+  with an unchecked AC. Context separately calls the github→collaboration
+  rename "an in-progress initiative," and Summary claims this item is
+  "completing" that rename — three different framings of the same
+  relationship, none reconciled. Since this item's Requirements, AC, and
+  Technical Notes all still reference the pre-rename `skills/github/**`
+  paths, the ordering and scope relationship to 0150 needs to be stated once,
+  consistently, rather than three times, differently.
+- **Glob-shaped scope language where a named-file list would be
+  unambiguous** (flagged by: scope, testability) — both Requirements'
+  call-site bullet ("every skill under `skills/github/**`") and AC3 ("the
+  migrated `skills/github/**` scripts are removed") use a directory glob where
+  the Technical Notes' two named source scripts would give a verifier a
+  self-contained boundary.
+
+### Findings
+
+#### Major
+
+- 🟡 **Clarity / Dependency**: "Resolved" status of work-item:0150 contradicts
+  its own draft status and the Context section's "in-progress" framing
+  **Location**: Dependencies
+  Dependencies groups work-item:0150 with three genuinely completed items
+  under "Prior blockers are resolved," but 0150's frontmatter shows
+  `status: draft` with an unchecked AC, and Context calls the same rename
+  "in-progress." A reader cannot tell whether 0150 must land first, is
+  merely a naming precedent, or represents an uncaptured path-collision risk
+  with this item's own `skills/github/**` references.
+
+#### Minor
+
+- 🔵 **Scope**: Summary claims the domain rename is completing here, but no
+  Requirement renames the skill directory
+  **Location**: Summary
+  Summary says this item is "completing the github→collaboration domain
+  rename for this cluster," but the skill directory stays named `github`
+  after this item ships (per AC2/Technical Notes) — the actual rename is
+  work-item:0150's, still in draft.
+- 🔵 **Scope**: Requirements scope call-site rewiring more broadly than
+  Acceptance Criteria
+  **Location**: Requirements
+  Requirements' second bullet says "every skill under `skills/github/**`"
+  while the corresponding AC narrows this to skills invoking the two named
+  helper scripts specifically — the same set described at two different
+  widths.
+- 🔵 **Completeness**: Requirements omit the script-removal and
+  registration-checklist obligations that Acceptance Criteria depend on
+  **Location**: Requirements
+  AC3 (script removal + floor decrement) and AC4 (registration checklist)
+  have no corresponding Requirements bullet, so scoping the work from
+  Requirements alone would miss two AC-gated obligations.
+- 🔵 **Completeness**: Context explains the split and naming decision but not
+  the substantive motivation for the migration itself
+  **Location**: Context
+  Context is entirely procedural (why the item was split, why the naming is
+  settled) — it never restates why migrating these scripts to Rust is worth
+  doing, leaving that entirely to the parent epic.
+- 🔵 **Testability**: AC1 defers the exact `gh` invocation spec and leaves
+  the required verification method ambiguous
+  **Location**: Acceptance Criteria
+  AC1's "repointed suites and/or characterization tests" doesn't say which
+  method (or both) is authoritative, and the specific `gh` sub-commands/flags
+  are deferred to implementation rather than enumerated now from the two
+  named source scripts.
+- 🔵 **Testability**: Suite-floor decrement in AC3 has no self-contained
+  target value
+  **Location**: Acceptance Criteria
+  AC3 requires floors "decremented in lockstep (see work-item:0174)" without
+  naming which suite(s) or by how much within this item, so verification
+  depends entirely on 0174 being finalised and aligned at implementation time.
+- 🔵 **Clarity**: "Repointed suites" is unglossed jargon
+  **Location**: Acceptance Criteria
+  The migration-specific term "repointed" is used without definition or a
+  link to where the convention is established (e.g. work-item:0167).
+- 🔵 **Dependency**: Possible uncaptured CI credential coupling for `gh`-CLI
+  verification
+  **Location**: Acceptance Criteria
+  It's unclear whether AC1's characterization tests require live,
+  authenticated `gh` CLI calls (implying a CI credential-provisioning
+  coupling not named anywhere) or a mocked interface.
+- 🔵 **Testability**: AC3's file scope for removal is stated as a glob
+  rather than the two named files
+  **Location**: Acceptance Criteria
+  AC3's `skills/github/**` glob requires cross-referencing Technical Notes
+  to know it's scoped to exactly two files rather than the whole tree.
+
+#### Suggestions
+
+- 🔵 **Completeness**: No Assumptions section despite reliance on
+  characterization-test parity
+  **Location**: Assumptions
+  Given AC1 defers behavioural parity to characterization tests, an explicit
+  assumption that the two named scripts represent the complete current
+  PR-helper behaviour would surface an implicit reliance.
+- 🔵 **Completeness**: Story kind — the beneficiary of the migration is not
+  explicitly named
+  **Location**: Acceptance Criteria
+  As a `story`-kind item, the beneficiary (skills authors, or cross-domain
+  naming consistency) is implicit rather than stated directly in
+  Summary/Context.
+
+### Strengths
+
+- ✅ Referents to the sub-binary name, the two source scripts, and the
+  `skills/github/**` paths are used consistently across Summary, Context,
+  Requirements, and Technical Notes.
+- ✅ Dependencies is unusually thorough: resolved prior blockers are cited
+  with concrete evidence (done / merged via PR #42), the external `gh` CLI
+  coupling is named with its precondition, and the downstream Blocks entry
+  (0174) is tied to a specific AC bullet.
+- ✅ Acceptance Criteria are mostly concrete and verifiable — AC2 bounds "all
+  skills" to a named, concrete set, and AC4 points to a fixed, enumerable
+  external checklist rather than a vague quality bar.
+- ✅ The item is a clean, single-purpose split from an over-bundled
+  predecessor (0173), with the split rationale documented explicitly rather
+  than left implicit.
+- ✅ Frontmatter is fully populated and internally consistent (kind, status,
+  priority, parent, derived_from all present and sensible).
+
+### Recommended Changes
+
+1. **Reconcile work-item:0150's status across Summary, Context, and
+   Dependencies** (addresses: the cross-cutting theme; both major findings).
+   State once, consistently, whether 0150 is a completed naming precedent
+   this item builds on, or a still-open rename this item's paths will need
+   to track — and whether any ordering/coordination is required.
+2. **Replace glob-shaped scope language with the two named files** in the
+   Requirements call-site bullet and AC3 (addresses: the second cross-cutting
+   theme, the two Scope/Testability findings on Requirements and AC3).
+3. **Add two Requirements bullets** covering script removal/floor decrement
+   and the registration checklist, so Requirements and Acceptance Criteria
+   correspond 1:1 (addresses: Completeness finding on Requirements).
+4. **Resolve AC1's "and/or"** into a single required verification method (or
+   state both are required), and consider enumerating the specific `gh`
+   sub-commands/flags now rather than deferring to implementation (addresses:
+   Testability finding on AC1).
+5. **Gloss "repointed suites"** on first use, and add one sentence to Context
+   restating the substantive motivation for the migration (addresses:
+   Clarity and Completeness findings on Context/AC).
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is largely clear: referents to the sub-binary,
+the two PR-helper scripts, and the skill paths remain stable across
+Summary, Context, Requirements, and Acceptance Criteria, and the Acceptance
+Criteria describe observable outcomes rather than vague properties. The main
+clarity problem is a genuine internal contradiction in how work-item:0150's
+status is characterised — Context calls the github→collaboration rename an
+"in-progress initiative" while Dependencies lists 0150 among "prior blockers
+[that] are resolved," leaving the reader unable to tell whether 0150 must
+complete before this item proceeds. A couple of unglossed process terms
+("repointed suites") are minor secondary issues.
+
+**Strengths**:
+- Referents to the sub-binary name, the two source scripts (`pr-base-repo`,
+  `pr-update-body`), and the `skills/github/**` paths are used consistently
+  and identically across Summary, Context, Requirements, and Technical
+  Notes — no drifting terminology.
+- The Context section explicitly resolves a prior ambiguity (the "open" vs
+  "fixed" naming wording flagged in 0173's review), rather than leaving it
+  implicit, which is a good clarity practice.
+- Acceptance Criteria are phrased as observable system states (the binary
+  reproduces behaviours, skills call the new subcommand, scripts are
+  removed, the checklist passes) rather than as vague desired properties.
+
+**Findings**:
+- 🟡 **Major** (confidence: high) — Location: Dependencies. "Resolved"
+  status of work-item:0150 contradicts Context's "in-progress" framing.
+  Dependencies states "Prior blockers are resolved" and then lists
+  `work-item:0150 (github→collaboration rename precedent)` alongside three
+  items explicitly marked done/merged. But Context describes the rename as
+  "an in-progress initiative across the codebase," and the parenthetical for
+  0150 conspicuously omits the word "done" the other three entries carry.
+  Suggestion: separate 0150 from the resolved-blocker list, or state
+  explicitly what about 0150 is resolved versus in-progress.
+- 🔵 **Minor** (confidence: medium) — Location: Acceptance Criteria.
+  "Repointed suites" is unglossed jargon. AC1's "repointed suites" is used
+  without definition. Suggestion: gloss on first use or link to the
+  migration-pattern document (e.g. 0167) where the term is established.
+
+### Completeness
+
+**Summary**: 0197 is a well-formed story with a clear, unambiguous Summary,
+a populated Dependencies section, four specific and verifiable Acceptance
+Criteria, and intact frontmatter. The main completeness gaps are in Context,
+which is almost entirely procedural rather than restating the substantive
+motivation for the migration itself, and a Requirements section that is
+thinner than the Acceptance Criteria it should ground — two AC items (script
+removal/floor decrement and the registration checklist) have no
+corresponding Requirements bullet. No Assumptions section is present, which
+is a minor gap given the behavioural-parity risk implicit in a bash-to-Rust
+migration.
+
+**Strengths**:
+- Acceptance Criteria are specific and numerous, each tied to a concrete
+  verification mechanism rather than vague outcome statements.
+- Dependencies is thorough: it enumerates resolved prior blockers by ID with
+  their resolution state, names the one open external coupling (gh CLI),
+  and states what this item blocks and its parent.
+- Frontmatter is fully populated and internally consistent.
+
+**Findings**:
+- 🔵 **Minor** (confidence: medium) — Location: Context. Context explains
+  the split and naming decision but not the substantive motivation for the
+  migration itself — a reader who lands on this story without first reading
+  0136 has no sense of the motivating problem. Suggestion: add one sentence
+  restating the substantive driver (e.g. replacing untestable bash under
+  the bash 3.2 floor with typed Rust).
+- 🔵 **Minor** (confidence: medium) — Location: Requirements. Requirements
+  omit the script-removal and registration-checklist obligations that AC3
+  and AC4 depend on. Suggestion: add two Requirements bullets so Requirements
+  and Acceptance Criteria correspond 1:1.
+- 🔵 **Suggestion** (confidence: low) — Location: Assumptions. No
+  Assumptions section despite reliance on characterization-test parity.
+  Suggestion: add a brief Assumptions section noting the two named source
+  scripts are treated as the complete PR-helper behavioural surface.
+- 🔵 **Suggestion** (confidence: low) — Location: Acceptance Criteria.
+  Story kind: the beneficiary of the migration is not explicitly named.
+  Suggestion: add a one-clause addition naming who benefits.
+
+### Dependency
+
+**Summary**: The Dependencies section is unusually well populated for a
+story: it names three resolved technical blockers with concrete evidence, an
+external `gh` CLI coupling carried forward from the source bash, a
+correctly-named downstream Blocks entry (0174) tied to a specific AC bullet,
+and the parent epic. The one significant gap is that work-item:0150 (the
+actual github→collaboration skill-directory rename) is listed among
+"resolved" prior blockers despite its own frontmatter showing `status: draft`
+and an unchecked AC — an uncaptured ordering ambiguity between this item's
+path-based Requirements/AC and 0150's still-pending rename of the very
+directory they reference.
+
+**Strengths**:
+- Downstream consumer is explicitly captured: work-item:0174 is named as a
+  Blocks entry and tied to the specific AC bullet.
+- The external `gh` CLI dependency is named with its install/authentication
+  precondition and explicitly flagged as a pre-existing coupling.
+- Prior technical blockers (0166, 0167, 0187) are each cited with concrete
+  completion evidence rather than a bare assertion.
+
+**Findings**:
+- 🟡 **Major** (confidence: high) — Location: Dependencies. work-item:0150
+  listed as a resolved prior blocker despite still being in draft/unstarted
+  status. Unlike the other three entries, 0150 is annotated only as a naming
+  precedent, not resolution evidence, and this item's Requirements/Technical
+  Notes still reference the pre-rename `skills/github/**` paths. Suggestion:
+  separate 0150 from the resolved list, or add a genuine coordination note
+  if directory-path collision is a real risk.
+- 🔵 **Minor** (confidence: low) — Location: Acceptance Criteria. Possible
+  uncaptured CI credential coupling for gh-CLI verification. It's unclear
+  whether AC1's characterization tests require live, authenticated `gh`
+  calls (implying a CI credential coupling not named anywhere) or a mocked
+  interface. Suggestion: clarify in Technical Notes or Dependencies.
+
+### Scope
+
+**Summary**: 0197 is a well-bounded slice of the 0173 split: it covers
+exactly one sub-binary migrating two PR-helper scripts, with Requirements,
+Dependencies, and Technical Notes describing a single coherent unit of work.
+Two internal wording mismatches create scope-boundary ambiguity worth
+tightening before implementation, but neither rises to a bundling or
+delivery-risk concern.
+
+**Strengths**:
+- The item is a clean, single-purpose split from an over-bundled predecessor
+  (0173), with the split rationale explicitly documented.
+- Scope is tightly bounded to one sub-binary and two named source scripts,
+  consistent across Requirements, Technical Notes, and most of the
+  Acceptance Criteria.
+- Dependencies correctly scopes the Blocks relationship to 0174 without
+  pulling in unrelated downstream work.
+
+**Findings**:
+- 🔵 **Minor** (confidence: medium) — Location: Requirements. Requirements
+  scope call-site rewiring more broadly than Acceptance Criteria — the
+  Requirements bullet says "every skill under `skills/github/**`" while the
+  AC scopes the same work to callers of the two named scripts. Suggestion:
+  align the Requirements bullet with the AC's precise framing.
+- 🔵 **Minor** (confidence: medium) — Location: Summary. Summary claims the
+  domain rename is completed, but no requirement renames the skill
+  directory — the actual directory-level rename is tracked separately in
+  work-item:0150, still in draft. Suggestion: narrow the Summary to describe
+  adopting the `collaboration` name for this binary specifically, ahead of
+  the full rename tracked in 0150.
+
+### Testability
+
+**Summary**: The acceptance criteria are largely testable: each ties to a
+concrete artefact rather than a subjective outcome, and the scope is bounded
+to two named helper scripts rather than open-ended language. The main gaps
+are that AC1 defers the exact gh invocation enumeration to implementation
+time and offers two alternative verification methods without saying which is
+required, and AC3's file scope and suite-floor decrement rely on
+cross-referencing other documents rather than stating a self-contained check.
+
+**Strengths**:
+- AC4 is a model testable criterion: it points to a fixed, enumerable
+  external checklist rather than a vague quality bar.
+- AC2 bounds "all skills" to a concrete, named set, avoiding the
+  unbounded-scope trap.
+- AC1 anchors "reproduces the PR-helper behaviours" to an existing,
+  inspectable reference rather than a subjective standard.
+
+**Findings**:
+- 🔵 **Minor** (confidence: medium) — Location: Acceptance Criteria. AC1
+  defers the exact gh invocation spec and offers unresolved alternative
+  verification methods ("repointed suites and/or characterization tests")
+  without saying which is authoritative. Suggestion: enumerate the specific
+  gh sub-commands/flags directly, or remove the "and/or" ambiguity.
+- 🔵 **Minor** (confidence: low) — Location: Acceptance Criteria. AC3's file
+  scope for removal is stated as a glob rather than the two named files,
+  requiring cross-reference to Technical Notes. Suggestion: restate AC3
+  with the explicit file paths.
+- 🔵 **Minor** (confidence: medium) — Location: Acceptance Criteria.
+  Suite-floor decrement in AC3 has no self-contained target value — no
+  suite(s) or amount named within this item. Suggestion: name the specific
+  suite(s), even if the exact number is TBD pending 0174.
+
+---
+
+## Re-Review (Pass 2) — 2026-08-06T01:05:48+00:00
+
+**Verdict:** COMMENT
+
+### Previously Identified Issues
+
+- 🟡 **Clarity/Dependency**: "Resolved" status of work-item:0150 contradicts
+  its draft status and Context's "in-progress" framing — Resolved.
+  Dependencies now explicitly separates 0150 into a "Not a blocker" entry;
+  both lenses cite the distinction as a strength on re-review.
+- 🔵 **Scope**: Summary claims the domain rename is completing here — Resolved.
+  Summary and Context now describe adopting the `collaboration` name for this
+  binary specifically, ahead of 0150's directory rename.
+- 🔵 **Scope**: Requirements scope call-site rewiring more broadly than AC —
+  Resolved. Both now name the same two source scripts.
+- 🔵 **Completeness**: Requirements omit script-removal/registration-checklist
+  obligations — Resolved. Requirements now correspond 1:1 with Acceptance
+  Criteria (see new suggestion below on the resulting duplication).
+- 🔵 **Completeness**: Context omits the substantive migration motivation —
+  Resolved. Context now states the bash-3.2-floor/typed-Rust rationale.
+- 🔵 **Testability**: AC1's "and/or" verification method is unresolved —
+  Resolved as stated (now "supplemented by"), though a narrower framing of
+  the same underlying concern resurfaced (see new issues below).
+- 🔵 **Testability**: AC3's suite-floor decrement has no named target — Still
+  present; left open pending work-item:0174 as before (deliberately not
+  addressed — no fabricated suite names).
+- 🔵 **Clarity**: "Repointed suites" is unglossed jargon — Resolved for this
+  specific term (now defined inline); two adjacent terms remain unglossed
+  (see new issues below).
+- 🔵 **Dependency**: Uncaptured CI credential coupling for `gh` verification —
+  Resolved. Dependencies now states verification should use a
+  mockable/injectable interface.
+- 🔵 **Testability**: AC3's file scope stated as a glob — Resolved. AC3 now
+  names the two files explicitly.
+- 🔵 **Completeness**: No Assumptions section — Resolved. Assumptions section
+  added.
+- 🔵 **Completeness**: Story beneficiary not named — Resolved. Summary now
+  names skills authors as the beneficiary.
+
+### New Issues Introduced
+
+- 🟡 **Dependency** (major): Sibling work-item:0196 (accelerator-design)
+  carries an explicit Coordination note naming this item and work-item:0195
+  as siblings registering sub-binaries via the same checklist around the
+  same time, flagging a shared-state (dispatch manifest / CI floor config)
+  merge-contention risk — but this item does not reciprocate that note, so
+  an implementer picking up 0197 in isolation has no signal of the coupling.
+- 🔵 **Dependency** (minor): The external `gh` CLI coupling names the
+  install/auth precondition but not the availability/SLA implications of
+  the underlying GitHub API (rate-limiting/outage behaviour) inherited by
+  the migrated subcommands.
+- 🔵 **Clarity/Testability** (minor): "Characterization tests" and "suite
+  floors" remain unglossed, and AC1's parenthetical still defers the exact
+  `gh` invocation enumeration to implementation time without stating
+  whether that enumeration already exists or is produced as a first
+  implementation sub-step — the same underlying "spec deferred to
+  implementation" concern as before, now framed more precisely, including a
+  request for a completion threshold on the characterization-test fallback.
+- 🔵 **Completeness/Testability** (suggestion): Requirements 2–4 now closely
+  restate their corresponding Acceptance Criteria (a natural consequence of
+  closing the 1:1 gap); no Open Questions section; AC2's call-site
+  verification method is implicit; call-site rewrite count is unbounded
+  (explicitly noted as a sizing signal, not a scope concern).
+
+### Assessment
+
+The major cross-cutting issue from pass 1 (work-item:0150's status) is
+fully resolved, along with every other pass-1 finding except the
+deliberately-deferred suite-floor naming. One new major finding surfaced
+during re-review: this item doesn't reciprocate a sibling coordination note
+that work-item:0196 already carries about concurrent sub-binary
+registration. It's a quick, low-risk addition (a single Dependencies
+bullet) and worth adding before implementation, even though it doesn't by
+itself cross the REVISE threshold. With that addition, the item is ready
+for planning.
+
+### Verdict Update — 2026-08-06T01:13:07+00:00
+
+**Verdict:** APPROVE
+
+The reciprocal Coordination note (naming siblings work-item:0195 and
+work-item:0196) has been added to Dependencies, closing out the sole new
+finding from Pass 2. All findings across both passes are now resolved or
+deliberately deferred with reasoning recorded. Verdict updated to APPROVE.
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
+++ b/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
@@ -83,7 +83,12 @@ tracked on the items themselves.
 - 0170 — Work-Item Lifecycle Subdomain
 - 0171 — Jira and Linear Integrations
 - 0172 — Migration Engine Subdomain
-- 0173 — Remaining Subdomains: corpus, design, collaboration
+- 0173 — Remaining Subdomains: corpus, design, collaboration *(abandoned
+  2026-08-05 — split into 0195/0196/0197, see Drafting Notes)*
+- 0195 — accelerator-corpus: ADR, Metadata, Frontmatter Validation, and
+  Linkage CLI
+- 0196 — accelerator-design: Design Inventory and Gap Tooling CLI
+- 0197 — accelerator-collaboration: PR Helper CLI
 
 **Cleanup (Phase 11):**
 - 0185 — Converge corpus-adapters on the Library-Backed VCS Adapter
@@ -156,6 +161,15 @@ questions are answered:)*
   subdomain, the hooks migration and the skill repoint — the parts that cannot
   be separated, since the shell hooks cannot be deleted before their
   replacements exist.
+- **Extended 2026-08-05 with 0195–0197, when 0173 was split.** A review-1 pass
+  on 0173 found it bundled three functionally independent efforts —
+  `accelerator-corpus`, `accelerator-design`, and `accelerator-collaboration` —
+  sharing no relationship beyond the registration pattern, each with its own
+  source scripts, target crate(s), skill domain, and test suite; the combined
+  scope was also judged undersized for a single `story`. 0173 is now
+  **abandoned**; 0195/0196/0197 each carry forward their slice of 0173's
+  Requirements/Acceptance Criteria (with the review's AC and Dependencies gaps
+  fixed) and are parented directly under this epic.
 
 ## References
 

--- a/meta/work/0173-remaining-subdomains-corpus-design-collaboration.md
+++ b/meta/work/0173-remaining-subdomains-corpus-design-collaboration.md
@@ -5,14 +5,14 @@ title: "Remaining Subdomains: corpus, design, collaboration"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
+status: abandoned
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0167", "work-item:0187"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
+relates_to: ["work-item:0195", "work-item:0196", "work-item:0197"]
 tags: [rust, corpus, design, collaboration, subdomains]
-last_updated: "2026-08-01T16:57:37+00:00"
+last_updated: "2026-08-05T19:03:35+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-194"
@@ -21,7 +21,7 @@ external_id: "PP-194"
 # 0173: Remaining Subdomains: corpus, design, collaboration
 
 **Kind**: Story
-**Status**: Draft
+**Status**: Abandoned
 **Priority**: Medium
 **Author**: Toby Clemson
 
@@ -74,21 +74,19 @@ granularity is wanted.
 
 ## Open Questions
 
-- Whether to split this into three separate work items (corpus / design /
-  collaboration) — left grouped per the user's selection.
 - Whether the Playwright executor stays shell (thin-wrapper exception) or is folded
   into `accelerator-design` — decided during implementation.
 
 ## Dependencies
 
-- Blocked by: 0166 (shared crates), 0167 (the invocation-contract pattern these
-  subdomains' call sites follow).
-- Blocked by: 0187 (generalises the sub-binary registration surface). This story
-  adds a dispatch token per subdomain; it does not generalise the surface.
-  Registration follows the checklist 0187 adds at
-  `tasks/README.md#registering-a-dispatched-sub-binary` — three times over, once
-  for each of corpus, design and collaboration. (2026-08-01)
-- Parent: epic 0136.
+- Blocked by: none currently. Prior blockers are resolved: work-item:0166 (shared
+  crates, done), work-item:0167 (invocation-contract pattern, done), work-item:0187
+  (sub-binary registration surface, merged via PR #42).
+- Registration for each of the three sub-binaries (corpus, design, collaboration)
+  should follow the checklist 0187 added at
+  `tasks/README.md#registering-a-dispatched-sub-binary` — applied three times over,
+  once per subdomain.
+- Parent: work-item:0136 (epic).
 
 ## Assumptions
 
@@ -108,13 +106,30 @@ granularity is wanted.
 
 - Treated as the Phase 10 story; grouped per the user's selection, carrying the
   resolved Q5 `accelerator-corpus` grouping and github→collaboration rename.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+- 2026-08-05: dependencies refreshed during interactive enrichment — all three
+  prior blockers (0166, 0167, 0187) are now done/merged, so `blocked_by` was
+  cleared and the Dependencies section rewritten. The stale open question about
+  splitting into three items was removed (already resolved in Context).
+  Acceptance criteria, requirements, and kind were not reviewed this round —
+  status intentionally left at `draft` pending that pass.
+- 2026-08-05: review-1 (`meta/reviews/work/0173-remaining-subdomains-corpus-design-collaboration-review-1.md`,
+  verdict REVISE) found the story bundled three functionally independent
+  efforts and was undersized for a `story` kind. Per that finding, this item is
+  **abandoned** in favour of a split into work-item:0195 (`accelerator-corpus`),
+  work-item:0196 (`accelerator-design`), and work-item:0197
+  (`accelerator-collaboration`), each parented directly under work-item:0136.
+  The review's other findings (missing AC for the skill-rewrite requirement,
+  Dependencies gaps, clarity ambiguities) were carried forward and addressed in
+  the three successor items rather than fixed here.
 
 ## References
 
 - Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
 - Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Related: `meta/work/0150-rename-github-skill-group-to-collaboration.md`
+  (github→collaboration rename precedent), `meta/work/0179-corpus-crates-parsing-conventions.md`
+  (the `corpus`/`corpus-adapters` crates this sub-binary sits on top of)
+- Superseded by: `meta/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli.md`,
+  `meta/work/0196-accelerator-design-inventory-gap-tooling-cli.md`,
+  `meta/work/0197-accelerator-collaboration-pr-helper-cli.md`
 - ADRs: ADR-0045, ADR-0048, ADR-0053

--- a/meta/work/0174-retire-shell-tooling-and-ci-guards.md
+++ b/meta/work/0174-retire-shell-tooling-and-ci-guards.md
@@ -9,7 +9,7 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0167", "work-item:0168", "work-item:0169", "work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173"]
+blocked_by: ["work-item:0167", "work-item:0168", "work-item:0169", "work-item:0170", "work-item:0171", "work-item:0172", "work-item:0195", "work-item:0196", "work-item:0197"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [shell, tooling, ci, cleanup]
 last_updated: "2026-06-28T17:01:56+00:00"
@@ -79,8 +79,9 @@ Playwright executor) and stays under the bash-3.2 floor.
 
 ## Dependencies
 
-- Blocked by: 0167, 0168, 0169, 0170, 0171, 0172, 0173 — retirement of each
-  checker follows the disappearance of the scripts it polices.
+- Blocked by: 0167, 0168, 0169, 0170, 0171, 0172, 0195, 0196, 0197 (0173's
+  successors, split 2026-08-05) — retirement of each checker follows the
+  disappearance of the scripts it polices.
 - Parent: epic 0136.
 
 ## Assumptions

--- a/meta/work/0179-corpus-crates-parsing-conventions.md
+++ b/meta/work/0179-corpus-crates-parsing-conventions.md
@@ -10,7 +10,7 @@ kind: task
 priority: high
 parent: "work-item:0166"
 external_id: PP-703
-blocks: ["work-item:0180", "work-item:0170", "work-item:0173", "work-item:0168"]
+blocks: ["work-item:0180", "work-item:0170", "work-item:0195", "work-item:0168"]
 tags: [rust, config, corpus, store, crates, dedup, frontmatter, serde, vcs, metadata]
 last_updated: "2026-07-11T11:10:04+00:00"
 last_updated_by: Toby Clemson
@@ -61,9 +61,10 @@ ways the investigation surfaced:
 3. It **consolidates duplications** that exist even inside the visualiser (two
    `{number:0Nd}` width parsers, three title-casers).
 
-Boundary with siblings: 0179 builds the **libraries**; 0173 (`accelerator-corpus`)
-is the inbound CLI that consumes them and owns corpus-frontmatter *validation*
-(out of scope here); 0168 folds the visualiser into `cli/` and touches the same
+Boundary with siblings: 0179 builds the **libraries**; 0195 (`accelerator-corpus`,
+split from the now-abandoned 0173) is the inbound CLI that consumes them and
+owns corpus-frontmatter *validation* (out of scope here); 0168 folds the
+visualiser into `cli/` and touches the same
 code this task extracts; 0170 (`accelerator-work`) is built *on top of* corpus
 and owns the work-item lifecycle and the ID pattern DSL compiler; 0180 lands the
 atomic-store primitives in `corpus-adapters`.
@@ -259,8 +260,9 @@ tag variant).
     creates.
   - 0170 (`accelerator-work`) — consumes `corpus`; cannot land its
     library-consuming work until these crates exist.
-  - 0173 (`accelerator-corpus` CLI) — consumes these libraries; owns
-    corpus-frontmatter validation (out of scope here).
+  - 0195 (`accelerator-corpus` CLI, split from the now-abandoned 0173) —
+    consumes these libraries; owns corpus-frontmatter validation (out of scope
+    here).
   - 0168 — folds the visualiser into `cli/` over the same code this task
     extracts; **0179 extracts first**, then 0168 folds the remaining server. The
     two are sequenced, not independent.
@@ -282,8 +284,9 @@ tag variant).
   pinned (`=0.0.29`), and fenced by a cargo-deny wrapper in this repo, so the
   serde-free-domain + serde-saphyr-in-adapters direction is a known-good pattern
   rather than a bet.
-- Corpus-frontmatter *validation* is 0173's concern, not 0179's; this task ships
-  the parse/convention primitives validation is later built on.
+- Corpus-frontmatter *validation* is 0195's concern (split from the
+  now-abandoned 0173), not 0179's; this task ships the parse/convention
+  primitives validation is later built on.
 
 ## Technical Notes
 
@@ -485,8 +488,8 @@ the slug bash-parity harness needing re-pathing when the crate moves into `cli/`
   Revisit only if a document legitimately needs a tag.
 - **Library-vs-CLI boundary**: interpreted 0179 as strictly the libraries and
   assigned artifact-metadata's *command* surface and corpus-frontmatter
-  *validation* to 0173. If the intent was for 0179 to also ship a CLI or the
-  validator, that boundary needs revisiting.
+  *validation* to 0173, later split into 0195. If the intent was for 0179 to
+  also ship a CLI or the validator, that boundary needs revisiting.
 - **Value-model policy**: chose config's big-int-as-`String` policy over the
   visualiser's `f64`/`Null` widening, and a no-tag-variant value model, to
   converge corpus with the already-shipped config semantics. These are
@@ -499,7 +502,8 @@ the slug bash-parity harness needing re-pathing when the crate moves into `cli/`
   `meta/work/0180-atomic-store-primitives-corpus-adapters.md`,
   `meta/work/0168-fold-visualiser-into-cli-workspace.md`,
   `meta/work/0170-work-item-subdomain-and-sync-engine.md`,
-  `meta/work/0173-remaining-subdomains-corpus-design-collaboration.md`
+  `meta/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli.md`
+  (split from the now-abandoned `meta/work/0173-remaining-subdomains-corpus-design-collaboration.md`)
 - Convention specs: ADR-0034 (typed-linkage), ADR-0045 (bash/Rust duplication),
   ADR-0053; `meta/work/0060` (unified frontmatter schema), `meta/work/0061`
   (typed-linkage vocabulary), `meta/work/0064` (canonical work-item-id/author)

--- a/meta/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli.md
+++ b/meta/work/0195-accelerator-corpus-adr-metadata-frontmatter-linkage-cli.md
@@ -1,0 +1,163 @@
+---
+type: work-item
+id: "0195"
+title: "accelerator-corpus: ADR, Metadata, Frontmatter Validation, and Linkage CLI"
+date: "2026-08-05T19:03:35+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0136"
+derived_from: ["work-item:0173"]
+tags: [rust, corpus, cli, adr, frontmatter, linkage]
+last_updated: "2026-08-06T00:06:12+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0195: accelerator-corpus: ADR, Metadata, Frontmatter Validation, and Linkage CLI
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Build `accelerator-corpus`, a thin inbound CLI over the shared
+`corpus`/`corpus-adapters` crates, covering ADR numbering/status, artifact
+metadata derivation, corpus-frontmatter validation, and typed-linkage
+extraction.
+
+## Context
+
+Split out of work-item:0173 (now abandoned) on 2026-08-05, per that item's
+review-1 scope finding: bundling `accelerator-corpus`, `accelerator-design`, and
+`accelerator-collaboration` into a single story risked partial-completion
+ambiguity and an oversized PR, since the three shared no functional relationship
+beyond the registration pattern. This item carries forward only the corpus
+subcommand cluster and its resolved grouping rationale: the light corpus ops
+are grouped into one `accelerator-corpus` binary over the shared
+`corpus`/`corpus-adapters` crates (no dependency-bleed rationale applies; they
+are one bounded context over `meta/`). This migration also removes the bash
+3.2 floor constraint for these scripts and collapses the cross-surface
+duplication (bash library / visualiser) that ADR-0045 identifies. Skill
+maintainers currently invoking these bash scripts, and the 0174
+shell-retirement effort (which depends on this migration completing to
+decrement its floors), both benefit from this migration.
+
+## Requirements
+
+- `accelerator-corpus` — a thin inbound CLI over the shared `corpus`/`corpus-adapters`
+  crates, structured as `accelerator corpus <noun> <verb>` with four noun
+  groups:
+  - `adr next-number` (from `adr-next-number.sh`) and `adr read-status` (from
+    `adr-read-status.sh`) — ADR numbering/status.
+  - `metadata derive` (from `artifact-derive-metadata.sh`) — artifact-metadata
+    derivation.
+  - `frontmatter validate` (from `validate-corpus-frontmatter.sh`) —
+    corpus-frontmatter validation.
+  - `linkage extract` (from `linkage-parser.sh`) — typed-linkage extraction
+    from an artifact's body sections (References, Dependencies, Historical
+    Context, Related Research, Source References), per ADR-0034/0038; distinct
+    from frontmatter validation since it parses body prose, not frontmatter.
+- Rewrite the call sites and `allowed-tools` of every skill invoking
+  `skills/decisions/scripts/adr-*.sh`, `scripts/artifact-derive-metadata.sh`,
+  `scripts/validate-corpus-frontmatter.sh`, and `scripts/linkage-parser.sh` to
+  call the new `accelerator corpus` subcommands, following the invocation
+  contract established in 0167.
+
+## Acceptance Criteria
+
+- [ ] For each of the five subcommands (`adr next-number`, `adr read-status`,
+      `metadata derive`, `frontmatter validate`, `linkage extract`):
+      characterization tests snapshot the source bash script's stdout, exit
+      code, and stderr (where the script writes to it) for the same inputs as
+      the golden baseline — the bash script's own current output for that
+      input. Where an existing bash test suite covers the subcommand, it is
+      repointed at the new subcommand and must cover at least one success and
+      one failure path. Where none exists, a new characterization test is
+      written meeting the same bar.
+- [ ] All callers of `skills/decisions/scripts/adr-*.sh`,
+      `scripts/artifact-derive-metadata.sh`, `scripts/validate-corpus-frontmatter.sh`,
+      and `scripts/linkage-parser.sh` — skills, CI workflows, `tasks/` build
+      tasks, and other scripts alike — now call the corresponding `accelerator
+      corpus <noun> <verb>` subcommand, with skills' `allowed-tools` updated to
+      match per the 0167 contract, or are named as an explicit, justified
+      exception. The closed set is defined by a repo-wide search for each
+      script's *executable* invocations at implementation time (`Bash(...)`
+      calls, `allowed-tools` entries, shell `source`/exec sites) — not bare
+      string mentions in documentation, ADRs, or other work items, which are
+      excluded from this criterion.
+- [ ] The migrated `skills/decisions/scripts/*`, `artifact-derive-metadata.sh`,
+      `validate-corpus-frontmatter.sh`, and `linkage-parser.sh` are removed, with
+      the affected suite floors decremented in lockstep (see work-item:0174).
+- [ ] `accelerator-corpus` passes every item of the sub-binary registration
+      checklist at `tasks/README.md#registering-a-dispatched-sub-binary`.
+
+## Dependencies
+
+- Blocked by: none currently. Prior blockers are resolved: work-item:0166
+  (shared crates, done), work-item:0179 (corpus/corpus-adapters crates, done —
+  supplies the libraries this CLI consumes), work-item:0167 (invocation-contract
+  pattern, done), work-item:0187 (sub-binary registration surface, merged via
+  PR #42).
+- Blocks: work-item:0174 (shell/CI-guard retirement — floor decrements from
+  this item's script removals feed its lockstep requirement).
+- Note: the compiled work-item-id scan regex needed by `linkage-parser`/
+  `validate-corpus-frontmatter` has no runtime dependency on work-item:0170.
+  `config` already models `work.id_pattern`/`work.default_project_code`
+  (`cli/config/src/catalogue.rs`), and `corpus-adapters` (0179, done) already
+  ships the compiler (`work_item_pattern::compile_scan_regex`) and the
+  `RegexScanner` port adapter — this CLI wires the two together, it does not
+  build either.
+- Parent: work-item:0136 (epic).
+
+## Assumptions
+
+- The light corpus ops share one bounded context and warrant a single binary
+  (carried forward from work-item:0173).
+
+## Technical Notes
+
+- Source bash: `skills/decisions/scripts/adr-*.sh`,
+  `scripts/artifact-derive-metadata.sh`, `scripts/validate-corpus-frontmatter.sh`,
+  `scripts/linkage-parser.sh`.
+- If the skill call-site count for `metadata derive` (or any noun group) turns
+  out to be large, delivery may be phased across multiple PRs per noun group
+  (`adr`, `metadata`, `frontmatter`, `linkage`) while remaining one story —
+  this keeps individual PRs reviewable without reopening the scope question
+  that led to splitting 0173. Noun groups ship independently as each PR lands
+  — a mixed bash/Rust state mid-migration is acceptable; the story is done
+  only once all four noun groups and their call-site migrations are complete.
+- `artifact-derive-metadata` is invoked by many skills; its output contract is
+  preserved as-is (no data-shape changes) — the "interface-redesign" language
+  in 0173's Requirements referred only to *how* skills invoke the script (the
+  call-site/`allowed-tools` rewrite in Requirements bullet 2), not to
+  `artifact-derive-metadata`'s own output. Treat the migration as a faithful
+  behavioural port; any output-contract change is out of scope for this item.
+
+## Drafting Notes
+
+- Split out of work-item:0173 on 2026-08-05 following that item's review-1
+  (verdict REVISE, scope lens): the three sub-binaries it bundled were
+  functionally independent and separately deliverable. This item carries the
+  resolved corpus-grouping rationale from 0173's Context section unchanged
+  (review-1's "Q5" label was dropped as untraceable outside 0173 — the
+  resolution text itself stands alone).
+- The skill call-site/`allowed-tools` rewrite requirement now has an explicit
+  matching Acceptance Criterion (0173's review-1 flagged this as missing — a
+  completeness/testability finding).
+
+## References
+
+- Split from: `meta/work/0173-remaining-subdomains-corpus-design-collaboration.md`
+  (abandoned)
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Related: `meta/work/0179-corpus-crates-parsing-conventions.md` (the
+  `corpus`/`corpus-adapters` crates this CLI sits on top of),
+  `meta/work/0174-retire-shell-tooling-and-ci-guards.md` (floor decrements this
+  item's removals feed into)
+- ADRs: ADR-0034 (typed-linkage), ADR-0038 (linkage resolution bands),
+  ADR-0045, ADR-0053

--- a/meta/work/0196-accelerator-design-inventory-gap-tooling-cli.md
+++ b/meta/work/0196-accelerator-design-inventory-gap-tooling-cli.md
@@ -1,0 +1,144 @@
+---
+type: work-item
+id: "0196"
+title: "accelerator-design: Design Inventory and Gap Tooling CLI"
+date: "2026-08-05T19:03:35+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0136"
+derived_from: ["work-item:0173"]
+tags: [rust, design, cli, playwright]
+last_updated: "2026-08-06T00:45:04+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0196: accelerator-design: Design Inventory and Gap Tooling CLI
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Migrate the design inventory/gap tooling (`inventory-design`,
+`analyse-design-gaps`) into an `accelerator-design` sub-binary, and resolve
+whether the Playwright executor (`run.sh`) stays a thin wrapper the binary
+execs or is folded into the binary, per the ADR-0048 thin-wrapper exception
+(see Open Questions).
+
+## Context
+
+Split out of work-item:0173 (now abandoned) on 2026-08-05, per that item's
+review-1 scope finding: bundling `accelerator-corpus`, `accelerator-design`, and
+`accelerator-collaboration` into a single story risked partial-completion
+ambiguity and an oversized PR. 0173 also stated the Playwright-executor's fate
+inconsistently — as a hedged either/or in Requirements, and separately as an
+unresolved Open Question — a clarity finding this item resolves by stating the
+choice once, in Open Questions, and requiring the decision be recorded once made.
+
+## Requirements
+
+- `accelerator-design` — design inventory/gap tooling for `skills/design/**`
+  maintainers and consumers, per the sub-binary consistency established by
+  parent epic work-item:0136 (`inventory-design/scripts/*`,
+  `analyse-design-gaps/scripts/*`; the subcommand set is whatever these two
+  script directories resolve to at implementation time — record the
+  concrete mapping in Drafting Notes once known). The Playwright executor
+  (`run.sh`, currently under `inventory-design/scripts/playwright/`) is
+  scoped by the Open Questions decision below.
+- Rewrite the call sites and `allowed-tools` of every skill under
+  `skills/design/**` to call the new `accelerator design` subcommands,
+  following the invocation contract established in 0167.
+
+## Acceptance Criteria
+
+- [ ] `accelerator design …` reproduces the inventory/gap behaviours, verified
+      against repointed suites (existing tests redirected to invoke the new
+      binary instead of the legacy shell scripts) and characterization tests
+      where none exist — each covering at least the primary success path and
+      one failure path per subcommand in the set recorded in Drafting Notes
+      once known (see Requirements).
+- [ ] Invoking the `inventory-design` subcommand's Playwright-driven path
+      execs `run.sh` (or its folded equivalent) and exits 0, producing a
+      report artefact that is byte-identical to the one the current shell
+      invocation produces for a fixed fixture input. Restructuring the
+      report format is out of scope for this item; if a future need to
+      restructure it arises, it is tracked as a separate follow-up item.
+- [ ] All skills previously invoking `skills/design/**/scripts/*` now call the
+      corresponding `accelerator design` subcommand, with `allowed-tools`
+      updated to match, per the 0167 contract.
+- [ ] The migrated `skills/design/**` scripts are removed (excepting `run.sh` if
+      the thin-wrapper exception is exercised), with the affected suite floors
+      decremented in lockstep (see work-item:0174).
+- [ ] `accelerator-design` passes every item of the sub-binary registration
+      checklist at `tasks/README.md#registering-a-dispatched-sub-binary`.
+
+## Open Questions
+
+- Whether the Playwright executor stays shell (thin-wrapper exception) or is
+  folded into `accelerator-design`. Default: stays a thin wrapper, consistent
+  with parent epic work-item:0136's resolved expectation of a thin residual
+  shell surface — folding it in is a substantially larger rewrite and should
+  only be taken as an explicit re-scope, confirmed before implementation
+  begins rather than decided mid-implementation. Record the resolution in
+  Drafting Notes once made.
+
+## Dependencies
+
+- Blocked by: none currently. Prior blockers are resolved: work-item:0166
+  (shared crates, done), work-item:0167 (invocation-contract pattern, done —
+  subsumes the earlier launcher/dispatch scaffold), work-item:0187
+  (sub-binary registration surface, merged via PR #42).
+- Blocks: work-item:0174 (shell/CI-guard retirement — floor decrements from
+  this item's script removals feed its lockstep requirement).
+- External: a Node/Playwright runtime must be available for the design-gap
+  tooling to function (pre-existing coupling, carried forward from the bash
+  scripts).
+- Coordination: siblings work-item:0195 (corpus) and work-item:0197
+  (collaboration) register sub-binaries via the same checklist around the
+  same time; if that checklist touches shared state (a central dispatch
+  manifest or CI floor config) rather than being purely additive per-binary,
+  coordinate to avoid merge contention.
+- Parent: work-item:0136 (epic).
+
+## Assumptions
+
+- Repointed suites plus characterization tests where none exist are
+  sufficient to establish behavioural parity with the legacy shell scripts.
+- A Node/Playwright runtime remains an acceptable external dependency for
+  `accelerator-design`, consistent with the pre-existing coupling in the
+  bash scripts.
+
+## Technical Notes
+
+- Source bash: `skills/design/**/scripts/*` (`inventory-design`,
+  `analyse-design-gaps`), including `run.sh` (confirmed at
+  `inventory-design/scripts/playwright/run.sh` — the Playwright executor
+  belongs to the `inventory-design` subcommand, not `analyse-design-gaps`).
+
+## Drafting Notes
+
+- Split out of work-item:0173 on 2026-08-05 following that item's review-1
+  (verdict REVISE, scope lens): the three sub-binaries it bundled were
+  functionally independent and separately deliverable.
+- The Playwright-executor either/or was previously stated twice, inconsistently,
+  in 0173 (a review-1 clarity finding); here it appears once, in Open Questions.
+- review-1 (2026-08-06, verdict REVISE) found the either/or had recurred
+  within this item itself — the Summary stated the decision as settled while
+  Requirements/Open Questions/AC still hedged it, and the two outcomes are
+  not equivalent effort. Resolved by: hedging the Summary consistently,
+  removing the restated either/or from Requirements, and adding a default
+  (thin wrapper) plus a pre-implementation confirmation gate to Open
+  Questions.
+
+## References
+
+- Split from: `meta/work/0173-remaining-subdomains-corpus-design-collaboration.md`
+  (abandoned)
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- ADRs: ADR-0048, ADR-0053

--- a/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
+++ b/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
@@ -1,0 +1,141 @@
+---
+type: work-item
+id: "0197"
+title: "accelerator-collaboration: PR Helper CLI"
+date: "2026-08-05T19:03:35+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0136"
+derived_from: ["work-item:0173"]
+tags: [rust, collaboration, cli, github, gh]
+last_updated: "2026-08-06T01:13:07+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0197: accelerator-collaboration: PR Helper CLI
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Migrate the PR helpers (`pr-base-repo`, `pr-update-body`) into an
+`accelerator-collaboration` sub-binary, adopting the `collaboration` domain
+name for this binary ahead of the full skill-directory rename tracked
+separately in work-item:0150. This replaces bash that skills authors
+currently shell out to with a typed, testable Rust implementation.
+
+## Context
+
+Split out of work-item:0173 (now abandoned) on 2026-08-05, per that item's
+review-1 scope finding: bundling `accelerator-corpus`, `accelerator-design`, and
+`accelerator-collaboration` into a single story risked partial-completion
+ambiguity and an oversized PR. The PR helpers stay separate as
+`accelerator-collaboration` per the github→collaboration rename (precedent:
+work-item:0150) — the domain is named `collaboration`, not `github`. This
+binary's own naming (`collaboration`) is fixed, not open (0173's review-1
+flagged the "open" wording as ambiguous on this point); this replaces
+untestable bash bound by the project's bash 3.2 floor, consistent with the
+broader shell-to-Rust migration epic (work-item:0136). The wider
+github→collaboration *directory* rename (renaming `skills/github/**` itself)
+is a separate, still-in-progress initiative tracked by work-item:0150 —
+this item does not depend on it and does not rename the skill directory
+(see Dependencies).
+
+## Requirements
+
+- `accelerator-collaboration` — the PR helpers (`pr-base-repo`,
+  `pr-update-body`); shells to `gh`. Domain named `collaboration`, not `github`.
+- Rewrite the call sites and `allowed-tools` of every skill invoking
+  `skills/github/scripts/pr-base-repo.sh` or
+  `skills/github/describe-pr/scripts/pr-update-body.sh` to call the new
+  `accelerator collaboration` subcommands, following the invocation contract
+  established in 0167.
+- Remove the migrated `skills/github/scripts/pr-base-repo.sh` and
+  `skills/github/describe-pr/scripts/pr-update-body.sh` scripts, with the
+  affected suite floors decremented in lockstep (see work-item:0174).
+- `accelerator-collaboration` satisfies every item of the sub-binary
+  registration checklist at
+  `tasks/README.md#registering-a-dispatched-sub-binary`.
+
+## Acceptance Criteria
+
+- [ ] `accelerator collaboration …` reproduces the PR-helper behaviours,
+      shelling to `gh` with the same invocations as the current bash (enumerate
+      the specific `gh` sub-commands/flags per helper during implementation),
+      verified via repointed suites (existing suites redirected to invoke
+      `accelerator collaboration` instead of the bash script) supplemented by
+      characterization tests for any current `gh` call-shape behaviour not
+      already covered by those suites.
+- [ ] All skills previously invoking `skills/github/scripts/pr-base-repo.sh` and
+      `skills/github/describe-pr/scripts/pr-update-body.sh` now call the
+      corresponding `accelerator collaboration` subcommand, with
+      `allowed-tools` updated to match, per the 0167 contract.
+- [ ] The migrated scripts (`skills/github/scripts/pr-base-repo.sh`,
+      `skills/github/describe-pr/scripts/pr-update-body.sh`) are removed, with
+      the affected suite floors decremented in lockstep (see work-item:0174).
+- [ ] `accelerator-collaboration` passes every item of the sub-binary
+      registration checklist at `tasks/README.md#registering-a-dispatched-sub-binary`.
+
+## Assumptions
+
+- The two named source scripts (`pr-base-repo.sh`, `pr-update-body.sh`)
+  represent the complete current PR-helper behavioural surface for this
+  migration; any undocumented edge-case behaviour they carry is expected to
+  surface via the characterization tests above rather than being
+  independently enumerated up front.
+
+## Dependencies
+
+- Blocked by: none currently. Prior blockers are resolved: work-item:0166
+  (shared crates, done), work-item:0167 (invocation-contract pattern, done),
+  work-item:0187 (sub-binary registration surface, merged via PR #42).
+- Not a blocker: work-item:0150 (github→collaboration rename, still
+  `status: draft`) establishes the naming precedent this item follows, but
+  this item does not depend on 0150 completing. 0150 renames the
+  `skills/github/**` directory itself; this item leaves that rename to 0150
+  and only migrates the two named scripts' behaviour and call sites within
+  the existing directory structure.
+- Coordination: siblings work-item:0195 (corpus) and work-item:0196 (design)
+  register sub-binaries via the same checklist around the same time; if that
+  checklist touches shared state (a central dispatch manifest or CI floor
+  config) rather than being purely additive per-binary, coordinate to avoid
+  merge contention.
+- Blocks: work-item:0174 (shell/CI-guard retirement — floor decrements from
+  this item's script removals feed its lockstep requirement).
+- External: the `gh` CLI must be installed and authenticated for
+  `accelerator collaboration`'s PR-helper subcommands at runtime
+  (pre-existing coupling, carried forward from the bash scripts). Test-time
+  verification (see Acceptance Criteria) should exercise `gh` invocation via
+  a mockable/injectable interface rather than requiring live authenticated
+  `gh` calls in CI.
+- Parent: work-item:0136 (epic).
+
+## Technical Notes
+
+- Source bash: `skills/github/scripts/pr-base-repo.sh`,
+  `skills/github/describe-pr/scripts/pr-update-body.sh`.
+
+## Drafting Notes
+
+- Split out of work-item:0173 on 2026-08-05 following that item's review-1
+  (verdict REVISE, scope lens): the three sub-binaries it bundled were
+  functionally independent and separately deliverable.
+- Domain-naming wording tightened per 0173's review-1 clarity finding: the
+  github→collaboration rename is an in-progress, codebase-wide initiative, but
+  this binary's own naming (`collaboration`) is settled, not open.
+
+## References
+
+- Split from: `meta/work/0173-remaining-subdomains-corpus-design-collaboration.md`
+  (abandoned)
+- Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Related: `meta/work/0150-rename-github-skill-group-to-collaboration.md`
+  (github→collaboration rename precedent)
+- ADRs: ADR-0053


### PR DESCRIPTION

# Split work-item 0173 into 0195/0196/0197, review each, and mark 0197 ready

## Summary

Work-item 0173 bundled three functionally independent efforts — `accelerator-corpus`, `accelerator-design`, and `accelerator-collaboration` — into a single oversized story, and its review-1 pass flagged this as a scope violation. This PR abandons 0173 and splits it into three new stories (0195, 0196, 0197) parented directly under the 0136 epic, reviews each of the three through all five work-item lenses, addresses the findings from 0197's review, and marks all three items `ready` for planning. It touches only `meta/work/` and `meta/reviews/work/` — no source code changes.

## Changes

- Abandon work-item:0173 (`status: abandoned`), record the split rationale in its Drafting Notes, and link forward to its three successors via `relates_to` and a new "Superseded by" reference.
- Add work-item:0195 (`accelerator-corpus`: ADR, metadata, frontmatter validation, and linkage CLI), work-item:0196 (`accelerator-design`: design inventory and gap tooling CLI), and work-item:0197 (`accelerator-collaboration`: PR helper CLI), each carrying forward its slice of 0173's Requirements/Acceptance Criteria/Dependencies with that review's gaps fixed, and each set to `status: ready`.
- Review 0173, 0195, 0196, and 0197 through the clarity, completeness, dependency, scope, and testability lenses; record each review under `meta/reviews/work/`. 0173's review-1 (verdict REVISE) is the scope finding that motivated the split. 0195 and 0196 land at verdict APPROVE. 0197 goes through two review passes: pass 1 (verdict COMMENT) surfaces a cross-cutting finding that 0197 inconsistently characterised work-item:0150's completion status across its Summary, Context, and Dependencies sections, plus several precision gaps (glob-shaped scope language, Requirements missing two AC-gated obligations, an ambiguous AC1 verification method); pass 2, after those edits, surfaces one new major finding — 0197 didn't reciprocate a sibling-coordination note that 0196 already carries about concurrent sub-binary registration touching shared state — which is then also addressed, bringing 0197 to verdict APPROVE.
- Update work-item:0136 (the epic)'s phase list and Drafting Notes to reflect the split, and update work-item:0174's `blocked_by` and work-item:0179's `blocks`/cross-references to point at 0195/0196/0197 instead of the now-abandoned 0173.

## Context

Part of the ongoing shell-to-Rust CLI migration epic (work-item:0136). 0173 was originally extracted from `codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture` as a single grouped story for the three remaining sub-binary domains; its review-1 found the grouping risked partial-completion ambiguity and an oversized PR, since the three sub-binaries share no functional relationship beyond the sub-binary registration pattern (work-item:0187).

## Testing

- [x] Confirmed every changed file's YAML frontmatter parses as valid YAML with the expected keys (ran a standalone parse check across all 11 touched files).
- [x] Confirmed 0173/0174/0179's cross-references to the split items are reciprocal (e.g. 0174's `blocked_by` lists 0195/0196/0197; 0196's Dependencies names 0195 and 0197 in its coordination note, which 0197 now reciprocates).
- [ ] No source code changed by this PR, so `mise run check`/`mise run` were not run — there is nothing in `cli/`, `server/`, `frontend/`, or `tasks/` for them to exercise.

## Notes for Reviewers

This is a documentation/work-item-management PR only; it reshapes planning artifacts ahead of implementation, not application behaviour. Actual implementation of 0195/0196/0197 (the three Rust sub-binaries themselves) is follow-up work, not part of this PR.

One known gap, left out of scope deliberately rather than fixed here: five already-completed/merged items (work-item:0166, 0167, 0169, 0172, 0187) still carry a `blocks: [..., "work-item:0173"]` frontmatter edge from before the split. Since 0173 is now abandoned rather than progressing, those edges are stale — they should arguably be retargeted at 0195/0196/0197 (mirroring what this PR already did for 0174 and 0179), but touching five unrelated, already-shipped items felt like scope creep for a PR whose job is the split itself. Flagging for a reviewer call on whether that cleanup belongs here, in a quick follow-up, or is fine left as historical record.
