### PR TITLE
Add the in-process section diff work item

### DIFF
--- a/meta/prs/56-description.md
+++ b/meta/prs/56-description.md
@@ -1,0 +1,46 @@
+---
+type: pr-description
+id: "56"
+title: "Add the in-process section diff work item"
+date: "2026-08-08T12:51:42+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "0201"
+parent: "work-item:0201"
+relates_to: ["work-item:0170", "work-item:0174", "work-item:0188", "work-item:0198"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/56"
+pr_number: 56
+tags: []
+revision: "41d384342e46b108f673ac9119b5d9913fa73ca3"
+repository: "accelerator"
+last_updated: "2026-08-08T12:51:42+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Add the in-process section diff work item
+
+## Summary
+
+Adds work item 0201, capturing a follow-up to 0170: replace `cli/work-adapters/src/diff_shellout.rs`'s subprocess-based `diff -u` invocation — writing two temp files and shelling out to the real `diff` binary — with an in-process Rust implementation. No code changes in this PR; it's a single new work item file.
+
+## Changes
+
+- **`meta/work/0201-in-process-section-diff.md`** — new `task`-kind work item, `status: draft`, `priority: medium`, parented under `work-item:0174` (the shell-tooling-retirement epic), relating to `work-item:0170` (where the subprocess diff was originally built), and `work-item:0188`/`work-item:0198` (the analogous subprocess-to-in-process migration pattern already applied on the VCS side).
+- Captures six Given/When/Then acceptance criteria covering: the diff renderer running fully in-process with no `std::process::Command`; the existing `=== name (- LOCAL / + REMOTE) ===` header/framing staying unchanged; empty-diff behaviour on identical sections; retiring or rewriting the `bash-parity` feature and `diff_shellout_parity.rs` suite (which currently assert byte-identical output against the real binary); removing or updating `cli/pup.ron`'s `work_adapters_filesystem_reads_in_process` rule (carved out solely to quarantine this one subprocess-spawning module); and a green `mise run` with no `diff` binary dependency left in the `work`/`work-adapters`/`work-cli` crates.
+- Names `similar` in Technical Notes as a researched (not mandated) default crate recommendation — dependency-free, provides `TextDiff::unified_diff()` directly, ~14.8M downloads/month — with `imara-diff` and `diffy` noted as alternatives.
+
+## Context
+
+Surfaced directly out of the 0170 PR (#55) review: `diff_shellout.rs`'s subprocess call was a deliberate choice during the bash-to-Rust port, to guarantee byte-identical output against the legacy script while the `bash-parity` suite verified it. That parity requirement no longer holds now that 0170 is done and merged — the diff body's internal hunk formatting doesn't need to match GNU diffutils byte-for-byte, only the existing header/framing contract does. A `meta/work` search turned up no existing item covering this; the closest candidates were 0170 (where the code lives) and 0174 (the general shell-retirement epic), used here as `relates_to`/`parent` respectively.
+
+## Testing
+
+- [x] Not applicable — this PR adds only a Markdown work item, no code. `mise run` is unaffected.
+
+## Notes for Reviewers
+
+- This is a pure work-item addition, deliberately based on `main` rather than stacked on the 0170 branch (#55), since it's unrelated follow-up work rather than part of that story.
+- Two open questions are recorded on the work item rather than resolved here, left for implementation-time judgment: whether `diff_shellout.rs`/the module should be renamed once it no longer shells out, and whether it's genuinely the only subprocess-spawning code in `work-adapters` (which would let the pup.ron isolation rule be deleted outright rather than narrowed).
+- The item is currently unsynced (no `external_id`) — Linear is the configured integration but the push was deliberately declined when the item was created; push later via `/sync-work-items` or `/create-linear-issue 0201` if desired.

--- a/meta/work/0201-in-process-section-diff.md
+++ b/meta/work/0201-in-process-section-diff.md
@@ -1,0 +1,164 @@
+---
+type: work-item
+id: "0201"
+title: "In-Process Section Diff"
+date: "2026-08-08T12:27:18+00:00"
+author: Toby Clemson
+producer: create-work-item
+status: draft
+kind: task
+priority: medium
+parent: "work-item:0174"
+relates_to: ["work-item:0170", "work-item:0188", "work-item:0198"]
+tags: [rust, work-items, tech-debt]
+last_updated: "2026-08-08T12:27:18+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0201: In-Process Section Diff
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Replace `cli/work-adapters/src/diff_shellout.rs`'s subprocess-based section
+diff — which writes two temp files and shells out to the real `diff -u`
+binary — with an in-process Rust implementation. This removes the crate's
+one external process dependency, its associated spawn/timeout failure mode,
+and the architecture-enforcement rule that exists solely to quarantine it.
+
+## Context
+
+`accelerator work diff` (the Rust port of `work-item-section-diff.sh`,
+delivered by 0170) renders per-section differences by shelling out to the
+system `diff` binary against two temp files, tolerating its exit-1-means-
+differ convention and capping it at a 10s timeout with a 10ms poll loop.
+This was a deliberate choice at the time — the same "shell the real tool"
+adapter pattern already used for `vcs status`/`vcs log` — and it guarantees
+byte-identical output against the legacy bash script during the port,
+verified by a `bash-parity` cargo feature that runs the real binary.
+
+That parity guarantee is no longer needed: the port is long complete (0170
+is done), and exact byte-for-byte matching against GNU diffutils' specific
+hunk-splitting heuristics is not a requirement callers depend on — only the
+existing `=== name (- LOCAL / + REMOTE) ===` header/framing contract is.
+Removing the subprocess call eliminates a portability assumption (`diff` on
+PATH), the spawn/timeout failure mode (`DiffUnavailable`), and lets
+`work-adapters` become fully in-process, which in turn should let
+`cli/pup.ron`'s `work_adapters_filesystem_reads_in_process` rule — carved
+out solely to isolate this one subprocess-spawning module — be removed or
+simplified.
+
+Research surfaced `similar` (Armin Ronacher / insta author) as the strongest
+default in-process crate for this: dependency-free, ships a one-call
+`TextDiff::unified_diff()` that builds hunk headers and `-`/`+` prefixes
+directly, Myers/Patience algorithms, ~14.8M downloads/month, actively
+maintained, Apache-2.0. `imara-diff` (lower-level, build-your-own-printer)
+and `diffy` (patch-parsing focused) are credible alternatives if a
+different tradeoff is wanted at implementation time.
+
+## Requirements
+
+- Replace the subprocess `diff -u` invocation in `diff_shellout.rs` with an
+  in-process Rust diff implementation — no `std::process::Command`, no temp
+  files.
+- Preserve the existing `=== name (- LOCAL / + REMOTE) ===` header and
+  blank-line section framing exactly; the diff body's internal hunk
+  formatting need not match GNU diffutils' output byte-for-byte.
+- Resolve the `DiffUnavailable` failure mode: since an in-process function
+  cannot fail to spawn or time out, determine whether `render`'s signature
+  becomes infallible or keeps a narrower error type for a different failure
+  mode (if any is identified during implementation).
+- Retire or rewrite the `bash-parity` cargo feature and
+  `cli/work-adapters/tests/diff_shellout_parity.rs`, which currently assert
+  byte-identical output against the real `diff` binary — replace with tests
+  asserting the new implementation's own output contract against fixed
+  expected text.
+- Remove the now-subprocess-specific unit tests (spawn failure, timeout/
+  `DEFAULT_CAP` handling) and replace with tests appropriate to an
+  in-process function.
+- Remove or simplify `cli/pup.ron`'s `work_adapters_filesystem_reads_in_process`
+  rule to reflect that `work-adapters` no longer spawns any subprocess, once
+  confirmed no other subprocess call remains in the crate.
+
+## Acceptance Criteria
+
+- [ ] Given two differing text sections, when the section-diff renderer
+      runs, then it returns a unified-diff-style body computed entirely
+      in-process, with no `std::process::Command` invocation anywhere in
+      `work-adapters`.
+- [ ] Given the existing `=== name (- LOCAL / + REMOTE) ===` header and
+      blank-line framing that `accelerator work diff` callers depend on,
+      when the in-process implementation replaces the subprocess one, then
+      that framing is unchanged.
+- [ ] Given two identical sections, when the renderer runs, then it reports
+      no differences (an empty diff body), matching current behaviour.
+- [ ] Given the `bash-parity` feature and `diff_shellout_parity.rs` suite,
+      when this change lands, then that suite is retired or rewritten to
+      assert the new implementation's own output contract, and
+      `cargo test -p work-adapters` no longer requires a `diff` binary on
+      `PATH`.
+- [ ] Given `cli/pup.ron`'s `work_adapters_filesystem_reads_in_process`
+      rule, when the migration completes and no subprocess call remains in
+      `work-adapters`, then the rule is removed or updated accordingly, and
+      `mise run pup:check` passes.
+- [ ] Given the full local CI mirror (`mise run`), when it runs after this
+      change, then it passes with no `diff` binary required anywhere in the
+      `work`/`work-adapters`/`work-cli` crates' build or test process.
+
+## Open Questions
+
+- Should the module (and file) keep the name `diff_shellout` once it no
+  longer shells out, or be renamed (e.g. `diff_render`)? Left for
+  implementation-time judgment rather than specified here.
+- Is `diff_shellout.rs` genuinely the only subprocess-spawning code in
+  `work-adapters`, such that the pup.ron isolation rule can be deleted
+  outright rather than narrowed? Needs confirming during implementation.
+
+## Dependencies
+
+- Blocked by: none.
+- Blocks: none.
+
+## Assumptions
+
+- The section-diff output is an internal rendering contract, not a
+  byte-for-byte frozen format some downstream skill parses or greps — if
+  wrong, scope would need to widen to check callers before changing the
+  diff body's formatting.
+- Adding an in-process diff crate as a new dependency does not itself
+  violate the workspace's cargo-deny allow-list — to verify at
+  implementation time; doesn't change this item's scope either way.
+
+## Technical Notes
+
+- `similar` (crates.io) is the researched default recommendation:
+  dependency-free, provides `TextDiff::unified_diff()` directly, Myers/
+  Patience algorithms, large active user base. `imara-diff` (lower-level,
+  Histogram algorithm, faster on large inputs) and `diffy` (patch-parsing
+  focused) are alternatives worth a quick comparison at implementation
+  time, but none is mandated by this work item.
+- Current implementation for reference: `cli/work-adapters/src/diff_shellout.rs`
+  (`render`, `render_with`, `run_capped`), consumed by `cli/work/src/section_diff.rs`
+  and exercised through `accelerator work diff`.
+
+## Drafting Notes
+
+- Parent set to 0174 (the general shell-tooling-retirement epic) since this
+  is philosophically part of that effort even though 0174 doesn't literally
+  scope this item today — confirm or drop if that linkage doesn't fit.
+- `relates_to` links 0170 (where this code was originally built) and
+  0188/0198 (the analogous subprocess-to-in-process migration pattern on
+  the VCS side) as architectural precedent, not because they share any
+  code.
+- `kind: task` chosen over `story` since there's no natural "as a user"
+  framing for an internal implementation swap with no externally visible
+  behaviour change.
+
+## References
+
+- Related: 0170, 0174, 0188, 0198


### PR DESCRIPTION

# Add the in-process section diff work item

## Summary

Adds work item 0201, capturing a follow-up to 0170: replace `cli/work-adapters/src/diff_shellout.rs`'s subprocess-based `diff -u` invocation — writing two temp files and shelling out to the real `diff` binary — with an in-process Rust implementation. No code changes in this PR; it's a single new work item file.

## Changes

- **`meta/work/0201-in-process-section-diff.md`** — new `task`-kind work item, `status: draft`, `priority: medium`, parented under `work-item:0174` (the shell-tooling-retirement epic), relating to `work-item:0170` (where the subprocess diff was originally built), and `work-item:0188`/`work-item:0198` (the analogous subprocess-to-in-process migration pattern already applied on the VCS side).
- Captures six Given/When/Then acceptance criteria covering: the diff renderer running fully in-process with no `std::process::Command`; the existing `=== name (- LOCAL / + REMOTE) ===` header/framing staying unchanged; empty-diff behaviour on identical sections; retiring or rewriting the `bash-parity` feature and `diff_shellout_parity.rs` suite (which currently assert byte-identical output against the real binary); removing or updating `cli/pup.ron`'s `work_adapters_filesystem_reads_in_process` rule (carved out solely to quarantine this one subprocess-spawning module); and a green `mise run` with no `diff` binary dependency left in the `work`/`work-adapters`/`work-cli` crates.
- Names `similar` in Technical Notes as a researched (not mandated) default crate recommendation — dependency-free, provides `TextDiff::unified_diff()` directly, ~14.8M downloads/month — with `imara-diff` and `diffy` noted as alternatives.

## Context

Surfaced directly out of the 0170 PR (#55) review: `diff_shellout.rs`'s subprocess call was a deliberate choice during the bash-to-Rust port, to guarantee byte-identical output against the legacy script while the `bash-parity` suite verified it. That parity requirement no longer holds now that 0170 is done and merged — the diff body's internal hunk formatting doesn't need to match GNU diffutils byte-for-byte, only the existing header/framing contract does. A `meta/work` search turned up no existing item covering this; the closest candidates were 0170 (where the code lives) and 0174 (the general shell-retirement epic), used here as `relates_to`/`parent` respectively.

## Testing

- [x] Not applicable — this PR adds only a Markdown work item, no code. `mise run` is unaffected.

## Notes for Reviewers

- This is a pure work-item addition, deliberately based on `main` rather than stacked on the 0170 branch (#55), since it's unrelated follow-up work rather than part of that story.
- Two open questions are recorded on the work item rather than resolved here, left for implementation-time judgment: whether `diff_shellout.rs`/the module should be renamed once it no longer shells out, and whether it's genuinely the only subprocess-spawning code in `work-adapters` (which would let the pup.ron isolation rule be deleted outright rather than narrowed).
- The item is currently unsynced (no `external_id`) — Linear is the configured integration but the push was deliberately declined when the item was created; push later via `/sync-work-items` or `/create-linear-issue 0201` if desired.
