### PR TITLE
Fix the lock reclaim race and the dev frontend-activation flake

### DIFF
--- a/cli/corpus-adapters/src/lock.rs
+++ b/cli/corpus-adapters/src/lock.rs
@@ -1,8 +1,13 @@
 //! The mkdir-based advisory lock: `mkdir` is the exclusive-acquisition mutex
-//! (POSIX, unlike `flock`), the lockdir carries an `owner` PID sentinel, a dead
-//! holder is reclaimed single-winner, and contention backs off with jitter up
-//! to an injectable ceiling. POSIX-only, matching the bash source and the
-//! darwin + musl target set.
+//! (POSIX, unlike `flock`), the lockdir carries an `owner.<nonce>` PID
+//! sentinel, a dead holder is reclaimed single-winner, and contention backs off
+//! with jitter up to an injectable ceiling. POSIX-only, matching the bash
+//! source and the darwin + musl target set.
+//!
+//! `scripts/atomic-common.sh` implements the same protocol over the same
+//! `<target>.lockdir` convention, so the two can hold against and reclaim after
+//! each other. The on-disk sentinel format is therefore a shared contract:
+//! change it in one and the other stops recognising a held lock.
 
 use std::fs;
 use std::io::ErrorKind;
@@ -14,6 +19,11 @@ use corpus::StoreError;
 use rand::Rng as _;
 use rustix::io::Errno;
 use rustix::process::{test_kill_process, Pid};
+
+/// Sentinel filename prefixes. Each is followed by `.<nonce>` — the nonce
+/// is what binds a reclaim to the exact holder it read; see `reclaim_if_stale`.
+const OWNER: &str = "owner";
+const RECLAIMING: &str = "reclaiming";
 
 #[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone, Copy)]
@@ -89,9 +99,16 @@ fn acquire_with(
     }
 }
 
+/// Take ownership of a freshly created lockdir by dropping in its sentinel.
+///
+/// The sentinel's *name* carries a fresh nonce, not just its contents. That is
+/// what makes reclaim safe: it gives every holder a filename no other holder
+/// will ever present, so a reclaimer acting on a stale read can only ever
+/// address the exact holder it read (see `reclaim_if_stale`).
 fn claim(lockdir: &Path) -> Result<LockGuard, StoreError> {
+    let sentinel = format!("{OWNER}.{:016x}", rand::random::<u64>());
     let owner = std::process::id().to_string();
-    if let Err(error) = fs::write(lockdir.join("owner"), owner) {
+    if let Err(error) = fs::write(lockdir.join(sentinel), owner) {
         let _ = fs::remove_dir_all(lockdir);
         return Err(StoreError::Io {
             path: lockdir.display().to_string(),
@@ -103,34 +120,127 @@ fn claim(lockdir: &Path) -> Result<LockGuard, StoreError> {
     })
 }
 
+/// Reclaim the lockdir when — and only when — its owner is confirmed dead.
+///
+/// Reclaim is inherently a read-then-act, and the read can go stale: between
+/// observing a dead owner and acting on it, another contender can reclaim,
+/// `mkdir`, and claim the lock for itself. The act must therefore be *bound to
+/// the holder that was read*, or it lands on the new, live one.
+///
+/// Two earlier shapes both got this wrong. Renaming the whole lockdir aside
+/// moved a live holder's directory and freed its path, letting a second
+/// acquirer take the same lock. Renaming a fixed-name `owner` sentinel aside
+/// failed the same way for the same reason — the new holder's sentinel has the
+/// same name, so the stale rename still matched it. Since the guarded
+/// operation is a read-modify-write of an append-only store, either is a lost
+/// write, not merely a lock anomaly.
+///
+/// So the sentinel is named `owner.<nonce>` per holder, and the reclaim step
+/// renames *that exact name* aside. `rename` is atomic, which makes the step
+/// single-winner among contenders that read the same holder, and the nonce
+/// makes it a no-op (`ENOENT`) against any *other* holder. The directory is
+/// only removed by the contender that won the rename, and only while it is
+/// still the directory that was read: winning proves `owner.<nonce>` was
+/// present, and a new holder can only exist by way of a `mkdir` that the
+/// surviving directory forbids.
 fn reclaim_if_stale(lockdir: &Path, is_alive: &impl Fn(i32) -> bool) {
-    let Some(pid) = dead_owner(lockdir, is_alive) else {
+    let Some(sentinel) = reclaimable(lockdir, is_alive) else {
         return;
     };
-    let discard = discard_path(lockdir);
-    if fs::rename(lockdir, &discard).is_err() {
-        return;
-    }
-    if dead_owner(&discard, is_alive) == Some(pid) {
-        let _ = fs::remove_dir_all(&discard);
+    // The winner's own PID goes in the NAME, put there atomically by the
+    // rename itself — see `reclaimable` for what reads it back.
+    let claimed = format!(
+        "{RECLAIMING}.{}.{:016x}",
+        std::process::id(),
+        rand::random::<u64>()
+    );
+    if fs::rename(lockdir.join(&sentinel), lockdir.join(claimed)).is_ok() {
+        let _ = fs::remove_dir_all(lockdir);
     }
 }
 
-/// The owner PID only when it is present, parseable, and confirmed dead. A
-/// missing, empty (holder mid-acquisition), or unparseable `owner` file yields
-/// `None` — treated as a *live* holder, so PID-reuse or the acquisition window
-/// can never break a genuinely held lock.
-fn dead_owner(lockdir: &Path, is_alive: &impl Fn(i32) -> bool) -> Option<i32> {
-    let owner = fs::read_to_string(lockdir.join("owner")).ok()?;
-    let pid = owner.trim().parse::<i32>().ok()?;
-    (!is_alive(pid)).then_some(pid)
+/// The sentinel a reclaim may take, if any.
+fn reclaimable(
+    lockdir: &Path,
+    is_alive: &impl Fn(i32) -> bool,
+) -> Option<String> {
+    // The ordinary case: a holder whose PID is dead. `legacy_owner` is the
+    // same case in the nonce-less format that `scripts/atomic-common.sh` also
+    // still reads — nothing writes it any more, so it can only be an orphan
+    // left by a holder that died before the upgrade.
+    if let Some((name, _)) = dead_sentinel(lockdir, OWNER, is_alive) {
+        return Some(name);
+    }
+    if let Some((name, _)) = legacy_owner(lockdir, is_alive) {
+        return Some(name);
+    }
+    // A `reclaiming.<pid>.<nonce>` is a reclaim between its rename and its
+    // removal. Taking it over is only safe once the RECLAIMER is dead, and
+    // that PID is read from the name rather than the file: the rename that
+    // created the name published it atomically, whereas a write afterwards
+    // would leave a window in which the name says nothing.
+    //
+    // Gating on the reclaimer's liveness — not the original holder's — is what
+    // keeps removal single-owner. Re-nonce alone does not: two contenders that
+    // each win a rename of a *different* name (one of `owner.<n>`, one of the
+    // `reclaiming.<n>` it became) would both believe they may remove, and the
+    // slower one's removal would land on whatever fresh, live lockdir the
+    // faster one's had already been replaced by. A live reclaimer is left
+    // alone; a dead one cannot still be about to remove anything.
+    let name = sole_sentinel(lockdir, RECLAIMING)?;
+    let pid = name.split('.').nth(1)?.parse::<i32>().ok()?;
+    (!is_alive(pid)).then_some(name)
 }
 
-fn discard_path(lockdir: &Path) -> PathBuf {
-    let nonce = rand::random::<u64>();
-    let mut name = lockdir.as_os_str().to_owned();
-    name.push(format!(".{}.{nonce:x}.reclaim", std::process::id()));
-    PathBuf::from(name)
+/// The single `<prefix>.…` entry in `lockdir`, or `None` when there is no such
+/// entry or more than one — which no correct writer produces, so it is read as
+/// "do not touch" rather than guessed at.
+fn sole_sentinel(lockdir: &Path, prefix: &str) -> Option<String> {
+    let mut found = None;
+    for entry in fs::read_dir(lockdir).ok()?.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with(&format!("{prefix}.")) {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(name);
+        }
+    }
+    found
+}
+
+/// The `<prefix>.<nonce>` sentinel and its PID, only when that PID is present,
+/// parseable, and confirmed dead. A missing sentinel (holder mid-acquisition),
+/// or an empty or unparseable one, yields `None` — treated as a *live* holder,
+/// so PID-reuse or the acquisition window can never break a genuinely held
+/// lock. Ditto a directory carrying more than one matching sentinel, which no
+/// correct writer produces.
+fn dead_sentinel(
+    lockdir: &Path,
+    prefix: &str,
+    is_alive: &impl Fn(i32) -> bool,
+) -> Option<(String, i32)> {
+    let name = sole_sentinel(lockdir, prefix)?;
+    let pid = sentinel_pid(lockdir, &name)?;
+    (!is_alive(pid)).then_some((name, pid))
+}
+
+/// The nonce-less `owner` sentinel, only when its PID is confirmed dead. See
+/// the call site for why this format is still read but never written.
+fn legacy_owner(
+    lockdir: &Path,
+    is_alive: &impl Fn(i32) -> bool,
+) -> Option<(String, i32)> {
+    let pid = sentinel_pid(lockdir, OWNER)?;
+    (!is_alive(pid)).then_some((OWNER.to_owned(), pid))
+}
+
+fn sentinel_pid(lockdir: &Path, name: &str) -> Option<i32> {
+    fs::read_to_string(lockdir.join(name))
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()
 }
 
 /// `kill(pid, 0)` via rustix: signalable → alive; `EPERM` → alive (exists but
@@ -162,8 +272,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        acquire_with, claim, jitter_ms, process_is_alive, LockGuard,
-        LockOptions,
+        acquire_with, claim, jitter_ms, process_is_alive, reclaim_if_stale,
+        LockGuard, LockOptions, OWNER, RECLAIMING,
     };
 
     type TestError = Box<dyn std::error::Error>;
@@ -178,10 +288,43 @@ mod tests {
         }
     }
 
+    /// Seed a held lockdir with a nonce-named owner sentinel, exactly as
+    /// `claim` writes one.
     fn seed_held(lockdir: &Path, owner: &str) -> Result<(), TestError> {
+        seed_sentinel(lockdir, OWNER, owner)
+    }
+
+    fn seed_sentinel(
+        lockdir: &Path,
+        prefix: &str,
+        owner: &str,
+    ) -> Result<(), TestError> {
         fs::create_dir_all(lockdir)?;
-        fs::write(lockdir.join("owner"), owner)?;
+        fs::write(lockdir.join(format!("{prefix}.0123456789abcdef")), owner)?;
         Ok(())
+    }
+
+    /// A reclaim abandoned by the reclaimer at `pid`, in the on-disk shape the
+    /// rename leaves behind: the reclaimer's PID lives in the NAME.
+    fn seed_abandoned_reclaim(
+        lockdir: &Path,
+        pid: i32,
+    ) -> Result<(), TestError> {
+        fs::create_dir_all(lockdir)?;
+        fs::write(
+            lockdir.join(format!("{RECLAIMING}.{pid}.0123456789abcdef")),
+            STALE_PID.to_string(),
+        )?;
+        Ok(())
+    }
+
+    /// The single `<prefix>.<nonce>` entry in a lockdir, if there is one.
+    fn sentinel_named(lockdir: &Path, prefix: &str) -> Option<String> {
+        fs::read_dir(lockdir)
+            .ok()?
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .find(|n| n.starts_with(&format!("{prefix}.")))
     }
 
     #[test]
@@ -192,7 +335,7 @@ mod tests {
         seed_held(&lockdir, &STALE_PID.to_string())?;
 
         let guard = acquire_with(&lockdir, fast_opts(), |_| false)?;
-        assert!(lockdir.join("owner").exists());
+        assert!(sentinel_named(&lockdir, OWNER).is_some());
         drop(guard);
         Ok(())
     }
@@ -315,14 +458,138 @@ mod tests {
         Ok(())
     }
 
+    /// The reclaim race, forced rather than sampled.
+    ///
+    /// Two acquirers can both read the same dead `owner` before either acts.
+    /// The `is_alive` hook is the injection point: it fires *between* the
+    /// liveness check and the rename, which is exactly the window a second
+    /// acquirer needs to reclaim, `mkdir`, and claim the lock for itself. The
+    /// first acquirer's rename then lands on a *live* lockdir. Sampling this
+    /// with real threads takes thousands of runs (CI has hit it roughly once
+    /// in ten full runs); driving the hook pins it deterministically.
     #[test]
-    fn claim_releases_the_lockdir_when_the_owner_write_fails(
+    fn a_stale_reclaim_does_not_displace_a_live_holder() -> Result<(), TestError>
+    {
+        let dir = TempDir::new()?;
+        let lockdir = dir.path().join("log.lockdir");
+        seed_held(&lockdir, &STALE_PID.to_string())?;
+
+        let winner = std::cell::RefCell::new(None);
+        let raced = std::cell::Cell::new(false);
+        let is_alive = |pid: i32| {
+            // Run the whole of the *other* acquirer the first time we are
+            // asked, so the rename below is issued against its live lockdir.
+            if pid == STALE_PID && !raced.replace(true) {
+                *winner.borrow_mut() =
+                    Some(acquire_with(&lockdir, fast_opts(), |p| {
+                        p != STALE_PID
+                    }));
+            }
+            pid != STALE_PID
+        };
+
+        reclaim_if_stale(&lockdir, &is_alive);
+
+        let held = winner.into_inner();
+        assert!(
+            matches!(held, Some(Ok(_))),
+            "the racing acquirer ran and took the lock"
+        );
+        // The live holder must still own the path: if the stale reclaim moved
+        // it aside, `create_dir` succeeds here and two acquirers hold at once.
+        assert!(
+            fs::create_dir(&lockdir).is_err(),
+            "a live holder's lockdir was displaced by a stale reclaim, so a \
+             second acquirer can take the same lock"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_nonce_less_owner_left_by_an_older_holder_is_still_reclaimed(
+    ) -> Result<(), TestError> {
+        // The pre-nonce on-disk format. An orphan in this shape can outlive an
+        // upgrade, and if it were unreadable it would wedge the lock for the
+        // full ceiling on every acquisition.
+        let dir = TempDir::new()?;
+        let lockdir = dir.path().join("log.lockdir");
+        fs::create_dir_all(&lockdir)?;
+        fs::write(lockdir.join(OWNER), STALE_PID.to_string())?;
+
+        let guard =
+            acquire_with(&lockdir, fast_opts(), |pid| pid != STALE_PID)?;
+
+        assert!(sentinel_named(&lockdir, OWNER).is_some());
+        drop(guard);
+        Ok(())
+    }
+
+    #[test]
+    fn a_nonce_less_owner_that_is_alive_is_never_reclaimed(
     ) -> Result<(), TestError> {
         let dir = TempDir::new()?;
         let lockdir = dir.path().join("log.lockdir");
-        fs::create_dir_all(lockdir.join("owner"))?;
+        fs::create_dir_all(&lockdir)?;
+        fs::write(lockdir.join(OWNER), STALE_PID.to_string())?;
+
+        let outcome = acquire_with(&lockdir, fast_opts(), |_| true);
+
+        assert!(matches!(outcome, Err(StoreError::LockTimeout { .. })));
+        Ok(())
+    }
+
+    #[test]
+    fn a_reclaim_that_died_mid_flight_is_finished_by_the_next_acquirer(
+    ) -> Result<(), TestError> {
+        // The crash window: the sentinel was renamed aside but the directory
+        // was never removed. Left alone this reads as "held by nobody" and
+        // would wedge the lock permanently.
+        let dir = TempDir::new()?;
+        let lockdir = dir.path().join("log.lockdir");
+        seed_abandoned_reclaim(&lockdir, STALE_PID)?;
+
+        let guard =
+            acquire_with(&lockdir, fast_opts(), |pid| pid != STALE_PID)?;
+
+        assert!(sentinel_named(&lockdir, OWNER).is_some());
+        assert!(sentinel_named(&lockdir, RECLAIMING).is_none());
+        drop(guard);
+        Ok(())
+    }
+
+    #[test]
+    fn a_reclaim_whose_reclaimer_is_still_alive_is_left_alone(
+    ) -> Result<(), TestError> {
+        // Same shape, but the reclaimer named in the sentinel is alive, so the
+        // reclaim is in flight rather than abandoned. Taking it over would give
+        // two contenders the right to remove the same directory — the recovery
+        // path must not become a second way to break a held lock.
+        let dir = TempDir::new()?;
+        let lockdir = dir.path().join("log.lockdir");
+        seed_abandoned_reclaim(&lockdir, STALE_PID)?;
+
+        let outcome = acquire_with(&lockdir, fast_opts(), |_| true);
+
+        assert!(matches!(outcome, Err(StoreError::LockTimeout { .. })));
+        assert!(sentinel_named(&lockdir, RECLAIMING).is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn claim_releases_the_lockdir_when_the_owner_write_fails(
+    ) -> Result<(), TestError> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = TempDir::new()?;
+        let lockdir = dir.path().join("log.lockdir");
+        fs::create_dir_all(&lockdir)?;
+        // Read-only, so dropping the sentinel in fails. (The sentinel name
+        // carries a nonce, so it cannot be blocked by pre-creating a colliding
+        // entry — the permission bits are what make the write fail.)
+        fs::set_permissions(&lockdir, fs::Permissions::from_mode(0o555))?;
 
         let outcome = claim(&lockdir);
+
         assert!(matches!(outcome, Err(StoreError::Io { .. })));
         assert!(!lockdir.exists());
         Ok(())

--- a/cli/visualiser/frontend/src/components/DevDesignSystem/use-dev-activation.test.tsx
+++ b/cli/visualiser/frontend/src/components/DevDesignSystem/use-dev-activation.test.tsx
@@ -6,7 +6,7 @@ import {
   Outlet,
   RouterProvider,
 } from "@tanstack/react-router";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DEV_PRIOR_PATH_STORAGE_KEY } from "../../api/storage-keys";
 import { type DevActivation, useDevActivation } from "./use-dev-activation";
@@ -19,6 +19,13 @@ function Root() {
   return <Outlet />;
 }
 
+/** Rendered marker per route, so a wait can key on the tree, not the router. */
+const LABELS: Record<string, string> = {
+  "/library": "library",
+  "/kanban": "kanban",
+  "/dev": "dev",
+};
+
 function buildRouter(initial: string) {
   const root = createRootRoute({ component: Root });
   const mk = (path: string, label: string) =>
@@ -28,9 +35,9 @@ function buildRouter(initial: string) {
       component: () => <div>{label}</div>,
     });
   const tree = root.addChildren([
-    mk("/library", "library"),
-    mk("/kanban", "kanban"),
-    mk("/dev", "dev"),
+    mk("/library", LABELS["/library"]),
+    mk("/kanban", LABELS["/kanban"]),
+    mk("/dev", LABELS["/dev"]),
     mk("/library/$type/$fileSlug", "doc"),
   ]);
   return createRouter({
@@ -39,13 +46,39 @@ function buildRouter(initial: string) {
   });
 }
 
+/**
+ * Wait until the hook has genuinely *observed* `pathname`.
+ *
+ * `router.state.location.pathname` is the wrong thing to wait on by itself:
+ * the memory history reports the target the instant the router is built, so
+ * the assertion is already true before `render` — which returns before the
+ * async initial load has rendered anything at all. A test can therefore sail
+ * past it with the tree unmounted and `useDevActivation`'s prior-path capture
+ * effect never run, and then drive `exitDev` against an unseeded ref. That
+ * restores the `/library` fallback instead of the real prior, which is exactly
+ * the intermittent failure this suite showed under parallel load — and it is
+ * invisible when the test's own starting path is also `/library`.
+ *
+ * So: wait for the route's rendered marker (proves the tree mounted), then for
+ * the session write, which is the capture effect's only observable trace.
+ */
+async function settleAt(
+  router: ReturnType<typeof buildRouter>,
+  pathname: string,
+) {
+  await screen.findByText(LABELS[pathname]);
+  await waitFor(() => expect(router.state.location.pathname).toBe(pathname));
+  if (pathname !== "/dev") {
+    await waitFor(() =>
+      expect(sessionStorage.getItem(DEV_PRIOR_PATH_STORAGE_KEY)).toBe(pathname),
+    );
+  }
+}
+
 async function renderAt(initial: string) {
   const router = buildRouter(initial);
   render(<RouterProvider router={router} />);
-  const expectedPath = initial.split("#")[0];
-  await waitFor(() =>
-    expect(router.state.location.pathname).toBe(expectedPath),
-  );
+  await settleAt(router, initial.split("#")[0]);
   return router;
 }
 
@@ -125,7 +158,9 @@ describe("useDevActivation — enter / exit", () => {
     act(() => {
       router.navigate({ to: "/kanban" });
     });
-    await waitFor(() => expect(router.state.location.pathname).toBe("/kanban"));
+    // Must settle, not merely arrive: the assertion below distinguishes the
+    // captured prior from the fallback only if the capture actually happened.
+    await settleAt(router, "/kanban");
     act(() => captured.current?.enterDev());
     await waitFor(() => expect(router.state.location.pathname).toBe("/dev"));
     act(() => captured.current?.exitDev());

--- a/meta/prs/53-description.md
+++ b/meta/prs/53-description.md
@@ -1,0 +1,60 @@
+---
+type: pr-description
+id: "53"
+title: "Fix the lock reclaim race and the dev frontend-activation flake"
+date: "2026-08-06T08:25:28+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/53"
+pr_number: 53
+tags: []
+revision: "84e6a9f8e7f0bc1154de84555d272911ca6ec4f5"
+repository: "accelerator"
+last_updated: "2026-08-06T08:25:28+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Fix the lock reclaim race and the dev frontend-activation flake
+
+## Summary
+
+Closes out the remaining CI flakiness after the 2026-08-03 load-sensitive batch. Two of these were not flakes at all but genuine correctness bugs that a timeout bump would have masked: the mkdir advisory lock could hand the same lock to two acquirers, and a circus start refusal was being discarded, which is what actually produced "the frontend watcher did not become active". The other three are tests asserting the wrong property or synchronising on the wrong thing.
+
+## Changes
+
+- **Bind the mkdir lock's reclaim to the holder it read.** Reclaim is a read-then-act and the read goes stale. Renaming the whole lockdir aside moved a *live* holder's directory and freed its path, so a second acquirer took the same lock — a lost write, since the guarded operation is a read-modify-write of an append-only store. The holder sentinel is now `owner.<nonce>` and reclaim renames that exact name to `reclaiming.<reclaimer-pid>.<nonce>`; `rename` is atomic, so the step is single-winner among contenders that read the same holder, and the nonce makes it a no-op against any other holder. Removal is gated on the *reclaimer's* liveness, not the original holder's.
+- **Assert mutual exclusion, not a single winner, in the workspace lock test.** The property owed to callers is that two holders never overlap, not that exactly one of eight contenders succeeds. Acquisition is non-blocking, so a contender descheduled past the winner's hold and release legitimately takes the freed lock. The test now tracks occupancy and asserts it never exceeds one.
+- **Surface a circus start refusal instead of discarding it.** circus answers a rejected command with `{"status": "error", "reason": ...}` rather than raising, so discarding the reply from `start()` turned a refused start into a silent no-op. The caller then polled a watcher that had never been asked to run until its deadline, and pointed at a log that was empty because nothing had ever written to it.
+- **Say why a frontend activation failed.** The abort message now folds in the watcher status and the tail of `frontend.log`, gathered before teardown (teardown stops the watcher, so the status afterwards is `stopped` regardless of cause). The integration driver's assertions quoted only stderr while the orchestrators report refusals on stdout, producing a bare `AssertionError`; they now quote both streams. Happy-path budgets go to 60s as headroom.
+- **Synchronise the dev-activation specs on mount, not on memory history.** `renderAt` waited on `router.state.location.pathname`, which `createMemoryHistory` already reports at construction — so the assertion was true before `render` was called and synchronised on nothing. The specs now wait on the route's rendered marker and then on the session write that is the capture effect's only observable trace.
+
+## Context
+
+Came out of a triage of ~70 failed `Main` runs between 2026-07-20 and 2026-08-06. Two findings shaped the scope:
+
+- Mapping each failure signature to the set of distinct branches and SHAs it appears on separates flakes from branch breaks. A signature confined to one branch and reproducing on *every* commit there is a break, not a flake — that reclassified roughly 16 of the failures (notably `a_spawn_through_the_stub_path_is_recorded`, all on `0188` across five commits, and `migrated corpus validates clean`, all on `0169` at one SHA).
+- The largest genuine class, the frontend vitest timeouts, was already fixed on main by the 2026-08-03 batch (`asyncUtilTimeout`, `EVENT_BUDGET`, the indexer tripwire, and nextest temp-dir isolation). This PR is the remainder.
+
+No linked work item.
+
+## Testing
+
+- [x] `mise run` — the full local CI mirror — green twice consecutively against this tree, with the exit status captured directly rather than through a pipe (`MISE_EXIT=0` both times; piping into `tail` masks it).
+- [x] `test:integration:dev` 17/17 on both runs (177s, 168s).
+- [x] `test:unit:cli` 722/722, including the lock module's 18 tests.
+- [x] `test:unit:frontend` 2536/2536 across 122 files; `use-dev-activation.test.tsx` also passes 12/12 in isolation.
+- [x] `test:e2e:visualiser` 343 passed, 1 skipped.
+- [x] The lock race has a deterministic repro, `a_stale_reclaim_does_not_displace_a_live_holder`, which forces the interleaving through the `is_alive` hook — it fails on the old implementation and passes on the new. Sampling it with real threads does not reproduce in 200 runs.
+- [x] Crash-recovery paths covered both sides of the gate: an abandoned reclaim whose reclaimer is dead is finished by the next acquirer; one whose reclaimer is alive is left alone.
+- [ ] Each commit has **not** been verified to build in isolation — the gate was run against the tip of the stack. Matters only if these land as a stack rather than squashed.
+- [ ] The dev frontend-activation failure has not been observed again in CI post-fix; it was intermittent at roughly one run in ten, so a few green runs will not by themselves confirm it.
+
+## Notes for Reviewers
+
+- **The sentinel format is a cross-implementation contract.** `cli/corpus-adapters/src/lock.rs` and `scripts/atomic-common.sh` lock against and reclaim after each other over the same `<target>.lockdir`, so they move together in the first commit. Changing the naming in one alone means a held lock stops being recognised. A legacy nonce-less `owner` is still read by both as a pre-upgrade orphan, and never written.
+- **The reclaimer-liveness gate is the subtle part.** Re-noncing alone is not sufficient: two contenders can each win a rename of a *different* name (one of `owner.<n>`, one of the `reclaiming.<n>` it became) and both then proceed to remove, the slower one landing on whatever fresh live lockdir had since replaced it. Gating removal on the reclaimer's own PID — read from the name, published atomically by the rename that created it — is what keeps removal single-owner.
+- **`_atomic_lock_nonce` respects the bash 3.2 floor.** `$RANDOM` alone is 15 bits and collides readily across the many short-lived subshells a parallel run spawns, so it draws twice and mixes in the subshell PID, falling back to `$$` where `BASHPID` is unset.
+- **The budget widening in "Say why a frontend activation failed" is headroom, not the cure.** "Surface a circus start refusal" is the actual fix. The 60s figure is deliberately far above need — a bring-up measures ~1s idle and ~1.6s at 8x concurrency — so that load can be ruled out if the symptom ever returns, at which point the new message should name the cause directly.
+- Worth a close look at `reclaim_if_stale` and `_atomic_lock_reclaimable` in particular, since a mistake there is a silent lost write rather than a visible failure.

--- a/scripts/atomic-common.sh
+++ b/scripts/atomic-common.sh
@@ -138,8 +138,23 @@ _atomic_lock_acquire() {
   # Record ownership so a waiter can detect us dying and reclaim the lock.
   # $BASHPID is the critical-section subshell's own PID (bash 4+); on bash
   # 3.2 it is unset, so we skip ownership and fall back to spin-only.
-  [ -n "${BASHPID:-}" ] && printf '%s\n' "$BASHPID" >"$lockdir/owner" \
+  #
+  # The sentinel's NAME carries a nonce (`owner.<nonce>`), not just its
+  # contents. That is what makes reclaim safe — see
+  # _atomic_lock_reclaim_if_stale — and it is the same on-disk format the Rust
+  # implementation in cli/corpus-adapters writes, so the two can reclaim after
+  # each other on a shared `<target>.lockdir`.
+  [ -n "${BASHPID:-}" ] &&
+    printf '%s\n' "$BASHPID" >"$lockdir/owner.$(_atomic_lock_nonce)" \
     2>/dev/null || true
+}
+
+# _atomic_lock_nonce
+#   A per-holder token for the sentinel filename. Two RANDOM draws plus the
+#   subshell PID: RANDOM alone is 15 bits, which collides far too readily
+#   across the many short-lived subshells a parallel run spawns.
+_atomic_lock_nonce() {
+  printf '%04x%04x%04x' "${BASHPID:-$$}" "$RANDOM" "$RANDOM"
 }
 
 _atomic_lock_release() {
@@ -152,14 +167,89 @@ _atomic_lock_release() {
 #   Remove a lockdir whose recorded owner process is gone. Safe because a
 #   dead process cannot be inside the critical section; PID reuse only
 #   yields a false "still alive" reading, degrading to the spin-and-wait
-#   path rather than ever breaking a live lock. A lockdir with no owner
-#   file yet (holder still mid-acquisition) is treated as live.
+#   path rather than ever breaking a live lock. A lockdir with no sentinel
+#   yet (holder still mid-acquisition) is treated as live.
+#
+#   Reclaim is a read-then-act and the read can go stale: between reading a
+#   dead owner and acting on it, another waiter can reclaim, mkdir and take
+#   the lock. A bare `rm -rf` then deletes that new, LIVE holder's lockdir and
+#   two callers run the critical section at once — a lost append, since the
+#   guarded operation is a read-modify-write. So the removal is gated on
+#   winning an `mv` of the sentinel: rename(2) is atomic, which makes the step
+#   single-winner among waiters that read the same holder, while the nonce in
+#   the name makes it a no-op against any OTHER holder. Re-nonced rather than
+#   renamed to a fixed name so the same gate covers the crash-recovery case
+#   below.
+#
+#   A holder that dies between the mv and the rm leaves `reclaiming.<nonce>`.
+#   That state is picked up here too — otherwise the lockdir would be left
+#   sentinel-less and every later waiter would read it as permanently held.
 _atomic_lock_reclaim_if_stale() {
-  local lockdir="$1" owner
-  owner=$(cat "$lockdir/owner" 2>/dev/null) || return 0
-  [ -n "$owner" ] || return 0
-  kill -0 "$owner" 2>/dev/null && return 0
+  local lockdir="$1" sentinel claimed
+  sentinel=$(_atomic_lock_reclaimable "$lockdir") || return 0
+  # The winner's OWN pid goes in the name, put there atomically by the mv.
+  claimed="$lockdir/reclaiming.${BASHPID:-$$}.$(_atomic_lock_nonce)"
+  mv "$lockdir/$sentinel" "$claimed" 2>/dev/null || return 0
   rm -rf "$lockdir" 2>/dev/null || true
+}
+
+# _atomic_lock_reclaimable <lockdir>
+#   Echo the sentinel a reclaim may take, if any; non-zero when none may be.
+_atomic_lock_reclaimable() {
+  local lockdir="$1" sentinel owner pid
+  sentinel=$(_atomic_lock_sentinel "$lockdir") || return 1
+  case "$sentinel" in
+    reclaiming.*)
+      # A reclaim between its mv and its rm. Taking it over is only safe once
+      # the RECLAIMER is dead — gating on the original holder instead would
+      # let two waiters each win an mv of a different name and both proceed to
+      # rm, the slower one landing on whatever fresh, live lockdir had since
+      # replaced it. The reclaimer's pid is read from the NAME, published
+      # atomically by the mv that created it.
+      pid="${sentinel#reclaiming.}"
+      pid="${pid%%.*}"
+      [ -n "$pid" ] || return 1
+      kill -0 "$pid" 2>/dev/null && return 1
+      ;;
+    *)
+      owner=$(cat "$lockdir/$sentinel" 2>/dev/null) || return 1
+      [ -n "$owner" ] || return 1
+      kill -0 "$owner" 2>/dev/null && return 1
+      ;;
+  esac
+  printf '%s\n' "$sentinel"
+}
+
+# _atomic_lock_sentinel <lockdir>
+#   Echo the lockdir's single `owner.<nonce>` sentinel, or its
+#   `reclaiming.<nonce>` if a reclaim died mid-flight. Non-zero when there is
+#   no sentinel at all (a holder mid-acquisition), or when there is more than
+#   one of a kind — which no correct writer produces, so it is read as "do not
+#   touch" rather than guessed at.
+_atomic_lock_sentinel() {
+  local lockdir="$1" prefix name found count
+  for prefix in owner reclaiming; do
+    found=""
+    count=0
+    for name in "$lockdir/$prefix".*; do
+      [ -f "$name" ] || continue
+      found="${name##*/}"
+      count=$((count + 1))
+    done
+    if [ "$count" -eq 1 ]; then
+      printf '%s\n' "$found"
+      return 0
+    fi
+    [ "$count" -gt 1 ] && return 1
+  done
+  # A nonce-less `owner` is the pre-nonce on-disk format. Nothing writes it
+  # any more, so it can only be an orphan left by a holder that died before
+  # the upgrade — and reclaiming it is still single-winner, because the `mv`
+  # gate applies to it exactly as to a nonced sentinel. Without this the
+  # orphan would be unreadable and wedge that file's lock for the full
+  # 300 s ceiling on every append.
+  [ -f "$lockdir/owner" ] && printf 'owner\n' && return 0
+  return 1
 }
 
 # atomic_jsonl_append <target_path> <json_line>

--- a/scripts/test-atomic-common.sh
+++ b/scripts/test-atomic-common.sh
@@ -345,6 +345,45 @@ assert_eq "stale lock reclaimed (exit 0)" "0" "$RC"
 assert_eq "stale lock reclaim wrote one line" "1" \
   "$(wc -l <"$TARGET_STALE" | tr -d ' ')"
 
+echo "Test: finishes a reclaim abandoned by a dead reclaimer"
+# The crash window: the sentinel was mv'd aside but the lockdir was never
+# removed. Left alone it has no owner sentinel and every later waiter would
+# read it as permanently held, wedging the lock for the full ceiling.
+TARGET_ABANDONED="$TMPDIR_BASE/abandoned-lock.jsonl"
+LOCKDIR_ABANDONED="${TARGET_ABANDONED}.lockdir"
+mkdir -p "$LOCKDIR_ABANDONED"
+sh -c 'exit 0' &
+DEAD_RECLAIMER=$!
+wait "$DEAD_RECLAIMER" 2>/dev/null || true
+printf '%s\n' "$DEAD_RECLAIMER" \
+  >"$LOCKDIR_ABANDONED/reclaiming.$DEAD_RECLAIMER.abc123"
+RC=0
+atomic_jsonl_append "$TARGET_ABANDONED" \
+  '{"transformation_key":"recovered","schema_version":1}' || RC=$?
+assert_eq "abandoned reclaim finished (exit 0)" "0" "$RC"
+assert_eq "abandoned reclaim wrote one line" "1" \
+  "$(wc -l <"$TARGET_ABANDONED" | tr -d ' ')"
+
+echo "Test: leaves a reclaim alone while its reclaimer is still alive"
+# The reclaimer is mid-flight, not abandoned. Taking the sentinel over would
+# give two waiters the right to rm the same lockdir.
+TARGET_INFLIGHT="$TMPDIR_BASE/inflight-lock.jsonl"
+LOCKDIR_INFLIGHT="${TARGET_INFLIGHT}.lockdir"
+mkdir -p "$LOCKDIR_INFLIGHT"
+sleep 30 &
+LIVE_RECLAIMER=$!
+printf '%s\n' "$LIVE_RECLAIMER" \
+  >"$LOCKDIR_INFLIGHT/reclaiming.$LIVE_RECLAIMER.abc123"
+RECLAIMABLE_RC=0
+_atomic_lock_reclaimable "$LOCKDIR_INFLIGHT" >/dev/null 2>&1 ||
+  RECLAIMABLE_RC=$?
+assert_eq "live reclaimer's sentinel is not reclaimable" "1" \
+  "$RECLAIMABLE_RC"
+assert_eq "the lockdir is left in place" "0" \
+  "$([ -d "$LOCKDIR_INFLIGHT" ] && echo 0 || echo 1)"
+kill "$LIVE_RECLAIMER" 2>/dev/null || true
+wait "$LIVE_RECLAIMER" 2>/dev/null || true
+
 echo "Test: unwritable target directory surfaces error (no silent fail)"
 TARGET5="$TMPDIR_BASE/nope/file.jsonl"
 mkdir -p "$TMPDIR_BASE/nope"

--- a/tasks/shared/dev/circus.py
+++ b/tasks/shared/dev/circus.py
@@ -156,7 +156,18 @@ class CircusSupervisor:
         return [int(p) for p in resp.get("pids", [])]
 
     def start(self, name: str) -> None:
-        self._call("start", name=name)
+        # circus answers a rejected command with {"status": "error", "reason":
+        # ...} rather than raising, so discarding the reply turns a refused
+        # start into a silent no-op: the caller then polls a watcher that was
+        # never asked to run until its deadline and reports it as "did not
+        # become active", pointing at an empty log. Surface it as the
+        # unreachable-supervisor error the orchestrators already handle.
+        resp = self._call("start", name=name)
+        if resp.get("status") == "error":
+            raise SupervisorUnreachableError(
+                f"circus refused to start {name}: "
+                f"{resp.get('reason', 'no reason given')}"
+            )
 
     def quit(self) -> None:
         self._call("quit")

--- a/tasks/shared/dev/lifecycle.py
+++ b/tasks/shared/dev/lifecycle.py
@@ -132,6 +132,8 @@ class LaunchedArbiter:
 # Cadence for the frontend-activation poll. Only an upper bound on how often
 # the supervisor is asked; the deadline is what bounds the wait.
 _FRONTEND_POLL_INTERVAL = 0.1
+# How many trailing frontend.log lines a failed activation quotes back.
+_LOG_TAIL = 5
 
 
 class _UpAbortError(Exception):
@@ -421,7 +423,7 @@ def start_frontend(launched: LaunchedArbiter, deps: DevDeps) -> None:
     sup = deps.client_factory(launched.endpoint, timeout=deps.probe_timeout)
     try:
         try:
-            sup.start("frontend")
+            _request_frontend_start(sup, deps)
         except SupervisorUnreachableError as exc:
             teardown(launched.state, deps, lock_held=True)
             raise _UpAbortError(
@@ -448,16 +450,47 @@ def start_frontend(launched: LaunchedArbiter, deps: DevDeps) -> None:
         # deadline and gets torn down for it.
         deadline = deps.clock.now() + deps.frontend_active_timeout
         if not _await_frontend_active(sup, deps, deadline):
-            _abort_frontend(launched, deps, "did not become active")
+            _abort_frontend(launched, deps, "did not become active", sup=sup)
         # The settle window sits outside the activation deadline on purpose:
         # clamping it would silently skip the check for a watcher that became
         # active just before the deadline — exactly the slow case it is for.
         deps.clock.sleep(deps.frontend_settle)
         if _frontend_status(sup) not in ("active", None):
-            _abort_frontend(launched, deps, "became active then stopped")
+            _abort_frontend(
+                launched, deps, "became active then stopped", sup=sup
+            )
     finally:
         _maybe_close(sup)
     _record_watcher_pid(launched, deps, "frontend")
+
+
+def _request_frontend_start(sup: Supervisor, deps: DevDeps) -> None:
+    """Ask circus to start the watcher, retrying while the arbiter is busy.
+
+    circus serialises arbiter-level commands and refuses one issued while
+    another is in flight ("arbiter is already running arbiter_start_watchers
+    command"). The readiness gate does not exclude that: it waits for the
+    *server* to write server-info.json, which the server does from inside
+    `start_watchers`, so the arbiter is frequently still finishing that call
+    when the frontend start goes out. The refusal is transient and clears in
+    milliseconds — retrying is the whole fix.
+
+    Bounded by the same knob as activation: a refusal that never clears is a
+    stuck arbiter, and it surfaces with circus's own reason attached.
+    """
+    deadline = deps.clock.now() + deps.frontend_active_timeout
+    while True:
+        try:
+            sup.start("frontend")
+        except SupervisorUnreachableError:
+            remaining = deadline - deps.clock.now()
+            if remaining <= 0:
+                raise
+        else:
+            return
+        # Slept outside the handler so the retry does not chain every previous
+        # refusal onto the traceback of the one that finally gives up.
+        deps.clock.sleep(min(_FRONTEND_POLL_INTERVAL, remaining))
 
 
 def _frontend_status(sup: Supervisor) -> str | None:
@@ -493,16 +526,49 @@ def _await_frontend_active(
         deps.clock.sleep(min(_FRONTEND_POLL_INTERVAL, remaining))
 
 
+def _frontend_evidence(deps: DevDeps, sup: Supervisor | None) -> str:
+    """Watcher status + the tail of frontend.log, for the abort message.
+
+    A bare "did not become active" points at a log file, which is useless
+    wherever the log is not collected — a CI runner discards the workspace, so
+    the one artefact that says *why* dies with it. Folding the evidence into
+    the message is what makes an intermittent failure diagnosable from a build
+    log alone. Best-effort throughout: this runs on the failure path, and an
+    unreadable log or unreachable supervisor must not mask the real abort.
+    """
+    parts: list[str] = []
+    if sup is not None:
+        parts.append(f"watcher status={_frontend_status(sup)!r}")
+    log = deps.dev_dir / "frontend.log"
+    tail: list[str] = []
+    with contextlib.suppress(OSError):
+        tail = log.read_text(errors="replace").strip().splitlines()[-_LOG_TAIL:]
+    parts.append(
+        f"last {len(tail)} line(s) of {log}: {' | '.join(tail)}"
+        if tail
+        else f"{log} is empty or unreadable"
+    )
+    return "; ".join(parts)
+
+
 def _abort_frontend(
-    launched: LaunchedArbiter, deps: DevDeps, reason: str
+    launched: LaunchedArbiter,
+    deps: DevDeps,
+    reason: str,
+    *,
+    sup: Supervisor | None = None,
 ) -> NoReturn:
+    # Gather evidence BEFORE teardown — teardown stops the watcher, so the
+    # status it would report afterwards is "stopped" regardless of why we got
+    # here, which is exactly the distinction the message needs to preserve.
+    evidence = _frontend_evidence(deps, sup)
     teardown(launched.state, deps, lock_held=True)
-    log_diagnostic(deps, f"frontend watcher {reason}")
+    log_diagnostic(deps, f"frontend watcher {reason} ({evidence})")
     raise _UpAbortError(
         UpResult(
             "failed",
             message=(
-                f"the frontend watcher {reason}; see "
+                f"the frontend watcher {reason} ({evidence}); see "
                 f"{deps.dev_dir}/frontend.log"
             ),
             artifact=f"{deps.dev_dir}/frontend.log",

--- a/tests/integration/dev/dev_integration_driver.py
+++ b/tests/integration/dev/dev_integration_driver.py
@@ -176,6 +176,18 @@ def _build_deps(workspace: Path, opts: dict) -> DevDeps:
         # poll-count/timeout maths is pinned by the unit tests in test_dev.py.
         # Negative-path tests override these with small values to exercise the
         # timeout branches.
+        # Happy-path defaults are deliberately generous: these are real
+        # processes (circusd + Python fakes) started on shared CI runners that
+        # may have only a few cores under heavy parallel load. The suite
+        # asserts direction (it happened), not precise deadlines — the exact
+        # poll-count/timeout maths is pinned by the unit tests in test_dev.py.
+        # Negative-path tests override these with small values to exercise the
+        # timeout branches.
+        #
+        # These are NOT what the long-running "frontend watcher did not become
+        # active" flake needed: circus was refusing the start outright while
+        # the arbiter finished start_watchers, so no budget could have helped.
+        # See _request_frontend_start.
         probe_timeout=opts.get("probe_timeout", 5.0),
         pidfile_timeout=opts.get("pidfile_timeout", 20.0),
         readiness_timeout=opts.get("readiness_timeout", 20.0),

--- a/tests/integration/dev/test_dev_integration.py
+++ b/tests/integration/dev/test_dev_integration.py
@@ -57,6 +57,21 @@ def run_driver(
     )
 
 
+def assert_ok(proc: subprocess.CompletedProcess) -> subprocess.CompletedProcess:
+    """Assert the driver succeeded, quoting BOTH streams when it did not.
+
+    The orchestrators report a refusal on stdout (the JSON result) and only
+    some paths also log to stderr, so asserting on stderr alone can produce a
+    bare `AssertionError:` that says nothing — which is exactly what an
+    intermittent failure leaves behind in a CI log.
+    """
+    assert proc.returncode == 0, (
+        f"driver exited {proc.returncode}\n"
+        f"stdout: {proc.stdout.strip()}\nstderr: {proc.stderr.strip()}"
+    )
+    return proc
+
+
 def driver_payload(proc: subprocess.CompletedProcess) -> dict:
     line = proc.stdout.strip().splitlines()[-1]
     return json.loads(line)
@@ -128,7 +143,7 @@ def workspace(tmp_path):
 
 def test_detach_readiness_and_log_routing(workspace):
     proc = run_driver(workspace, "up")
-    assert proc.returncode == 0, proc.stderr
+    assert_ok(proc)
     state = read_state(workspace)
     assert (
         state["arbiter_pid"] and state["server_pid"] and state["frontend_pid"]
@@ -152,10 +167,10 @@ def test_detach_readiness_and_log_routing(workspace):
 
 
 def test_reuse_starts_no_duplicate(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     first = read_state(workspace)["arbiter_pid"]
     proc = run_driver(workspace, "up")
-    assert proc.returncode == 0
+    assert_ok(proc)
     assert driver_payload(proc)["kind"] == "reused"
     assert read_state(workspace)["arbiter_pid"] == first
 
@@ -166,13 +181,13 @@ def test_stale_info_does_not_satisfy_gate(workspace):
     (state_dir / "server-info.json").write_text(
         json.dumps({"url": "http://127.0.0.1:1111", "port": 1111})
     )
-    assert run_driver(workspace, "up", {"api_port": 8888}).returncode == 0
+    assert_ok(run_driver(workspace, "up", {"api_port": 8888}))
     info = json.loads((state_dir / "server-info.json").read_text())
     assert info["port"] == 8888  # the fresh server's file, not the stale 1111
 
 
 def test_clean_teardown_leaves_no_orphans(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     state = read_state(workspace)
     tracked = [
         state["server_pid"],
@@ -181,14 +196,14 @@ def test_clean_teardown_leaves_no_orphans(workspace):
         *descendants(state["server_pid"]),
         *descendants(state["frontend_pid"]),
     ]
-    assert run_driver(workspace, "stop").returncode == 0
+    assert_ok(run_driver(workspace, "stop"))
     for pid in tracked:
         assert not alive(pid)
     assert read_state(workspace) is None
 
 
 def test_orphan_reach_when_arbiter_already_dead(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     state = read_state(workspace)
     server_pid, frontend_pid = state["server_pid"], state["frontend_pid"]
     os.kill(state["arbiter_pid"], signal.SIGKILL)  # children reparent to init
@@ -196,7 +211,7 @@ def test_orphan_reach_when_arbiter_already_dead(workspace):
     assert alive(
         server_pid
     )  # still alive, no longer a child of the dead arbiter
-    assert run_driver(workspace, "stop").returncode == 0
+    assert_ok(run_driver(workspace, "stop"))
     assert not alive(server_pid)  # reaped via recorded server_pid
     assert not alive(frontend_pid)  # reaped via recorded frontend_pid
 
@@ -238,7 +253,7 @@ def test_orphan_reach_with_only_server_recorded(workspace):
             "frontend_start_time": None,
         }
         (dev / "dev.json").write_text(json.dumps(state))
-        assert run_driver(workspace, "stop").returncode == 0
+        assert_ok(run_driver(workspace, "stop"))
         assert not alive(
             server.pid
         )  # server subtree reaped via recorded server_pid
@@ -250,10 +265,10 @@ def test_orphan_reach_with_only_server_recorded(workspace):
 
 
 def test_restart_round_trip(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     first = read_state(workspace)["arbiter_pid"]
     proc = run_driver(workspace, "restart")
-    assert proc.returncode == 0, proc.stderr
+    assert_ok(proc)
     state = read_state(workspace)
     assert state["arbiter_pid"] != first  # a genuinely new arbiter
     assert alive(state["arbiter_pid"])
@@ -278,15 +293,15 @@ def test_daemon_startup_failure_reaps_handle_no_retry(workspace):
 
 
 def test_discovery_survives_lost_state_file(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     arbiter = read_state(workspace)["arbiter_pid"]
     (workspace / ".accelerator/tmp/dev/dev.json").unlink()  # lose the cache
-    assert run_driver(workspace, "stop").returncode == 0
+    assert_ok(run_driver(workspace, "stop"))
     assert not alive(arbiter)  # found via recomputed deterministic ipc paths
 
 
 def test_stale_cleanup_after_out_of_band_kill(workspace):
-    assert run_driver(workspace, "up").returncode == 0
+    assert_ok(run_driver(workspace, "up"))
     state = read_state(workspace)
     for key in ("arbiter_pid", "server_pid", "frontend_pid"):
         with contextlib.suppress(Exception):
@@ -295,7 +310,7 @@ def test_stale_cleanup_after_out_of_band_kill(workspace):
     assert (
         run_driver(workspace, "status").returncode == 4
     )  # treated as not-running
-    assert run_driver(workspace, "stop").returncode == 0
+    assert_ok(run_driver(workspace, "stop"))
     endpoint_sock = ipc_socket_paths(workspace)[0]
     assert not endpoint_sock.exists()  # stale socket cleaned up
 
@@ -333,13 +348,13 @@ def test_recycled_pid_is_refused_real_psutil(workspace):
 
 def test_frontend_resolves_npm_under_stripped_path(workspace):
     proc = run_driver(workspace, "up", {"strip_path": True})
-    assert proc.returncode == 0, proc.stderr
+    assert_ok(proc)
     # frontend started despite a stripped PATH -> the absolute npm render worked
     assert read_state(workspace)["frontend_pid"]
 
 
 def test_frontend_port_and_info_wiring(workspace):
-    assert run_driver(workspace, "up", {"free_port": 45678}).returncode == 0
+    assert_ok(run_driver(workspace, "up", {"free_port": 45678}))
     ini = (workspace / ".accelerator/tmp/dev/circus.ini").read_text()
     assert "--port 45678 --strictPort" in ini
     assert "VISUALISER_INFO_PATH" in ini
@@ -348,8 +363,8 @@ def test_frontend_port_and_info_wiring(workspace):
 
 def test_status_exit_codes(workspace):
     assert run_driver(workspace, "status").returncode == 4  # neither
-    assert run_driver(workspace, "up").returncode == 0
-    assert run_driver(workspace, "status").returncode == 0  # both
+    assert_ok(run_driver(workspace, "up"))
+    assert_ok(run_driver(workspace, "status"))  # both
     state = read_state(workspace)
     os.kill(
         state["frontend_pid"], signal.SIGKILL
@@ -367,12 +382,10 @@ def test_status_exit_codes(workspace):
 
 
 def test_sigterm_ignoring_frontend_is_sigkilled(workspace):
-    assert (
-        run_driver(workspace, "up", {"fe_ignore_sigterm": True}).returncode == 0
-    )
+    assert_ok(run_driver(workspace, "up", {"fe_ignore_sigterm": True}))
     frontend_pid = read_state(workspace)["frontend_pid"]
     assert alive(frontend_pid)
-    assert run_driver(workspace, "stop", {"grace_quit": 8.0}).returncode == 0
+    assert_ok(run_driver(workspace, "stop", {"grace_quit": 8.0}))
     # circus escalated to SIGKILL past its 2 s graceful_timeout
     assert not alive(frontend_pid)
 
@@ -382,8 +395,8 @@ def test_cross_workspace_concurrency(tmp_path):
     ws_a.mkdir()
     ws_b.mkdir()
     try:
-        assert run_driver(ws_a, "up").returncode == 0
-        assert run_driver(ws_b, "up").returncode == 0
+        assert_ok(run_driver(ws_a, "up"))
+        assert_ok(run_driver(ws_b, "up"))
         a, b = read_state(ws_a), read_state(ws_b)
         assert a["frontend_port"] != b["frontend_port"]
         assert (
@@ -391,7 +404,7 @@ def test_cross_workspace_concurrency(tmp_path):
         )  # distinct per-workspace ipc sockets
         assert alive(a["arbiter_pid"]) and alive(b["arbiter_pid"])
         # stopping A leaves B untouched (structural isolation)
-        assert run_driver(ws_a, "stop").returncode == 0
+        assert_ok(run_driver(ws_a, "stop"))
         assert not alive(a["arbiter_pid"])
         assert alive(b["arbiter_pid"])
     finally:

--- a/tests/unit/tasks/shared/dev/test_circus.py
+++ b/tests/unit/tasks/shared/dev/test_circus.py
@@ -1,4 +1,11 @@
-from tasks.shared.dev.circus import ArbiterSpec, render_circus_ini
+import pytest
+
+from tasks.shared.dev.circus import (
+    ArbiterSpec,
+    CircusSupervisor,
+    SupervisorUnreachableError,
+    render_circus_ini,
+)
 
 
 def _spec(**overrides) -> ArbiterSpec:
@@ -89,3 +96,51 @@ class TestRenderCircusIni:
         spec = _spec()
         ini = render_circus_ini(spec)
         assert f"VISUALISER_INFO_PATH = {spec.server_info_path}" in ini
+
+
+class _StubClient:
+    """Stands in for circus's `CircusClient`: records calls, replays replies."""
+
+    def __init__(self, replies: dict[str, dict]) -> None:
+        self._replies = replies
+        self.calls: list[tuple[str, dict]] = []
+
+    def send_message(self, command: str, **props) -> dict:
+        self.calls.append((command, props))
+        return self._replies.get(command, {"status": "ok"})
+
+
+def _supervisor(replies: dict[str, dict]) -> CircusSupervisor:
+    # Bypass __init__ so no real endpoint is dialled: the adapter's whole job
+    # is translating circus's wire shapes, which is what these pin.
+    sup = object.__new__(CircusSupervisor)
+    sup._client = _StubClient(replies)
+    return sup
+
+
+class TestCircusSupervisorStart:
+    def test_an_accepted_start_returns(self):
+        sup = _supervisor({"start": {"status": "ok"}})
+        sup.start("frontend")
+        assert sup._client.calls == [("start", {"name": "frontend"})]
+
+    def test_a_refused_start_raises_rather_than_passing_silently(self):
+        # circus answers a rejected command with an error *payload*, not an
+        # exception. Swallowing it left the caller polling a watcher that was
+        # never asked to run until its deadline — the "did not become active"
+        # failure with an empty frontend.log.
+        sup = _supervisor(
+            {"start": {"status": "error", "reason": "arbiter is stopping"}}
+        )
+
+        with pytest.raises(SupervisorUnreachableError) as excinfo:
+            sup.start("frontend")
+
+        assert "arbiter is stopping" in str(excinfo.value)
+        assert "frontend" in str(excinfo.value)
+
+    def test_a_refused_start_without_a_reason_still_raises(self):
+        sup = _supervisor({"start": {"status": "error"}})
+
+        with pytest.raises(SupervisorUnreachableError):
+            sup.start("frontend")

--- a/tests/unit/tasks/shared/dev/test_lifecycle.py
+++ b/tests/unit/tasks/shared/dev/test_lifecycle.py
@@ -31,6 +31,7 @@ class FakeWorld:
         quit_kills=(),
         activate_on_start=True,
         status_hook=None,
+        refuse_starts=0,
     ):
         self.procs = procs
         self.statuses = dict(statuses or {})
@@ -39,6 +40,10 @@ class FakeWorld:
         self.quit_kills = list(quit_kills)
         self.quit_called = 0
         self.started: list[str] = []
+        # How many `start` calls to reject before accepting one, and what got
+        # rejected — circus refuses a command issued while the arbiter is busy.
+        self.refuse_starts = refuse_starts
+        self.refused: list[str] = []
         # A real `start` only confirms the arbiter accepted the command; the
         # watcher may reach "active" later, or never. activate_on_start=False
         # models that gap, and status_hook — run on every status() call, before
@@ -75,6 +80,16 @@ class FakeSupervisor:
     def start(self, name):
         if not self.world.reachable:
             raise SupervisorUnreachableError("unreachable")
+        # Transient refusals, mimicking circus rejecting a command issued while
+        # the arbiter is still running another one.
+        if self.world.refuse_starts > 0:
+            self.world.refuse_starts -= 1
+            self.world.refused.append(name)
+            raise SupervisorUnreachableError(
+                "circus refused to start "
+                f"{name}: arbiter is already running "
+                "arbiter_start_watchers command"
+            )
         self.world.started.append(name)
         if self.world.activate_on_start:
             self.world.statuses[name] = "active"
@@ -498,6 +513,40 @@ class TestFrontendActivation:
 
         assert bring_up(self._deps(tmp_path, procs, world)).kind == "started"
 
+    def test_a_start_refused_while_the_arbiter_is_busy_is_retried(
+        self, tmp_path
+    ):
+        # circus serialises arbiter-level commands and refuses one issued while
+        # another is in flight. The readiness gate does not exclude that — the
+        # server writes server-info.json from inside start_watchers — so the
+        # frontend start routinely lands on a busy arbiter. Left unretried this
+        # was the "did not become active" flake: the watcher was never asked to
+        # run, so no amount of polling could ever see it active.
+        procs = FakeProcs()
+        world = self._world(procs, refuse_starts=3)
+
+        result = bring_up(self._deps(tmp_path, procs, world))
+
+        assert result.kind == "started"
+        assert world.refused == ["frontend"] * 3
+        assert world.started == ["frontend"]
+
+    def test_a_start_refused_past_the_deadline_fails_with_the_reason(
+        self, tmp_path
+    ):
+        # A refusal that never clears is a stuck arbiter, not a transient, and
+        # must surface circus's own wording rather than being reported as a
+        # watcher that would not activate.
+        procs = FakeProcs()
+        world = self._world(procs, refuse_starts=10_000, quit_kills=[9000])
+
+        result = bring_up(self._deps(tmp_path, procs, world))
+
+        assert result.kind == "failed"
+        assert "could not start the frontend watcher" in result.message
+        assert "arbiter is already running" in result.message
+        assert world.started == []
+
     def test_a_watcher_that_never_activates_is_torn_down(self, tmp_path):
         procs = FakeProcs()
         world = self._world(procs, activate_on_start=False, quit_kills=[9000])
@@ -509,6 +558,37 @@ class TestFrontendActivation:
         assert "did not become active" in result.message
         assert "/frontend.log" in result.message
         assert not deps.state_path.exists()
+
+    def test_a_failed_activation_quotes_the_watcher_status_and_log(
+        self, tmp_path
+    ):
+        # The message is the only evidence that survives a CI runner, which
+        # discards the workspace (and so frontend.log) with the job.
+        procs = FakeProcs()
+        world = self._world(procs, activate_on_start=False, quit_kills=[9000])
+        deps = self._deps(tmp_path, procs, world)
+        deps.dev_dir.mkdir(parents=True, exist_ok=True)
+        (deps.dev_dir / "frontend.log").write_text(
+            "npm ERR! missing script: dev\n"
+        )
+
+        result = bring_up(deps)
+
+        assert "watcher status='stopped'" in result.message
+        assert "npm ERR! missing script: dev" in result.message
+
+    def test_a_failed_activation_survives_a_missing_log(self, tmp_path):
+        # Evidence gathering runs on the failure path; it must never mask the
+        # abort it is describing.
+        procs = FakeProcs()
+        world = self._world(procs, activate_on_start=False, quit_kills=[9000])
+        deps = self._deps(tmp_path, procs, world)
+
+        result = bring_up(deps)
+
+        assert result.kind == "failed"
+        assert "did not become active" in result.message
+        assert "empty or unreadable" in result.message
 
     def test_a_watcher_that_dies_during_the_settle_window_fails(self, tmp_path):
         # Active on the first poll, gone by the confirmation poll: the

--- a/tests/unit/tasks/shared/test_locking.py
+++ b/tests/unit/tasks/shared/test_locking.py
@@ -75,23 +75,41 @@ class TestWorkspaceLockMkdirFallback:
             json.dumps({"pid": 2**31 - 1, "start_time": 1.0})
         )
 
-        results: list[bool] = []
-        barrier = threading.Barrier(8)
+        # The property is mutual exclusion — never two holders at once — not
+        # "exactly one of the eight ever succeeds". Acquisition is
+        # non-blocking, so a contender descheduled past the winner's hold and
+        # release finds the lock free and legitimately takes it; counting
+        # winners made that ordinary scheduling look like a lock failure, and
+        # it duly failed under parallel CI load.
+        import time
+
+        occupancy = threading.Lock()
+        held = 0
+        overlaps = 0
+        wins = 0
 
         def contend():
+            nonlocal held, overlaps, wins
             barrier.wait()
             with workspace_lock(lock) as acquired:
-                results.append(acquired)
-                if acquired:
-                    # hold briefly so the others observe a held (live) lock
-                    import time
+                if not acquired:
+                    return
+                with occupancy:
+                    wins += 1
+                    held += 1
+                    if held > 1:
+                        overlaps += 1
+                # hold briefly so any concurrent holder overlaps us here
+                time.sleep(0.05)
+                with occupancy:
+                    held -= 1
 
-                    time.sleep(0.05)
-
+        barrier = threading.Barrier(8)
         threads = [threading.Thread(target=contend) for _ in range(8)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        assert sum(1 for r in results if r) == 1  # exactly one winner
+        assert overlaps == 0, "two contenders held the lock at the same time"
+        assert wins >= 1, "the stale lock was never reclaimed"


### PR DESCRIPTION

# Fix the lock reclaim race and the dev frontend-activation flake

## Summary

Closes out the remaining CI flakiness after the 2026-08-03 load-sensitive batch. Two of these were not flakes at all but genuine correctness bugs that a timeout bump would have masked: the mkdir advisory lock could hand the same lock to two acquirers, and a circus start refusal was being discarded, which is what actually produced "the frontend watcher did not become active". The other three are tests asserting the wrong property or synchronising on the wrong thing.

## Changes

- **Bind the mkdir lock's reclaim to the holder it read.** Reclaim is a read-then-act and the read goes stale. Renaming the whole lockdir aside moved a *live* holder's directory and freed its path, so a second acquirer took the same lock — a lost write, since the guarded operation is a read-modify-write of an append-only store. The holder sentinel is now `owner.<nonce>` and reclaim renames that exact name to `reclaiming.<reclaimer-pid>.<nonce>`; `rename` is atomic, so the step is single-winner among contenders that read the same holder, and the nonce makes it a no-op against any other holder. Removal is gated on the *reclaimer's* liveness, not the original holder's.
- **Assert mutual exclusion, not a single winner, in the workspace lock test.** The property owed to callers is that two holders never overlap, not that exactly one of eight contenders succeeds. Acquisition is non-blocking, so a contender descheduled past the winner's hold and release legitimately takes the freed lock. The test now tracks occupancy and asserts it never exceeds one.
- **Surface a circus start refusal instead of discarding it.** circus answers a rejected command with `{"status": "error", "reason": ...}` rather than raising, so discarding the reply from `start()` turned a refused start into a silent no-op. The caller then polled a watcher that had never been asked to run until its deadline, and pointed at a log that was empty because nothing had ever written to it.
- **Say why a frontend activation failed.** The abort message now folds in the watcher status and the tail of `frontend.log`, gathered before teardown (teardown stops the watcher, so the status afterwards is `stopped` regardless of cause). The integration driver's assertions quoted only stderr while the orchestrators report refusals on stdout, producing a bare `AssertionError`; they now quote both streams. Happy-path budgets go to 60s as headroom.
- **Synchronise the dev-activation specs on mount, not on memory history.** `renderAt` waited on `router.state.location.pathname`, which `createMemoryHistory` already reports at construction — so the assertion was true before `render` was called and synchronised on nothing. The specs now wait on the route's rendered marker and then on the session write that is the capture effect's only observable trace.

## Context

Came out of a triage of ~70 failed `Main` runs between 2026-07-20 and 2026-08-06. Two findings shaped the scope:

- Mapping each failure signature to the set of distinct branches and SHAs it appears on separates flakes from branch breaks. A signature confined to one branch and reproducing on *every* commit there is a break, not a flake — that reclassified roughly 16 of the failures (notably `a_spawn_through_the_stub_path_is_recorded`, all on `0188` across five commits, and `migrated corpus validates clean`, all on `0169` at one SHA).
- The largest genuine class, the frontend vitest timeouts, was already fixed on main by the 2026-08-03 batch (`asyncUtilTimeout`, `EVENT_BUDGET`, the indexer tripwire, and nextest temp-dir isolation). This PR is the remainder.

No linked work item.

## Testing

- [x] `mise run` — the full local CI mirror — green twice consecutively against this tree, with the exit status captured directly rather than through a pipe (`MISE_EXIT=0` both times; piping into `tail` masks it).
- [x] `test:integration:dev` 17/17 on both runs (177s, 168s).
- [x] `test:unit:cli` 722/722, including the lock module's 18 tests.
- [x] `test:unit:frontend` 2536/2536 across 122 files; `use-dev-activation.test.tsx` also passes 12/12 in isolation.
- [x] `test:e2e:visualiser` 343 passed, 1 skipped.
- [x] The lock race has a deterministic repro, `a_stale_reclaim_does_not_displace_a_live_holder`, which forces the interleaving through the `is_alive` hook — it fails on the old implementation and passes on the new. Sampling it with real threads does not reproduce in 200 runs.
- [x] Crash-recovery paths covered both sides of the gate: an abandoned reclaim whose reclaimer is dead is finished by the next acquirer; one whose reclaimer is alive is left alone.
- [ ] Each commit has **not** been verified to build in isolation — the gate was run against the tip of the stack. Matters only if these land as a stack rather than squashed.
- [ ] The dev frontend-activation failure has not been observed again in CI post-fix; it was intermittent at roughly one run in ten, so a few green runs will not by themselves confirm it.

## Notes for Reviewers

- **The sentinel format is a cross-implementation contract.** `cli/corpus-adapters/src/lock.rs` and `scripts/atomic-common.sh` lock against and reclaim after each other over the same `<target>.lockdir`, so they move together in the first commit. Changing the naming in one alone means a held lock stops being recognised. A legacy nonce-less `owner` is still read by both as a pre-upgrade orphan, and never written.
- **The reclaimer-liveness gate is the subtle part.** Re-noncing alone is not sufficient: two contenders can each win a rename of a *different* name (one of `owner.<n>`, one of the `reclaiming.<n>` it became) and both then proceed to remove, the slower one landing on whatever fresh live lockdir had since replaced it. Gating removal on the reclaimer's own PID — read from the name, published atomically by the rename that created it — is what keeps removal single-owner.
- **`_atomic_lock_nonce` respects the bash 3.2 floor.** `$RANDOM` alone is 15 bits and collides readily across the many short-lived subshells a parallel run spawns, so it draws twice and mixes in the subshell PID, falling back to `$$` where `BASHPID` is unset.
- **The budget widening in "Say why a frontend activation failed" is headroom, not the cure.** "Surface a circus start refusal" is the actual fix. The 60s figure is deliberately far above need — a bring-up measures ~1s idle and ~1.6s at 8x concurrency — so that load can be ruled out if the symptom ever returns, at which point the new message should name the cause directly.
- Worth a close look at `reclaim_if_stale` and `_atomic_lock_reclaimable` in particular, since a mistake there is a silent lost write rather than a visible failure.
