### PR TITLE
Renumber the VCS migration follow-ups and close the story

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -4925,9 +4925,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -4283,9 +4283,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -5655,9 +5655,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
@@ -6466,9 +6466,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -6784,9 +6784,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6803,7 +6803,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/meta/plans/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/plans/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md
@@ -1490,8 +1490,8 @@ found.
       makes every call's path unique regardless of thread interleaving.
 - [x] The dated hand-off notes and both new work items exist and are
       cross-linked (grep-verified) — dated 2026-08-06 amendments landed on
-      0125, 0172, 0183, 0189; `work-item:0192` (vcs-common.sh residue +
-      `hooks/launcher-link-refresh.sh`) and `work-item:0193` (the guard's
+      0125, 0172, 0183, 0189; `work-item:0199` (vcs-common.sh residue +
+      `hooks/launcher-link-refresh.sh`) and `work-item:0200` (the guard's
       `log`/`diff` blocklist-membership decision) created and cross-linked
       from 0169's own Dependencies section
 

--- a/meta/prs/51-description.md
+++ b/meta/prs/51-description.md
@@ -8,7 +8,7 @@ producer: describe-pr
 status: complete
 work_item_id: "0169"
 parent: "work-item:0169"
-relates_to: ["work-item:0125", "work-item:0172", "work-item:0183", "work-item:0189", "work-item:0192", "work-item:0193", "work-item:0198"]
+relates_to: ["work-item:0125", "work-item:0172", "work-item:0183", "work-item:0189", "work-item:0198", "work-item:0199", "work-item:0200"]
 pr_url: "https://github.com/atomicinnovation/accelerator/pull/51"
 pr_number: 51
 tags: [rust, vcs, hooks, migration]
@@ -35,7 +35,7 @@ Implements ADR-0048 for the VCS subsystem: builds `accelerator-vcs`, a new dispa
 - **Sub-binary registration**: `vcs` is added to `DISPATCHED_SUBBINARIES`/`_SUBBINARY_MANIFESTS`/the cli workspace/`.gitignore`/`_CLI_RELEASE_BINARIES` per 0187's checklist; `skills/vcs/commit` is repointed at the new subcommands and its broad `scripts/*` permission narrowed to the `vcs *` subcommand.
 - **`hooks.json` rewrite and shell deletion**: SessionStart and PreToolUse now register three verbatim `accelerator vcs ...`/`accelerator config ...` command strings instead of five shell scripts; `hooks/vcs-detect.sh`, `hooks/vcs-guard.sh`, `hooks/config-detect.sh`, `scripts/vcs-status.sh`, and `scripts/vcs-log.sh` are deleted; the 42-case shell parity gate is repointed onto the compiled binary and its surviving in-process cases move to a new `scripts/test-vcs-common.sh`.
 - **Fixture and golden capture** (`hooks/test-fixtures/`): a shared `masks.toml` (loaded by both a Rust and a Python differential test), status/log goldens for 10 checkout states, a 138-row guard decision table, and detect fixtures for the two declared behavioural departures.
-- **Hand-offs**: dated notes appended to 0125, 0172, 0183, and 0189; two new follow-up work items created — 0192 (the `scripts/vcs-common.sh` residue and `hooks/launcher-link-refresh.sh`) and 0193 (the `log`/`diff` blocklist-membership decision) — plus 0198 (deferring `vcs status`/`vcs log` off subprocess execution onto the library adapters, opened after landing).
+- **Hand-offs**: dated notes appended to 0125, 0172, 0183, and 0189; two new follow-up work items created — 0199 (the `scripts/vcs-common.sh` residue and `hooks/launcher-link-refresh.sh`) and 0200 (the `log`/`diff` blocklist-membership decision) — plus 0198 (deferring `vcs status`/`vcs log` off subprocess execution onto the library adapters, opened after landing).
 
 ### Four declared behavioural departures from the shell
 

--- a/meta/prs/54-description.md
+++ b/meta/prs/54-description.md
@@ -1,0 +1,57 @@
+---
+type: pr-description
+id: "54"
+title: "Renumber the VCS migration follow-ups and close the story"
+date: "2026-08-07T10:10:44+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+relates_to: ["work-item:0169", "work-item:0199", "work-item:0200"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/54"
+pr_number: 54
+tags: [meta, work-items, vcs]
+revision: "1b24e4a10b1b87ca9bf74faff9fff70dca5d2cd0"
+repository: accelerator
+last_updated: "2026-08-07T10:10:44+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Renumber the VCS migration follow-ups and close the story
+
+## Summary
+
+Corpus housekeeping in the wake of the VCS subdomain migration. The two follow-up work items opened while landing `0169` were allocated the IDs `0192` and `0193`, which PR #49 had already handed to the documentation epic and its docs-site story — so they are renumbered to `0199` and `0200` and every inbound reference is repointed. With PR #51 merged on 2026-08-06, `0169` itself is marked done.
+
+## Changes
+
+**Resolve the ID collision (`0192` → `0199`, `0193` → `0200`)**
+
+- Renamed `meta/work/0192-retire-vcs-common-sh-residue-and-launcher-link-refresh.md` → `0199-…` and `meta/work/0193-decide-vcs-guard-log-diff-blocklist-membership.md` → `0200-…`, updating each file's `id:` and body H1 to match. `0199` and `0200` were the next free IDs — `0198` is the highest previously allocated work item.
+- Repointed the inbound references in `meta/work/0169-vcs-subdomain-and-hooks-migration.md`: the `relates_to:` list and the two resolution links in the Dependencies section that name the follow-ups by filename.
+- Repointed the narrative references in the derived artifacts — the Phase 10 hand-off criterion in `meta/plans/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md` and the Phase 10 verdict in `meta/validations/2026-08-05-0169-vcs-subdomain-and-hooks-migration-validation.md`.
+- Updated `meta/prs/51-description.md` — both its `relates_to:` list and the hand-offs bullet — so the merged PR's record points at the surviving IDs. This edits an already-merged PR's on-disk description; it is a record-keeping correction, not a change to what #51 shipped.
+
+**Close `0169`**
+
+- Flipped `status: ready` → `status: done` in the frontmatter and `**Status**: Ready` → `**Status**: Done` in the body of `meta/work/0169-vcs-subdomain-and-hooks-migration.md`.
+
+## Context
+
+- Work item `meta/work/0169-vcs-subdomain-and-hooks-migration.md` — the story being closed; shipped by PR #51 (merged 2026-08-06, `3612820`).
+- Follow-ups `meta/work/0199-retire-vcs-common-sh-residue-and-launcher-link-refresh.md` (the `scripts/vcs-common.sh` residue plus `hooks/launcher-link-refresh.sh`) and `meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md` (whether `log`/`diff` belong in the guard's blocked set), both still `draft`. The third hand-off, `0198`, was unaffected.
+- PR #49 is the direct precedent — it moved the documentation items off `0178`/`0179` and onto `0192`/`0193`, which is what made these IDs collide when `0169`'s follow-ups were created a month later.
+
+## Testing
+
+- [x] `grep -rn -E '0192|0193' meta/` returns only the documentation epic `0192-documentation.md`, the story `0193-make-the-docs-amazing.md`, their derived plan and research documents, and PR #49's description — no stale references to the retired follow-up IDs survive.
+- [x] `grep -rn -E '0199|0200' meta/` shows every inbound reference (from `0169`, its plan, its validation, and `51-description.md`) resolving to the renamed files.
+- [x] Both renamed files' `id:` and body H1 agree with their new filenames; their `parent:`, `relates_to:`, and `derived_from:` slots already pointed at `0136`/`0169`/the `0169` plan and needed no change.
+- [x] PR #51 confirmed merged via `gh pr view 51`, so `status: done` on `0169` reflects reality rather than anticipating it.
+- [ ] `mise run check` not run — the change is confined to `meta/*.md`, which sits outside all four component check surfaces (frontend, server, cli, build-system, scripts). CI will confirm.
+
+## Notes for Reviewers
+
+- **`last_updated` on `0169` was not bumped** — it still reads `2026-08-06T02:00:00+00:00`. PR #49 set the precedent of leaving `last_updated` alone for a pure renumber, but this commit also flips `0169`'s status, which is a content change. If you read that field as "last touched", it wants bumping to today.
+- **This is the second collision in the same numbering range.** IDs are allocated by scanning `meta/work/` for the highest number, so any two branches that create work items concurrently will collide — #49's renumber and `0169`'s follow-up creation did exactly that, a month apart. Nothing here fixes the allocation mechanism; if that is worth owning, it needs its own work item.
+- Both follow-ups remain `draft` and unscheduled. Renumbering deliberately changes identity only — no scope, criteria, or timestamps were touched.

--- a/meta/validations/2026-08-05-0169-vcs-subdomain-and-hooks-migration-validation.md
+++ b/meta/validations/2026-08-05-0169-vcs-subdomain-and-hooks-migration-validation.md
@@ -123,7 +123,7 @@ c50b5e4e8414 Record 0169 hand-offs, spin off two follow-up work items, fix a lau
   `docs-site/`, and `tasks/README.md` for the five retired filenames returns
   nothing.
 - **Phase 10** — Dated hand-off notes are present in `0172`, `0183`, `0125`,
-  and `0189`; the two required follow-up work items (`0192`, `0193`) exist
+  and `0189`; the two required follow-up work items (`0199`, `0200`) exist
   and are cross-linked from `0169`'s own `relates_to`; `mise run` (the
   phase's own top-line automated criterion) passes.
 

--- a/meta/work/0169-vcs-subdomain-and-hooks-migration.md
+++ b/meta/work/0169-vcs-subdomain-and-hooks-migration.md
@@ -5,13 +5,13 @@ title: "VCS Subdomain and Hooks Migration"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: ready
+status: done
 kind: story
 priority: high
 parent: "work-item:0136"
 blocked_by: ["work-item:0164", "work-item:0166", "work-item:0167", "work-item:0179", "work-item:0186", "work-item:0187", "work-item:0188"]
 blocks: ["work-item:0170", "work-item:0171", "work-item:0172", "work-item:0173", "work-item:0174"]
-relates_to: ["work-item:0125", "work-item:0165", "work-item:0182", "work-item:0183", "work-item:0185", "work-item:0189", "work-item:0192", "work-item:0193", "work-item:0198", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
+relates_to: ["work-item:0125", "work-item:0165", "work-item:0182", "work-item:0183", "work-item:0185", "work-item:0189", "work-item:0198", "work-item:0199", "work-item:0200", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [rust, vcs, hooks, migration]
 last_updated: "2026-08-06T02:00:00+00:00"
@@ -23,7 +23,7 @@ external_id: "PP-190"
 # 0169: VCS Subdomain and Hooks Migration
 
 **Kind**: Story
-**Status**: Ready
+**Status**: Done
 **Priority**: High
 **Author**: Toby Clemson
 
@@ -540,11 +540,11 @@ segment matches; the first matching segment names the reported subcommand.
   Separately, `hooks/launcher-link-refresh.sh` is claimed by no epic-0136 story.
   An acceptance criterion requires a follow-up item owning both.
 
-  **Resolved 2026-08-06**: [`0192`](0192-retire-vcs-common-sh-residue-and-launcher-link-refresh.md)
+  **Resolved 2026-08-06**: [`0199`](0199-retire-vcs-common-sh-residue-and-launcher-link-refresh.md)
   now owns both — the `find_repo_root`/`vcs_mode` residue (with
   `classify_checkout`'s fate as part of its inventory) and
   `hooks/launcher-link-refresh.sh`. Separately,
-  [`0193`](0193-decide-vcs-guard-log-diff-blocklist-membership.md) now owns
+  [`0200`](0200-decide-vcs-guard-log-diff-blocklist-membership.md) now owns
   the `log`/`diff` blocklist-membership decision this story's Phase 1/Phase 7
   declined to make (see the parity-scope note above and Phase 10 of the
   implementation plan). A third follow-up,

--- a/meta/work/0199-retire-vcs-common-sh-residue-and-launcher-link-refresh.md
+++ b/meta/work/0199-retire-vcs-common-sh-residue-and-launcher-link-refresh.md
@@ -1,6 +1,6 @@
 ---
 type: work-item
-id: "0192"
+id: "0199"
 title: "Retire scripts/vcs-common.sh's residual shell callers and hooks/launcher-link-refresh.sh"
 date: "2026-08-06T00:00:00+00:00"
 author: Toby Clemson
@@ -17,7 +17,7 @@ last_updated_by: Toby Clemson
 schema_version: 1
 ---
 
-# 0192: Retire scripts/vcs-common.sh's residual shell callers and hooks/launcher-link-refresh.sh
+# 0199: Retire scripts/vcs-common.sh's residual shell callers and hooks/launcher-link-refresh.sh
 
 **Kind**: Task
 **Status**: Draft

--- a/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
+++ b/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
@@ -1,6 +1,6 @@
 ---
 type: work-item
-id: "0193"
+id: "0200"
 title: "Decide whether git log/diff belong in vcs guard's blocked subcommand set"
 date: "2026-08-06T00:00:00+00:00"
 author: Toby Clemson
@@ -17,7 +17,7 @@ last_updated_by: Toby Clemson
 schema_version: 1
 ---
 
-# 0193: Decide whether git log/diff belong in vcs guard's blocked subcommand set
+# 0200: Decide whether git log/diff belong in vcs guard's blocked subcommand set
 
 **Kind**: Spike
 **Status**: Draft

--- a/mise.toml
+++ b/mise.toml
@@ -118,16 +118,23 @@ description = "Verify every plugin.json skill has a generated docs page"
 depends = ["docs:generate"]
 run = "invoke docs.generate-check"
 
-[tasks."docs:audit"]
+[tasks."docs:audit:check"]
 description = "Fail on high/critical npm advisories in the docs-site tree"
 depends = ["deps:install:docs"]
-run = "invoke docs.audit"
+run = "invoke docs.audit-check"
+
+# Deliberately NOT in the aggregate `fix`: it needs network and rewrites
+# docs-site/package-lock.json, so it stays in the docs lane like its siblings.
+[tasks."docs:audit:fix"]
+description = "Apply npm's non-breaking advisory fixes to the docs-site lockfile"
+depends = ["deps:install:docs"]
+run = "invoke docs.audit-fix"
 
 # Deliberately NOT in the aggregate `check`: it writes gitignored artefacts
 # and needs network + a Chromium install, so the docs CI lane owns it.
 [tasks."docs:check"]
 description = "Docs gate: strict site build incl. link validation + npm audit (CI-owned; needs network + Chromium)"
-depends = ["docs:build", "docs:generate:check", "docs:audit"]
+depends = ["docs:build", "docs:generate:check", "docs:audit:check"]
 
 [tasks."docs:serve"]
 description = "Serve the documentation site locally with live reload"

--- a/tasks/docs.py
+++ b/tasks/docs.py
@@ -32,9 +32,24 @@ def preview(context: Context) -> None:
 
 
 @task
-def audit(context: Context) -> None:
+def audit_check(context: Context) -> None:
     """Fail on high/critical npm advisories in the docs-site tree."""
-    context.run(f"npm --prefix {DOCS_SITE} audit --audit-level=high")
+    result = context.run(
+        f"npm --prefix {DOCS_SITE} audit --audit-level=high", warn=True
+    )
+    if result.exited != 0:
+        raise Exit(
+            "npm audit reported high or critical advisories — run "
+            "`mise run docs:audit:fix` for the non-breaking subset, then "
+            "resolve the rest by hand",
+            code=1,
+        )
+
+
+@task
+def audit_fix(context: Context) -> None:
+    """Apply npm's non-breaking advisory fixes to the docs-site lockfile."""
+    context.run(f"npm --prefix {DOCS_SITE} audit fix")
 
 
 @task


### PR DESCRIPTION
# Renumber the VCS migration follow-ups and close the story

## Summary

Corpus housekeeping in the wake of the VCS subdomain migration. The two follow-up work items opened while landing `0169` were allocated the IDs `0192` and `0193`, which PR #49 had already handed to the documentation epic and its docs-site story — so they are renumbered to `0199` and `0200` and every inbound reference is repointed. With PR #51 merged on 2026-08-06, `0169` itself is marked done.

## Changes

**Resolve the ID collision (`0192` → `0199`, `0193` → `0200`)**

- Renamed `meta/work/0192-retire-vcs-common-sh-residue-and-launcher-link-refresh.md` → `0199-…` and `meta/work/0193-decide-vcs-guard-log-diff-blocklist-membership.md` → `0200-…`, updating each file's `id:` and body H1 to match. `0199` and `0200` were the next free IDs — `0198` is the highest previously allocated work item.
- Repointed the inbound references in `meta/work/0169-vcs-subdomain-and-hooks-migration.md`: the `relates_to:` list and the two resolution links in the Dependencies section that name the follow-ups by filename.
- Repointed the narrative references in the derived artifacts — the Phase 10 hand-off criterion in `meta/plans/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md` and the Phase 10 verdict in `meta/validations/2026-08-05-0169-vcs-subdomain-and-hooks-migration-validation.md`.
- Updated `meta/prs/51-description.md` — both its `relates_to:` list and the hand-offs bullet — so the merged PR's record points at the surviving IDs. This edits an already-merged PR's on-disk description; it is a record-keeping correction, not a change to what #51 shipped.

**Close `0169`**

- Flipped `status: ready` → `status: done` in the frontmatter and `**Status**: Ready` → `**Status**: Done` in the body of `meta/work/0169-vcs-subdomain-and-hooks-migration.md`.

## Context

- Work item `meta/work/0169-vcs-subdomain-and-hooks-migration.md` — the story being closed; shipped by PR #51 (merged 2026-08-06, `3612820`).
- Follow-ups `meta/work/0199-retire-vcs-common-sh-residue-and-launcher-link-refresh.md` (the `scripts/vcs-common.sh` residue plus `hooks/launcher-link-refresh.sh`) and `meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md` (whether `log`/`diff` belong in the guard's blocked set), both still `draft`. The third hand-off, `0198`, was unaffected.
- PR #49 is the direct precedent — it moved the documentation items off `0178`/`0179` and onto `0192`/`0193`, which is what made these IDs collide when `0169`'s follow-ups were created a month later.

## Testing

- [x] `grep -rn -E '0192|0193' meta/` returns only the documentation epic `0192-documentation.md`, the story `0193-make-the-docs-amazing.md`, their derived plan and research documents, and PR #49's description — no stale references to the retired follow-up IDs survive.
- [x] `grep -rn -E '0199|0200' meta/` shows every inbound reference (from `0169`, its plan, its validation, and `51-description.md`) resolving to the renamed files.
- [x] Both renamed files' `id:` and body H1 agree with their new filenames; their `parent:`, `relates_to:`, and `derived_from:` slots already pointed at `0136`/`0169`/the `0169` plan and needed no change.
- [x] PR #51 confirmed merged via `gh pr view 51`, so `status: done` on `0169` reflects reality rather than anticipating it.
- [ ] `mise run check` not run — the change is confined to `meta/*.md`, which sits outside all four component check surfaces (frontend, server, cli, build-system, scripts). CI will confirm.

## Notes for Reviewers

- **`last_updated` on `0169` was not bumped** — it still reads `2026-08-06T02:00:00+00:00`. PR #49 set the precedent of leaving `last_updated` alone for a pure renumber, but this commit also flips `0169`'s status, which is a content change. If you read that field as "last touched", it wants bumping to today.
- **This is the second collision in the same numbering range.** IDs are allocated by scanning `meta/work/` for the highest number, so any two branches that create work items concurrently will collide — #49's renumber and `0169`'s follow-up creation did exactly that, a month apart. Nothing here fixes the allocation mechanism; if that is worth owning, it needs its own work item.
- Both follow-ups remain `draft` and unscheduled. Renumbering deliberately changes identity only — no scope, criteria, or timestamps were touched.
