### PR TITLE
Raise the file-descriptor limit before the zig cross-compiles

### DIFF
--- a/meta/prs/58-description.md
+++ b/meta/prs/58-description.md
@@ -1,0 +1,55 @@
+---
+type: pr-description
+id: "58"
+title: "Raise the file-descriptor limit before the zig cross-compiles"
+date: "2026-08-08T15:48:43+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+relates_to: ["work-item:0165"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/58"
+pr_number: 58
+tags: []
+revision: "f62edd18cbb829785e5db832f023c24dddf4506c"
+repository: "accelerator"
+last_updated: "2026-08-08T15:48:43+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Raise the file-descriptor limit before the zig cross-compiles
+
+## Summary
+
+`mise run build:cli:cross-compile` failed from a stock macOS shell with `ProcessFdQuotaExceeded` partway through linking. The cause was not the build: zig's linker opens every object file of a link simultaneously, a release link of the `cli/` workspace passes it several hundred (~640 for `accelerator`), and macOS's launchd default soft limit is 256 descriptors. Both cross-compile tasks now raise `RLIMIT_NOFILE` before their first `cargo zigbuild`, so no contributor needs a `ulimit -n` in their shell profile.
+
+## Changes
+
+- **`tasks/shared/limits.py`** (new) — `raise_descriptor_limit()` reads `RLIMIT_NOFILE` and raises the soft limit toward `LINK_DESCRIPTOR_TARGET` (65536: comfortably above the largest link in the workspace, but deliberately not "as high as possible" since the soft limit is inherited by every child and some tools size per-descriptor bookkeeping off it). The clamping is split out as `descriptor_limit_raise_to(soft, hard, *, wanted)`, a pure function over the `getrlimit` pair, so the thresholds are unit-testable without mutating the test runner's own limits — the same shape as `assert_fixture_size_floor` in `tasks/build.py`.
+- **`tasks/build.py`** — `raise_descriptor_limit()` at the top of both `cli_cross_compile` and `server_cross_compile`, before the first `cargo zigbuild`. `setrlimit` is inherited across `fork`/`exec`, so one call in the task process covers cargo, rustc and the zig wrapper beneath them; nothing needs to be threaded through the `context.run` calls.
+- **`tests/unit/tasks/test_limits.py`** (new) — nine tests: the macOS 256-descriptor case, clamping to a finite hard limit (Linux) versus `RLIM_INFINITY` (macOS), the no-op cases where the limit already suffices, the never-lower invariant when the hard limit is at or below the soft limit, plus live-limit tests that lower this process to 256, raise through the helper, and restore in a `finally`.
+- **`tasks/README.md`** — a "File-descriptor limit on the cross-compiles" subsection under Conventions, recording why the call exists so it does not read as removable noise.
+
+## Context
+
+No work item drives this; it came out of diagnosing a local `build:cli:cross-compile` failure. It relates to `work-item:0165`, which built the cross-compile tasks being amended here.
+
+The failure was environment-specific rather than nondeterministic, which is what made it confusing: the task passed when run from a shell with a raised limit and failed from an ordinary interactive shell on the same machine. `launchctl limit maxfiles` reports 256 as the system default soft limit, and the first casualty in the log was `config-adapters-fixture` at 257 object files — one more than the limit.
+
+Semantics worth flagging: the raise is best-effort. It never lowers an adequate limit, clamps to the hard limit, and warns rather than aborting if `setrlimit` is refused. That is deliberately fail-open, unlike the static-linking and fixture-size assertions alongside it in `tasks/build.py`, which fail closed. Those guard artefact correctness, where a silent pass ships a broken binary; this one is an environment accommodation, and a build under an already-generous limit or with few enough objects links fine without it. Aborting would convert a survivable condition into a hard stop, and the link itself fails loudly if the limit really was the constraint.
+
+## Testing
+
+- [x] The decisive check — the full task under the exact limit that broke it: `(ulimit -n 256; mise run build:cli:cross-compile)` exits 0, with zero occurrences of `ProcessFdQuotaExceeded` in the log. Relinks were forced (`touch` on `cli/launcher/src/main.rs` and `cli/config-adapters/src/lib.rs`, the two crates that failed originally) so this is not a cache no-op.
+- [x] The failure was reproduced before the fix at the same limit, confirming causation rather than correlation: same crate, same error. Raising to 4096 with nothing else changed made the identical link succeed.
+- [x] `mise run check` exits 0.
+- [x] `uv run pytest tests/unit/tasks/` — 728 passed, including the 9 new tests.
+- [x] All of the above re-run on the current base after the branch rebased onto `main` (the PR #56 merge and the `accelerator-work` addition to `_CLI_RELEASE_BINARIES`), not only on the base the change was written against.
+- [ ] Not verified: behaviour on a Linux host, where the hard limit is a finite ceiling rather than `RLIM_INFINITY`. That path is covered by unit tests over the pure clamping function, not by a real cross-compile.
+
+## Notes for Reviewers
+
+- The fail-open choice is the main judgment call worth a second opinion — see Context. Easy to flip if the house preference is to fail closed alongside the neighbouring assertions.
+- Scope is limited to the two tasks that invoke `cargo zigbuild`. `cli_fixture_size_check` is untouched: it builds host-native through the system linker, which does not hold every object open, and its failure mode was never this.
+- CI is unaffected today — the release cross-compile lane already passes on `macos-latest` — so this is not a fix for a broken pipeline. The raise is a no-op wherever the limit already suffices, and gives that lane headroom as object counts grow.
+- `LINK_DESCRIPTOR_TARGET` is a judgment call, not a measurement. 65536 is roughly 100x the largest current link; if that reads as too generous for a value every child inherits, it is a one-line change.

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -290,6 +290,24 @@ mise-pinned stable `1.90.0`.
   build or the rustup nightly (an accepted unverified surface for the isolated
   lane).
 
+### File-descriptor limit on the cross-compiles
+
+`cargo zigbuild` links through zig, which opens **every** object file of a link
+at once, and a release link of the `cli/` workspace passes it several hundred
+(~640 for `accelerator`). macOS's launchd default soft limit is **256**
+descriptors, so from a stock shell the link dies partway through with
+`ProcessFdQuotaExceeded` on an object it cannot open — a failure that reads like
+a broken build but is purely an environment limit.
+
+Both cross-compile tasks therefore call `raise_descriptor_limit()`
+(`tasks/shared/limits.py`) before their first `cargo zigbuild`. `setrlimit` is
+inherited across `fork`/`exec`, so raising it once in the task process covers
+cargo, rustc and the zig wrapper beneath them, and no contributor needs a
+`ulimit -n` in their shell profile. The raise is best-effort: it never lowers an
+adequate limit, clamps to the hard limit (finite on Linux, `RLIM_INFINITY` on
+macOS), and warns rather than aborting if `setrlimit` is refused — the link
+itself fails loudly if the limit really was the constraint.
+
 ### Contributor environment variables
 
 Local-only toolchain escape hatches. **CI ignores both** (it runs the

--- a/tasks/build.py
+++ b/tasks/build.py
@@ -11,6 +11,7 @@ from invoke import Context, task
 
 from tasks.shared.errors import InvalidVersionError
 from tasks.shared.files import atomic_write_text
+from tasks.shared.limits import raise_descriptor_limit
 from tasks.shared.paths import (
     CARGO_TOML,
     CLI_DIR,
@@ -352,6 +353,7 @@ def server_cross_compile(context: Context) -> None:
     the manifest flow signs and the launcher fetches), after asserting the
     artifact carries no dev-frontend insecure-bypass symbol.
     """
+    raise_descriptor_limit()
     RELEASE_STAGING.mkdir(parents=True, exist_ok=True)
     for triple, platform in TARGETS:
         context.run(
@@ -404,6 +406,7 @@ def cli_cross_compile(context: Context) -> None:
     Stages each `accelerator-{platform}` and `accelerator-verify-{platform}`
     into dist/release/ after magic-byte and (musl) static-linking assertions.
     """
+    raise_descriptor_limit()
     RELEASE_STAGING.mkdir(parents=True, exist_ok=True)
     for triple, platform in TARGETS:
         context.run(

--- a/tasks/shared/limits.py
+++ b/tasks/shared/limits.py
@@ -1,0 +1,65 @@
+"""Raise this process's file-descriptor soft limit for link-heavy builds.
+
+zig's linker opens every object file of a link at once, and a release link of
+the cli workspace passes it several hundred. macOS's launchd default soft limit
+is 256 descriptors, so a `cargo zigbuild` from a stock shell fails partway
+through with `ProcessFdQuotaExceeded` (EMFILE) on an object it cannot open —
+a failure that reads like a broken build but is purely an environment limit.
+
+`setrlimit` is inherited across `fork`/`exec`, so raising it in the task process
+covers cargo, rustc, and the zig wrapper beneath them.
+"""
+
+import resource
+import sys
+
+# Comfortably above the largest link in the workspace (~640 objects) with room
+# for the descriptors cargo and rustc hold alongside it. Deliberately not
+# "as high as possible": the soft limit is inherited by every child, and some
+# tools size per-descriptor bookkeeping off it.
+LINK_DESCRIPTOR_TARGET = 65_536
+
+
+def descriptor_limit_raise_to(
+    soft: int, hard: int, *, wanted: int = LINK_DESCRIPTOR_TARGET
+) -> int | None:
+    """Return the soft limit to set, or ``None`` if no raise applies.
+
+    Pure over the ``getrlimit`` pair so the clamping is unit-testable without
+    mutating the test runner's own limits. Never lowers an already-adequate
+    limit, and never exceeds the hard limit — on Linux that is a finite ceiling
+    an unprivileged process cannot cross, whereas macOS reports it as
+    ``RLIM_INFINITY``.
+    """
+    if soft == resource.RLIM_INFINITY or soft >= wanted:
+        return None
+    target = wanted if hard == resource.RLIM_INFINITY else min(wanted, hard)
+    return target if target > soft else None
+
+
+def raise_descriptor_limit(
+    *, wanted: int = LINK_DESCRIPTOR_TARGET
+) -> int | None:
+    """Raise the soft descriptor limit toward ``wanted``; report what was set.
+
+    Best-effort by design: a build under an already-generous limit needs no
+    raise, and one that cannot raise may still link fine (few enough objects).
+    Failing here would turn a survivable condition into a hard stop, so a
+    refused `setrlimit` warns and continues — the link itself fails loudly if
+    the limit really was the constraint.
+    """
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target = descriptor_limit_raise_to(soft, hard, wanted=wanted)
+    if target is None:
+        return None
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+    except (OSError, ValueError) as exc:
+        print(
+            f"warning: could not raise the file-descriptor limit from {soft} "
+            f"to {target} ({exc}); a link with more objects than the limit "
+            "will fail with ProcessFdQuotaExceeded",
+            file=sys.stderr,
+        )
+        return None
+    return target

--- a/tests/unit/tasks/test_limits.py
+++ b/tests/unit/tasks/test_limits.py
@@ -1,0 +1,73 @@
+"""Unit tests for the file-descriptor limit raised ahead of zig links."""
+
+import resource
+
+import pytest
+
+from tasks.shared.limits import (
+    LINK_DESCRIPTOR_TARGET,
+    descriptor_limit_raise_to,
+    raise_descriptor_limit,
+)
+
+_INF = resource.RLIM_INFINITY
+
+
+class TestDescriptorLimitRaiseTo:
+    def test_raises_a_macos_default_soft_limit_to_the_target(self):
+        # 256 is launchd's default and cannot cover a several-hundred-object
+        # link; this is the case the guard exists for.
+        assert descriptor_limit_raise_to(256, _INF) == LINK_DESCRIPTOR_TARGET
+
+    def test_clamps_to_a_finite_hard_limit(self):
+        # Linux reports a finite ceiling an unprivileged process cannot cross.
+        assert descriptor_limit_raise_to(1024, 4096, wanted=65_536) == 4096
+
+    @pytest.mark.parametrize(
+        ("soft", "hard"),
+        [
+            (65_536, _INF),  # already exactly the target
+            (1_048_576, _INF),  # already generous
+            (_INF, _INF),  # already unlimited
+        ],
+    )
+    def test_no_raise_when_the_limit_already_suffices(self, soft, hard):
+        assert descriptor_limit_raise_to(soft, hard) is None
+
+    def test_no_raise_when_the_hard_limit_is_at_or_below_the_soft_limit(self):
+        # Clamping must never yield a lowering setrlimit call.
+        assert descriptor_limit_raise_to(4096, 4096, wanted=65_536) is None
+        assert descriptor_limit_raise_to(4096, 2048, wanted=65_536) is None
+
+
+class TestRaiseDescriptorLimit:
+    def test_raises_the_live_limit_and_restores_it(self):
+        original = resource.getrlimit(resource.RLIMIT_NOFILE)
+        soft, hard = original
+        # Lower ourselves to the macOS default, raise back through the helper,
+        # then restore — so the runner's own limit is unchanged either way.
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (256, hard))
+            assert raise_descriptor_limit(wanted=2048) == 2048
+            assert resource.getrlimit(resource.RLIMIT_NOFILE)[0] == 2048
+        finally:
+            resource.setrlimit(resource.RLIMIT_NOFILE, original)
+        assert resource.getrlimit(resource.RLIMIT_NOFILE) == original
+        assert soft == original[0]
+
+    def test_returns_none_without_touching_an_adequate_limit(self):
+        before = resource.getrlimit(resource.RLIMIT_NOFILE)
+        assert raise_descriptor_limit(wanted=1) is None
+        assert resource.getrlimit(resource.RLIMIT_NOFILE) == before
+
+    def test_a_refused_setrlimit_warns_and_continues(self, monkeypatch, capsys):
+        def refuse(*_args, **_kwargs):
+            raise OSError(1, "Operation not permitted")
+
+        monkeypatch.setattr(resource, "getrlimit", lambda _which: (256, _INF))
+        monkeypatch.setattr(resource, "setrlimit", refuse)
+        assert raise_descriptor_limit() is None
+        assert (
+            "could not raise the file-descriptor limit"
+            in capsys.readouterr().err
+        )


### PR DESCRIPTION

# Raise the file-descriptor limit before the zig cross-compiles

## Summary

`mise run build:cli:cross-compile` failed from a stock macOS shell with `ProcessFdQuotaExceeded` partway through linking. The cause was not the build: zig's linker opens every object file of a link simultaneously, a release link of the `cli/` workspace passes it several hundred (~640 for `accelerator`), and macOS's launchd default soft limit is 256 descriptors. Both cross-compile tasks now raise `RLIMIT_NOFILE` before their first `cargo zigbuild`, so no contributor needs a `ulimit -n` in their shell profile.

## Changes

- **`tasks/shared/limits.py`** (new) — `raise_descriptor_limit()` reads `RLIMIT_NOFILE` and raises the soft limit toward `LINK_DESCRIPTOR_TARGET` (65536: comfortably above the largest link in the workspace, but deliberately not "as high as possible" since the soft limit is inherited by every child and some tools size per-descriptor bookkeeping off it). The clamping is split out as `descriptor_limit_raise_to(soft, hard, *, wanted)`, a pure function over the `getrlimit` pair, so the thresholds are unit-testable without mutating the test runner's own limits — the same shape as `assert_fixture_size_floor` in `tasks/build.py`.
- **`tasks/build.py`** — `raise_descriptor_limit()` at the top of both `cli_cross_compile` and `server_cross_compile`, before the first `cargo zigbuild`. `setrlimit` is inherited across `fork`/`exec`, so one call in the task process covers cargo, rustc and the zig wrapper beneath them; nothing needs to be threaded through the `context.run` calls.
- **`tests/unit/tasks/test_limits.py`** (new) — nine tests: the macOS 256-descriptor case, clamping to a finite hard limit (Linux) versus `RLIM_INFINITY` (macOS), the no-op cases where the limit already suffices, the never-lower invariant when the hard limit is at or below the soft limit, plus live-limit tests that lower this process to 256, raise through the helper, and restore in a `finally`.
- **`tasks/README.md`** — a "File-descriptor limit on the cross-compiles" subsection under Conventions, recording why the call exists so it does not read as removable noise.

## Context

No work item drives this; it came out of diagnosing a local `build:cli:cross-compile` failure. It relates to `work-item:0165`, which built the cross-compile tasks being amended here.

The failure was environment-specific rather than nondeterministic, which is what made it confusing: the task passed when run from a shell with a raised limit and failed from an ordinary interactive shell on the same machine. `launchctl limit maxfiles` reports 256 as the system default soft limit, and the first casualty in the log was `config-adapters-fixture` at 257 object files — one more than the limit.

Semantics worth flagging: the raise is best-effort. It never lowers an adequate limit, clamps to the hard limit, and warns rather than aborting if `setrlimit` is refused. That is deliberately fail-open, unlike the static-linking and fixture-size assertions alongside it in `tasks/build.py`, which fail closed. Those guard artefact correctness, where a silent pass ships a broken binary; this one is an environment accommodation, and a build under an already-generous limit or with few enough objects links fine without it. Aborting would convert a survivable condition into a hard stop, and the link itself fails loudly if the limit really was the constraint.

## Testing

- [x] The decisive check — the full task under the exact limit that broke it: `(ulimit -n 256; mise run build:cli:cross-compile)` exits 0, with zero occurrences of `ProcessFdQuotaExceeded` in the log. Relinks were forced (`touch` on `cli/launcher/src/main.rs` and `cli/config-adapters/src/lib.rs`, the two crates that failed originally) so this is not a cache no-op.
- [x] The failure was reproduced before the fix at the same limit, confirming causation rather than correlation: same crate, same error. Raising to 4096 with nothing else changed made the identical link succeed.
- [x] `mise run check` exits 0.
- [x] `uv run pytest tests/unit/tasks/` — 728 passed, including the 9 new tests.
- [x] All of the above re-run on the current base after the branch rebased onto `main` (the PR #56 merge and the `accelerator-work` addition to `_CLI_RELEASE_BINARIES`), not only on the base the change was written against.
- [ ] Not verified: behaviour on a Linux host, where the hard limit is a finite ceiling rather than `RLIM_INFINITY`. That path is covered by unit tests over the pure clamping function, not by a real cross-compile.

## Notes for Reviewers

- The fail-open choice is the main judgment call worth a second opinion — see Context. Easy to flip if the house preference is to fail closed alongside the neighbouring assertions.
- Scope is limited to the two tasks that invoke `cargo zigbuild`. `cli_fixture_size_check` is untouched: it builds host-native through the system linker, which does not hold every object open, and its failure mode was never this.
- CI is unaffected today — the release cross-compile lane already passes on `macos-latest` — so this is not a fix for a broken pipeline. The raise is a no-op wherever the limit already suffices, and gives that lane headroom as object counts grow.
- `LINK_DESCRIPTOR_TARGET` is a judgment call, not a measurement. 65536 is roughly 100x the largest current link; if that reads as too generous for a value every child inherits, it is a one-line change.
