### PR TITLE
[0185] Converge corpus-adapters on the Library-Backed VCS Adapter

### DIFF
--- a/cli/corpus-adapters/Cargo.toml
+++ b/cli/corpus-adapters/Cargo.toml
@@ -17,6 +17,13 @@ workspace = true
 # on a machine without the toolchain. CI enables it (tasks/test/cli.py).
 bash-parity = []
 
+# Black-box entry point for the zero-spawn proof over the metadata-read path —
+# not a shipped artifact. Lives under tests/fixtures/ so it stays off the
+# crate's normal build surface, mirroring vcs-adapters-fixture.
+[[bin]]
+name = "corpus-adapters-fixture"
+path = "tests/fixtures/corpus_adapters_fixture.rs"
+
 [dependencies]
 corpus = { path = "../corpus" }
 document = { path = "../document" }

--- a/cli/corpus-adapters/src/metadata.rs
+++ b/cli/corpus-adapters/src/metadata.rs
@@ -3,8 +3,7 @@
 //! The clock adapter, the `vcs`/`vcs-adapters`-backed implementation of
 //! `corpus::RepoFactsProbe`, and the composition of a clock and a
 //! repository probe into the block the authoring skills stamp artifacts
-//! with. This subsumes the three bash metadata helpers, which differ only
-//! in the filename timestamp they render.
+//! with.
 //!
 //! [`VcsBackedRepoFactsProbe`] is the only place in this module that
 //! depends on `vcs`/`vcs-adapters` — `derive_at` takes its facts probe by
@@ -64,9 +63,8 @@ pub fn format_utc_iso(instant: OffsetDateTime) -> String {
     )
 }
 
-/// Renders `instant` in the shape the given helper's filenames use. `instant`
-/// is rendered in whatever offset it already carries, so a caller wanting a
-/// host-local stamp passes a host-local instant.
+/// Rendered in whatever offset `instant` already carries, so a caller wanting
+/// a host-local stamp passes a host-local instant.
 #[must_use]
 pub fn format_filename_timestamp(
     instant: OffsetDateTime,
@@ -91,8 +89,8 @@ pub fn format_filename_timestamp(
     }
 }
 
-/// The label the helpers give the filename line. The date-only helper calls it
-/// a date; the two that carry a time call it a timestamp.
+/// A format carrying no time of day is labelled a date; the two that carry one
+/// are labelled timestamps.
 const fn filename_label(format: FilenameTimestampFormat) -> &'static str {
     match format {
         FilenameTimestampFormat::DateOnly => "Date For Filename",
@@ -101,8 +99,7 @@ const fn filename_label(format: FilenameTimestampFormat) -> &'static str {
     }
 }
 
-/// The real clock: UTC for the ISO line, host-local for the filename stamp,
-/// matching bash's `date -u` and plain `date` respectively.
+/// The real clock: UTC for the ISO line, host-local for the filename stamp.
 #[derive(Debug, Clone, Copy)]
 pub struct SystemClock {
     offset: UtcOffset,
@@ -120,8 +117,7 @@ impl SystemClock {
     ///
     /// Returns [`ClockError`] when the offset cannot be resolved, rather than
     /// falling back to UTC and stamping artifacts with a wrong-zone
-    /// provenance. This is a deliberate divergence from the bash helpers, which
-    /// degrade silently; `tzdata` or `TZ` is a runtime prerequisite.
+    /// provenance. `tzdata` or `TZ` is a runtime prerequisite.
     pub fn try_new() -> Result<Self, ClockError> {
         let output = Command::new("date")
             .arg("+%z")
@@ -206,21 +202,12 @@ pub fn derive(
     }
 }
 
-/// Resolves repository facts through the library-backed VCS adapter.
+/// Reading the revision does not snapshot the working copy.
 ///
-/// No `corpus-adapters` write path depends on the CLI's snapshot-on-read side
-/// effect (writing a new commit for unsnapshotted working-copy changes): the
-/// one production write path that persists frontmatter (`work create`) reads
-/// only the derived timestamp, never the revision or repository name.
-///
-/// This does not extend to the authoring skills that call `corpus metadata
-/// derive` directly and copy its printed `Current Revision:` line into
-/// committed `meta/` frontmatter. Those consumers inherit a staleness window:
-/// an artifact authored with unsnapshotted working-copy edits present records
-/// the last recorded operation's commit rather than a freshly snapshotted one.
-/// Accepted as a best-effort provenance degradation, not a correctness
-/// regression — nothing downstream treats these fields as exact — but it is a
-/// real, if narrow, change to persisted data, not only to stdout.
+/// An artifact authored with unsnapshotted edits present therefore records the
+/// last recorded commit. No write path here reads the revision, but the
+/// authoring skills copy the printed one into committed frontmatter, and that
+/// staleness is accepted as a best-effort provenance degradation.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct VcsBackedRepoFactsProbe;
 
@@ -250,8 +237,8 @@ pub fn derive_at(
     Ok(derive(&clock, facts.as_ref(), format))
 }
 
-/// Renders the metadata as the labelled block the bash helpers print and the
-/// authoring skills read. Absent facts drop their line entirely, as in bash.
+/// Renders the metadata as the labelled block the authoring skills read.
+/// Absent facts drop their line entirely.
 #[must_use]
 pub fn render(
     metadata: &ArtifactMetadata,
@@ -308,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn each_helper_s_filename_format_is_pinned() -> Result<(), TestError> {
+    fn each_filename_format_is_pinned() -> Result<(), TestError> {
         let instant = instant()?;
         assert_eq!(
             format_filename_timestamp(

--- a/cli/corpus-adapters/src/metadata.rs
+++ b/cli/corpus-adapters/src/metadata.rs
@@ -206,6 +206,21 @@ pub fn derive(
     }
 }
 
+/// Resolves repository facts through the library-backed VCS adapter.
+///
+/// No `corpus-adapters` write path depends on the CLI's snapshot-on-read side
+/// effect (writing a new commit for unsnapshotted working-copy changes): the
+/// one production write path that persists frontmatter (`work create`) reads
+/// only the derived timestamp, never the revision or repository name.
+///
+/// This does not extend to the authoring skills that call `corpus metadata
+/// derive` directly and copy its printed `Current Revision:` line into
+/// committed `meta/` frontmatter. Those consumers inherit a staleness window:
+/// an artifact authored with unsnapshotted working-copy edits present records
+/// the last recorded operation's commit rather than a freshly snapshotted one.
+/// Accepted as a best-effort provenance degradation, not a correctness
+/// regression — nothing downstream treats these fields as exact — but it is a
+/// real, if narrow, change to persisted data, not only to stdout.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct VcsBackedRepoFactsProbe;
 

--- a/cli/corpus-adapters/src/work_item_pattern.rs
+++ b/cli/corpus-adapters/src/work_item_pattern.rs
@@ -1,12 +1,10 @@
 //! Compiles a work-item `id_pattern` (the token DSL) into the ERE scan regex
 //! whose first capture group is the id number run.
 //!
-//! This is a Rust port of `_wip_compile` (scan mode) in
-//! `skills/work/scripts/work-item-common.sh`; a parity test cross-checks the
-//! output against that script so the two implementations cannot drift. It lives
-//! beside [`RegexScanner`](crate::RegexScanner) — the adapter that compiles the
-//! scan-regex string this produces — so the whole `work.id_pattern` → scanner
-//! pipeline sits in the corpus adapter layer, shared by every Rust consumer.
+//! It lives beside [`RegexScanner`](crate::RegexScanner) — the adapter that
+//! compiles the scan-regex string this produces — so the whole
+//! `work.id_pattern` → scanner pipeline sits in the corpus adapter layer,
+//! shared by every Rust consumer.
 
 // DSL pattern strings such as "{project}" are literal token markers, not
 // format args.
@@ -217,9 +215,8 @@ fn compile_token(
 }
 
 /// Internal pattern compiler shared by [`compile_scan_regex`] and
-/// [`compile_format_string`]. Port of `_wip_compile`
-/// (`work-item-common.sh:43-207`), mode-driven exactly like the shell
-/// original rather than duplicating the token-walking loop per mode.
+/// [`compile_format_string`], mode-driven rather than duplicating the
+/// token-walking loop per mode.
 fn compile(
     pattern: &str,
     project_value: &str,
@@ -316,8 +313,7 @@ pub fn compile_scan_regex(
     compile(pattern, project_value, Mode::Scan)
 }
 
-/// Compile `pattern` into its `printf`-style format string. Port of
-/// `wip_compile_format` (`work-item-common.sh:231-237`).
+/// Compile `pattern` into its `printf`-style format string.
 ///
 /// # Errors
 ///
@@ -329,8 +325,7 @@ pub fn compile_format_string(
     compile(pattern, project_value, Mode::Format)
 }
 
-/// The configured `{number}` width's cap: `10^N - 1`. Port of
-/// `wip_pattern_max_number` (`work-item-common.sh:239-265`).
+/// The configured `{number}` width's cap: `10^N - 1`.
 ///
 /// # Errors
 ///
@@ -355,9 +350,8 @@ pub fn pattern_max_number(pattern: &str) -> Result<u64, PatternError> {
     cap.checked_sub(1).ok_or(PatternError::WidthOverflow(width))
 }
 
-/// Finds the width `N` of a `{number:0Nd}` token anywhere in `pattern` — a
-/// blind substring search mirroring the shell's own
-/// `[[ "$pattern" =~ \{number:0([1-9][0-9]*)d\} ]]`, not a full token walk.
+/// Finds the width `N` of a `{number:0Nd}` token anywhere in `pattern`, by
+/// blind substring search rather than a full token walk.
 fn explicit_number_width(pattern: &str) -> Option<usize> {
     let idx = pattern.find("{number:0")?;
     let rest = &pattern[idx + "{number:0".len()..];
@@ -382,9 +376,7 @@ enum TokenKind {
 }
 
 /// Builds a capturing regex for `pattern` plus the ordered list of which
-/// capture group is `{project}` vs `{number...}`, mirroring
-/// `wip_parse_full_id`'s own literal-substitution approach
-/// (`work-item-common.sh:289-347`).
+/// capture group is `{project}` vs `{number...}`.
 fn build_full_id_regex(
     pattern: &str,
 ) -> Result<(String, Vec<TokenKind>), PatternError> {
@@ -435,8 +427,7 @@ pub struct ParsedId {
     pub number: String,
 }
 
-/// Parses `id` against `pattern`. Port of `wip_parse_full_id`
-/// (`work-item-common.sh:289-347`).
+/// Parses `id` against `pattern`.
 ///
 /// # Errors
 ///
@@ -519,8 +510,7 @@ fn apply_number_format(format: &str, number: u64) -> String {
 }
 
 /// Canonicalises a work-item ID, composing [`parse_full_id`] and
-/// [`compile_format_string`] — no new parsing logic of its own. Port of
-/// `wip_canonicalise_id` (`work-item-common.sh:356-425`).
+/// [`compile_format_string`] — no new parsing logic of its own.
 ///
 /// # Errors
 ///
@@ -649,7 +639,7 @@ mod tests {
             Err(PatternError::UnknownToken(_))
         ));
         // `number:` with nothing after the colon is an unknown token, not a
-        // bad-spec, matching the shell's `^number(:(.+))?$` match.
+        // bad-spec: a spec has to be non-empty to be judged malformed.
         assert!(matches!(
             compile_scan_regex("{number:}", ""),
             Err(PatternError::UnknownToken(_))

--- a/cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs
+++ b/cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs
@@ -1,11 +1,8 @@
-//! The metadata-read path as a black-box entry point: resolves a start
-//! directory's repository facts through the real composition —
-//! [`VcsBackedRepoFactsProbe`] into `vcs_adapters::facts` — and **prints
-//! them**.
+//! The metadata-read path as a black-box entry point.
 //!
-//! Printing is what makes the zero-spawn assertion meaningful: the comparison
-//! is between a run with the real `git`/`jj` reachable and one without, so a
-//! probe degrading to absence has to show up as a changed value rather than as
+//! Printing is what makes the zero-spawn assertion meaningful: it compares a
+//! run with the real `git`/`jj` reachable against one without, so a probe
+//! degrading to absence has to show up as a changed value rather than as
 //! silence.
 //!
 //! Usage: `corpus-adapters-fixture <start-dir>`.

--- a/cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs
+++ b/cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs
@@ -1,0 +1,40 @@
+//! The metadata-read path as a black-box entry point: resolves a start
+//! directory's repository facts through the real composition —
+//! [`VcsBackedRepoFactsProbe`] into `vcs_adapters::facts` — and **prints
+//! them**.
+//!
+//! Printing is what makes the zero-spawn assertion meaningful: the comparison
+//! is between a run with the real `git`/`jj` reachable and one without, so a
+//! probe degrading to absence has to show up as a changed value rather than as
+//! silence.
+//!
+//! Usage: `corpus-adapters-fixture <start-dir>`.
+#![allow(clippy::print_stdout, clippy::print_stderr, clippy::restriction)]
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use corpus::RepoFactsProbe as _;
+use corpus_adapters::VcsBackedRepoFactsProbe;
+
+fn main() -> ExitCode {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    let [start] = arguments.as_slice() else {
+        eprintln!("usage: corpus-adapters-fixture <start-dir>");
+        return ExitCode::from(2);
+    };
+
+    let facts = VcsBackedRepoFactsProbe.facts(Path::new(start));
+    let rendered = facts.map_or_else(
+        || "absent".to_owned(),
+        |facts| {
+            format!(
+                "name={} revision={}",
+                facts.name,
+                facts.revision.unwrap_or_else(|| "none".to_owned())
+            )
+        },
+    );
+    println!("facts\t{rendered}");
+    ExitCode::SUCCESS
+}

--- a/cli/corpus-adapters/tests/parity.rs
+++ b/cli/corpus-adapters/tests/parity.rs
@@ -1,9 +1,11 @@
-//! Differential parity: the Rust doc-type matcher and work-item scan-regex
-//! compiler must agree with their live bash oracles.
-//!
-//! The bash scripts are the oracle. An absent script or bash hard-fails
+//! Differential parity: the Rust doc-type matcher must agree with the live
+//! bash matcher, which is the oracle. An absent script or bash hard-fails
 //! rather than skipping: Rust's harness has no skip primitive, so a silent
 //! early return would register as a green PASS.
+//!
+//! The scan-regex case alongside it has no bash oracle left — the shell
+//! implementation it was measured against is gone — so it pins the compiled
+//! regex's own behaviour end to end instead.
 #![cfg(feature = "bash-parity")]
 
 mod common;

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -1,7 +1,10 @@
 //! The zero-spawn property, proven across a crate boundary.
 //!
-//! Exercised from `corpus-adapters` — the crate that will converge onto the
-//! library-backed probe — through `vcs_test_support`'s public API only.
+//! Two levels, each through its own black-box binary: the individual taxonomy
+//! queries via `vcs-adapters`' reference artefact, and the metadata-read path
+//! this crate composes out of them — `VcsBackedRepoFactsProbe` into
+//! `vcs_adapters::facts` — via this crate's own. Both idioms for the latter,
+//! since `facts` dispatches per `VcsKind`.
 //!
 //! Scoped to `git`/`jj` specifically rather than "no subprocess at all", because
 //! `SystemClock::try_new` spawns `date` unconditionally.
@@ -12,11 +15,14 @@
 #![cfg(feature = "bash-parity")]
 
 use std::fmt::Write as _;
+use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 
 use vcs_test_support::fixtures;
 use vcs_test_support::fixtures::Matrix;
+use vcs_test_support::hermetic::Hermetic;
 use vcs_test_support::stubs::assert_shadowing_holds;
 use vcs_test_support::stubs::reference_artefact;
 use vcs_test_support::stubs::Mode;
@@ -101,4 +107,79 @@ fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
         );
     }
     Ok(())
+}
+
+/// The metadata-read path's own entry point: `VcsBackedRepoFactsProbe` into
+/// `vcs_adapters::facts`, the composition the tests below prove rather than the
+/// individual queries the reference artefact above covers.
+fn derived_facts(
+    start: &Path,
+    stubs: Option<&Stubs>,
+) -> Result<String, TestError> {
+    let mut command =
+        Command::new(env!("CARGO_BIN_EXE_corpus-adapters-fixture"));
+    command.arg(start);
+    if let Some(stubs) = stubs {
+        stubs.apply(&mut command);
+    }
+    let output = command.output()?;
+    if !output.status.success() {
+        return Err(format!(
+            "the metadata fixture failed for {}: {}",
+            start.display(),
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn assert_reads_without_spawning(root: &Path) -> Result<(), TestError> {
+    let stub_base = tempfile::Builder::new()
+        .prefix("corpus-zero-spawn-stubs-")
+        .tempdir()?;
+    let stubs = Stubs::rooted_at(stub_base.path())?;
+
+    let unrestricted = derived_facts(root, None)?;
+    let stubbed = derived_facts(root, Some(&stubs))?;
+
+    assert_eq!(
+        stubs.spawns()?,
+        None,
+        "a git or jj subprocess was spawned; the stub recorded it"
+    );
+    assert_eq!(
+        unrestricted, stubbed,
+        "the facts changed when the real binaries were removed, so the \
+         metadata-read path degraded rather than reading in-process"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_git_metadata_read_spawns_no_subprocess() -> Result<(), TestError> {
+    let base = tempfile::Builder::new()
+        .prefix("corpus-zero-spawn-git-")
+        .tempdir()?;
+    let environment = Hermetic::rooted_at(base.path())?;
+
+    let root = base.path().join("repository");
+    fs::create_dir_all(&root)?;
+    environment.git(&["init", "--quiet"], &root)?;
+    environment
+        .git(&["commit", "--allow-empty", "--quiet", "-m", "root"], &root)?;
+
+    assert_reads_without_spawning(&root.canonicalize()?)
+}
+
+#[test]
+fn a_jj_metadata_read_spawns_no_subprocess() -> Result<(), TestError> {
+    let base = tempfile::Builder::new()
+        .prefix("corpus-zero-spawn-jj-")
+        .tempdir()?;
+    let environment = Hermetic::rooted_at(base.path())?;
+    let root: PathBuf =
+        fixtures::pure_jj(&base.path().join("repository"), &environment)?;
+
+    assert_reads_without_spawning(&root)
 }

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -15,14 +15,11 @@
 #![cfg(feature = "bash-parity")]
 
 use std::fmt::Write as _;
-use std::fs;
 use std::path::Path;
-use std::path::PathBuf;
 use std::process::Command;
 
 use vcs_test_support::fixtures;
 use vcs_test_support::fixtures::Matrix;
-use vcs_test_support::hermetic::Hermetic;
 use vcs_test_support::stubs::assert_shadowing_holds;
 use vcs_test_support::stubs::reference_artefact;
 use vcs_test_support::stubs::Mode;
@@ -131,52 +128,46 @@ fn derived_facts(
     Ok(String::from_utf8(output.stdout)?)
 }
 
-fn assert_reads_without_spawning(root: &Path) -> Result<(), TestError> {
+/// One plain-git and one pure-jj shape, because `facts` resolves the revision
+/// through a different route per `VcsKind`. Drawn from the shared matrix rather
+/// than built here: building needs the real binaries, which the strong form has
+/// already moved out of reach by the time a test body runs.
+const IDIOMS: [&str; 2] = ["PG-r", "PJ"];
+
+#[test]
+fn the_metadata_read_resolves_both_idioms_without_spawning_them(
+) -> Result<(), TestError> {
+    let mode = Mode::from_environment()?;
+    assert_shadowing_holds(mode)?;
+
+    let (_matrix_guard, root) = fixtures::matrix_root()?;
+    let matrix = Matrix::build_or_adopt(&root)?;
+
     let stub_base = tempfile::Builder::new()
-        .prefix("corpus-zero-spawn-stubs-")
+        .prefix("corpus-zero-spawn-metadata-")
         .tempdir()?;
     let stubs = Stubs::rooted_at(stub_base.path())?;
 
-    let unrestricted = derived_facts(root, None)?;
-    let stubbed = derived_facts(root, Some(&stubs))?;
+    let mut mismatches = String::new();
+    for key in IDIOMS {
+        let start = matrix.start(key)?;
+        let unrestricted = derived_facts(start, None)?;
+        let stubbed = derived_facts(start, Some(&stubs))?;
+        if unrestricted != stubbed {
+            writeln!(mismatches, "  {key}: {unrestricted} != {stubbed}")?;
+        }
+    }
 
     assert_eq!(
         stubs.spawns()?,
         None,
         "a git or jj subprocess was spawned; the stub recorded it"
     );
-    assert_eq!(
-        unrestricted, stubbed,
+    assert!(
+        mismatches.is_empty(),
         "the facts changed when the real binaries were removed, so the \
-         metadata-read path degraded rather than reading in-process"
+         metadata-read path degraded rather than reading in-process:\n\
+         {mismatches}"
     );
     Ok(())
-}
-
-#[test]
-fn a_git_metadata_read_spawns_no_subprocess() -> Result<(), TestError> {
-    let base = tempfile::Builder::new()
-        .prefix("corpus-zero-spawn-git-")
-        .tempdir()?;
-    let environment = Hermetic::rooted_at(base.path())?;
-
-    let root = base.path().join("repository");
-    fs::create_dir_all(&root)?;
-    environment.git(&["init", "--quiet"], &root)?;
-    environment
-        .git(&["commit", "--allow-empty", "--quiet", "-m", "root"], &root)?;
-
-    assert_reads_without_spawning(&root.canonicalize()?)
-}
-
-#[test]
-fn a_jj_metadata_read_spawns_no_subprocess() -> Result<(), TestError> {
-    let base = tempfile::Builder::new()
-        .prefix("corpus-zero-spawn-jj-")
-        .tempdir()?;
-    let environment = Hermetic::rooted_at(base.path())?;
-    let root: PathBuf =
-        fixtures::pure_jj(&base.path().join("repository"), &environment)?;
-
-    assert_reads_without_spawning(&root)
 }

--- a/cli/corpus-adapters/tests/zero_spawn.rs
+++ b/cli/corpus-adapters/tests/zero_spawn.rs
@@ -109,9 +109,6 @@ fn the_queries_read_git_and_jj_without_spawning_them() -> Result<(), TestError>
     Ok(())
 }
 
-/// The metadata-read path's own entry point: `VcsBackedRepoFactsProbe` into
-/// `vcs_adapters::facts`, the composition the tests below prove rather than the
-/// individual queries the reference artefact above covers.
 fn derived_facts(
     start: &Path,
     stubs: Option<&Stubs>,

--- a/cli/deny.toml
+++ b/cli/deny.toml
@@ -66,16 +66,33 @@ confidence-threshold = 0.8
 
 # uluru is gix-pack's LRU pack cache, enabled by gix-odb's default features, so
 # it cannot be feature-gated out. MPL-2.0 is file-level weak copyleft: we ship
-# no modifications, and §3.2's notice obligation does not bind because dead-code
-# elimination removes the whole gix/jj-lib closure from the only shipped binary
-# that reaches it. Re-check that when anything makes the visualiser reach
-# vcs-adapters: once the trees link, distributing the binary requires telling
-# recipients how to obtain the source, which the release upload set carries no
-# artefact for.
+# no modifications, but §3.2's notice obligation binds wherever the closure is
+# actually linked — distributing such a binary requires telling recipients how
+# to obtain the source, which the release upload set carries no artefact for.
 #
-# Verify with: an unstripped --release accelerator-visualiser carries neither
-# the `extensions.objectFormat` (gix) nor the `There is no Jujutsu repo`
-# (jj-lib) literal, both of which the linked reference artefact does carry.
+# Measured across all six dispatched sub-binaries, unstripped --release,
+# aarch64-apple-darwin, by counting `gix_`/`jj_lib`/`uluru` symbols:
+#
+#   accelerator-vcs, -work, -collaboration, -migrate  uluru linked
+#   accelerator-corpus                                uluru linked
+#   accelerator-visualiser                            no gix, jj-lib or uluru
+#
+# The first four are a pre-existing finding, not a new one: each constructs
+# InProcessProbe directly, and each already carried the closure before the
+# metadata-read path moved onto it. accelerator-corpus is the one this switch
+# caused — it carried none of the three before and carries all of them after.
+# So the notice obligation is live today for five shipped binaries, and a
+# third-party attribution artefact is owed by the release upload set.
+#
+# The visualiser alone still links none of it, so its original exception
+# rationale stands unchanged. Re-check when any code under
+# cli/visualiser/server calls vcs_adapters::facts or derive_at.
+#
+# Verify by symbol count, not by string literal: `extensions.objectFormat`
+# (gix) and `There is no Jujutsu repo` (jj-lib) prove presence when found, but
+# both are absent from binaries that demonstrably link the closure, so absence
+# proves nothing. Plain `grep` over a Mach-O binary reports false positives
+# here; use `nm -a` or `strings -a` piped to grep.
 [[licenses.exceptions]]
 crate = "uluru"
 allow = ["MPL-2.0"]

--- a/cli/vcs-adapters/src/lib.rs
+++ b/cli/vcs-adapters/src/lib.rs
@@ -1,10 +1,10 @@
 //! The outbound VCS adapters, and the composition root that picks one.
 //!
-//! [`subprocess`] runs the `jj`/`git` binaries in a child process and is what
-//! [`facts`] uses. [`library`] reads both idioms in the calling process and
-//! additionally carries the taxonomy queries the subprocess pair has no
-//! equivalent for. Keeping them apart is what lets [`library`] carry an import
-//! rule denying `std::process` while [`subprocess`] spawns by design.
+//! [`library`] reads both idioms in the calling process and is what [`facts`]
+//! uses; it additionally carries the taxonomy queries the subprocess side has
+//! no equivalent for. [`subprocess`] runs the `jj`/`git` binaries in a child
+//! process. Keeping them apart is what lets [`library`] carry an import rule
+//! denying `std::process` while [`subprocess`] spawns by design.
 //!
 //! What both agree on — the ancestor walk and the marker reading — lives in a
 //! third, private module that each delegates *to*.
@@ -17,12 +17,12 @@ use std::path::Path;
 
 use vcs::RepoFacts;
 
-use crate::subprocess::{CommandProbe, MarkerWalkRoot};
+use crate::library::InProcessProbe;
 
 /// The facts for the repository containing `start`.
 #[must_use]
 pub fn facts(start: &Path) -> Option<RepoFacts> {
-    vcs::facts(start, &MarkerWalkRoot, &CommandProbe::new())
+    vcs::facts(start, &InProcessProbe, &InProcessProbe)
 }
 
 #[cfg(test)]

--- a/cli/vcs-adapters/src/lib.rs
+++ b/cli/vcs-adapters/src/lib.rs
@@ -1,13 +1,14 @@
-//! The outbound VCS adapters, and the composition root that picks one.
+//! The outbound VCS adapters, and the composition root over them.
 //!
-//! [`library`] reads both idioms in the calling process and is what [`facts`]
-//! uses; it additionally carries the taxonomy queries the subprocess side has
-//! no equivalent for. [`subprocess`] runs the `jj`/`git` binaries in a child
-//! process. Keeping them apart is what lets [`library`] carry an import rule
-//! denying `std::process` while [`subprocess`] spawns by design.
+//! [`library`] answers every port a repository is probed through — including
+//! [`facts`] — by reading both idioms in the calling process, and carries the
+//! taxonomy queries besides. [`subprocess`] survives only for `status`/`log`,
+//! the two human-facing renderings with no library equivalent. Keeping them
+//! apart is what lets [`library`] carry an import rule denying `std::process`
+//! while [`subprocess`] spawns by design.
 //!
-//! What both agree on — the ancestor walk and the marker reading — lives in a
-//! third, private module that each delegates *to*.
+//! The ancestor walk and the marker reading live in a third, private module
+//! that [`library`] delegates *to*.
 
 pub mod library;
 mod markers;

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -186,6 +186,27 @@ impl std::error::Error for Error {
 }
 
 /// Reads a repository's root, idiom and revision in-process.
+///
+/// Parses repository-controlled data in the caller's address space — no
+/// subprocess boundary, no time bound, no memory bound, no crash isolation.
+///
+/// This removes a protection that existed at the [`crate::facts`] call site
+/// before the composition root moved here: the subprocess probe it replaced
+/// ran under a 10-second cap with kill-on-timeout. The sharpest blast radius
+/// reached through `facts` is `work create`, which holds a work-item creation
+/// lock for the duration of the derivation this port serves — the lock's
+/// reclaim mechanism only reclaims a dead holder, so a hang here fails every
+/// subsequent `work create` after its own five-minute lock-acquisition wait,
+/// until an operator kills the hung process.
+///
+/// This is a deliberate decision, not an oversight: the same unbounded
+/// exposure already runs in production for the `vcs detect`/`vcs guard` hook
+/// path, no crash-isolation precedent exists anywhere in this workspace, and
+/// adding one here would be a first-of-its-kind primitive introduced ahead of
+/// any incident that demonstrates the need. Revisit when any code under
+/// `cli/visualiser/server` calls [`crate::facts`] — this was priced against a
+/// single-shot CLI/hook caller, not a persistent multi-request one — or if a
+/// lock-holding hang is observed in practice.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InProcessProbe;
 

--- a/cli/vcs-adapters/src/library.rs
+++ b/cli/vcs-adapters/src/library.rs
@@ -187,26 +187,13 @@ impl std::error::Error for Error {
 
 /// Reads a repository's root, idiom and revision in-process.
 ///
-/// Parses repository-controlled data in the caller's address space — no
-/// subprocess boundary, no time bound, no memory bound, no crash isolation.
-///
-/// This removes a protection that existed at the [`crate::facts`] call site
-/// before the composition root moved here: the subprocess probe it replaced
-/// ran under a 10-second cap with kill-on-timeout. The sharpest blast radius
-/// reached through `facts` is `work create`, which holds a work-item creation
-/// lock for the duration of the derivation this port serves — the lock's
-/// reclaim mechanism only reclaims a dead holder, so a hang here fails every
-/// subsequent `work create` after its own five-minute lock-acquisition wait,
-/// until an operator kills the hung process.
-///
-/// This is a deliberate decision, not an oversight: the same unbounded
-/// exposure already runs in production for the `vcs detect`/`vcs guard` hook
-/// path, no crash-isolation precedent exists anywhere in this workspace, and
-/// adding one here would be a first-of-its-kind primitive introduced ahead of
-/// any incident that demonstrates the need. Revisit when any code under
-/// `cli/visualiser/server` calls [`crate::facts`] — this was priced against a
-/// single-shot CLI/hook caller, not a persistent multi-request one — or if a
-/// lock-holding hang is observed in practice.
+/// Parses repository-controlled data in the caller's address space, with no
+/// time, memory or crash bound. That is deliberate, and priced against
+/// single-shot CLI and hook callers only. The sharpest exposure is `work
+/// create`, which holds a creation lock across [`crate::facts`] and whose
+/// reclaim only frees a dead holder, so a hang there blocks every later
+/// `work create` until an operator intervenes. Revisit if a persistent,
+/// multi-request caller reaches this, or if such a hang is ever observed.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InProcessProbe;
 

--- a/cli/vcs-adapters/src/subprocess.rs
+++ b/cli/vcs-adapters/src/subprocess.rs
@@ -25,12 +25,12 @@ const DEFAULT_CAP: Duration = Duration::from_secs(10);
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
-/// `jj status`, or `git diff --cached --stat` for `Git`/`None` (matching the
-/// shell's implicit git fallback when no repository is found at all).
+/// `jj status`, or `git diff --cached --stat` for `Git`/`None` — git is the
+/// fallback when no repository is found at all.
 ///
-/// Never fails: falls back to the shell's literal `(... unavailable)` text on
-/// any [`run_capped`] failure, which is already `warn!`-logged internally and
-/// so diagnosable via `ACCELERATOR_LOG` rather than silently indistinguishable
+/// Never fails: falls back to the literal `(... unavailable)` text on any
+/// [`run_capped`] failure, which is already `warn!`-logged internally and so
+/// diagnosable via `ACCELERATOR_LOG` rather than silently indistinguishable
 /// from a clean, empty repository.
 #[must_use]
 pub fn status(root: &Path, kind: VcsKind) -> String {
@@ -304,36 +304,34 @@ mod tests {
     }
 
     #[test]
-    fn a_probe_that_outlives_its_cap_reports_no_revision() {
+    fn a_command_that_outlives_its_cap_is_killed_and_reports_nothing() {
         let mut command = Command::new("sleep");
         command.arg("30");
 
         let started = std::time::Instant::now();
-        let revision = run_capped(command, Duration::from_millis(100), "test");
+        let output = run_capped(command, Duration::from_millis(100), "test");
 
-        assert_eq!(revision, None);
+        assert_eq!(output, None);
         assert!(
             started.elapsed() < Duration::from_secs(5),
-            "the probe should have been killed at its cap, not waited out"
+            "it should have been killed at its cap, not waited out"
         );
     }
 
     #[test]
-    fn a_probe_that_cannot_be_spawned_reports_no_revision() {
+    fn a_command_that_cannot_be_spawned_reports_nothing() {
         let command = Command::new("accelerator-no-such-binary");
         assert_eq!(run_capped(command, Duration::from_secs(1), "test"), None);
     }
 
     #[test]
-    fn a_probe_that_exits_non_zero_reports_no_revision() {
+    fn a_command_that_exits_non_zero_reports_nothing() {
         let command = Command::new("false");
         assert_eq!(run_capped(command, Duration::from_secs(1), "test"), None);
     }
 
     #[test]
-    fn a_probe_that_says_nothing_reports_empty_output_not_failure() {
-        // Unlike `revision`, `run_capped` itself does not treat empty output
-        // as a failure — a clean `status`/`log` legitimately says nothing.
+    fn an_empty_output_is_not_itself_a_failure() {
         let command = Command::new("true");
         assert_eq!(
             run_capped(command, Duration::from_secs(1), "test").as_deref(),

--- a/cli/vcs-adapters/src/subprocess.rs
+++ b/cli/vcs-adapters/src/subprocess.rs
@@ -1,142 +1,29 @@
-//! The subprocess-backed probes: a marker walk for the root, and the VCS
-//! binaries themselves for the working-copy revision.
+//! The VCS binaries' own `status` and `log` text, from a child process.
+//!
+//! Every port a repository is *probed* through is implemented in-process by
+//! [`crate::library`]; this module answers only for the two human-facing
+//! renderings that have no library equivalent.
 //!
 //! The subprocess runs with a scrubbed environment and colour disabled, so
-//! ambient config cannot redirect the root or inject ANSI into a revision. Every
-//! way it can fail to answer resolves to `None` and is warn-logged, so a real
-//! failure does not read like a revision-less repository.
+//! ambient config cannot redirect it or inject ANSI into its output. Every way
+//! it can fail to answer resolves to the literal `(... unavailable)` text and
+//! is warn-logged, so a real failure does not read like a clean repository.
 //!
 //! Spawning lives here and only here; [`crate::library`] carries an import rule
 //! denying `std::process`.
 
-use std::fs;
 use std::io::Read as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use tracing::warn;
-use vcs::origin_remote::OriginRemote;
-use vcs::{RepoRoot, VcsKind, VcsProbe};
-
-use crate::markers::{carries_any_marker, marker_kind, walk_up};
+use vcs::VcsKind;
 
 /// Headroom for a lock-contended repository, while still bounding derivation.
 const DEFAULT_CAP: Duration = Duration::from_secs(10);
 
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
-
-/// Finds the repository root by walking ancestors for the first `.jj` or `.git`
-/// marker, testing existence so a `.git` *file* counts alongside a directory.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct MarkerWalkRoot;
-
-impl RepoRoot for MarkerWalkRoot {
-    fn discover(&self, start: &Path) -> Option<PathBuf> {
-        walk_up(start, carries_any_marker)
-    }
-
-    fn repository_root(&self, working_copy_root: &Path) -> PathBuf {
-        jj_repository_root(working_copy_root)
-            .unwrap_or_else(|| working_copy_root.to_path_buf())
-    }
-}
-
-/// Resolves a jj secondary workspace to the repository whose store it shares.
-///
-/// A secondary workspace's `.jj/repo` is a *file* pointing at the shared
-/// `<repo>/.jj/repo`, so the repository is the store's grandparent; a primary
-/// workspace's `.jj/repo` is that store directory.
-fn jj_repository_root(working_copy_root: &Path) -> Option<PathBuf> {
-    let marker = working_copy_root.join(".jj").join("repo");
-    let metadata = fs::symlink_metadata(&marker).ok()?;
-    if !metadata.is_file() {
-        return None;
-    }
-    let pointer = fs::read_to_string(&marker).ok()?;
-    let store =
-        fs::canonicalize(working_copy_root.join(".jj").join(pointer.trim()))
-            .ok()?;
-    Some(store.parent()?.parent()?.to_path_buf())
-}
-
-/// Reads the repository's idiom from its markers and its revision by running
-/// the matching VCS binary.
-#[derive(Debug, Clone, Copy)]
-pub struct CommandProbe {
-    cap: Duration,
-}
-
-impl CommandProbe {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self { cap: DEFAULT_CAP }
-    }
-
-    /// A probe bounded by `cap` rather than the default.
-    #[must_use]
-    pub const fn with_cap(cap: Duration) -> Self {
-        Self { cap }
-    }
-}
-
-impl Default for CommandProbe {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl VcsProbe for CommandProbe {
-    fn kind(&self, root: &Path) -> VcsKind {
-        marker_kind(root)
-    }
-
-    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String> {
-        let mut command = match kind {
-            VcsKind::Jj => {
-                let mut command = Command::new("jj");
-                command.args([
-                    "--color=never",
-                    "--no-pager",
-                    "log",
-                    "-r",
-                    "@",
-                    "--no-graph",
-                    "-T",
-                    "commit_id",
-                ]);
-                command
-            }
-            VcsKind::Git => {
-                let mut command = Command::new("git");
-                command.args(["-c", "color.ui=false", "rev-parse", "HEAD"]);
-                command
-            }
-            VcsKind::None => return None,
-        };
-
-        command.current_dir(root);
-        scrub_environment(&mut command);
-
-        let vcs = kind.as_str();
-        let stdout = run_capped(command, self.cap, vcs)?;
-        if stdout.is_empty() {
-            warn!(vcs, "the revision probe reported no revision");
-            return None;
-        }
-        Some(stdout)
-    }
-}
-
-impl OriginRemote for CommandProbe {
-    fn origin_url(&self, root: &Path) -> Result<Option<String>, kernel::Error> {
-        let mut command = Command::new("git");
-        command.args(["remote", "get-url", "origin"]);
-        command.current_dir(root);
-        scrub_environment(&mut command);
-        run_checked(command, self.cap, "git")
-    }
-}
 
 /// `jj status`, or `git diff --cached --stat` for `Git`/`None` (matching the
 /// shell's implicit git fallback when no repository is found at all).
@@ -282,9 +169,10 @@ fn wait_capped(
 /// Runs `command` and returns its trimmed stdout, or `None` — warn-logged —
 /// when it cannot be spawned, exits non-zero, or outlives `cap`.
 ///
-/// Unlike [`CommandProbe::revision`], empty output is not itself treated as a
-/// failure here: a clean `git diff --cached --stat` or an empty `jj status`
-/// are legitimate, common results for [`status`]/[`log`], not failures.
+/// Empty output is not itself treated as a failure: a clean `git diff --cached
+/// --stat` or an empty `jj status` are legitimate, common results for
+/// [`status`]/[`log`], so only a spawn failure, a non-zero exit or the cap
+/// folds to `None`.
 fn run_capped(
     mut command: Command,
     cap: Duration,
@@ -323,103 +211,17 @@ fn run_capped(
     Some(stdout.trim_end().to_owned())
 }
 
-/// [`wait_capped`]'s `Result`-returning twin, for callers that must
-/// distinguish a probe malfunction (wait failure, cap exceeded) from every
-/// other outcome rather than folding it to `None`.
-fn wait_capped_checked(
-    child: &mut std::process::Child,
-    cap: Duration,
-    vcs: &str,
-) -> Result<std::process::ExitStatus, kernel::Error> {
-    let deadline = Instant::now() + cap;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return Ok(status),
-            Ok(None) => {}
-            Err(error) => {
-                return Err(kernel::Error::Failed(format!(
-                    "could not await {vcs}: {error}"
-                )))
-            }
-        }
-
-        if Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(kernel::Error::Failed(format!(
-                "{vcs} outlived its {cap:?} time cap and was killed"
-            )));
-        }
-
-        std::thread::sleep(POLL_INTERVAL);
-    }
-}
-
-/// Runs `command` and returns its trimmed stdout, distinguishing a clean
-/// "no such remote" exit from every other failure — unlike [`run_capped`],
-/// which folds every failure to `None` alike, callers of this need to tell
-/// "cleanly absent" apart from "the probe itself malfunctioned".
-fn run_checked(
-    mut command: Command,
-    cap: Duration,
-    vcs: &str,
-) -> Result<Option<String>, kernel::Error> {
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    let mut child = command.spawn().map_err(|error| {
-        kernel::Error::Failed(format!("could not run {vcs}: {error}"))
-    })?;
-
-    let status = wait_capped_checked(&mut child, cap, vcs)?;
-
-    let mut stderr = String::new();
-    if let Some(mut pipe) = child.stderr.take() {
-        let _ = pipe.read_to_string(&mut stderr);
-    }
-
-    if !status.success() {
-        if stderr.contains("No such remote") {
-            return Ok(None);
-        }
-        return Err(kernel::Error::Failed(format!(
-            "{vcs} exited with {status}: {}",
-            stderr.trim()
-        )));
-    }
-
-    let mut stdout = String::new();
-    if let Some(mut pipe) = child.stdout.take() {
-        pipe.read_to_string(&mut stdout).map_err(|error| {
-            kernel::Error::Failed(format!(
-                "could not read {vcs}'s output: {error}"
-            ))
-        })?;
-    }
-
-    let trimmed = stdout.trim().to_owned();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-    Ok(Some(trimmed))
-}
-
 #[cfg(test)]
 mod tests {
     use std::error::Error;
     use std::fs;
     use std::os::unix::fs::PermissionsExt as _;
-    use std::path::PathBuf;
     use std::process::Command;
     use std::time::Duration;
 
     use vcs::VcsKind;
 
-    use super::{
-        run_capped, run_vcs_text, scrub_environment, CommandProbe, StatusOrLog,
-    };
+    use super::{run_capped, run_vcs_text, scrub_environment, StatusOrLog};
 
     type TestError = Box<dyn Error>;
 
@@ -565,69 +367,5 @@ mod tests {
             run_capped(command, Duration::from_secs(1), "test").as_deref(),
             Some("unset")
         );
-    }
-
-    fn origin_repo() -> Result<(tempfile::TempDir, PathBuf), TestError> {
-        use vcs_test_support::hermetic::Hermetic;
-
-        let dir = tempfile::Builder::new()
-            .prefix("vcs-subprocess-origin-")
-            .tempdir()?;
-        let env = Hermetic::rooted_at(dir.path())?;
-        let root = dir.path().join("repo");
-        fs::create_dir_all(&root)?;
-        env.git(&["init", "--quiet"], &root)?;
-        Ok((dir, root))
-    }
-
-    #[test]
-    fn a_configured_origin_is_reported() -> Result<(), TestError> {
-        use vcs::origin_remote::OriginRemote as _;
-        use vcs_test_support::hermetic::Hermetic;
-
-        let (dir, root) = origin_repo()?;
-        let env = Hermetic::rooted_at(dir.path())?;
-        env.git(
-            &[
-                "remote",
-                "add",
-                "origin",
-                "https://github.com/atomicinnovation/accelerator.git",
-            ],
-            &root,
-        )?;
-
-        let probe = CommandProbe::new();
-        assert_eq!(
-            probe.origin_url(&root)?,
-            Some(
-                "https://github.com/atomicinnovation/accelerator.git"
-                    .to_owned()
-            )
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn no_origin_remote_is_reported_as_none() -> Result<(), TestError> {
-        use vcs::origin_remote::OriginRemote as _;
-
-        let (_dir, root) = origin_repo()?;
-        let probe = CommandProbe::new();
-        assert_eq!(probe.origin_url(&root)?, None);
-        Ok(())
-    }
-
-    #[test]
-    fn a_directory_with_no_repository_is_an_error() -> Result<(), TestError> {
-        use vcs::origin_remote::OriginRemote as _;
-
-        let dir = tempfile::Builder::new()
-            .prefix("vcs-subprocess-origin-none-")
-            .tempdir()?;
-
-        let probe = CommandProbe::new();
-        assert!(probe.origin_url(dir.path()).is_err());
-        Ok(())
     }
 }

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -81,18 +81,13 @@ fn git_repo_with_a_commit(label: &str) -> Result<TempDir, TestError> {
 }
 
 /// The probe asks for the *full* working-copy id — 40 hex digits from both jj
-/// (`commit_id`) and git (`rev-parse HEAD`) — so a short or decorated id fails.
-///
-/// Note this rejects a **sha256** repository's 64-hex id. That is deliberate:
-/// no fixture in this suite uses one, and such a repository is unsupported —
-/// `gix` cannot read it at all, so `revision` reports absence rather than a
-/// wider id.
+/// and git — so a short or decorated id fails. A sha256 repository's 64-hex id
+/// is rejected deliberately: no fixture here uses one, and such a repository
+/// reports no revision at all.
 fn is_full_revision_id(revision: &str) -> bool {
     revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// The facts for `start`, composed the way the crate's own composition root
-/// composes them.
 fn facts(start: &Path) -> Option<RepoFacts> {
     vcs::facts(start, &InProcessProbe, &InProcessProbe)
 }

--- a/cli/vcs-adapters/tests/detection.rs
+++ b/cli/vcs-adapters/tests/detection.rs
@@ -14,12 +14,8 @@ use std::process::Command;
 
 use tempfile::TempDir;
 use vcs::RepoFacts;
-use vcs::RepoRoot;
 use vcs::VcsKind;
-use vcs::VcsProbe;
 use vcs_adapters::library::InProcessProbe;
-use vcs_adapters::subprocess::CommandProbe;
-use vcs_adapters::subprocess::MarkerWalkRoot;
 
 type TestError = Box<dyn std::error::Error>;
 
@@ -84,73 +80,21 @@ fn git_repo_with_a_commit(label: &str) -> Result<TempDir, TestError> {
     Ok(dir)
 }
 
-/// The probes ask for the *full* working-copy id — 40 hex digits from both jj
+/// The probe asks for the *full* working-copy id — 40 hex digits from both jj
 /// (`commit_id`) and git (`rev-parse HEAD`) — so a short or decorated id fails.
 ///
-/// Note this rejects a **sha256** repository's 64-hex id. That is deliberate
-/// here: no fixture in this suite uses one. Any wider revision validation has to
-/// accept both widths or record sha256 as unsupported — a decision the
-/// composition-root switch inherits, since it is what exposes users to it.
+/// Note this rejects a **sha256** repository's 64-hex id. That is deliberate:
+/// no fixture in this suite uses one, and such a repository is unsupported —
+/// `gix` cannot read it at all, so `revision` reports absence rather than a
+/// wider id.
 fn is_full_revision_id(revision: &str) -> bool {
     revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// The facts for `start`, composed from an injected pair rather than the
-/// hard-wired composition root, so every case below runs against both
-/// implementations.
-fn facts_via(
-    start: &Path,
-    root: &dyn RepoRoot,
-    probe: &dyn VcsProbe,
-) -> Option<RepoFacts> {
-    vcs::facts(start, root, probe)
-}
-
-/// The retained subprocess pair — the values this suite has always pinned.
+/// The facts for `start`, composed the way the crate's own composition root
+/// composes them.
 fn facts(start: &Path) -> Option<RepoFacts> {
-    facts_via(start, &MarkerWalkRoot, &CommandProbe::new())
-}
-
-/// The library-backed pair.
-fn library_facts(start: &Path) -> Option<RepoFacts> {
-    facts_via(start, &InProcessProbe, &InProcessProbe)
-}
-
-/// Asserts the two implementations produce identical `RepoFacts`, for every
-/// `VcsKind`.
-///
-/// Full equality on both idioms: the library-backed probe reads the jj
-/// working-copy commit id out of the checkout state and the operation store, so
-/// there is no field either implementation cannot answer.
-///
-/// The one shape where the two can legitimately differ is out of reach here.
-/// Asking the `jj` binary snapshots the working copy first, so with
-/// unsnapshotted changes present it reports — and records — a *new* commit,
-/// while the in-process route reports the last recorded one. Every fixture in
-/// this suite is built and then read without an intervening edit, so the
-/// recorded operation is current and both agree. `library.rs` pins the
-/// divergence itself.
-///
-/// Agreement between two implementations is not on its own an oracle, which is
-/// why every case below also keeps its fixed expected values. This dual
-/// comparison is transitional: it collapses to the library-backed pair alone
-/// when the subprocess probe is deleted.
-fn assert_implementations_agree(start: &Path) {
-    let subprocess = facts(start);
-    let in_process = library_facts(start);
-
-    let (Some(subprocess), Some(in_process)) = (&subprocess, &in_process)
-    else {
-        assert_eq!(
-            subprocess.is_some(),
-            in_process.is_some(),
-            "the two implementations disagreed about whether a repository              exists at {}",
-            start.display()
-        );
-        return;
-    };
-
-    assert_eq!(subprocess, in_process, "the two implementations disagreed");
+    vcs::facts(start, &InProcessProbe, &InProcessProbe)
 }
 
 #[test]
@@ -175,7 +119,6 @@ fn a_git_repository_reports_its_root_name_and_revision() -> Result<(), TestError
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
-    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -190,7 +133,6 @@ fn the_walk_finds_the_root_from_a_nested_directory() -> Result<(), TestError> {
     let derived = facts(&nested).ok_or("expected the walk to find the root")?;
 
     assert_eq!(derived.root, root);
-    assert_implementations_agree(&nested);
     Ok(())
 }
 
@@ -208,7 +150,6 @@ fn a_git_repository_with_no_commits_has_no_revision() -> Result<(), TestError> {
         derived.revision, None,
         "a commitless repo must report no revision, not an empty one"
     );
-    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -236,7 +177,6 @@ fn a_colocated_repository_is_driven_as_jj() -> Result<(), TestError> {
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
-    assert_implementations_agree(&root);
     Ok(())
 }
 
@@ -277,7 +217,6 @@ fn a_secondary_jj_workspace_roots_at_its_own_marker() -> Result<(), TestError> {
         "a workspace's name is the repository it shares a store with, not the \
          ephemeral workspace directory"
     );
-    assert_implementations_agree(&secondary);
     Ok(())
 }
 
@@ -317,7 +256,6 @@ fn a_worktree_whose_git_marker_is_a_file_is_recognised() -> Result<(), TestError
         is_full_revision_id(&revision),
         "not a full revision id: {revision}"
     );
-    assert_implementations_agree(&worktree);
     Ok(())
 }
 
@@ -346,6 +284,5 @@ fn a_bare_repository_has_no_facts() -> Result<(), TestError> {
         None,
         "a bare repository must resolve to no facts, not an empty root"
     );
-    assert_implementations_agree(&bare);
     Ok(())
 }

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -408,6 +408,23 @@ fn an_unreadable_checkout_state_reports_absence_rather_than_a_wrong_commit(
 }
 
 #[test]
+fn unreadable_git_ref_data_reports_absence_rather_than_a_wrong_commit(
+) -> Result<(), TestError> {
+    require("git")?;
+    let dir = git_repo_with_a_commit("revision-broken-head")?;
+    let root = path_of(&dir)?;
+
+    assert!(
+        InProcessProbe.revision(&root, VcsKind::Git).is_some(),
+        "the fixture must answer before it is broken, or this proves nothing"
+    );
+    fs::write(root.join(".git/HEAD"), b"\xff\xfe truncated")?;
+
+    assert_eq!(InProcessProbe.revision(&root, VcsKind::Git), None);
+    Ok(())
+}
+
+#[test]
 fn reading_the_revision_writes_nothing() -> Result<(), TestError> {
     require("jj")?;
     let dir = tempdir("revision-readonly")?;

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -207,7 +207,6 @@ fn the_walk_finds_the_boundary_from_a_nested_directory() -> Result<(), TestError
 
 // --- The probe against real checkout shapes ---
 
-/// The commit id the `git` binary reports for `HEAD`.
 fn git_revision_oracle(root: &Path) -> Result<String, TestError> {
     let output = Command::new("git")
         .args(["rev-parse", "HEAD"])
@@ -302,7 +301,6 @@ fn a_main_workspace_resolves_to_itself() -> Result<(), TestError> {
 
 // --- The jj revision route ---
 
-/// The commit id the `jj` binary reports for `@`.
 fn jj_revision_oracle(root: &Path) -> Result<String, TestError> {
     let output = Command::new("jj")
         .args(["log", "-r", "@", "--no-graph", "-T", "commit_id"])

--- a/cli/vcs-adapters/tests/library.rs
+++ b/cli/vcs-adapters/tests/library.rs
@@ -1,11 +1,12 @@
-//! The library-backed probe against real repository shapes, alongside the
-//! subprocess pair.
+//! The library-backed probe against real repository shapes.
 //!
-//! Two properties. The boundary rule: `RepoRoot::discover` reports the start
+//! Three groups. The boundary rule: `RepoRoot::discover` reports the start
 //! path's nearest marked ancestor and never one above it, paired with the
 //! negative assertion that an unbounded `gix::discover` on the same fixture
-//! *does* escape — without which the containment claim holds vacuously. And
-//! parity with `CommandProbe` on every port method.
+//! *does* escape — without which the containment claim holds vacuously. The
+//! probe's `kind`/`repository_root` behaviour across real checkout shapes,
+//! against fixed expected values. And revision agreement with the real `jj` and
+//! `git` binaries, asked directly as oracles.
 //!
 //! These need real `jj` and `git` binaries and hard-fail when one is absent:
 //! Rust's harness has no skip primitive, so an early return would register as a
@@ -22,8 +23,6 @@ use vcs::RepoRoot;
 use vcs::VcsKind;
 use vcs::VcsProbe;
 use vcs_adapters::library::InProcessProbe;
-use vcs_adapters::subprocess::CommandProbe;
-use vcs_adapters::subprocess::MarkerWalkRoot;
 
 type TestError = Box<dyn std::error::Error>;
 
@@ -206,48 +205,36 @@ fn the_walk_finds_the_boundary_from_a_nested_directory() -> Result<(), TestError
     Ok(())
 }
 
-// --- Parity with the subprocess pair ---
+// --- The probe against real checkout shapes ---
 
-/// Asserts the two implementations agree on every port method, both idioms
-/// included.
-///
-/// `revision` is compared unconditionally. The fixtures are built and then read
-/// with no intervening edit, so the jj working copy's recorded operation is
-/// current and the snapshot the `jj` binary takes is a no-op; the one shape
-/// where the two legitimately differ is pinned separately by
-/// `an_unsnapshotted_edit_is_the_one_documented_divergence`.
-fn assert_parity(root: &Path) {
-    let kind = InProcessProbe.kind(root);
-    assert_eq!(kind, CommandProbe::new().kind(root), "kind disagreed");
-    assert_eq!(
-        InProcessProbe.repository_root(root),
-        MarkerWalkRoot.repository_root(root),
-        "repository_root disagreed"
-    );
-    assert_eq!(
-        InProcessProbe.revision(root, kind),
-        CommandProbe::new().revision(root, kind),
-        "revision disagreed"
-    );
+/// The commit id the `git` binary reports for `HEAD`.
+fn git_revision_oracle(root: &Path) -> Result<String, TestError> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(root)
+        .output()?;
+    assert!(output.status.success(), "the git oracle failed: {output:?}");
+    Ok(String::from_utf8(output.stdout)?.trim().to_owned())
 }
 
 #[test]
-fn a_plain_git_repository_agrees_with_the_subprocess_pair(
-) -> Result<(), TestError> {
+fn a_plain_git_repository_reports_git_kind() -> Result<(), TestError> {
     require("git")?;
-    let root = git_repo_with_a_commit("parity-git")?;
+    let root = git_repo_with_a_commit("shape-git")?;
     let root = path_of(&root)?;
 
     assert_eq!(InProcessProbe.kind(&root), VcsKind::Git);
-    assert_parity(&root);
+    assert_eq!(
+        InProcessProbe.revision(&root, VcsKind::Git),
+        Some(git_revision_oracle(&root)?),
+    );
     Ok(())
 }
 
 #[test]
-fn a_commitless_repository_agrees_and_reports_no_revision(
-) -> Result<(), TestError> {
+fn a_commitless_repository_reports_no_revision() -> Result<(), TestError> {
     require("git")?;
-    let root = tempdir("parity-commitless")?;
+    let root = tempdir("shape-commitless")?;
     let root = path_of(&root)?;
     run("git", &["init", "--quiet"], &root)?;
 
@@ -256,16 +243,14 @@ fn a_commitless_repository_agrees_and_reports_no_revision(
         None,
         "a commitless repository has no revision, and that is not a failure"
     );
-    assert_parity(&root);
     Ok(())
 }
 
 #[test]
-fn a_colocated_repository_agrees_and_is_driven_as_jj() -> Result<(), TestError>
-{
+fn a_colocated_checkout_is_driven_as_jj_in_process() -> Result<(), TestError> {
     require("jj")?;
     require("git")?;
-    let root = colocated_repo("parity-colocated")?;
+    let root = colocated_repo("shape-colocated")?;
     let root = path_of(&root)?;
 
     assert_eq!(
@@ -273,7 +258,6 @@ fn a_colocated_repository_agrees_and_is_driven_as_jj() -> Result<(), TestError>
         VcsKind::Jj,
         "jj must win over git in a colocated checkout"
     );
-    assert_parity(&root);
     Ok(())
 }
 
@@ -282,9 +266,9 @@ fn a_secondary_workspace_resolves_to_the_repository_it_shares(
 ) -> Result<(), TestError> {
     require("jj")?;
     require("git")?;
-    let main = colocated_repo("parity-main")?;
+    let main = colocated_repo("shape-main")?;
     let main = path_of(&main)?;
-    let secondary_root = tempdir("parity-secondary")?;
+    let secondary_root = tempdir("shape-secondary")?;
     let secondary = path_of(&secondary_root)?.join("workspace");
     run(
         "jj",
@@ -302,7 +286,6 @@ fn a_secondary_workspace_resolves_to_the_repository_it_shares(
         "a secondary workspace resolves through the loader to its main \
          repository, not to its own working copy"
     );
-    assert_parity(&secondary);
     Ok(())
 }
 
@@ -310,11 +293,10 @@ fn a_secondary_workspace_resolves_to_the_repository_it_shares(
 fn a_main_workspace_resolves_to_itself() -> Result<(), TestError> {
     require("jj")?;
     require("git")?;
-    let root = colocated_repo("parity-main-workspace")?;
+    let root = colocated_repo("shape-main-workspace")?;
     let root = path_of(&root)?;
 
     assert_eq!(InProcessProbe.repository_root(&root), root);
-    assert_parity(&root);
     Ok(())
 }
 
@@ -472,19 +454,19 @@ fn an_unsnapshotted_edit_is_the_one_documented_divergence(
         "the in-process route must not snapshot"
     );
 
-    // The subprocess probe snapshots first, so it reports a different commit —
-    // and creates it. That write is what the in-process route removes.
-    let snapshotted = CommandProbe::new().revision(&root, VcsKind::Jj);
-    assert!(snapshotted.is_some());
+    // Asking the binary snapshots first, so it reports a different commit — and
+    // creates it. That write is what the in-process route removes.
+    let snapshotted = jj_revision_oracle(&root)?;
     assert_ne!(
-        snapshotted, recorded,
+        Some(snapshotted.clone()),
+        recorded,
         "asking the jj binary snapshots, so it should report a new commit here"
     );
 
     // The recorded state has now moved, and the two agree again.
     assert_eq!(
         InProcessProbe.revision(&root, VcsKind::Jj),
-        snapshotted,
+        Some(snapshotted),
         "after the binary snapshots, the recorded commit is the new one"
     );
     Ok(())

--- a/cli/vcs-adapters/tests/queries.rs
+++ b/cli/vcs-adapters/tests/queries.rs
@@ -18,6 +18,8 @@ use vcs::checkout::DualRoots;
 use vcs::checkout::JjRepositoryFacts;
 use vcs::checkout::JjWorkspaceRole;
 use vcs::checkout::WorktreeFacts;
+use vcs::VcsKind;
+use vcs::VcsProbe as _;
 use vcs_adapters::library::Error;
 use vcs_adapters::library::InProcessProbe;
 use vcs_test_support::fixtures::Matrix;
@@ -569,6 +571,10 @@ fn an_unsupported_object_format_fails_rather_than_misreads(
     assert!(probe.is_bare(sha256).is_err());
     assert!(probe.worktree(sha256).is_err());
     assert!(probe.dual_roots(sha256).git.is_err());
+
+    // `revision` carries no error channel, so the same unreadable repository
+    // folds to absence there — sha256 is unsupported rather than misread.
+    assert_eq!(probe.revision(sha256, VcsKind::Git), None);
 
     // The reftable backend, by contrast, reads normally.
     let reftable = matrix.start("RF")?;

--- a/cli/vcs/src/lib.rs
+++ b/cli/vcs/src/lib.rs
@@ -69,6 +69,10 @@ pub trait VcsProbe {
     /// The full working-copy revision, or `None` when the repository has none
     /// and when the probe cannot answer. A caller cannot distinguish the two;
     /// an adapter is expected to log the failure.
+    ///
+    /// A sha256-format repository is unsupported: the underlying `gix` query
+    /// fails to read one at all, so this folds to `None` like any other probe
+    /// failure, rather than misreading the revision.
     fn revision(&self, root: &Path, kind: VcsKind) -> Option<String>;
 }
 

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -1,0 +1,872 @@
+---
+type: plan
+id: "2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
+title: "Converge corpus-adapters on the Library-Backed VCS Adapter Implementation Plan"
+date: "2026-08-10T15:52:48+00:00"
+author: Toby Clemson
+producer: create-plan
+status: ready
+work_item_id: "work-item:0185"
+parent: "work-item:0185"
+derived_from: ["codebase-research:2026-08-10-0185-converge-corpus-adapters-library-backed-vcs"]
+tags: [rust, vcs, cleanup, tech-debt]
+revision: "1e785e44f25480111414fe805bf645510d028fef"
+repository: "accelerator"
+last_updated: "2026-08-10T16:52:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Converge corpus-adapters on the Library-Backed VCS Adapter Implementation Plan
+
+## Overview
+
+`cli/corpus-adapters` reads repository facts (`name`, `revision`) through
+`vcs_adapters::facts`, which today wires the subprocess-based `CommandProbe`
+(spawns `jj`/`git`). 0188 delivered a fully-implemented, unwired
+library-backed alternative, `InProcessProbe` (`gix`/`jj-lib`, no subprocess
+spawn). This plan repoints `facts`'s composition root onto `InProcessProbe`,
+deletes `CommandProbe`, and extends the crate's zero-spawn test guarantee to
+cover the corpus metadata-read path — closing the two-implementation state
+0169 deliberately left behind.
+
+## Current State Analysis
+
+- `vcs_adapters::facts` (`cli/vcs-adapters/src/lib.rs:22-26`) hard-wires
+  `MarkerWalkRoot` + `CommandProbe::new()` with no injection seam.
+- `CommandProbe` (`cli/vcs-adapters/src/subprocess.rs:65-139`) spawns `jj log
+  -r @ -T commit_id` / `git rev-parse HEAD` for `revision`, and `git remote
+  get-url origin` for `OriginRemote`, through shared `scrub_environment`/
+  `run_capped` helpers.
+- `InProcessProbe` (`cli/vcs-adapters/src/library.rs:190` onward) already
+  implements every port `CommandProbe` implements — `RepoRoot`, `VcsProbe`,
+  `OriginRemote`, plus taxonomy queries `CommandProbe` doesn't need — with no
+  gaps. `tests/detection.rs` already asserts full `RepoFacts` equality
+  between the two adapters across seven checkout shapes.
+- The sole non-hook, non-`vcs`-subdomain production consumer of
+  `vcs_adapters::facts` is `VcsBackedRepoFactsProbe::facts`
+  (`cli/corpus-adapters/src/metadata.rs:214`), a one-line delegation reached
+  through the injected `RepoFactsProbe` port from `derive_at`
+  (`metadata.rs:228-236`).
+- The existing zero-spawn proof (`cli/corpus-adapters/tests/zero_spawn.rs`)
+  exercises `InProcessProbe`'s individual queries via a reference binary
+  (`vcs-adapters-fixture`, declared in `cli/vcs-adapters/Cargo.toml:23-25`),
+  but that binary never calls `vcs_adapters::facts` or
+  `VcsBackedRepoFactsProbe` — the metadata-read path is unproven.
+- `tests/detection.rs` runs a transitional dual-adapter comparison
+  (`facts` via `CommandProbe`, `library_facts` via `InProcessProbe`, asserted
+  equal by `assert_implementations_agree`) that must collapse to the
+  library-backed path alone once `CommandProbe` is gone.
+  `tests/library.rs` runs a second, separate dual-adapter comparison
+  (`assert_parity`, plus a direct `CommandProbe::new().revision(...)` call
+  in `an_unsnapshotted_edit_is_the_one_documented_divergence`) that must
+  collapse too — easy to miss because it lives in a different file from the
+  one named in the work item's Technical Notes.
+
+### Key Discoveries:
+
+- The corpus-adapters call site has moved behind a `RepoFactsProbe`
+  injection seam since the work item's own Technical Notes were last
+  checked — the repoint target is the single line
+  `cli/corpus-adapters/src/metadata.rs:214`, not an inline call inside
+  `derive_at`.
+- `cli/corpus-adapters/tests/work_item_pattern_parity.rs`, named in the work
+  item's AC2, does not exist in the tree. The suites that must keep passing
+  unchanged are the ones that actually exist and touch this path:
+  `cli/corpus-adapters/tests/zero_spawn.rs`,
+  `cli/corpus-adapters/tests/metadata.rs`, and
+  `cli/corpus-adapters/tests/parity.rs`.
+- `scrub_environment`/`run_capped` (`subprocess.rs:231-246,248-324`) are
+  shared with 0198's `run_vcs_text` (the `status`/`log` subprocess path) and
+  must survive `CommandProbe`'s deletion; `run_checked`/
+  `wait_capped_checked` (`subprocess.rs:329-407`) are used only by
+  `CommandProbe`'s `OriginRemote` impl and delete cleanly alongside it.
+- `markers.rs` is shared ancestor-walk/marker logic that both adapters
+  delegate to rather than duplicate; it must not be touched.
+- `gix` 0.85 cannot read a sha256 repository at all — every query returns
+  `Err`, which `InProcessProbe::revision` already folds to `None` via its
+  documented fallible-to-`Option` contract. No new error handling is
+  required; only the policy needs recording.
+- `cli/visualiser/server` does not call `vcs_adapters::facts`,
+  `VcsBackedRepoFactsProbe`, or `derive_at` anywhere today — the whole
+  `gix`/`jj-lib` closure is dead-code-eliminated from the shipped binary.
+  The work item's framing that this switch "first makes the server
+  reachable" does not hold against the current codebase; the MPL-2.0
+  re-check (Phase 4) records whatever the unstripped build actually shows
+  rather than assuming reachability changes.
+- The visualiser is not the only dispatched sub-binary in this position,
+  though: four of the six `DISPATCHED_SUBBINARIES` tokens
+  (`tasks/shared/paths.py:29-36`) already reach `vcs_adapters` today,
+  independent of this plan, through call sites unrelated to `facts`/
+  `derive_at` — `cli/vcs-cli` and `cli/collaboration-cli` construct
+  `InProcessProbe` directly for `detect`/`guard`/origin resolution;
+  `cli/migrate-adapters` (`context.rs`'s `FileMigrationContext::revision`
+  and `dirty_path_scanner.rs`'s `VcsDirtyPathScanner::dirty_paths`, both
+  called unconditionally from `migrate-cli`'s default run path) does the
+  same for migration scanning; `cli/work-adapters`'s
+  `VcsBackedIdentityProbe` (`author.rs`) does the same for `work create`'s
+  author resolution, unrelated to the `derive_at` path this plan repoints.
+  Their shipped binaries (`accelerator-vcs`, `accelerator-collaboration`,
+  `accelerator-migrate`, `accelerator-work`) very likely already carry the
+  closure. 0188's MPL-2.0 verification checked none of them. Only `corpus`
+  becomes newly reachable through this plan's switch — `corpus-adapters`
+  has no other call site into `vcs_adapters` today. Phase 4 broadens its
+  re-check to every one of the six dispatched sub-binary tokens, not the
+  visualiser alone.
+- `InProcessProbe` already runs unbounded, synchronously, in production
+  today on the `SessionStart`/`PreToolUse` hook path (`vcs detect`/`vcs
+  guard`, wired via `cli/vcs-cli/src/main.rs:27-69`). This switch extends
+  the same code path's reach — most sharply at `work-cli`'s `create`, which
+  holds a work-item creation lock for the duration of the `derive_at` call
+  this port serves, and whose reclaim mechanism only reclaims a dead
+  holder — so a hang here is a new, not merely inherited, blast radius even
+  though the underlying exposure is not new in kind.
+- No `cli/corpus-adapters` write path depends on the CLI's snapshot-on-read
+  side effect. The two production callers of `derive_at` are `corpus-cli`'s
+  `corpus metadata derive` (prints to stdout only) and `work-cli`'s `work
+  create` (persists frontmatter, but reads only `metadata.datetime_utc`,
+  never `.revision`/`.repository_name`). This does not extend to `SKILL.md`
+  workflows (`create-plan`, `research-issue`, `create-note`, and others)
+  that call `corpus metadata derive` directly and copy its printed
+  `Current Revision:` line into committed `meta/` frontmatter — those
+  consumers inherit the same staleness window, accepted as a best-effort
+  provenance degradation rather than a correctness regression.
+
+## Desired End State
+
+`vcs_adapters::facts` resolves `RepoFacts` entirely in-process via
+`InProcessProbe`, with no `Command::new` for `jj`/`git` remaining anywhere in
+`cli/vcs-adapters`'s non-test code that serves `facts`. `CommandProbe` no
+longer exists. A black-box test proves the corpus-adapters metadata-read path
+spawns no subprocess. Three policy decisions (sha256 handling, containment
+bound, snapshot-on-read dependency) are recorded in the codebase, not left
+open. `mise run` is green end to end.
+
+**Verification**: `mise run check` passes; `cargo nextest run -p
+vcs-adapters -p corpus-adapters` passes, including the new zero-spawn
+extension; a repo-wide search for `CommandProbe` and `MarkerWalkRoot`
+returns no matches outside history; unstripped `--release` builds of all
+six `DISPATCHED_SUBBINARIES` (`accelerator-visualiser`, `accelerator-vcs`,
+`accelerator-work`, `accelerator-corpus`, `accelerator-collaboration`,
+`accelerator-migrate`) are each checked against the MPL-2.0 literals and
+`cli/deny.toml`'s exception comment reflects the actual finding for all
+six.
+
+## What We're NOT Doing
+
+- Not touching `status`/`log`'s separate subprocess path (`run_vcs_text` in
+  `subprocess.rs`) — owned by 0198, explicitly out of scope, and the reason
+  `scrub_environment`/`run_capped` survive.
+- Not adding a timeout, memory cap, or crash-isolation wrapper around
+  `InProcessProbe` — Phase 1 records a deliberate decision that none is
+  needed, not an implementation of one.
+- Not building a reusable bounded-execution primitive for every
+  `InProcessProbe` call site (`facts`, `detect`, `guard`) — out of scope for
+  this item; it would also address the pre-existing hook-path exposure,
+  which nothing here requires.
+- Not creating `cli/corpus-adapters/tests/work_item_pattern_parity.rs` — the
+  work item's AC2 reference to it is stale; the plan targets the suites that
+  actually exist.
+- Not changing `markers.rs` — the shared ancestor-walk/marker logic both
+  `MarkerWalkRoot` and `InProcessProbe` delegate to stays as it is.
+  `MarkerWalkRoot` itself is not left unchanged: it is deleted in Phase 3
+  once its last caller (the dual-adapter comparisons) is gone — see Phase 3,
+  item 1.
+- Not widening `is_full_revision_id` or any revision-format validation to
+  accept 64-hex sha256 ids — `gix` cannot read such a repository regardless
+  of hex width, so widening the check would not change behaviour.
+
+## Implementation Approach
+
+Four independently-mergeable phases, ordered so every behavioural change is
+preceded by the policy decisions it depends on, and every deletion is
+preceded by the collapse of whatever still references the thing being
+deleted:
+
+1. Record the three pending policy decisions as doc comments — no behaviour
+   change, unblocks the repoint.
+2. Add failing zero-spawn coverage for the corpus metadata-read path, then
+   flip the composition root — classic red/green within one mergeable
+   change, since a failing test can't ship alone without breaking CI.
+3. Delete `CommandProbe` and `MarkerWalkRoot`, and collapse the transitional
+   dual-adapter test comparisons in both `detection.rs` and `library.rs` —
+   now safe, since nothing else references any of them.
+4. Re-run the MPL-2.0 licence check across every dispatched sub-binary that
+   reaches `vcs_adapters`, and update the recorded finding.
+
+## Phase 1: Record the pending policy decisions
+
+### Overview
+
+Three decisions the work item's Acceptance Criteria require to be "made and
+recorded" before the composition root changes. Mostly documentation-only —
+no logic changes to non-test `.rs` code — with two test additions that back
+the decisions being recorded rather than leaving them as unproven claims:
+a sha256 `revision()` case (no existing test actually exercises `revision`
+against a sha256 fixture) and a git-side malformed-ref-data case (the
+containment-bound decision's "failure distinguishes itself from absence"
+claim currently has jj-side proof only).
+
+### Changes Required:
+
+#### 1. sha256 revision-handling policy
+
+**File**: `cli/vcs/src/lib.rs`
+**Changes**: Add a doc comment to `VcsProbe::revision` (`:65-73`) recording
+that a sha256 repository is unsupported: `gix` 0.85 cannot read one at all
+(every query returns `Err`), so `revision` folds that failure to `None`
+through its existing fallible-to-`Option` contract — the same path as any
+other probe failure. Follows the precedent set by
+`OriginRemote::origin_url`'s doc comment (`cli/vcs/src/origin_remote.rs:12-22`)
+of recording port-behaviour policy at the trait method.
+
+```rust
+/// Reports a repository's idiom and its working-copy revision.
+pub trait VcsProbe {
+    fn kind(&self, root: &Path) -> VcsKind;
+
+    /// The full working-copy revision, or `None` when the repository has none
+    /// and when the probe cannot answer. A caller cannot distinguish the two;
+    /// an adapter is expected to log the failure.
+    ///
+    /// A sha256-format repository is unsupported: the underlying `gix` query
+    /// fails to read one at all, so this folds to `None` like any other
+    /// probe failure, rather than misreading the revision.
+    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String>;
+}
+```
+
+Also add a test proving this: extend `cli/vcs-adapters/tests/queries.rs` (or
+add a sibling near `an_unsupported_object_format_fails_rather_than_misreads`)
+with a case that calls `InProcessProbe.revision(&sha256_root, VcsKind::Git)`
+against the crate's existing S256 fixture and asserts `None`. The two
+existing sha256 tests (`queries.rs`, `classify.rs`) cover `is_bare`/
+`worktree`/`dual_roots`/`classify` failing on this fixture, but neither
+calls `revision`, so the doc comment's claim is otherwise unproven.
+
+#### 2. Containment-bound decision
+
+**File**: `cli/vcs-adapters/src/library.rs`
+**Changes**: Add a doc comment above `InProcessProbe` (`:190`) recording the
+decision that no timeout, memory cap, or crash-isolation bound is added.
+Rationale: the same unbounded exposure already runs in production today for
+`vcs detect`/`vcs guard` on the hook path; no crash-isolation precedent
+exists anywhere in `cli/`; and `InProcessProbe`'s `Result<Option<T>, Error>`
+return already distinguishes failure from absence, which is containment of
+meaning, not blast radius, but is the containment this port promises. The
+comment names what this removes, not only what it declines to add:
+`CommandProbe` ran the `facts()` call site under a 10-second cap with
+kill-on-timeout, and this decision takes that away from it. The sharpest
+blast radius reached *through `facts()`* is `work-cli`'s `create`, which
+holds a work-item creation lock for the duration of the call — the lock's
+reclaim mechanism only reclaims a dead holder, so a hang here fails every
+subsequent `work create` after its own five-minute lock-acquisition wait,
+until an operator kills the hung process (a comparable, pre-existing
+exposure already applies to `migrate-adapters`' own direct, non-`facts`
+`InProcessProbe` calls under `migrate`'s run lock — untouched by this
+plan). The revisit condition is stated structurally, not by ticket number:
+no work item currently owns adding a server call site into `facts`, so
+there is nothing to cross-reference yet; the condition is written so it
+applies regardless of which future item does it.
+
+```rust
+/// Parses repository-controlled data in the caller's address space — no
+/// subprocess boundary, no time bound, no memory bound, no crash isolation.
+///
+/// This removes a protection that existed at the `facts()` call site before
+/// this switch: `CommandProbe` ran under a 10-second cap with
+/// kill-on-timeout. The sharpest blast radius reached through `facts()` is
+/// `work-cli`'s `create`, which holds a work-item creation lock for the
+/// duration of the `derive_at` call this port serves — the lock's reclaim
+/// mechanism only reclaims a dead holder, so a hang here fails every
+/// subsequent `work create` after its own five-minute lock-acquisition
+/// wait, until an operator kills the hung process.
+///
+/// This is a deliberate decision, not an oversight: the same unbounded
+/// exposure already runs in production for the `vcs detect`/`vcs guard`
+/// hook path, no crash-isolation precedent exists anywhere in this
+/// workspace, and adding one here would be a first-of-its-kind primitive
+/// introduced ahead of any incident that demonstrates the need. Revisit
+/// when any code under `cli/visualiser/server` calls `vcs_adapters::facts`,
+/// `derive_at`, or `VcsBackedRepoFactsProbe` — this decision was priced
+/// against a single-shot CLI/hook caller, not a persistent multi-request
+/// one — or if a lock-holding hang is observed in practice.
+pub struct InProcessProbe;
+```
+
+#### 3. Malformed git-ref revision test
+
+**File**: `cli/vcs-adapters/tests/library.rs`
+**Changes**: `an_unreadable_checkout_state_reports_absence_rather_than_a_wrong_commit`
+already proves the jj side of the containment-bound decision's "failure
+distinguishes itself from absence" claim — writing garbage bytes over
+`.jj/working_copy/checkout` and asserting `revision` returns `None` rather
+than panicking. There is no git-side equivalent. Add a sibling test that
+corrupts a git repository's ref data after a valid initial read (e.g.
+overwrite `.git/HEAD` or the relevant `refs/heads/*` file with non-UTF-8 or
+truncated bytes) and asserts `InProcessProbe.revision(&root, VcsKind::Git)`
+returns `None` rather than panicking, so both dispatch paths this switch
+widens the reach of have a proven graceful-failure case, not only the jj
+one.
+
+#### 4. Snapshot-on-read dependency confirmation
+
+**File**: `cli/corpus-adapters/src/metadata.rs`
+**Changes**: Add a doc comment to `VcsBackedRepoFactsProbe`
+(`:211-212`) recording that no corpus-adapters write path depends on the
+CLI's snapshot-on-read side effect. `work-cli`'s `create` (the one
+production write path that persists frontmatter) reads only
+`metadata.datetime_utc`, never `.revision`/`.repository_name`;
+`corpus-cli`'s `corpus metadata derive` only prints to stdout. This
+confirmation is scoped to `cli/corpus-adapters`' own Rust write paths; it
+does not cover `SKILL.md` workflows (`create-plan`, `research-issue`,
+`create-note`, and others) that call `corpus metadata derive` directly and
+copy its printed `Current Revision:` line into committed `meta/`
+frontmatter — the doc comment records that scope explicitly rather than
+implying the question is closed for those consumers too.
+
+```rust
+/// Resolves repository facts through the library-backed VCS adapter.
+///
+/// No `cli/corpus-adapters` write path depends on the CLI's
+/// snapshot-on-read side effect (writing a new commit for unsnapshotted
+/// working-copy changes): the one production write path that persists
+/// frontmatter (`work create`) reads only `metadata.datetime_utc`, never
+/// `.revision`/`.repository_name`.
+///
+/// This does not extend to `SKILL.md` workflows that call `corpus metadata
+/// derive` directly and copy its printed `Current Revision:` line into
+/// committed `meta/` frontmatter (e.g. `create-plan`, `research-issue`,
+/// `create-note`). Those consumers inherit a staleness window this switch
+/// introduces: an artefact authored with unsnapshotted working-copy edits
+/// present records the last recorded operation's commit rather than a
+/// freshly snapshotted one. Accepted as a best-effort provenance
+/// degradation, not a correctness regression — nothing downstream treats
+/// these fields as exact — but it is a real, if narrow, change to
+/// persisted data, not only to stdout.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VcsBackedRepoFactsProbe;
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] Workspace builds: `cargo build --workspace` (run from `cli/`)
+- [ ] New sha256 `revision()` test passes and demonstrably calls `revision`
+      (not only `is_bare`/`worktree`/`dual_roots`/`classify`):
+      `cargo test -p vcs-adapters --features bash-parity --test queries`
+- [ ] New malformed-git-ref `revision()` test passes:
+      `cargo test -p vcs-adapters --features bash-parity --test library`
+- [ ] `cli` component check passes: `mise run cli:check`
+- [ ] Full check suite passes: `mise run check`
+
+#### Manual Verification:
+
+- [ ] Each doc comment reads as a decision record (states the choice and the
+      reason), not a description of what the code already shows
+
+---
+
+## Phase 2: Extend zero-spawn coverage, then repoint `facts`
+
+### Overview
+
+Prove — before making the change — that the corpus metadata-read path can be
+made to spawn no subprocess, then make it true. The `vcs-test-support`
+`Stubs` harness only patches a spawned child process's `PATH`, so the new
+assertion needs the code under test running as a subprocess itself; the
+existing `vcs-adapters-fixture` binary can't be extended to cover this,
+since `vcs-adapters` cannot depend on `corpus-adapters` (wrong dependency
+direction) — a new `corpus-adapters`-local reference binary is needed.
+
+### Changes Required:
+
+#### 1. New reference binary for the metadata-read path
+
+**File**: `cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs`
+(new)
+**Changes**: A minimal binary, mirroring `vcs-adapters-fixture`'s shape and
+placement, that takes a repository path as its argument, constructs a
+`VcsBackedRepoFactsProbe`, calls `.facts(path)`, and prints the result to
+stdout. Declared in `cli/corpus-adapters/Cargo.toml` as a `[[bin]]` sourced
+from `tests/fixtures/`, not `src/bin/`, matching `vcs-adapters-fixture`'s
+own placement — its `Cargo.toml` comment records that choice as keeping the
+binary off the crate's normal build surface, and `tasks/build.py`'s
+release-staging glob only looks under `src/bin/`, so a diagnostic-only
+binary placed there would be one glob change away from shipping. Matching
+that sibling exactly (not merely its placement): the `[[bin]]` entry itself
+carries no `required-features` gate and always builds; only the two new
+zero-spawn tests that invoke it (change #2 below) are gated behind
+`bash-parity`, the same split `vcs-adapters-fixture` uses between its
+always-built binary and its `#![cfg(feature = "bash-parity")]`-gated
+tests.
+
+#### 2. Failing-first zero-spawn assertion
+
+**File**: `cli/corpus-adapters/tests/zero_spawn.rs`
+**Changes**: Two new tests, `a_git_metadata_read_spawns_no_subprocess` and
+`a_jj_metadata_read_spawns_no_subprocess`, following the existing test's
+pattern: build a git fixture repository and a jj fixture repository (via
+`vcs-test-support`'s `fixtures` module), run the new
+`corpus-adapters-fixture` binary twice per fixture (unrestricted vs.
+`Stubs`-applied `PATH`), assert identical stdout and `!stubs.spawns()` for
+each. Two kinds, not one: `facts` dispatches differently per `VcsKind`
+(`git_revision`/`jj_revision` are separate code paths in `library.rs`), and
+the point of this test is proving the *composition* —
+`VcsBackedRepoFactsProbe` → `vcs_adapters::facts` → `InProcessProbe` —
+spawns nothing end-to-end for either dispatch path, not re-proving the
+individual queries' zero-spawn property (already proven per-query by the
+existing `vcs-adapters-fixture`-driven test).
+
+Confirm both tests fail against the current `CommandProbe` wiring (a marker
+is written) before proceeding — this is the red step. Do not skip running it
+red; the point is proving the assertion actually exercises the composition
+root being changed.
+
+#### 3. Repoint the composition root
+
+**File**: `cli/vcs-adapters/src/lib.rs`
+**Changes**: Replace the `MarkerWalkRoot`/`CommandProbe::new()` wiring with
+`InProcessProbe`, serving both the `RepoRoot` and `VcsProbe` positions from
+the single unit-struct value.
+
+```rust
+use crate::library::InProcessProbe;
+
+#[must_use]
+pub fn facts(start: &Path) -> Option<RepoFacts> {
+    vcs::facts(start, &InProcessProbe, &InProcessProbe)
+}
+```
+
+Also update the crate's module-level doc comment (`:1-10`), which
+currently states "[`subprocess`] ... is what [`facts`] uses" — false the
+moment this repoint lands. At minimum, correct that one sentence to name
+`library`/`InProcessProbe` as what `facts` uses now; Phase 3's deletion of
+`MarkerWalkRoot` further changes what's true of `subprocess` (see Phase 3,
+item 1's note on this same doc comment), so a second, smaller update lands
+there rather than getting both changes right in one pass here.
+
+One narrow behavioural note carried by this repoint, not requiring a code
+change: `InProcessProbe::discover`/`.repository_root` canonicalise
+(resolve symlinks); `MarkerWalkRoot`'s did not. `VcsBackedRepoFactsProbe`
+only forwards `.name`/`.revision`, not `.root`, so this only surfaces if
+the repository directory itself (not merely an ancestor) is a symlink, in
+which case the canonicalised final path component can change the
+`Repository Name:` value persisted into frontmatter. Narrow enough not to
+warrant new test infrastructure for this item, but worth naming here
+rather than leaving silent.
+
+Confirm Phase 2's new tests now pass (green), alongside every existing
+`vcs-adapters`/`corpus-adapters` test.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] Both new zero-spawn tests fail before the composition-root change
+      (verified manually during implementation, not a lasting CI state)
+- [ ] Both new zero-spawn tests pass after the composition-root change:
+      `cargo test -p corpus-adapters --features bash-parity --test
+      zero_spawn`
+- [ ] Existing corpus-adapters suites pass unchanged: `cargo test -p
+      corpus-adapters --test parity --test metadata`
+- [ ] `cli` component check passes: `mise run cli:check`
+- [ ] `mise run check` passes
+
+#### Manual Verification:
+
+- [ ] `corpus metadata derive` run against a real jj repository still
+      prints the expected `Repository Name:`/`Current Revision:` lines
+
+---
+
+## Phase 3: Delete `CommandProbe` and collapse the dual-adapter comparison
+
+### Overview
+
+Nothing production-facing references `CommandProbe` after Phase 2. This
+phase removes it, its `OriginRemote`-only helpers, its redundant unit tests,
+and the transitional test scaffolding that compared it against
+`InProcessProbe` — in both `tests/detection.rs` and `tests/library.rs`. The
+latter is easy to miss: it imports `CommandProbe` directly, and its
+`an_unsnapshotted_edit_is_the_one_documented_divergence` test is the sole
+automated proof of the snapshot-on-read behavioural difference Phase 1
+documents, so its rework (not deletion) matters.
+
+### Changes Required:
+
+#### 1. Delete `CommandProbe`, `MarkerWalkRoot`, and their dedicated helpers
+
+**File**: `cli/vcs-adapters/src/subprocess.rs`
+**Changes**: Delete the `CommandProbe` struct, its preceding doc comment,
+and its `VcsProbe`/`OriginRemote` impls (`:63-139` — the doc comment
+("Reads the repository's idiom from its markers and its revision by
+running the matching VCS binary.") sits just above the struct at `:63-64`;
+stopping the range at `:65` leaves it dangling, silently re-attached to
+whatever follows). Delete `run_checked`/`wait_capped_checked` and their
+preceding doc comment (`:326-407`, used only by `CommandProbe`'s
+`OriginRemote` impl; same off-by-a-comment-block reasoning as above). Delete
+the three `CommandProbe`-specific unit tests together with the
+`origin_repo()` helper that only they call (`:570-632` — `origin_repo()`
+sits just above the tests and has no caller once they're gone; deleting the
+tests alone without it leaves an orphaned private function). Within that
+same test module, also drop its own now-unused imports: `use
+std::path::PathBuf;` (`:414`, used only by the deleted `origin_repo()`'s
+return type) and `CommandProbe` from the `use super::{run_capped,
+run_vcs_text, scrub_environment, CommandProbe, StatusOrLog};` list (`:421`,
+used only by the three deleted tests) — narrowing that line to `use
+super::{run_capped, run_vcs_text, scrub_environment, StatusOrLog};`. These
+are a second, deeper scope from the top-level imports trimmed below, easy
+to miss for the same reason the top-level ones were missed in the previous
+revision of this plan: the compiler will catch the omission (`unused_imports`
+denies the build under this workspace's `warnings = "deny"` policy), but
+getting the list right here avoids the wasted iteration.
+
+Also delete `MarkerWalkRoot` and its private `jj_repository_root` helper
+(`:29-61`): once change #3 below reworks `tests/library.rs`'s parity assertions,
+`MarkerWalkRoot` has no remaining caller anywhere in the crate — its only
+uses today are the dual-adapter comparisons in `detection.rs` and
+`library.rs`, both collapsed by this phase. (`InProcessProbe` has its own,
+separate `jj_repository_root` in `library.rs`, so this deletion doesn't
+touch the surviving implementation.) Keep `scrub_environment`,
+`run_capped`/`wait_capped` (shared with 0198's `run_vcs_text`), and every
+test exercising them directly via generic shell stand-ins (`:442-568`).
+
+Trim the module's top-level imports (`:12-22`) to what the surviving code
+(`status`, `log`, `run_vcs_text`, `scrub_environment`, `run_capped`,
+`wait_capped`) actually uses — this workspace's `warnings = "deny"` lint
+policy (`cli/Cargo.toml`) turns leftover imports into a build failure, not
+a lint warning:
+- `use std::fs;` — delete; only the deleted `jj_repository_root` used it.
+- `use std::path::{Path, PathBuf};` — narrow to `use std::path::Path;`;
+  `PathBuf` was only returned by the deleted `MarkerWalkRoot`/
+  `jj_repository_root` code.
+- `use vcs::origin_remote::OriginRemote;` — delete; only `CommandProbe`'s
+  deleted impl used it.
+- `use vcs::{RepoRoot, VcsKind, VcsProbe};` — narrow to
+  `use vcs::VcsKind;`; `status`/`log` still take a `VcsKind` parameter,
+  but `RepoRoot`/`VcsProbe` were only implemented by the deleted structs.
+- `use crate::markers::{carries_any_marker, marker_kind, walk_up};` —
+  delete entirely; all three were used only by `MarkerWalkRoot::discover`
+  and `CommandProbe::kind`, both deleted.
+
+Also update the module-level doc comment (`:1-10`), which currently
+describes this file as "a marker walk for the root, and the VCS binaries
+themselves for the working-copy revision" — no longer accurate once the
+marker walk (`MarkerWalkRoot`) is gone. Retitle it to describe what
+remains: the `status`/`log` subprocess text retrieval 0198 owns, no longer
+a `RepoRoot`/`VcsProbe` implementation.
+
+`run_capped`'s own doc comment (`:285`) reads "Unlike
+[`CommandProbe::revision`], empty output is not itself treated as a
+failure here..." — an intra-doc link to a symbol this change deletes.
+`run_capped` itself survives, so this comment isn't removed by any
+deletion range above; rewrite the comparison to describe the general
+failure-folding semantics it's contrasting against rather than naming the
+now-deleted `CommandProbe::revision`.
+
+Finish the crate-level doc comment update Phase 2 started
+(`cli/vcs-adapters/src/lib.rs:1-10`): its sentence "What both agree on —
+the ancestor walk and the marker reading — lives in a third, private
+module that each delegates *to*" describes `subprocess`/`library` as two
+peer delegators into `markers`; once `MarkerWalkRoot` is deleted here,
+`library`/`InProcessProbe` is the only remaining delegator, so that framing
+no longer holds either.
+
+#### 2. Collapse the dual-adapter comparison
+
+**File**: `cli/vcs-adapters/tests/detection.rs`
+**Changes**: Remove the `CommandProbe`/`MarkerWalkRoot` imports, the
+`facts`/`library_facts` pairing, and `assert_implementations_agree`'s
+two-probe comparison. Replace every call site with a single helper — e.g.
+rename `library_facts` to `facts` — that calls `vcs::facts(&x,
+&InProcessProbe, &InProcessProbe)` directly, and update each of the seven
+shape-specific tests to assert against that single result rather than
+comparing two. "Directly" means bypassing the file's own private
+`facts_via(start, root: &dyn RepoRoot, probe: &dyn VcsProbe)` indirection,
+not just the deleted `facts`/`CommandProbe` pairing: `facts_via` exists
+solely to let the old `facts`/`library_facts` pair construct two
+differently-probed calls for `assert_implementations_agree` to compare, and
+has no other caller. Once that comparison is gone, delete `facts_via`
+itself along with the `use vcs::RepoRoot;`/`use vcs::VcsProbe;` imports it
+required — leaving it in place, unreachable from a single-probe helper,
+would orphan it the same way `subprocess.rs`'s `origin_repo()` was
+orphaned by change #1 above until caught.
+
+#### 3. Rework `tests/library.rs`'s parity assertions
+
+**File**: `cli/vcs-adapters/tests/library.rs`
+**Changes**: Remove the `vcs_adapters::subprocess::CommandProbe`/
+`MarkerWalkRoot` imports. Delete `assert_parity` outright rather than
+reducing it: its three assertions (`kind`, `repository_root`, `revision`)
+are each a comparison against the now-removed subprocess implementations,
+so a "single-implementation" version of the same assertion
+(`InProcessProbe.kind(root) == InProcessProbe.kind(root)`) would be
+tautological.
+
+Deleting `assert_parity`'s `revision` comparison removes the only place in
+the crate that oracle-verifies `InProcessProbe`'s git-side revision against
+the real `git` binary — the jj side keeps its own oracle
+(`jj_revision_oracle`, used by three other tests in this file), so losing
+the git side without replacement would be a new asymmetry, not a symmetric
+simplification, and would leave `detection.rs`'s `is_full_revision_id` (a
+40-hex-character format check, not a value check) as the only thing
+standing between a git-side mutation and a passing test suite. Close this
+by adding a `git_revision_oracle` helper mirroring the existing
+`jj_revision_oracle` (`git rev-parse HEAD` via the file's own `run`
+helper), and use it in the renamed git-kind test below.
+
+The five call sites
+(`a_plain_git_repository_agrees_with_the_subprocess_pair`,
+`a_commitless_repository_agrees_and_reports_no_revision`,
+`a_colocated_repository_agrees_and_is_driven_as_jj`,
+`a_secondary_workspace_resolves_to_the_repository_it_shares`,
+`a_main_workspace_resolves_to_itself`) already carry their own
+independently meaningful `kind`/`repository_root` assertions ahead of the
+`assert_parity(&root)` call (e.g. `VcsKind::Jj` for the colocated case), so
+nothing of value is lost there by dropping the call along with the helper.
+Rename the three whose names describe the deleted comparison
+(`a_plain_git_repository_agrees_with_the_subprocess_pair`,
+`a_commitless_repository_agrees_and_reports_no_revision`,
+`a_colocated_repository_agrees_and_is_driven_as_jj`) to describe what they
+assert standalone instead — e.g. `a_plain_git_repository_reports_git_kind`
+— matching how the other two in the group are already named around their
+own standalone assertion. When renaming
+`a_colocated_repository_agrees_and_is_driven_as_jj`, don't drop straight to
+`a_colocated_repository_is_driven_as_jj`: `cli/vcs-adapters/tests/detection.rs`
+already has a different test by that exact name, and a same-named test in a
+sibling file is confusing to grep for even though it's not a compile
+conflict — keep a `library`-scoped qualifier instead, e.g.
+`a_colocated_checkout_is_driven_as_jj_in_process`, matching this file's own
+`a_colocated_checkout_roots_at_its_own_markers` naming a few lines above
+it. Add the new `git_revision_oracle` assertion to
+the renamed `a_plain_git_repository_reports_git_kind` test specifically
+(`assert_eq!(InProcessProbe.revision(&root, VcsKind::Git),
+Some(git_revision_oracle(&root)?))`), so git-side revision correctness
+keeps an independent oracle check rather than only a kind check. Update or
+remove the `// --- Parity with the subprocess pair ---` section-divider
+comment above this group, since the tests beneath it no longer compare
+against a subprocess pair.
+
+Rewrite `an_unsnapshotted_edit_is_the_one_documented_divergence` to
+snapshot via the real `jj` binary directly (mirroring the file's own
+`jj_revision_oracle` helper, e.g. `run("jj", &["log", "-r", "@", ...])`)
+rather than through `CommandProbe::new().revision(...)`, so this file keeps
+its role of proving the documented divergence — the in-process route does
+not snapshot; asking the real `jj` binary does — after `CommandProbe` is
+gone.
+
+Retitle the module doc comment: "parity with `CommandProbe` on every port
+method" no longer describes what the file proves once there is only one
+implementation. The file has three distinct test groups after this rework,
+not two — describe all three rather than compressing them: (1) the
+boundary rule (`the_boundary_is_the_nearest_marker_not_an_ancestor` and its
+neighbours, unchanged by this phase); (2) `InProcessProbe`'s standalone
+`kind`/`repository_root` behaviour across real checkout shapes (the
+renamed former-parity group — fixed-value checks, not oracle comparisons,
+except where noted next); (3) revision-oracle agreement against the real
+`jj` and `git` binaries directly (`jj_revision_oracle`, used by the
+existing jj-route tests, and the new `git_revision_oracle`, used by
+`a_plain_git_repository_reports_git_kind`). Don't fold (2) into (3) — most
+of group (2)'s tests assert a fixed expected value, not an oracle
+comparison; only the one test that also carries the new
+`git_revision_oracle` assertion belongs to both groups.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] No `CommandProbe` reference remains: `grep -r CommandProbe cli/
+      --include=*.rs` returns no matches
+- [ ] No `MarkerWalkRoot` reference remains: `grep -r MarkerWalkRoot cli/
+      --include=*.rs` returns no matches
+- [ ] No `Command::new` for `jj`/`git` remains in `vcs-adapters`'s non-test
+      code serving `facts`: manual review of `cli/vcs-adapters/src/*.rs`
+      confirms `run_vcs_text` (0198's path) is the only surviving
+      `std::process::Command` use
+- [ ] `cargo test -p vcs-adapters --features bash-parity` passes, including
+      the reworked `tests/library.rs` and `tests/detection.rs`
+- [ ] `cli` component check passes: `mise run cli:check`
+- [ ] `mise run check` passes
+- [ ] `mise run` passes end to end
+
+#### Manual Verification:
+
+- [ ] `an_unsnapshotted_edit_is_the_one_documented_divergence`'s rewritten
+      form still fails if the "does not snapshot" behaviour regresses (spot
+      check by temporarily reverting the assertion's expected value)
+
+---
+
+## Phase 4: Re-run the MPL-2.0 licence check
+
+### Overview
+
+`cli/deny.toml`'s `uluru` exception was recorded conditionally on
+`vcs-adapters` being unreachable from the visualiser's call graph, verified
+at the time (per 0188) only against `accelerator-visualiser`, the launcher,
+and `accelerator-verify`. But `cli/vcs-cli`, `cli/collaboration-cli`,
+`cli/migrate-adapters`, and `cli/work-adapters` each already construct
+`InProcessProbe` directly and call it unconditionally today, independent of
+this plan — dead-code elimination cannot remove directly-called code, so
+their shipped, dispatched binaries (`accelerator-vcs`,
+`accelerator-collaboration`, `accelerator-migrate`, `accelerator-work`)
+very likely already carry the closure. This phase's scope is therefore
+every `DISPATCHED_SUBBINARIES` token (`tasks/shared/paths.py:29-36`) — all
+six: `visualiser`, `vcs`, `work`, `corpus`, `collaboration`, `migrate` — not
+a hand-picked subset. Enumerate from that list directly rather than
+re-deriving it by memory: a prior pass at this same broadening missed
+`migrate` by doing exactly that. Records whatever the build actually shows
+for each; the point is confirming with evidence, not assuming any outcome,
+including for the four binaries already suspected to carry it.
+
+### Changes Required:
+
+#### 1. Build and inspect unstripped release binaries
+
+**Procedure**: Build all six dispatched sub-binaries —
+`accelerator-visualiser`, `accelerator-vcs`, `accelerator-work`,
+`accelerator-corpus`, `accelerator-collaboration`, `accelerator-migrate` —
+with `cargo build --release --config profile.release.strip=false` (the
+workspace's `[profile.release]` sets `strip = true` by default, so a plain
+`cargo build --release` would still strip; the override is needed to
+inspect debug-adjacent build artefacts, though the two grep targets below
+are `.rodata` string literals that `strip` does not remove either way).
+Grep each binary for the two literals that indicate the `gix`/`jj-lib`
+closure is present: `extensions.objectFormat` (gix) and `There is no
+Jujutsu repo` (jj-lib).
+
+#### 2. Update the recorded finding
+
+**File**: `cli/deny.toml`
+**Changes**: Update the `uluru` exception's comment (`:67-81`) with the
+actual current finding for every binary checked above, not only the
+visualiser. If `accelerator-vcs`, `accelerator-collaboration`,
+`accelerator-migrate`, or `accelerator-work` are found to already carry the
+closure — independent of this plan, since each calls `InProcessProbe`
+directly today through a call site unrelated to `facts`/`derive_at` —
+record that as a pre-existing finding this item surfaces, and treat
+MPL-2.0 §3.2's notice obligation as already live for those binaries
+regardless of what this switch does to the visualiser or `corpus`. Only
+`corpus`'s reachability is actually caused by this plan's switch — `work`
+already reaches the closure through `VcsBackedIdentityProbe`'s author
+resolution, not through the `derive_at` path this plan touches. For each
+binary where the closure is unreachable, record that explicitly and note
+the trigger condition remains live for whenever a server or other call
+site is added. Where the closure is reachable (already, or newly via
+`corpus`), flag that a third-party attribution artefact is required for
+`_release_uploads()` (`tasks/github.py:231-248`) and its
+`test_workflows.py` coverage assertion — as a follow-up, since building
+that artefact generation is a separate, larger piece of work than this
+item's stated scope of re-running the check.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] `cargo build --release --config profile.release.strip=false -p
+      accelerator-visualiser -p accelerator-vcs -p accelerator-work -p
+      accelerator-corpus -p accelerator-collaboration -p
+      accelerator-migrate` succeeds
+- [ ] `mise run build-system:check` passes (if `deny.toml`'s comment is the
+      only change, this only needs to stay green, not gain new coverage)
+- [ ] `mise run check` passes
+- [ ] `mise run` passes end to end
+
+#### Manual Verification:
+
+- [ ] The grep-for-literals procedure was actually run against each of the
+      six built binaries, and its outcome (present/absent for each
+      literal, per binary) is recorded in the updated comment
+- [ ] If `accelerator-vcs`, `accelerator-collaboration`,
+      `accelerator-migrate`, or `accelerator-work` are found to already
+      carry the closure, each is called out explicitly as a pre-existing
+      finding rather than folded silently into a comment scoped to the
+      visualiser or attributed incorrectly to this plan's switch
+- [ ] If any binary's closure is found reachable, a follow-up work item is
+      filed for the attribution artefact rather than attempting it inline
+      here
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `VcsProbe::revision`'s sha256 folding behaviour is partially covered by
+  `cli/vcs-adapters/tests/queries.rs`'s
+  `an_unsupported_object_format_fails_rather_than_misreads` and
+  `cli/vcs-adapters/tests/classify.rs`, but neither calls `revision` itself
+  — Phase 1 adds the missing case so the doc comment's claim is backed by a
+  test, not only by adjacent coverage of `is_bare`/`worktree`/
+  `dual_roots`/`classify`.
+- `InProcessProbe`'s existing unit tests (`library.rs:1009-1107`) already
+  cover the four cases `CommandProbe`'s deleted tests covered, plus one they
+  didn't (`an_unreadable_repository_is_an_error`) — no new unit test needed
+  for the deletion itself.
+- The containment-bound decision's "failure distinguishes itself from
+  absence" claim has jj-side proof today
+  (`an_unreadable_checkout_state_reports_absence_rather_than_a_wrong_commit`
+  in `tests/library.rs`) but no git-side equivalent — Phase 1 adds a
+  malformed-git-ref case so both dispatch paths this switch widens the
+  reach of are backed.
+
+### Integration Tests:
+
+- Phase 2's new `zero_spawn.rs` tests are the key end-to-end proof for this
+  item: the corpus metadata-read path, driven through the real
+  `VcsBackedRepoFactsProbe`/`derive_at` composition, spawns no subprocess —
+  for both a git and a jj fixture, since `facts` dispatches differently per
+  `VcsKind`.
+- Phase 3's collapsed `detection.rs` continues proving `InProcessProbe`
+  agrees with itself across all seven checkout shapes (no longer "agrees
+  with `CommandProbe`", since there's only one implementation left).
+- Phase 3's reworked `tests/library.rs` keeps proving the documented
+  snapshot-on-read divergence, now against the real `jj` binary directly
+  rather than through `CommandProbe`.
+
+### Manual Testing Steps:
+
+1. Run `corpus metadata derive` against a real jj repository with
+   unsnapshotted working-copy edits present; confirm `Current Revision:`
+   names the last recorded commit, not a freshly snapshotted one (the one
+   known, accepted behavioural difference from before this switch).
+2. Run `corpus metadata derive` against a bare repository; confirm it still
+   reports no facts.
+3. Run `vcs detect`/`vcs guard` (the hook path) after the switch; confirm
+   no regression, since these paths already used `InProcessProbe` before
+   this item.
+
+## Performance Considerations
+
+None expected — `InProcessProbe` avoids process-spawn overhead entirely
+compared to `CommandProbe`, so the metadata-read path should be faster, not
+slower.
+
+## Migration Notes
+
+No data migration. The one user-visible behavioural change — loss of the
+jj snapshot-on-read side effect on `corpus metadata derive` — is stdout-only
+for `cli/corpus-adapters`' own write paths (per Phase 1's recorded
+confirmation), but skills that copy `corpus metadata derive`'s printed
+`Current Revision:` line into committed `meta/` frontmatter (`create-plan`,
+`research-issue`, `create-note`, and others) inherit the same staleness
+window: an artefact authored with unsnapshotted working-copy edits present
+records the last recorded operation's commit rather than a freshly
+snapshotted one. Accepted as a best-effort provenance degradation, not a
+correctness regression — nothing downstream treats these fields as exact —
+but it is a real, if narrow, change to persisted data, not only to stdout.
+
+## References
+
+- Original work item:
+  `meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md`
+- Related research:
+  `meta/research/codebase/2026-08-10-0185-converge-corpus-adapters-library-backed-vcs.md`
+- Prior review (APPROVE):
+  `meta/reviews/work/0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md`
+- Adapter delivery: `meta/work/0188-library-backed-vcs-adapter.md`
+- Boundary rationale:
+  `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -766,28 +766,33 @@ item's stated scope of re-running the check.
 
 #### Automated Verification:
 
-- [ ] `cargo build --release --config profile.release.strip=false -p
+- [x] `cargo build --release --config profile.release.strip=false -p
       accelerator-visualiser -p accelerator-vcs -p accelerator-work -p
       accelerator-corpus -p accelerator-collaboration -p
       accelerator-migrate` succeeds
-- [ ] `mise run build-system:check` passes (if `deny.toml`'s comment is the
+- [x] `mise run build-system:check` passes (if `deny.toml`'s comment is the
       only change, this only needs to stay green, not gain new coverage)
-- [ ] `mise run check` passes
-- [ ] `mise run` passes end to end
+- [x] `mise run check` passes
+- [x] `mise run` passes end to end
 
 #### Manual Verification:
 
-- [ ] The grep-for-literals procedure was actually run against each of the
+- [x] The grep-for-literals procedure was actually run against each of the
       six built binaries, and its outcome (present/absent for each
-      literal, per binary) is recorded in the updated comment
-- [ ] If `accelerator-vcs`, `accelerator-collaboration`,
+      literal, per binary) is recorded in the updated comment — **deviation**:
+      the literals proved unsound as an absence test (both are missing from
+      binaries that demonstrably link the closure), so the recorded finding
+      is a `gix_`/`jj_lib`/`uluru` symbol count via `nm -a`, with the
+      literals' unreliability itself recorded in the comment
+- [x] If `accelerator-vcs`, `accelerator-collaboration`,
       `accelerator-migrate`, or `accelerator-work` are found to already
       carry the closure, each is called out explicitly as a pre-existing
       finding rather than folded silently into a comment scoped to the
-      visualiser or attributed incorrectly to this plan's switch
-- [ ] If any binary's closure is found reachable, a follow-up work item is
+      visualiser or attributed incorrectly to this plan's switch — all four
+      measured against a pre-switch build, not inferred
+- [x] If any binary's closure is found reachable, a follow-up work item is
       filed for the attribution artefact rather than attempting it inline
-      here
+      here — `work-item:0203`
 
 ---
 

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -465,19 +465,19 @@ Confirm Phase 2's new tests now pass (green), alongside every existing
 
 #### Automated Verification:
 
-- [ ] Both new zero-spawn tests fail before the composition-root change
+- [x] Both new zero-spawn tests fail before the composition-root change
       (verified manually during implementation, not a lasting CI state)
-- [ ] Both new zero-spawn tests pass after the composition-root change:
+- [x] Both new zero-spawn tests pass after the composition-root change:
       `cargo test -p corpus-adapters --features bash-parity --test
       zero_spawn`
-- [ ] Existing corpus-adapters suites pass unchanged: `cargo test -p
+- [x] Existing corpus-adapters suites pass unchanged: `cargo test -p
       corpus-adapters --test parity --test metadata`
-- [ ] `cli` component check passes: `mise run cli:check`
-- [ ] `mise run check` passes
+- [x] `cli` component check passes: `mise run cli:check`
+- [x] `mise run check` passes
 
 #### Manual Verification:
 
-- [ ] `corpus metadata derive` run against a real jj repository still
+- [x] `corpus metadata derive` run against a real jj repository still
       prints the expected `Repository Name:`/`Current Revision:` lines
 
 ---

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -5,7 +5,7 @@ title: "Converge corpus-adapters on the Library-Backed VCS Adapter Implementatio
 date: "2026-08-10T15:52:48+00:00"
 author: Toby Clemson
 producer: create-plan
-status: ready
+status: done
 work_item_id: "work-item:0185"
 parent: "work-item:0185"
 derived_from: ["codebase-research:2026-08-10-0185-converge-corpus-adapters-library-backed-vcs"]

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -678,23 +678,23 @@ comparison; only the one test that also carries the new
 
 #### Automated Verification:
 
-- [ ] No `CommandProbe` reference remains: `grep -r CommandProbe cli/
+- [x] No `CommandProbe` reference remains: `grep -r CommandProbe cli/
       --include=*.rs` returns no matches
-- [ ] No `MarkerWalkRoot` reference remains: `grep -r MarkerWalkRoot cli/
+- [x] No `MarkerWalkRoot` reference remains: `grep -r MarkerWalkRoot cli/
       --include=*.rs` returns no matches
-- [ ] No `Command::new` for `jj`/`git` remains in `vcs-adapters`'s non-test
+- [x] No `Command::new` for `jj`/`git` remains in `vcs-adapters`'s non-test
       code serving `facts`: manual review of `cli/vcs-adapters/src/*.rs`
       confirms `run_vcs_text` (0198's path) is the only surviving
       `std::process::Command` use
-- [ ] `cargo test -p vcs-adapters --features bash-parity` passes, including
+- [x] `cargo test -p vcs-adapters --features bash-parity` passes, including
       the reworked `tests/library.rs` and `tests/detection.rs`
-- [ ] `cli` component check passes: `mise run cli:check`
-- [ ] `mise run check` passes
-- [ ] `mise run` passes end to end
+- [x] `cli` component check passes: `mise run cli:check`
+- [x] `mise run check` passes
+- [x] `mise run` passes end to end
 
 #### Manual Verification:
 
-- [ ] `an_unsnapshotted_edit_is_the_one_documented_divergence`'s rewritten
+- [x] `an_unsnapshotted_edit_is_the_one_documented_divergence`'s rewritten
       form still fails if the "does not snapshot" behaviour regresses (spot
       check by temporarily reverting the assertion's expected value)
 

--- a/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -352,18 +352,18 @@ pub struct VcsBackedRepoFactsProbe;
 
 #### Automated Verification:
 
-- [ ] Workspace builds: `cargo build --workspace` (run from `cli/`)
-- [ ] New sha256 `revision()` test passes and demonstrably calls `revision`
+- [x] Workspace builds: `cargo build --workspace` (run from `cli/`)
+- [x] New sha256 `revision()` test passes and demonstrably calls `revision`
       (not only `is_bare`/`worktree`/`dual_roots`/`classify`):
       `cargo test -p vcs-adapters --features bash-parity --test queries`
-- [ ] New malformed-git-ref `revision()` test passes:
+- [x] New malformed-git-ref `revision()` test passes:
       `cargo test -p vcs-adapters --features bash-parity --test library`
-- [ ] `cli` component check passes: `mise run cli:check`
-- [ ] Full check suite passes: `mise run check`
+- [x] `cli` component check passes: `mise run cli:check`
+- [x] Full check suite passes: `mise run check`
 
 #### Manual Verification:
 
-- [ ] Each doc comment reads as a decision record (states the choice and the
+- [x] Each doc comment reads as a decision record (states the choice and the
       reason), not a description of what the code already shows
 
 ---

--- a/meta/prs/61-description.md
+++ b/meta/prs/61-description.md
@@ -1,0 +1,64 @@
+---
+type: pr-description
+id: "61"
+title: "[0185] Converge corpus-adapters on the Library-Backed VCS Adapter"
+date: "2026-08-11T09:46:24+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+work_item_id: "0185"
+parent: "work-item:0185"
+relates_to: ["work-item:0188", "work-item:0198", "work-item:0203"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/61"
+pr_number: 61
+tags: [rust, vcs, cleanup, tech-debt]
+revision: "47987ff4ddf94a1cda3617c0ad163709d0277570"
+repository: "accelerator"
+last_updated: "2026-08-11T09:46:24+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# [0185] Converge corpus-adapters on the Library-Backed VCS Adapter
+
+## Summary
+
+`vcs_adapters::facts` resolved repository facts by spawning `jj log -r @ -T commit_id` and `git rev-parse HEAD`. 0188 delivered a fully-implemented in-process alternative — `InProcessProbe`, backed by `gix` and `jj-lib` — but deliberately left it unwired, so the crate carried two complete implementations of the same ports. This PR repoints the composition root onto the library-backed probe, deletes the subprocess pair, extends the crate's zero-spawn guarantee to cover the corpus metadata-read path, and records the three policy decisions the switch depends on in the code itself. It also corrects a licensing finding that turned out to be wrong for five of the six shipped sub-binaries.
+
+## Changes
+
+- **Composition root repointed**: `vcs_adapters::facts` now composes `InProcessProbe` for both the `RepoRoot` and `VcsProbe` positions. No `Command::new` for `jj` or `git` remains anywhere on the `facts` path.
+- **Subprocess probes deleted**: `CommandProbe`, `MarkerWalkRoot`, their private `jj_repository_root` helper, and the `OriginRemote`-only `run_checked`/`wait_capped_checked` pair are gone, along with the transitional dual-adapter comparisons in `tests/detection.rs` (`assert_implementations_agree`, `facts_via`) and `tests/library.rs` (`assert_parity`). `scrub_environment`/`run_capped` survive untouched — 0198's `status`/`log` subprocess path shares them, and `subprocess.rs` is now scoped to that alone.
+- **Zero-spawn proof extended across the composition**: a new `corpus-adapters-fixture` reference binary drives the real `VcsBackedRepoFactsProbe` → `vcs_adapters::facts` → `InProcessProbe` chain as a black box, and `tests/zero_spawn.rs` proves it resolves both a plain-git and a pure-jj repository with `git`/`jj` stubbed off `PATH`. Previously only the individual taxonomy queries were proven; the metadata-read path the corpus actually uses was unproven. The fixture lives under `tests/fixtures/` rather than `src/bin/`, mirroring `vcs-adapters-fixture`, so it stays off the crate's normal build surface and out of release staging.
+- **Three policy decisions recorded in code, not left open**: (1) a sha256-format repository is unsupported — `gix` 0.85 cannot read one at all, so `revision` folds to `None` through its existing fallible-to-`Option` contract rather than misreading; (2) no timeout, memory cap, or crash-isolation bound is added around `InProcessProbe`, with the decision naming what it *removes* (the old 10-second cap with kill-on-timeout) and the sharpest blast radius it exposes (`work create` holds a creation lock for the duration of the call, and its reclaim mechanism only reclaims a dead holder); (3) no `corpus-adapters` write path depends on jj's snapshot-on-read side effect, scoped explicitly so it does not imply the same for the authoring skills that copy `Current Revision:` into committed frontmatter.
+- **New tests backing those decisions rather than asserting them**: a sha256 `revision()` case (the existing sha256 tests covered `is_bare`/`worktree`/`dual_roots`/`classify` but never `revision`), and a malformed-git-`HEAD` case giving the git dispatch path the graceful-failure proof the jj path already had.
+- **Git-side revision oracle added**: deleting `assert_parity` removed the only place that cross-checked `InProcessProbe`'s git revision against the real `git` binary, leaving a 40-hex format check as the sole guard. A `git_revision_oracle` helper mirroring the existing `jj_revision_oracle` closes that, so the simplification stays symmetric.
+- **MPL-2.0 finding corrected**: `cli/deny.toml`'s `uluru` exception was recorded on the premise that dead-code elimination stripped the whole `gix`/`jj-lib` closure from every shipped binary. Measured across all six `DISPATCHED_SUBBINARIES` on unstripped `--release` builds, the premise holds only for the visualiser. `accelerator-vcs`, `accelerator-work`, `accelerator-collaboration` and `accelerator-migrate` already linked it *before* this change (each constructs `InProcessProbe` directly through call sites unrelated to `facts`); `accelerator-corpus` is the one this switch causes. Follow-up `work-item:0203` filed for the attribution artefact the release upload set now owes.
+- **Verification method corrected too**: the two string literals the original procedure relied on (`extensions.objectFormat`, `There is no Jujutsu repo`) are unsound as an absence test — both are missing from binaries that demonstrably link the closure. The recorded finding is now a `gix_`/`jj_lib`/`uluru` symbol count via `nm -a`, with the literals' unreliability recorded alongside it so the next person does not repeat the mistake.
+
+## Context
+
+Implements `work-item:0185` (Converge corpus-adapters on the Library-Backed VCS Adapter), researched in `meta/research/codebase/2026-08-10-0185-converge-corpus-adapters-library-backed-vcs.md`, planned in `meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md`, reviewed at both the work-item and plan level (`meta/reviews/work/0185-...-review-1.md` and `meta/reviews/plans/2026-08-10-0185-...-review-1.md`, both APPROVE), and validated in `meta/validations/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-validation.md` (result: pass).
+
+Completes the convergence 0169 deliberately deferred and `work-item:0188` set up: 0188 built and proved `InProcessProbe` without wiring it, so that the composition switch could be reviewed on its own merits. Bounded against `work-item:0198`, which owns the separate `status`/`log` subprocess path and is the reason `scrub_environment`/`run_capped` survive this deletion.
+
+Surfaces `work-item:0203` as its own follow-up: MPL-2.0 §3.2's notice obligation is live today for five shipped binaries, four of them independently of this change.
+
+## Testing
+
+- [x] `mise run check` — the read-only CI-equivalent gate across frontend, server, cli, build-system and scripts — exits 0.
+- [x] `mise run test:unit:cli` — 1486/1486 pass across the whole `cli/` workspace, including the reworked `detection.rs`/`library.rs` and both new decision-backing tests.
+- [x] `mise run test:integration:zero-spawn` — passes. The metadata-read test is verified non-vacuous: both shapes resolve real facts (`name=PG revision=1cbe1df0…`, `name=c revision=32922826…`) rather than matching as "absent" twice.
+- [x] The strong-form zero-spawn lane was simulated locally — the compiled `zero_spawn` binary run under `env -i` with a `PATH` carrying no `git`/`jj` and the fixture matrix handed over via `ACCELERATOR_ZERO_SPAWN_MATRIX`. This caught a real break in the first cut of the new tests (they built fixtures inside the test body, which the shadow window cannot support) and verified the fix against a proven red.
+- [x] No `CommandProbe` or `MarkerWalkRoot` reference remains anywhere under `cli/`; the only surviving `std::process::Command` uses in `vcs-adapters` non-test code serve 0198's `status`/`log` path.
+- [x] The MPL-2.0 finding reproduces independently by symbol count on the existing release artefacts, matching what `cli/deny.toml` now records.
+- [ ] Not verified this session: the Linux CI lane, and the real `test:integration:zero-spawn:strong` job — it `sudo mv`s system `git`/`jj` and belongs on an ephemeral runner, so it was covered by the simulation above rather than run locally.
+
+## Notes for Reviewers
+
+- **The one user-visible behavioural change** is the loss of jj's snapshot-on-read side effect on `corpus metadata derive`. For `corpus-adapters`' own Rust write paths this is stdout-only (`work create` reads the derived timestamp, never the revision). It is *not* stdout-only for the authoring skills — `create-plan`, `research-issue`, `create-note` and others copy the printed `Current Revision:` into committed `meta/` frontmatter, so an artifact authored with unsnapshotted edits present now records the last recorded commit. Accepted as a best-effort provenance degradation rather than a correctness regression, and documented as such on `VcsBackedRepoFactsProbe`.
+- **The containment decision deserves a second opinion.** It removes a 10-second cap with kill-on-timeout from the `facts()` call site and adds nothing in its place, on the grounds that the same unbounded exposure already runs on the hook path and no crash-isolation precedent exists in the workspace. The doc comment names the `work create` lock blast radius explicitly and states a structural revisit condition. If you disagree with the trade, this is the place to say so.
+- **`work-item:0203` is a licensing obligation, not a nice-to-have.** It is filed but `ready`, not done. Four of the five affected binaries were already shipping the MPL-2.0 closure before this PR, so the obligation predates it — flagging so the finding is not read as introduced here, nor assumed closed by it.
+- **One narrow behaviour is documented but untested**: `InProcessProbe::repository_root` canonicalises where `MarkerWalkRoot` did not, so if the repository directory itself is a symlink the canonicalised final path component can change the persisted `Repository Name:`. Judged too narrow to warrant new test infrastructure; say if you would rather it were pinned.
+- **One commit exceeds the plan's stated scope**: "Strip comments that restate the code or name deleted implementations" also removes stale bash-port references from `corpus-adapters`' `work_item_pattern.rs` and `tests/parity.rs`, files the plan never named. Consistent with the repo's comment policy and with prior precedent, but called out rather than folded in silently.
+- **History reviews commit by commit**: policy decisions → composition switch → deletion → licence finding → comment cleanup → zero-spawn lane fix → validation. The deletion commit is large but purely subtractive.

--- a/meta/research/codebase/2026-08-10-0185-converge-corpus-adapters-library-backed-vcs.md
+++ b/meta/research/codebase/2026-08-10-0185-converge-corpus-adapters-library-backed-vcs.md
@@ -1,0 +1,681 @@
+---
+type: codebase-research
+id: "2026-08-10-0185-converge-corpus-adapters-library-backed-vcs"
+title: "Research: Converge corpus-adapters on the Library-Backed VCS Adapter (0185)"
+date: "2026-08-10T14:55:36+00:00"
+author: Toby Clemson
+producer: research-codebase
+status: complete
+work_item_id: "0185"
+parent: "work-item:0185"
+relates_to: ["codebase-research:2026-08-02-0188-library-backed-vcs-adapter", "codebase-research:2026-07-29-0169-vcs-subdomain-and-hooks-migration"]
+topic: "Converge corpus-adapters on the Library-Backed VCS Adapter (0185)"
+tags: [research, codebase, rust, vcs, corpus-adapters, vcs-adapters, gix, jj-lib]
+revision: "63fe1c0a8b6673b026f71c7506943ca50cbec0e9"
+repository: "accelerator"
+last_updated: "2026-08-10T14:55:36+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Research: Converge corpus-adapters on the Library-Backed VCS Adapter (0185)
+
+**Date**: 2026-08-10T14:55:36+00:00
+**Author**: Toby Clemson
+**Git Commit**: 63fe1c0a8b6673b026f71c7506943ca50cbec0e9
+**Branch**: (jj workspace, no active bookmark)
+**Repository**: accelerator
+
+## Research Question
+
+What does the live codebase look like for work item
+[0185](../../work/0185-converge-corpus-adapters-on-library-backed-vcs.md) —
+"Converge corpus-adapters on the Library-Backed VCS Adapter" — so a plan can
+be written for it? Specifically: what does `vcs_adapters::facts` wire up
+today, what exactly is `CommandProbe` and what depends on it, how does
+`cli/corpus-adapters` consume `RepoFacts`, what is the shared zero-spawn test
+harness and how would it extend to the metadata-read path, what do the
+licence/lint gates (`deny.toml`, `pup.ron`) say today, where would the
+sha256-repository policy decision be recorded, and does the visualiser server
+or a hook path already reach the code this item repoints?
+
+## Summary
+
+0185 is a well-scoped wiring-plus-deletion task with a **completed,
+APPROVE-verdict work-item review already on file**
+(`meta/reviews/work/0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md`,
+Pass 2, 2026-08-10) — the item text itself is internally consistent and ready
+for implementation. Its blocker, 0188, is done and delivered a fully
+functional `InProcessProbe` with no gaps: `revision` and `kind` are both
+completely implemented, not partial. The mechanical core of the task —
+repoint `vcs_adapters::facts`, delete `CommandProbe`, collapse the transitional
+dual-adapter test comparison — is small and precisely bounded.
+
+Three things the live codebase shows that the work item's own text does not
+(all worth carrying into the plan):
+
+1. **The `corpus-adapters` call site has moved behind a new abstraction since
+   the work item's Technical Notes were last checked.** It is no longer an
+   inline call inside `derive_at`; it is a one-line body inside
+   `VcsBackedRepoFactsProbe::facts` (`cli/corpus-adapters/src/metadata.rs:214`),
+   a narrower and cleaner blast radius than the work item describes. The line
+   numbers the work item cites (`:201`, `:185-186`) no longer apply.
+2. **`cli/corpus-adapters/tests/work_item_pattern_parity.rs`, named in AC2,
+   does not exist** — the closest thing is a unit-test module inside
+   `work_item_pattern.rs` and an unrelated regex test in `parity.rs`, neither
+   of which is VCS-related.
+3. **The existing zero-spawn test (`corpus-adapters/tests/zero_spawn.rs`)
+   does not yet cover the metadata-read path at all.** It proves
+   `InProcessProbe`'s individual queries don't spawn (via a reference binary
+   in `vcs-adapters`), but that reference binary never calls
+   `vcs_adapters::facts` or `VcsBackedRepoFactsProbe`. AC3's "extend the
+   zero-spawn assertion to cover a `corpus-adapters` metadata read" is new
+   test-authoring work, not an extension of an existing assertion, and the
+   `Stubs` harness is `Command`-shaped (it patches a child process's `PATH`),
+   so the extension most naturally needs a new small reference-binary entry
+   point rather than an in-process call from the test itself.
+
+Everything else lines up cleanly with the work item's own text: `markers.rs`
+is genuinely shared and must not be touched; `scrub_environment`/`run_capped`
+(the "capped_stdout" helpers) are genuinely shared with 0198's
+`run_vcs_text` and must survive; no discovered write path depends on the
+jj snapshot-on-read side effect; the `uluru` MPL-2.0 exception, the `gix`/
+`jj-lib` pins, and the `vcs_adapters_library_reads_in_process` pup rule are
+all exactly as described; `check-zero-spawn` is confirmed to be a standalone
+CI job, not part of default `mise run`/`mise run check`; and the visualiser
+server does not yet reach `vcs_adapters::facts` at all today (dead-code
+elimination strips the whole `gix`/`jj-lib` closure from the shipped
+binary), though `InProcessProbe` already runs unbounded, synchronously, on
+the hook path for `detect`/`guard` — a pre-existing, uncontained exposure
+this item's containment AC should be read against.
+
+## Detailed Findings
+
+### `cli/vcs-adapters` — composition root, `CommandProbe`, `InProcessProbe`
+
+**Composition root** — `cli/vcs-adapters/src/lib.rs:22-26`:
+```rust
+use crate::subprocess::{CommandProbe, MarkerWalkRoot};
+
+#[must_use]
+pub fn facts(start: &Path) -> Option<RepoFacts> {
+    vcs::facts(start, &MarkerWalkRoot, &CommandProbe::new())
+}
+```
+This is the entire repoint: swap the import and the two arguments for
+`library::InProcessProbe`, which already implements both `RepoRoot` and
+`VcsProbe` and can serve both positions as a single value (unit struct,
+`Default`). `lib.rs:12-14` declares `pub mod library; mod markers; pub mod
+subprocess;` — `markers` is crate-private.
+
+**`CommandProbe`** — `cli/vcs-adapters/src/subprocess.rs:65-139`. Struct +
+`cap: Duration`, `impl VcsProbe` (`kind` delegates to
+`crate::markers::marker_kind`, shared with `InProcessProbe::kind`; `revision`
+spawns `jj log -r @ -T commit_id` / `git rev-parse HEAD` via
+`scrub_environment` + `run_capped`) and `impl OriginRemote` (spawns `git
+remote get-url origin` via `scrub_environment` + `run_checked`). This whole
+span is what 0185 deletes.
+
+**Safe-to-delete alongside it**: `wait_capped_checked`/`run_checked`
+(`subprocess.rs:329-407`) — used only by `CommandProbe`'s `OriginRemote` impl,
+nothing else calls them; and three `CommandProbe`-flavoured unit tests
+(`subprocess.rs:583-632`, `a_configured_origin_is_reported`,
+`no_origin_remote_is_reported_as_none`, `a_directory_with_no_repository_is_an_error`)
+— redundant, since `library.rs:1009-1107` already carries equivalent
+`InProcessProbe`-based versions of all three (plus a fourth,
+`an_unreadable_repository_is_an_error`, that `subprocess.rs` has no
+counterpart for).
+
+**Must NOT be deleted — shared with 0198's `status`/`log` path** (verifies
+the work item's own caution): `scrub_environment` (`subprocess.rs:231-246`)
+is called by `CommandProbe::revision` (`:119`), `CommandProbe`'s
+`OriginRemote::origin_url` (`:136`), **and** `run_vcs_text` (`:215`, the
+function backing `status`/`log`, owned by 0198). `run_capped`/`wait_capped`
+(`:248-324`, the actual name of the "capped_stdout" helper — there is no
+literal function called `capped_stdout`) are likewise called by both
+`CommandProbe::revision` (`:122`) and `run_vcs_text`'s final line (`:226`).
+Eight unit tests inside `subprocess.rs` (`:442-568`) exercise these two
+helpers directly with generic `sh`/`sleep`/`true`/`false`/`printf` stand-ins,
+never touching `CommandProbe` — these belong to the 0198-owned surface and
+must be kept as-is.
+
+**`MarkerWalkRoot`** (`subprocess.rs:31-43`) is not on the delete list — it
+delegates to `crate::markers` and is still referenced by
+`tests/library.rs`'s own parity assertions today; nothing in 0185's scope
+requires removing it, only the `facts()` composition that currently wires it
+in.
+
+**`InProcessProbe`** (`cli/vcs-adapters/src/library.rs:190` onward, 1108
+lines total) — implements `RepoRoot` (`:446-455`), `VcsProbe` (`:457-478`),
+`UserIdentityProbe` (`:480-497`), `OriginRemote` (`:499-503`),
+`vcs::classify::CheckoutProbe` (`:409-431`) and `vcs::mode::ModeProbe`
+(`:433-444`), plus the six inherent taxonomy queries (`is_bare` `:201-204`,
+`worktree` `:212-238`, `superproject` `:248-269`, `jj_workspace_root`
+`:276-288`, `jj_repository` `:297-330`, `dual_roots` `:334-339`). **Both
+`revision` and `kind` are fully implemented with no `todo!`/`unimplemented!`
+anywhere in the file.** `revision`'s jj half (`:594-628`) reads the
+checkout-state protobuf and op-store directly — no `jj` binary, no snapshot
+side effect; the git half (`:533-554`) uses `gix::discover`.
+
+**`markers.rs`** (51 lines) — its own doc comment states its purpose
+directly: *"The ancestor walk and marker reading both adapters share. Each
+delegates to these rather than to the other, so retiring either strands
+nothing."* Both `subprocess.rs` and `library.rs` import from it. Must not be
+deleted.
+
+**`tests/detection.rs`** (352 lines, gated `#![cfg(feature = "bash-parity")]`)
+— the "dual comparison" is two helper functions plus a shared assertion, not
+a table or macro:
+```rust
+fn facts(start: &Path) -> Option<RepoFacts> {
+    facts_via(start, &MarkerWalkRoot, &CommandProbe::new())
+}
+fn library_facts(start: &Path) -> Option<RepoFacts> {
+    facts_via(start, &InProcessProbe, &InProcessProbe)
+}
+```
+plus `assert_implementations_agree(start)` (`:138-154`), called at the end of
+each of the seven shape-specific tests. Collapsing it means deleting the
+`CommandProbe`/`MarkerWalkRoot` imports and the `facts`/`facts_via`/
+`assert_implementations_agree` scaffolding, and having every test call
+`vcs::facts(&x, &InProcessProbe, &InProcessProbe)` (or a single renamed
+`facts` helper) directly.
+
+**A discrepancy worth flagging to the plan**: the work item's Requirements
+describe a ".git-as-file worktree case" that "keeps today's
+(`CommandProbe`-oracle) value" as a known, pinned divergence. No such
+divergence exists in `detection.rs` today —
+`a_worktree_whose_git_marker_is_a_file_is_recognised` (`:284-322`) calls the
+same `assert_implementations_agree` as every other test and the two probes
+agree on it. **The only documented divergence anywhere in the crate is the
+jj-snapshot-on-read case**, pinned in
+`cli/vcs-adapters/tests/library.rs:431-474`
+(`an_unsnapshotted_edit_is_the_one_documented_divergence`), and
+`detection.rs`'s own doc comment on `assert_implementations_agree`
+(`:126-132`) explicitly defers to it: *"The one shape where the two can
+legitimately differ is out of reach here... `library.rs` pins the divergence
+itself."* Treat the work item's worktree-divergence framing as stale; the
+real, single divergence is the snapshot one.
+
+**`Cargo.toml`** — `bash-parity` (`:12-16`) is an empty feature flag gating,
+via `#![cfg(feature = "bash-parity")]`, every real-binary integration test
+across `tests/detection.rs`, `tests/library.rs`, `tests/scrub.rs`,
+`tests/classify.rs`, `tests/queries.rs`. It means "needs real `jj`/`git` to
+build fixtures," not "shells out in production," and stays relevant after
+0185 (fixtures are still built with real binaries).
+
+### `cli/corpus-adapters` — the consumer
+
+**Current call site** — `cli/corpus-adapters/src/metadata.rs:209-220`:
+```rust
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VcsBackedRepoFactsProbe;
+
+impl RepoFactsProbe for VcsBackedRepoFactsProbe {
+    fn facts(&self, start: &Path) -> Option<RepositoryFacts> {
+        let facts = vcs_adapters::facts(start)?;
+        Some(RepositoryFacts {
+            name: facts.name,
+            revision: facts.revision,
+        })
+    }
+}
+```
+`derive_at` (`:228-236`) takes `facts_probe: &dyn RepoFactsProbe` by
+injection and calls `facts_probe.facts(start)` — the `vcs_adapters` name
+never appears there. This is narrower than the work item's described blast
+radius (an inline call "inside `derive_at`" at `:201`) — an intermediate
+`RepoFactsProbe` seam has been introduced since the work item's Technical
+Notes were written, and since `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md`
+was researched. **0185's actual repoint target is the single line
+`vcs_adapters::facts(start)` at `metadata.rs:214`** — nothing else in
+`corpus-adapters` needs to change signature. `derive` (`:196-207`) reads
+`.name`/`.revision` a second time from the already-translated
+`RepositoryFacts`, at `:204-205`, formatting them via `render()`
+(`:241-260`) into `"Repository Name: {name}"`/`"Current Revision: {revision}"`
+lines. This module only computes/formats a string block; it writes no file
+itself.
+
+**`tests/zero_spawn.rs`** (105 lines, `#![cfg(feature = "bash-parity")]`) —
+spawns the compiled `vcs-adapters-fixture` binary (declared in
+`cli/vcs-adapters/Cargo.toml:23-25`) as a subprocess, running every fixture
+through it twice (unrestricted vs. `Stubs`-applied `PATH`), asserting
+identical stdout and no marker written. **This never exercises
+`vcs_adapters::facts` or `corpus_adapters::metadata` at all** — the fixture
+binary's `main()` calls `vcs_adapters::library::InProcessProbe` directly,
+never the composition in `lib.rs`. Extending coverage to the metadata read
+(AC3) needs either (a) a new query added to the `vcs-adapters-fixture`
+binary that calls `vcs_adapters::facts` itself (that binary already lives in
+the `vcs-adapters` crate, so no new dependency edge), or (b) a
+`corpus-adapters`-local reference binary calling `VcsBackedRepoFactsProbe`/
+`derive_at` directly. Either way, `Stubs::apply` only patches a
+`std::process::Command`'s `PATH`, so the harness inherently needs the code
+under test to run as a spawned child process, not called in-process from the
+test.
+
+**`tests/parity.rs`, `tests/metadata.rs`** — both read in full. Neither
+touches `CommandProbe`, subprocess timing, or the jj snapshot-on-read side
+effect. `parity.rs` is entirely doc-type-inference/regex-compilation
+testing, no VCS import at all. `metadata.rs` (no `bash-parity` gate — always
+runs) builds `RepositoryFacts` by hand via a local `facts()` test helper and
+never constructs a real `VcsBackedRepoFactsProbe`; its only host-touching
+tests call `SystemClock::try_new()`, which spawns `date`, never `jj`/`git`.
+Both suites should genuinely "keep passing unchanged" through the
+`CommandProbe → InProcessProbe` swap, as AC2 requires.
+
+**`tests/work_item_pattern_parity.rs`, named in AC2, does not exist.** The
+crate's actual test files are `zero_spawn.rs`, `metadata.rs`, `parity.rs`,
+`doc_type_single_source.rs`, `store.rs`. The logic that name suggests lives
+as unit tests inside `src/work_item_pattern.rs`'s own `#[cfg(test)] mod
+tests` — pure-Rust, no VCS, no bash oracle. Flag this as a stale AC reference
+to correct or drop when the plan revisits acceptance criteria.
+
+**Separately**: a bash-oracle metadata parity test referenced in the 0188
+research (`derive_at_agrees_with_the_live_metadata_helper`, comparing
+against `scripts/artifact-derive-metadata.sh`) no longer exists in the tree
+— both the test and the script are gone, presumably retired when
+`corpus-cli` subsumed the bash metadata helpers.
+
+**No write path depends on the snapshot-on-read side effect.** Two
+production callers of `derive_at`/`VcsBackedRepoFactsProbe` exist in the
+whole `cli/` workspace:
+- `cli/corpus-cli/src/main.rs:72-86` (`corpus metadata derive`) — prints the
+  rendered block, including revision, to **stdout only**; no file write.
+- `cli/work-cli/src/create.rs:258-301` (`work create`, the one Rust write
+  path that persists frontmatter via `AtomicWrite::write` at `:301`) — reads
+  only `metadata.datetime_utc` (`:285`, from the injected `Clock`).
+  `metadata.revision`/`.repository_name` are computed but never referenced
+  in the written frontmatter.
+
+This satisfies the AC requiring confirmation that no corpus write path
+depends on the snapshot side effect — with the caveat that this research did
+not trace into `scripts/`/skill layer beyond the Rust boundary, in case a
+shell skill separately consumes the printed revision from `corpus metadata
+derive`'s stdout.
+
+**`Cargo.toml`** — `corpus-adapters` already depends on `vcs-adapters`
+(`:25`, normal dependency — no manifest change needed for the repoint) and
+on `vcs-test-support` (`:37`, dev-only, with an explanatory comment about why
+it must stay dev-only: `cli/visualiser/server` depends on `corpus-adapters`,
+so fixture-building machinery must not leak into production). It does not
+depend on the `vcs` crate directly — only on `vcs_adapters::facts`'s
+`Option<vcs::RepoFacts>` return, immediately translated into corpus's own
+`RepositoryFacts`.
+
+A separate consumer outside this sweep: `cli/migrate-adapters/src/context.rs:89`
+calls `vcs::facts` directly (not `vcs_adapters::facts`) with its own injected
+probe — an independent subsystem (the migration engine), out of scope for
+0185.
+
+### `cli/vcs-test-support` — the shared zero-spawn harness
+
+Located at `cli/vcs-test-support/` (workspace member). Public API across
+four modules (`src/lib.rs:1-11`):
+
+- **`stubs.rs`** — `Stubs::rooted_at(base)` writes marker-writing shell-script
+  stubs for `git`/`jj` and computes a synthetic `PATH` (stub dir first, then
+  every PATH entry that doesn't itself resolve a real `git`/`jj`).
+  `Stubs::apply(&self, command: &mut Command)` sets `PATH` on a `Command`;
+  `Stubs::spawns()` reports whether a stub ran. `Mode` (`PathOnly`/`Strong`)
+  is read from `ACCELERATOR_ZERO_SPAWN_MODE`; `assert_shadowing_holds(mode)`
+  re-verifies the `Strong`-mode shadow list at runtime.
+  `unshadowed_paths()` returns the absolute-path shadow list — every `PATH`
+  entry with a real `git`/`jj`, plus a hardcoded superset
+  (`/usr/bin/git`, `/usr/local/bin/git`, `/opt/homebrew/bin/git` and the `jj`
+  equivalents) checked unconditionally via `is_executable()`. "Platform-aware"
+  means the *same* fixed list is checked everywhere, with platform
+  differences arising from which paths actually resolve on a given host, not
+  from separate compiled lists. All privileged shadowing (`sudo mv`) lives in
+  `tasks/test/integration.py`, not in this crate — the crate only reports
+  paths, never mutates outside its own temp directories.
+- **`hermetic.rs`** — `Hermetic::rooted_at(base)` builds an empty `HOME`/
+  `XDG_CONFIG_HOME` plus a fixed-identity `jj.toml`; `apply(&self, command)`
+  sets `HOME`, `XDG_CONFIG_HOME`, `JJ_CONFIG`, `GIT_CEILING_DIRECTORIES`,
+  `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null`, and strips 8
+  ambient `GIT_*` variables. Also exposes `assert_no_repository_ancestor`,
+  `assert_jj_matches`, `assert_git_is_recent_enough`.
+- **`fixtures.rs`** — `Matrix`/`Fixture`/`matrix_root()`/`pure_jj()`, the full
+  checkout-shape fixture matrix builder.
+- **`masks.rs`** — golden-output redaction, shared with a Python golden
+  generator via `hooks/test-fixtures/masks.toml`.
+
+**Flagship consumer**: `cli/corpus-adapters/tests/zero_spawn.rs` is the one
+proving the harness works across a crate boundary — it drives `fixtures`,
+`stubs::{Stubs, Mode, assert_shadowing_holds, reference_artefact,
+unshadowed_paths}` end to end. Nine other files across `vcs-cli`,
+`vcs-adapters`, `corpus-cli`, and `migrate-cli` also depend on it, mostly for
+`Hermetic`.
+
+**`check-zero-spawn` CI job** (`.github/workflows/main.yml:323-377`) — its
+own `ubuntu-latest` job (macOS can't shadow system binaries under SIP), wired
+into `prerelease.needs` (`:436`). Underlying task:
+`test:integration:zero-spawn:strong` → `tasks/test/integration.py:181-241`,
+refusing to run unless `ACCELERATOR_ZERO_SPAWN_SHADOW=yes`, `sudo mv`-ing
+real binaries aside, running the nextest suite, restoring in a `finally`.
+**Confirmed: neither the `PathOnly` nor `Strong` form is reachable from
+`mise run`, `mise run check`, or any roll-up task** — `test:integration`,
+`test`, `check`, and `default` in `mise.toml` all deliberately exclude it
+(confirmed by grep and by the tasks' own doc comments: "its own CI job, not
+the test roll-up"). This directly answers AC3's open question: the strong
+form runs only via `check-zero-spawn` in CI, gated separately from the
+default `mise run`/`check` invocation the item's frontmatter otherwise
+requires green.
+
+### Licence and lint gates
+
+**`cli/deny.toml:67-81`** — the `uluru` exception, quoted in full:
+```toml
+# uluru is gix-pack's LRU pack cache, enabled by gix-odb's default features, so
+# it cannot be feature-gated out. MPL-2.0 is file-level weak copyleft: we ship
+# no modifications, and §3.2's notice obligation does not bind because dead-code
+# elimination removes the whole gix/jj-lib closure from the only shipped binary
+# that reaches it. Re-check that when anything makes the visualiser reach
+# vcs-adapters: once the trees link, distributing the binary requires telling
+# recipients how to obtain the source, which the release upload set carries no
+# artefact for.
+#
+# Verify with: an unstripped --release accelerator-visualiser carries neither
+# the `extensions.objectFormat` (gix) nor the `There is no Jujutsu repo`
+# (jj-lib) literal, both of which the linked reference artefact does carry.
+[[licenses.exceptions]]
+crate = "uluru"
+allow = ["MPL-2.0"]
+```
+This re-check is a **manual procedure, not an automated test** — confirmed
+by a repo-wide search for the two literal strings (`extensions.objectFormat`,
+`There is no Jujutsu repo`), which appear only in prose/comments, never as a
+grep target inside a `.py`/`.rs` test. `tests/integration/deny/test_vcs_library_graph.py`
+(384 lines, 12 tests) covers version pinning, feature presence/absence,
+MSRV, and build-script/proc-macro checks — none build or grep an unstripped
+visualiser binary. The plan should treat this as a step to perform (build
+`--release` unstripped, count `gix`/`jj-lib`/`clru`/`uluru` symbols against a
+baseline, grep both literals), matching the procedure already carried out
+for 0188 and recorded in `meta/validations/2026-08-03-0188-library-backed-vcs-adapter-validation.md:328-341`.
+
+**`cli/Cargo.toml:72-73`** — `jj-lib = "=0.43.0"`; `gix = { version =
+"~0.85.0", default-features = false }`, both with inline coupling comments,
+exactly as the work item states.
+
+**`cli/pup.ron:140-163`** — the `vcs_adapters_library_reads_in_process` rule,
+quoted in full:
+```
+Module((
+    name: "vcs_adapters_library_reads_in_process",
+    matches: Module("^vcs_adapters::library($|::)"),
+    rules: [
+        RestrictImports(
+            allowed_only: Some([
+                "^(std|core|alloc)(::|$)", "^dunce(::|$)", "^etcetera(::|$)",
+                "^gix(::|$)", "^jj_lib(::|$)", "^pollster(::|$)",
+                "^prost(::|$)", "^tracing(::|$)", "^vcs(::|$)", "^crate(::|$)",
+            ]),
+            denied: Some(["^std::process(::|$)"]),
+            severity: Error,
+        ),
+    ],
+)),
+```
+Slightly broader than the work item's shorthand ("permit `std`, `gix`,
+`jj_lib`, `kernel`, `vcs`, `crate::`") — it also permits `dunce`, `etcetera`,
+`pollster`, `prost`, `tracing` (jj-lib's own helper crates) and does not
+mention `kernel` at all. No equivalent rule exists for `corpus-adapters`.
+
+**`tasks/github.py:231-248`** (not `tasks/build.py` — the work item's file
+guess is off by one module) — `_release_uploads()` enumerates debug
+archives, the launcher binary + signature, the release manifest + signature,
+and per-sub-binary assets. **No licence-file/attribution-artefact machinery
+exists anywhere in `tasks/` today** — confirmed by search, and consistent
+with 0188's own validation record noting an earlier draft comment falsely
+claimed a staged licence file existed. Coverage is enforced by
+`tests/unit/tasks/test_workflows.py:207-221`
+(`test_attest_globs_cover_every_published_asset`), which asserts every path
+`_release_uploads()` returns is matched by a CI attest-step glob — so adding
+an attribution artefact (if AC5 requires one) needs a generation step, a
+path helper, an `uploads.append(...)` inside `_release_uploads()`, and a
+matching CI glob, or that test fails.
+
+### `cli/vcs` — port contracts, `RepoFacts`, and where the sha256 decision belongs
+
+`cli/vcs/src/lib.rs:19-73` — `VcsKind` (`Jj`/`Git`/`None`), `RepoFacts { root,
+name, kind, revision }`, `RepoRoot` (infallible, `Option`-returning), and
+`VcsProbe`:
+```rust
+/// Reports a repository's idiom and its working-copy revision.
+pub trait VcsProbe {
+    fn kind(&self, root: &Path) -> VcsKind;
+
+    /// The full working-copy revision, or `None` when the repository has none
+    /// and when the probe cannot answer. A caller cannot distinguish the two;
+    /// an adapter is expected to log the failure.
+    fn revision(&self, root: &Path, kind: VcsKind) -> Option<String>;
+}
+```
+
+**No README or markdown file exists under `cli/vcs/` or `cli/vcs-adapters/`**
+— the crate's "port-contract documentation" is entirely doc comments on the
+traits themselves, and there is clear existing precedent for recording
+exactly this kind of policy decision there:
+`OriginRemote::origin_url`'s doc comment
+(`cli/vcs/src/origin_remote.rs:12-22`) explicitly documents a divergent
+error-handling contract ("callers must be able to distinguish 'cleanly
+absent' from 'probe malfunctioned', unlike `RepoRoot`/`VcsProbe`'s infallible
+fold-to-`None` convention"), and `CheckoutProbe`'s trait doc
+(`cli/vcs/src/classify.rs:78-90`) and `checkout::DualRoots`'s struct doc
+(`cli/vcs/src/checkout.rs:31-36`) do the same for their own fallibility
+rules. **The natural location for the sha256 decision is a doc comment on
+`VcsProbe`/`VcsProbe::revision` in `cli/vcs/src/lib.rs:65-73`**, following
+that precedent.
+
+`is_full_revision_id` exists **only** in `cli/vcs-adapters/tests/detection.rs:94-96`
+— not in production code anywhere — and already carries a doc comment naming
+the exact decision this item must record:
+```rust
+/// Note this rejects a **sha256** repository's 64-hex id. That is deliberate
+/// here: no fixture in this suite uses one. Any wider revision validation has to
+/// accept both widths or record sha256 as unsupported — a decision the
+/// composition-root switch inherits, since it is what exposes users to it.
+fn is_full_revision_id(revision: &str) -> bool {
+    revision.len() == 40 && revision.chars().all(|c| c.is_ascii_hexdigit())
+}
+```
+
+The sha256 failure mode itself (`gix` 0.85 returns `Err` rather than
+misreading) is already documented and tested in
+`cli/vcs-adapters/tests/queries.rs:562-567`
+(`an_unsupported_object_format_fails_rather_than_misreads`) and
+`cli/vcs-adapters/tests/classify.rs:191-198`. `VcsProbe::revision` is
+infallible, so `library.rs`'s `git_revision` already folds any `gix`
+failure — sha256 included — to `None` with a `warn!` log
+(`library.rs:533-539`), matching `revision`'s documented contract. No new
+`Error` variant is strictly required to represent the failure; what's
+missing is only the policy decision and where it's written down.
+`kernel::Error` (`cli/kernel/src/lib.rs:10-20`) has `LogFilter`/`Failed`/
+`Refusal` variants and no unsupported-format-specific one; `vcs_adapters::library::Error`
+(`library.rs:69-108`) already carries `Git { path, source }`, which a
+sha256-triggered `gix` failure naturally routes through today.
+
+### Visualiser server and hook-path reachability
+
+**No code path inside `cli/visualiser/server/src` calls `derive_at`,
+`VcsBackedRepoFactsProbe`, or `vcs_adapters::facts` today.** The only two
+production callers of `derive_at` in the whole workspace are
+`cli/work-cli/src/create.rs:258-263` and `cli/corpus-cli/src/main.rs:72-86` —
+both short-lived, skill-invoked CLI processes, not the server. The
+server does depend on `corpus_adapters`/`vcs-adapters` at the Cargo level
+(`visualiser/server/Cargo.toml:22-23` → `corpus-adapters/Cargo.toml:25`,
+unconditional), but the three `corpus_adapters` surfaces it actually calls
+(`frontmatter.rs`, `compose.rs`, `file_driver.rs`) are frontmatter parsing,
+the work-item-id regex scanner, and the status-only frontmatter patcher —
+none touch `corpus_adapters::metadata`. This matches 0188's own verified
+finding (quoted in 0185's Amendment inheritance 5): the whole `gix`/`jj-lib`
+closure is currently dead-code-eliminated from the shipped
+`accelerator-visualiser` binary. **0185's framing that "this switch is what
+first makes `cli/visualiser/server` reachable into `vcs-adapters`'s closure"
+appears to describe a server-side call site that does not exist in this
+codebase yet** — worth flagging to whoever owns 0185/0168, since the
+containment decision may need to be made proactively rather than in
+response to an already-live path.
+
+**The hook path already runs `InProcessProbe` synchronously, today, for a
+different surface.** `hooks/hooks.json` wires `vcs detect --format=hook
+--fail-safe --descriptive` at `SessionStart` and `vcs guard --format=hook
+--fail-safe` at `PreToolUse` (matching `Bash`). `cli/vcs-cli/src/main.rs:27-34,59-69`
+already constructs `InProcessProbe` for both. So the *type* this item
+repoints `facts()` onto is already exercised, unbounded, on the
+session-start and every-Bash-call hook path — just not via `facts()`/
+`RepoFacts` (which `detect`/`guard` don't use). This is useful context for
+the containment-bound AC: the risk class 0185 is being asked to price
+already exists in production for `detect`/`guard`, uncontained, and 0185
+would be extending the same code paths' reach rather than introducing an
+entirely new exposure.
+
+**No timeout/crash-isolation precedent exists in `cli/vcs-adapters` or at
+any `InProcessProbe` call site.** `CommandProbe`'s containment
+(`DEFAULT_CAP = 10s`, `wait_capped`'s poll-then-kill, `scrub_environment`) is
+process-boundary containment being deleted along with the struct — though
+its shared helpers survive for 0198. In the server, the closest existing
+precedent is `server.rs:34,261`'s `TimeoutLayer` (30s) — cooperative
+async-cancellation only, no preemption of blocking synchronous work — and
+`file_driver.rs:197-220`'s `spawn_blocking` pattern for isolating blocking
+I/O onto a dedicated thread, which has no timeout or reclaim-on-hang
+behaviour of its own. **No `catch_unwind` exists anywhere in `cli/`.**
+`InProcessProbe`'s `Result<Option<T>, Error>` return shape already
+distinguishes failure from absence (the work item's own "containment of
+meaning, not blast radius" framing), but no time/memory/crash bound wraps
+any of it today.
+
+## Code References
+
+- `cli/vcs-adapters/src/lib.rs:22-26` — `facts()` composition root to repoint.
+- `cli/vcs-adapters/src/subprocess.rs:65-139` — `CommandProbe` to delete.
+- `cli/vcs-adapters/src/subprocess.rs:231-246,248-324` — `scrub_environment`/`run_capped`, shared with 0198, must survive.
+- `cli/vcs-adapters/src/subprocess.rs:329-407` — `run_checked`/`wait_capped_checked`, deletable with `CommandProbe`.
+- `cli/vcs-adapters/src/subprocess.rs:583-632` — `CommandProbe`-specific unit tests, redundant with `library.rs`.
+- `cli/vcs-adapters/src/library.rs:190-478` — `InProcessProbe` and its port impls.
+- `cli/vcs-adapters/src/library.rs:1009-1107` — existing `InProcessProbe` unit-test equivalents to the deleted `CommandProbe` tests.
+- `cli/vcs-adapters/src/markers.rs` — shared walk/marker helpers, must not be touched.
+- `cli/vcs-adapters/tests/detection.rs:101-154` — dual-comparison scaffolding to collapse.
+- `cli/vcs-adapters/tests/library.rs:431-474` — the one documented probe divergence (jj snapshot-on-read).
+- `cli/corpus-adapters/src/metadata.rs:189-236` — `derive`/`derive_at`/`VcsBackedRepoFactsProbe`, actual repoint target at `:214`.
+- `cli/corpus-adapters/tests/zero_spawn.rs` — existing cross-crate zero-spawn proof, does not yet cover the metadata read.
+- `cli/vcs-test-support/src/stubs.rs`, `src/hermetic.rs`, `src/fixtures.rs` — the shared harness.
+- `.github/workflows/main.yml:323-377` — `check-zero-spawn` CI job.
+- `tasks/test/integration.py:181-241` — `test:integration:zero-spawn:strong` implementation.
+- `cli/deny.toml:67-81` — the `uluru` exception and its re-check trigger.
+- `cli/Cargo.toml:72-73` — the `jj-lib`/`gix` pins.
+- `cli/pup.ron:140-163` — `vcs_adapters_library_reads_in_process`.
+- `tasks/github.py:231-248` — `_release_uploads()`.
+- `tests/unit/tasks/test_workflows.py:207-221` — attest-glob coverage over release uploads.
+- `cli/vcs/src/lib.rs:65-73` — `VcsProbe`, the natural home for the sha256 policy decision.
+- `cli/vcs/src/origin_remote.rs:12-22` — precedent doc-comment style for recording a port policy.
+- `cli/vcs-adapters/tests/detection.rs:87-96` — `is_full_revision_id`, already names the sha256 decision.
+- `hooks/hooks.json` — `vcs detect`/`vcs guard` hook wiring.
+- `cli/vcs-cli/src/main.rs:27-69` — `InProcessProbe` already in use on the hook path today.
+- `cli/visualiser/server/src/server.rs:34,261` — `TimeoutLayer`, cooperative-only precedent.
+- `cli/visualiser/server/src/file_driver.rs:197-220` — `spawn_blocking` precedent.
+
+## Architecture Insights
+
+- **Ports-and-adapters throughout** (ADR-0053): `cli/vcs` is a pure domain
+  crate with zero I/O; `cli/vcs-adapters` supplies two adapters
+  (`CommandProbe`/`MarkerWalkRoot`, and `InProcessProbe`) behind the same
+  ports, exactly the shape `cli/corpus`/`cli/corpus-adapters` mirrors —
+  0185 is a same-shape convergence to one this pattern already anticipated.
+- **Delegation over duplication for shared walk logic**: both adapters route
+  through `markers.rs` rather than each having their own copy, which is
+  exactly why deleting one "strands nothing," per that module's own doc
+  comment.
+- **Injection composition roots stay thin and are the deliberate seam for
+  this kind of swap**: `vcs_adapters::facts()` is a two-line function whose
+  entire job is choosing which adapter pair to wire in — a pattern this repo
+  uses consistently (`corpus_adapters::metadata::VcsBackedRepoFactsProbe` is
+  itself another injection point one layer up).
+- **Fallibility conventions are deliberate and documented at the port**:
+  `RepoRoot`/`VcsProbe` fold to `Option`/`None` on purpose (a caller cannot
+  distinguish "no repo" from "probe failed," and an adapter is expected to
+  warn-log); `OriginRemote`/`CheckoutProbe` are `Result`-returning because
+  that distinction matters for those callers. This crate has existing,
+  citable precedent for recording exactly this kind of "why does this port
+  behave this way" decision in trait-level doc comments — the natural
+  mechanism for 0185's sha256 decision.
+- **Zero-spawn is enforced two ways at once**: structurally, via a
+  `cargo-pup` import-restriction rule scoped to the `library` module
+  (`std::process` denied); and behaviourally, via a black-box test harness
+  (`vcs-test-support`) that stubs and shadows real binaries and asserts no
+  marker file appears. Neither alone would catch every regression — the pup
+  rule can't see a spawn originating inside `gix`/`jj-lib` itself, and the
+  black-box test alone wouldn't stop an in-crate `std::process::Command`
+  from creeping back in.
+
+## Historical Context
+
+- `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md`
+  (Pass 3/4) is the review that split 0169 into 0185/0186/0187/0188, on a
+  unanimous scope-lens finding that the `corpus-adapters`/`CommandProbe`
+  migration was "orthogonal, own risk profile, nothing in the hooks
+  migration needs it."
+- `meta/work/0188-library-backed-vcs-adapter.md` (done) delivered
+  `InProcessProbe` deliberately unwired, specifically so 0185 could adopt it
+  once proven — including reversing an earlier, wrong spike finding
+  (amendment 8, withdrawn) that jj `revision` was out of reach; it is fully
+  delivered (amendment 10).
+- `meta/work/0198-migrate-vcs-status-log-onto-library-backed-adapters.md`
+  (draft, low priority) owns the separate `status`/`log` subprocess path in
+  the same `subprocess.rs` module (`run_vcs_text`) — explicitly out of
+  0185's scope, and the reason `scrub_environment`/`run_capped` must survive
+  `CommandProbe`'s deletion.
+- `meta/reviews/work/0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md`
+  (Pass 2, 2026-08-10, **APPROVE**) already reconciled the work item's
+  earlier internal contradictions (stale attributions to 0169, an
+  "invisible to callers" claim contradicted by the known snapshot
+  divergence, ungated containment/sha256/licence decisions) into checkable
+  Acceptance Criteria and Dependencies entries. One item was deliberately
+  left as an in-line AC rather than split out: the MPL-2.0
+  attribution-artefact work, judged cheap enough to track without a separate
+  work item.
+- `meta/work/0125-converge-vcs-detection-on-probe-layer.md` (draft) — a
+  separate, shell-side convergence (`find_repo_root`/`vcs_mode`) whose
+  stated rationale (probing costs 1-3 subprocesses, must work with no
+  `git`/`jj` on `PATH`) is dissolved *for consumers that reach the Rust
+  adapter* by 0188/0185, though its own ~26 shell call sites are unaffected
+  until later epic-0136 phases migrate them.
+
+## Related Research
+
+- `meta/research/codebase/2026-08-02-0188-library-backed-vcs-adapter.md` —
+  the spike/API-surface research behind `InProcessProbe`'s delivery. Note:
+  its `corpus-adapters` call-site line references (`derive_at` at `:201`)
+  are now stale per this research's findings above.
+- `meta/research/codebase/2026-07-29-0169-vcs-subdomain-and-hooks-migration.md`
+  and `meta/research/codebase/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md`
+  — pre- and post-split research for 0169, the parent story this item was
+  extracted from.
+- `meta/research/codebase/2026-08-06-0195-accelerator-corpus-cli-implementation-surface.md`
+  — notes the `vcs`/`vcs-adapters` and `corpus`/`corpus-adapters` crate
+  pairs share the same hexagonal port-injection shape.
+
+## Open Questions
+
+- **How should AC3's zero-spawn extension actually be structured?** The
+  existing `zero_spawn.rs`/`vcs-adapters-fixture` pairing tests raw
+  `InProcessProbe` queries, not the `facts()` composition or
+  `VcsBackedRepoFactsProbe`. The plan needs to decide between adding a
+  `facts`-calling query to the existing reference binary versus a new
+  `corpus-adapters`-local one.
+- **Should AC2 be corrected to drop the non-existent
+  `work_item_pattern_parity.rs`, or does that suite need to be created as
+  part of this item?** The work item's phrasing ("its existing suites pass
+  unchanged") suggests the former, but this should be confirmed with
+  whoever owns the AC text before the plan finalises it.
+- **Is the visualiser-server containment question premature?** No call site
+  in `cli/visualiser/server` reaches `vcs_adapters::facts` today, so the
+  "this switch is what first makes the server reachable" framing in the
+  work item's Dependencies/Amendment does not match the current codebase.
+  Confirm with the 0168 owner whether a server-side metadata call site is
+  imminent, or whether the containment AC should be reframed as
+  precautionary rather than reactive.
+- **Where exactly should the sha256 decision doc comment land** — on
+  `VcsProbe` itself, on `VcsProbe::revision` specifically, or on both? The
+  precedent (`OriginRemote::origin_url`) puts it on the method; `RepoFacts`/
+  `VcsKind` have no obvious place to record it since they're plain data
+  types.

--- a/meta/reviews/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
+++ b/meta/reviews/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
@@ -8,7 +8,6 @@ producer: review-plan
 status: complete
 parent: "plan:2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
 target: "plan:2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
-relates_to: []
 reviewer: Toby Clemson
 verdict: APPROVE
 lenses: [architecture, code-quality, test-coverage, correctness, security, safety, compatibility]

--- a/meta/reviews/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
+++ b/meta/reviews/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
@@ -1,0 +1,273 @@
+---
+type: plan-review
+id: "2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-review-1"
+title: "Plan Review: Converge corpus-adapters on the Library-Backed VCS Adapter Implementation Plan"
+date: "2026-08-10T16:06:48+00:00"
+author: Toby Clemson
+producer: review-plan
+status: complete
+parent: "plan:2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
+target: "plan:2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
+relates_to: []
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [architecture, code-quality, test-coverage, correctness, security, safety, compatibility]
+review_number: 1
+review_pass: 4
+tags: []
+last_updated: "2026-08-10T16:52:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Plan Review: Converge corpus-adapters on the Library-Backed VCS Adapter Implementation Plan
+
+**Verdict:** REVISE
+
+The plan is carefully sequenced and its Current State Analysis is unusually well-verified against the live codebase — it corrects several stale claims from the source work item rather than propagating them. Its core wiring change (repointing `vcs_adapters::facts` at `InProcessProbe`) is logically sound and its boundary-preservation claims mostly hold up. However, Phase 3's `CommandProbe` deletion is scoped incompletely in a way that will break the build, and the plan's three Phase 1 policy decisions (containment bound, sha256 handling, snapshot-on-read) are each less complete than their doc comments claim once checked against the wider consumer set and the specific call sites this switch newly exposes.
+
+### Cross-Cutting Themes
+
+- **`tests/library.rs` is missing from Phase 3's file inventory** (flagged by: code-quality, test-coverage, correctness, compatibility) — four independent lenses found the same certain compile break: `cli/vcs-adapters/tests/library.rs` imports and constructs `CommandProbe` directly, including in the one test that pins the plan's own documented snapshot-on-read divergence. This is the single most corroborated finding in the review.
+
+- **The containment-bound decision is under-analysed relative to what's actually changing** (flagged by: architecture, security, safety) — three lenses converge on the same underlying gap from different angles: the plan frames the choice as "subprocess isolation vs. nothing" without evaluating a cheap in-process middle path (Security); it removes `CommandProbe`'s existing 10-second cap from a call site that now runs while a work-item creation lock is held, with no reclaim path for a hung-but-alive holder (Safety); and the "revisit if that changes" language in the doc comment has no concrete, tracked trigger tying it to 0168's server-integration work (Architecture, Security).
+
+- **The snapshot-on-read "no persisted-data impact" claim is scoped too narrowly** (flagged by: safety, compatibility) — both lenses independently found that Phase 1's confirmation only audits corpus-adapters' own Rust write paths, missing the dozens of `SKILL.md` workflows that copy `corpus metadata derive`'s printed `Current Revision:` line verbatim into committed `meta/` document frontmatter. The plan's own frontmatter is itself an example of this pattern.
+
+- **Fixture-binary placement/gating deviates from the established sibling-crate convention** (flagged by: architecture, code-quality, test-coverage) — three lenses independently noticed the new `corpus-adapters-fixture` binary sits in `src/bin/` rather than following `vcs-adapters-fixture`'s deliberate `tests/fixtures/` placement, with no note explaining the divergence.
+
+### Tradeoff Analysis
+
+- **Scope discipline vs. containment robustness**: the plan's "What We're NOT Doing" section explicitly declines to build any bounded-execution primitive, framing that as appropriately out of scope for a wiring-and-deletion task. Security's critical finding pushes the other way — arguing a narrow, call-site-specific bound (a timeout thread plus panic-catching around just the widened calls) is cheap enough that "out of scope" undersells the risk, particularly at the lock-holding `work create` call site Safety separately identified. This is a real judgement call: the plan's scope boundary is reasonable in isolation, but the two lenses together suggest the boundary was drawn without weighing the specific new exposure this switch introduces, rather than as a considered tradeoff.
+
+### Findings
+
+#### Critical
+
+- 🔴 **Code Quality, Test Coverage, Correctness, Compatibility**: `CommandProbe` deletion omits `tests/library.rs`, which will fail to compile
+  **Location**: Phase 3: Delete `CommandProbe` and collapse the dual-adapter comparison
+  `cli/vcs-adapters/tests/library.rs` imports `CommandProbe` and uses it in `assert_parity` (several tests) and in `an_unsnapshotted_edit_is_the_one_documented_divergence` — the sole automated proof of the plan's own documented behavioural exception. Phase 3's Changes Required lists only `subprocess.rs` and `tests/detection.rs`; as scoped, `cargo test -p vcs-adapters --features bash-parity` and the `grep -r CommandProbe` check both fail.
+
+- 🔴 **Security**: Containment-bound decision treats subprocess-isolation-vs-nothing as the only two options
+  **Location**: Phase 1, item 2: Containment-bound decision / "What We're NOT Doing"
+  `CommandProbe` actively provides a 10-second cap, kill-on-timeout, and scrubbed environment for the `facts()` composition root today — this plan removes that protection from this call site rather than merely declining to add a new one, without evaluating a cheap in-process middle path (timeout thread + `catch_unwind`) that wouldn't require reintroducing a subprocess boundary.
+
+- 🔴 **Compatibility**: Phase 4's MPL-2.0 re-check is scoped to `accelerator-visualiser` only, missing sub-binaries that already call `InProcessProbe` directly
+  **Location**: Phase 4: Re-run the MPL-2.0 licence check
+  `cli/vcs-cli` (`accelerator-vcs`) and `cli/collaboration-cli` (`accelerator-collaboration`) both construct `InProcessProbe` directly and call it unconditionally from `main()` — dead-code elimination cannot remove directly-called code, so the `gix`/`jj-lib` closure (including `uluru`) is very likely already linked into and reachable from these two already-shipped, dispatched sub-binaries, independent of this plan. After this switch, `accelerator-corpus` and `accelerator-work` join them. Re-checking only `accelerator-visualiser` leaves the `deny.toml` comment's "actual finding" claim incomplete.
+
+#### Major
+
+- 🟡 **Safety, Compatibility**: Snapshot-on-read confirmation audits only Rust write paths, missing skill-layer consumers of the printed revision
+  **Location**: Phase 1, item 3: Snapshot-on-read dependency confirmation / Migration Notes
+  Multiple `SKILL.md` workflows (`create-plan`, `research-issue`, `create-note`, and others) invoke `corpus metadata derive` and persist its `Current Revision:` output into committed frontmatter. The Migration Notes' claim of "no persisted-data impact" doesn't hold at this broader scope — an artefact authored with unsnapshotted edits present will silently record a stale revision after the switch.
+
+- 🟡 **Safety**: Dropping the timeout removes a hang guard specifically at a lock-holding call site
+  **Location**: Phase 1, item 2 (containment-bound decision)
+  `work-cli`'s `create` acquires a work-item-creation lockdir guard and then calls `derive_at`, which after this switch reaches an unbounded `InProcessProbe` with no cap. The lockdir's reclaim mechanism only reclaims a *dead* holder — a hung-but-alive process is never reclaimed, so a pathological repository state could block every subsequent `work create` indefinitely.
+
+- 🟡 **Architecture, Security**: No tracked trigger to revisit the containment-bound decision when server reachability changes
+  **Location**: Phase 1, item 2 (containment-bound decision) / Phase 4
+  The doc comment's "revisit if that changes" has no concrete follow-up mechanism, and Phase 4 requires filing a follow-up work item only for the licensing consequence of increased reachability, not for containment — even though both are triggered by the same event (a server call site into `facts`).
+
+- 🟡 **Security**: No adversarial-input test proves `InProcessProbe` fails gracefully rather than hanging or panicking
+  **Location**: Phase 2: Extend zero-spawn coverage, then repoint `facts` / Testing Strategy section
+  Existing unit tests cover permission-denial and absent repositories, but none exercise structurally malformed input (a truncated `.jj` checkout protobuf, a corrupted git object graph) — exactly the class of input a now-wider caller set is more likely to encounter.
+
+- 🟡 **Test Coverage**: The sha256 revision-folding policy is documented as "already covered" by tests that don't actually exercise `revision()`
+  **Location**: Phase 1, item 1: sha256 revision-handling policy
+  `an_unsupported_object_format_fails_rather_than_misreads` and its `classify.rs` counterpart assert other queries fail on a sha256 fixture, but neither calls `probe.revision(...)`. No test in the suite exercises `revision()` against a sha256 repository, so the doc comment's specific behavioural claim is unproven.
+
+- 🟡 **Test Coverage**: The new zero-spawn test's fixture scope may not exercise both the git and jj composition paths
+  **Location**: Phase 2: Failing-first zero-spawn assertion
+  The new test is described against a single, unspecified-kind fixture. Since `facts` dispatches differently per `VcsKind`, a single-kind test may not prove the zero-spawn property holds for both dispatch paths through the new composition.
+
+#### Minor
+
+- 🔵 **Architecture, Code Quality, Test Coverage**: New fixture binary's placement and gating diverge from the sibling crate's established convention
+  **Location**: Phase 2, item 1: New reference binary for the metadata-read path
+  `vcs-adapters-fixture` is deliberately placed under `tests/fixtures/` (with a `Cargo.toml` comment explaining why) rather than `src/bin/`. The new `corpus-adapters-fixture` binary is proposed at `src/bin/`, gated by `required-features` instead — a different mechanism for the same category of artefact, undiscussed.
+
+- 🔵 **Correctness**: `RepoRoot` canonicalisation semantics differ between the two implementations, unaddressed by the plan
+  **Location**: Phase 2: Extend zero-spawn coverage, then repoint `facts` / Current State Analysis
+  `InProcessProbe::discover` canonicalises (resolves symlinks); `MarkerWalkRoot::discover` does not. Every existing/planned test pre-canonicalises its fixture root, structurally masking this divergence, so the "invisible to callers" claim holds only for the tests, not necessarily for a caller passing a relative or symlink-laden path.
+
+- 🔵 **Security**: Environment-scrubbing asymmetry between `CommandProbe` and `InProcessProbe` is not addressed
+  **Location**: Phase 1: Record the pending policy decisions
+  `CommandProbe` scrubs `GIT_DIR`/`GIT_CONFIG`/`JJ_CONFIG` and related variables before spawning; `InProcessProbe`'s `gix`/jj-lib calls have no equivalent scrubbing. Not surfaced as a policy decision alongside the other three.
+
+- 🔵 **Safety**: sha256-repository failure folds to a silent "no VCS here" with only debug-gated logging
+  **Location**: Phase 1, item 1 (sha256 revision-handling policy)
+  The failure is `warn!`-logged, but this codebase gates logging behind `ACCELERATOR_LOG`, so a typical run shows no signal distinguishing "unsupported format" from "no repository at all."
+
+- 🔵 **Compatibility**: No automated guard ties `deny.toml`'s reachability rationale to the actual call graph
+  **Location**: Phase 4: Re-run the MPL-2.0 licence check
+  The exception rationale is a point-in-time prose comment with no CI check re-verifying it when a new call site is added — the scope gap found above illustrates how easily this drifts.
+
+#### Suggestions
+
+- 🔵 **Architecture**: Reachability verification method is a byte-literal proxy sensitive to dependency wording changes
+  **Location**: Phase 4: Re-run the MPL-2.0 licence check
+  Grepping for `extensions.objectFormat` / `There is no Jujutsu repo` is carried over unchanged from 0188; worth a note that it should be re-validated, not just re-run, whenever `gix`/`jj-lib` are upgraded.
+
+### Strengths
+
+- ✅ The four phases are ordered so policy decisions precede the behaviour change that depends on them, and deletions are deferred until nothing else references what's being removed — each phase stays independently mergeable and low-risk to review in isolation.
+- ✅ Phase 2 requires proving the new zero-spawn test fails against the current `CommandProbe` wiring before flipping the composition root — genuine red/green discipline, not an assertion added alongside code that already satisfies it.
+- ✅ The Current State Analysis is unusually well-verified: it traces actual current line numbers and call sites, corrects the work item's stale `work_item_pattern_parity.rs` reference, and independently confirms (rather than assumes) that the visualiser server has no current call site into `facts`.
+- ✅ The plan is disciplined about scope: it keeps `scrub_environment`/`run_capped` (shared with 0198) and `MarkerWalkRoot`/`markers.rs` untouched, having confirmed actual callers before proposing any deletion.
+- ✅ Recording the sha256, containment-bound, and snapshot-on-read decisions as doc comments in the code (rather than leaving them implicit) is good practice for auditable, security-relevant tradeoffs — the content gaps found above are about completeness, not about the practice itself.
+
+### Recommended Changes
+
+1. **Add `cli/vcs-adapters/tests/library.rs` to Phase 3's Changes Required** (addresses: the four-lens critical finding). Decide explicitly whether `an_unsnapshotted_edit_is_the_one_documented_divergence` is rewritten to invoke the real `jj` binary directly (mirroring the file's own `jj_revision_oracle` helper) or deleted with the loss of coverage acknowledged; update or remove the remaining `assert_parity`-based tests since parity with a deleted type is meaningless.
+
+2. **Broaden Phase 4's MPL-2.0 re-check to every dispatched sub-binary that reaches `vcs_adapters`** (addresses: compatibility critical), not just `accelerator-visualiser` — at minimum `accelerator-vcs`, `accelerator-collaboration`, and after this switch `accelerator-corpus`/`accelerator-work`. If the closure is already reachable in the first two independent of this plan, that's a pre-existing finding worth its own urgency, not one to fold silently into a comment scoped to the visualiser alone.
+
+3. **Re-scope the containment-bound decision to reflect what's actually changing** (addresses: the three-lens containment theme, both major findings on this topic). At minimum, record that a protection is being removed from the `facts()` call site (not just declined-to-add), weigh the lock-holding blast radius at `work create` explicitly, and either accept a narrow call-site-specific bound or record why even that's rejected — with the acceptance tied to a concrete trigger (e.g. a cross-reference to 0168) rather than an unenforced "revisit if that changes."
+
+4. **Broaden the snapshot-on-read confirmation to cover skill-layer consumers** (addresses: safety + compatibility major). Either extend the doc comment and Migration Notes to explicitly address the `SKILL.md` workflows that persist `Current Revision:` into frontmatter and accept the staleness with that scope in view, or flag it as a genuine known regression rather than a closed question.
+
+5. **Back the sha256 doc comment's claim with an actual test of `revision()`** (addresses: test-coverage major) — extend or add a sibling to `an_unsupported_object_format_fails_rather_than_misreads` that calls `InProcessProbe.revision(...)` against the sha256 fixture and asserts `None`.
+
+6. **Add at least one malformed-input test for `InProcessProbe`'s parsers** (addresses: security major) — a truncated checkout protobuf and/or corrupted git object graph, asserting `Err`/`None` rather than a panic or hang, before this path's reach widens.
+
+7. **Confirm and state the new zero-spawn test's coverage across both git and jj composition paths** (addresses: test-coverage major) — either loop the test over both kinds or state explicitly why one is sufficient.
+
+8. **Align the new fixture binary with the established `tests/fixtures/` convention, or note why it diverges** (addresses: the three-lens minor finding).
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: The plan is a well-bounded, cleanly-sequenced convergence of two probe implementations onto one, correctly reasons about crate dependency direction and about which claims in the work item are stale versus still true, and takes care not to overreach into 0198's neighbouring subprocess path. Its main architectural weight sits in the resilience/containment decision it defers: collapsing the last isolation boundary between subprocess and in-process VCS reading onto a single unbounded implementation, mitigated only by a doc comment rather than any tracked trigger. A secondary, lower-stakes concern is a build-surface inconsistency between the new test-support binary's placement and the sibling crate's established convention for the equivalent artefact.
+
+**Strengths**:
+- Phase 2 correctly reasons about dependency direction — `vcs-adapters` cannot depend on `corpus-adapters`, so the existing `vcs-adapters-fixture` binary cannot be extended, and a new `corpus-adapters`-local binary is needed instead.
+- Phase 4 declines to accept the work item's framing that the switch "first makes the server reachable" at face value; the Current State Analysis independently verifies the server's actual call graph.
+- The four phases sequence every deletion after the thing that would break from it has already collapsed, avoiding a half-migrated intermediate state landing in the tree.
+- The plan is disciplined about scope, confirming via file inspection which helpers are `CommandProbe`-exclusive before proposing their deletion.
+
+**Findings**:
+- 🟡 Major — Containment-bound decision has no tracked revisit trigger (Phase 1, item 2). See merged cross-cutting finding above.
+- 🔵 Minor — Fixture binary placement diverges from sibling-crate convention (Phase 2, item 1). See merged finding above.
+- 🔵 Suggestion — MPL check method is a byte-literal proxy sensitive to dependency wording changes (Phase 4).
+
+### Code Quality
+
+**Summary**: The plan itself is well-structured — phased so policy decisions precede behaviour changes and deletions are preceded by collapsing their last references, with TDD (red/green) called out explicitly for the zero-spawn extension. However, it has one significant gap that will break the build as scoped: Phase 3's `CommandProbe` deletion does not account for `tests/library.rs`. There is also an unexplained deviation from this codebase's consistent fixture-binary convention in Phase 2's new binary.
+
+**Strengths**:
+- The four phases are ordered so policy decisions land before the behaviour change that depends on them, and deletions are deferred until nothing else references what's being removed.
+- Phase 2 explicitly requires proving the new zero-spawn test fails against the current `CommandProbe` wiring before flipping the composition root.
+- The plan traced actual current line numbers and call sites rather than trusting the stale work item, and explicitly corrected a stale reference instead of propagating it.
+
+**Findings**:
+- 🔴 Critical — `CommandProbe` deletion omits `tests/library.rs`, which will fail to compile (Phase 3). See merged cross-cutting finding above.
+- 🔵 Minor — New fixture binary deviates from the repo's established fixture-binary convention without explanation (Phase 2, item 1). See merged finding above.
+
+### Test Coverage
+
+**Summary**: The plan follows solid TDD discipline for its central deliverable (the failing-first zero-spawn test in Phase 2) and correctly reuses the crate's established fixture/stub test patterns. However, it has a significant blind spot around `tests/library.rs`, and it overstates existing coverage for the sha256 revision-folding policy being recorded in Phase 1. A secondary gap is that the new zero-spawn test's fixture scope may not exercise both the jj and git dispatch paths.
+
+**Strengths**:
+- Phase 2 explicitly requires running the new zero-spawn test red before flipping the composition root, and calls out why that step must not be skipped.
+- The new zero-spawn test is designed to mirror the existing `zero_spawn.rs` test's dual-run pattern and two-part assertion, correctly reusing a proven anti-flakiness structure.
+- The plan is explicit and specific about which existing suites must keep passing unchanged, and corrects the work item's stale reference to a test file that doesn't exist.
+
+**Findings**:
+- 🔴 Critical — `tests/library.rs`'s dependency on `CommandProbe`, including the sole regression test for the plan's documented behavioural divergence, is not addressed (Phase 3). See merged cross-cutting finding above.
+- 🟡 Major — The sha256 revision-folding policy is documented as already covered by tests that don't actually exercise `revision()` (Phase 1, item 1).
+- 🟡 Major — The new zero-spawn test's fixture scope may not exercise both the git and jj composition paths (Phase 2).
+- 🔵 Minor — New fixture binary's feature-gating approach diverges from the crate's established pattern (Phase 2, item 1). See merged finding above.
+
+### Correctness
+
+**Summary**: The plan's core wiring change is logically sound and its claims about the snapshot-on-read side effect and dead-code-elimination reachability check out against the actual source. However, Phase 3's deletion of `CommandProbe` is scoped incompletely — it omits `tests/library.rs` — and there's an unaddressed semantic divergence between the old and new `RepoRoot` implementations' path canonicalisation.
+
+**Strengths**:
+- The plan traces the two actual production write paths and correctly verifies, against the real source, that neither reads `.revision`/`.repository_name` from the derived metadata.
+- The plan correctly identifies that `scrub_environment`/`run_capped` are shared with 0198's still-active path and must survive, while `run_checked`/`wait_capped_checked` are `CommandProbe`-only and safe to delete.
+- Sequencing the new zero-spawn test as failing-first before the composition-root flip is sound practice.
+
+**Findings**:
+- 🔴 Critical — `CommandProbe` deletion omits `tests/library.rs`, which still depends on it (Phase 3). See merged cross-cutting finding above.
+- 🔵 Minor — `RepoRoot` canonicalisation semantics differ between `MarkerWalkRoot` and `InProcessProbe`, unaddressed by the plan (Phase 2).
+
+### Security
+
+**Summary**: The plan is careful to document the isolation-boundary tradeoff explicitly rather than deciding it silently, and correctly re-verifies rather than assumes the visualiser server's current reachability into the `gix`/`jj-lib` closure. However, its containment-bound decision treats the choice as binary without evaluating a cheap middle path for the specific call site being widened, and it deletes `CommandProbe`'s existing protections without a replacement or adversarial-input test proving the replacement degrades gracefully. The forward-looking risk is tracked for MPL-2.0 licensing but not for containment.
+
+**Strengths**:
+- Phase 1 records the containment-bound, sha256-handling, and snapshot-on-read decisions as auditable doc comments rather than leaving them implicit.
+- Phase 4 empirically re-runs the MPL-2.0/reachability check against a real unstripped build rather than assuming either outcome.
+- The plan preserves `scrub_environment`/`run_capped`, which remain load-bearing for 0198's still-active path.
+- Phase 2's red/green sequencing gives genuine evidence the subprocess call is actually removed, rather than relying on code inspection alone.
+
+**Findings**:
+- 🔴 Critical — Containment-bound decision treats subprocess-isolation-vs-nothing as the only two options (Phase 1, item 2). See merged cross-cutting finding above.
+- 🟡 Major — No adversarial-input test proves `InProcessProbe` fails gracefully rather than hanging or panicking (Phase 2).
+- 🟡 Major — Forward-looking server reachability is tracked for licensing but not for containment (Phase 4). See merged cross-cutting finding above.
+- 🔵 Minor — Environment-scrubbing asymmetry between `CommandProbe` and `InProcessProbe` is not addressed (Phase 1).
+
+### Safety
+
+**Summary**: The plan is careful and well-evidenced on the two deletions it foregrounds and correctly establishes that the hook path is unaffected, since it already runs `InProcessProbe` today. However, its safety analysis of the two behavioural changes it does introduce is narrower than it appears: the snapshot-on-read confirmation misses the skill layer that persists `Current Revision:` into frontmatter, and the containment-bound decision doesn't account for the lock-holding call site at `work create`.
+
+**Strengths**:
+- The plan independently verifies that the one Rust write path persisting frontmatter reads only `datetime_utc` and never `.revision`/`.repository_name`.
+- The plan correctly identifies that `InProcessProbe` already runs unbounded on the hook path today, so this switch does not newly expose the hook path itself.
+- `CommandProbe`'s `OriginRemote` implementation and its dedicated helpers are already unused in production, so Phase 3's deletion doesn't orphan a still-needed capability.
+- The failing-first structure for the new zero-spawn test avoids a window where the guarantee is claimed but unproven.
+
+**Findings**:
+- 🔴 Major (elevated from the lens's own critical rating in cross-cutting synthesis; retained at major here to avoid double-counting the merged cross-cutting critical) — Snapshot-on-read loss is confirmed against too narrow a consumer set (Phase 1, item 3). See merged cross-cutting finding above.
+- 🟡 Major — Dropping the timeout removes a hang guard specifically at a lock-holding call site (Phase 1, item 2). See merged finding above.
+- 🔵 Minor — sha256-repository failure folds to a silent "no VCS here" with only debug-gated logging (Phase 1, item 1).
+
+### Compatibility
+
+**Summary**: The plan is careful about preserving the `vcs_adapters::facts` boundary contract and correctly scopes `CommandProbe`'s deletion to a workspace-internal, unpublished crate with no external consumers. However it has a concrete, compile-breaking gap in Phase 3's file inventory, and its Phase 4 MPL-2.0 re-verification is scoped too narrowly against the actual set of distributed sub-binaries that already reach the `gix`/`jj-lib` closure.
+
+**Strengths**:
+- `CommandProbe` is referenced nowhere outside `cli/vcs-adapters` itself, and the crate carries `publish = false`, so its deletion carries no external semver risk.
+- The `vcs_adapters::facts` boundary contract is explicitly test-locked before and after the switch across all seven checkout-shape assertions.
+- The red/green ordering in Phase 2 is a sound way to prove the compatibility guarantee is real rather than assumed.
+- Recording the sha256, containment-bound, and snapshot-on-read decisions at the port-contract level is a good choice for forward compatibility.
+
+**Findings**:
+- 🔴 Critical — Phase 3's file inventory omits `tests/library.rs` (Phase 3). See merged cross-cutting finding above.
+- 🔴 Critical — Phase 4 only re-verifies `accelerator-visualiser`, missing sub-binaries that already call `InProcessProbe` directly (Phase 4). See merged cross-cutting finding above.
+- 🟡 Major — The snapshot-on-read consumer audit covers only Rust write paths, missing `SKILL.md` workflows (Phase 1, item 3). See merged finding above.
+- 🔵 Minor — No automated guard ties `deny.toml`'s reachability rationale to the actual call graph (Phase 4).
+
+## Re-Review (Pass 4) — 2026-08-10
+
+**Verdict:** APPROVE
+
+Three iterative fix-and-re-review rounds followed the initial REVISE verdict, each re-running the affected lenses against the updated plan. The pattern across all three: fixes for one round's findings were themselves source-verified and precise, but each round's edits introduced a small number of new, narrowly-scoped gaps of the same character (an incomplete file inventory, an orphaned import, a doc comment that outran what the surrounding code actually proved) — caught and closed by the next round. By pass 4, no lens found any new issue; the plan converges to a state every lens has independently checked against the live codebase.
+
+### Previously Identified Issues
+
+- 🔴 **Code Quality, Test Coverage, Correctness, Compatibility**: `tests/library.rs` omission from Phase 3 — Resolved (Phase 3 now reworks the file explicitly; further hardened across passes 2–3 to also delete `assert_parity` outright, rename tests describing the deleted comparison, and add a `git_revision_oracle` closing a git-side coverage gap the rework itself would otherwise have introduced)
+- 🔴 **Security**: Containment-bound decision framed as binary (subprocess vs. nothing) — Resolved via the user's explicit "document only" scope decision; the doc comment now names the protection removed, the specific lock-holding blast radius, and a structural (not dead-ticket) revisit trigger
+- 🔴 **Compatibility**: Phase 4 MPL-2.0 re-check scoped to the visualiser alone — Resolved; broadened across passes 2–3 to all six `DISPATCHED_SUBBINARIES` tokens after two intermediate omissions (`accelerator-migrate`, then a work/corpus attribution error) were each caught by independent lenses and corrected
+- 🟡 Major findings (snapshot-on-read scope, lock-holding hang risk, sha256 test gap, zero-spawn git/jj coverage, adversarial-input test, containment revisit tracking) — all Resolved; see per-round detail below
+- 🔵 Minor findings (fixture binary convention, symlink canonicalisation, env-scrubbing asymmetry, sha256 silent failure, deny.toml drift guard) — fixture binary convention Resolved; symlink canonicalisation documented (accepted as narrow, no new test infrastructure); env-scrubbing asymmetry, sha256 silent failure, and the deny.toml drift guard remain accepted open items, unchanged from the original review — none were part of the recommended-changes list and none blocked approval
+
+### New Issues Introduced (across passes 2–3, all now Resolved)
+
+- 🔴/🟡 `subprocess.rs`'s `CommandProbe`/`MarkerWalkRoot` deletion left dangling top-level imports, an orphaned `origin_repo()` test helper, and (caught a round later) a second, deeper-scoped orphaned import inside the test module itself (`PathBuf`, `CommandProbe` in a `use super::{...}` list) — fully enumerated and fixed by pass 3, independently confirmed by both correctness and test-coverage
+- 🟡 `detection.rs`'s `facts_via` helper and its `RepoRoot`/`VcsProbe` imports were left orphaned by the "calls `vcs::facts` directly" phrasing — fixed
+- 🟡 `lib.rs`'s crate-level module doc comment went stale after the repoint/deletion with no scheduled update — fixed, split correctly across Phase 2 (the sentence that goes false first) and Phase 3 (the sentence that goes false once `MarkerWalkRoot` is gone), verified to leave a truthful intermediate state at each independently-mergeable phase boundary
+- 🟡 The containment-bound doc comment's revisit trigger named work item 0168, which is closed and — per the plan's own Current State Analysis — never performs the triggering action; replaced with a structural condition (any code under `cli/visualiser/server` calling into `facts`) that holds regardless of which future item does it
+- 🔵 Several `tests/library.rs` doc/naming loose ends (stale section header, ambiguous `assert_parity` disposition, three test names still describing the deleted comparison, a retitled module doc comment that first overstated then under-differentiated its own test groups, a renamed test colliding with an existing name in `detection.rs`) — all fixed
+- 🔵 The new fixture binary's described `required-features` gating contradicted the actual sibling convention it claimed to match — fixed
+- 🔵 `run_capped`'s own doc comment carried a dangling intra-doc link to the deleted `CommandProbe::revision`, and two deletion ranges started one comment-block short of the doc comment actually preceding the deleted item — fixed
+
+### Assessment
+
+The plan is in good shape for implementation. Its core wiring change is sound, its policy decisions are recorded with the specific blast radii they carry (not just the abstract exposure), and its test-coverage claims are now backed by tests that actually exercise what they claim to. The remaining open items (env-scrubbing asymmetry, sha256 silent-failure UX, no automated guard on `deny.toml` drift) are legitimate but narrowly-scoped follow-up candidates, not blockers — none were part of any round's recommended-changes list, and each was independently re-confirmed as intentionally out of scope rather than overlooked.
+
+---
+*Review generated by /accelerator:review-plan*

--- a/meta/reviews/work/0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
+++ b/meta/reviews/work/0185-converge-corpus-adapters-on-library-backed-vcs-review-1.md
@@ -1,0 +1,532 @@
+---
+type: work-item-review
+id: "0185-converge-corpus-adapters-on-library-backed-vcs-review-1"
+title: "Work Item Review: 0185: Converge corpus-adapters on the Library-Backed VCS Adapter"
+date: "2026-08-10T00:55:56+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0185"
+work_item_id: "0185"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-10T08:20:28+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: 0185: Converge corpus-adapters on the Library-Backed VCS Adapter
+
+**Verdict:** REVISE
+
+The item is a well-scoped, well-anchored task — Requirements and Acceptance
+Criteria describe the same single unit of work one-to-one, file:line
+references are concrete throughout, and the 2026-08-03 amendment does real
+work surfacing couplings a lighter edit would have missed. The core problem
+is that the amendment corrects several claims made earlier in the document
+(which item delivers the adapter, whether the switch is "invisible to
+callers", which file `CommandProbe` lives in, whether the item is still
+blocked) without those earlier sections being edited in place, so the
+document is internally contradictory unless read end-to-end and manually
+reconciled. Two further consequences the item itself treats as
+switch-triggered — an MPL-2.0 licence-attribution obligation and an
+unhardened new coupling into the distributed visualiser binary — are
+documented only as prose in Open Questions/Amendment, not as Dependencies
+entries or Acceptance Criteria, so a verifier working strictly from the
+Dependencies/AC sections could miss them entirely.
+
+### Cross-Cutting Themes
+
+- **Amendment corrections were appended, not applied in place** (flagged by:
+  clarity, completeness) — the Summary/Context (adapter attributed to 0169
+  instead of 0188), Requirements ("invisible to callers"), Technical Notes
+  (stale `lib.rs` line references and a stale "0169 will need to alter this
+  anyway" premise), References (a stale anchor into 0169), and frontmatter
+  (`blocked_by: ["work-item:0188"]` despite 0188 having landed) all retain
+  claims the item's own Amendment block says are wrong or stale. A reader who
+  trusts the first read of any of these sections walks away with an
+  incorrect picture, even though the correct information is present
+  somewhere later in the same document.
+- **The MPL-2.0 licence-attribution consequence is under-captured** (flagged
+  by: testability, dependency, scope) — the Amendment states in directive
+  language that the licence exception "has to be re-checked when `facts`
+  flips" and that this item's switch is "the expected trigger" invalidating
+  it, but this lives only in Open-Questions prose. It appears in no
+  Acceptance Criterion (testability) and no Dependencies entry (dependency),
+  and is scope-orthogonal work (Python release tooling, not the Rust VCS
+  crates this task otherwise touches) that risks being resolved hastily
+  in-line (scope).
+- **The new, unhardened coupling into `cli/visualiser/server` is
+  under-captured** (flagged by: scope, dependency) — after this switch,
+  `InProcessProbe` parses repository-controlled data with no timeout, memory
+  bound, or crash isolation inside a distributed, network-facing binary for
+  the first time. This is treated as an open question about sizing but never
+  surfaces as a Related entry to the item that owns the visualiser's
+  integration boundary.
+- **sha256-repository handling is unresolved and may already be decided
+  elsewhere** (flagged by: testability, dependency) — the item states this
+  switch is what "first exposes a user" to gix's inability to read sha256
+  repositories, but 0169 (now done) recorded the identical finding about its
+  own shipped hook paths, so the decision may need to be made once, in a
+  shared location, rather than re-litigated independently per consumer.
+
+### Findings
+
+#### Major
+
+- 🟡 **Clarity / Completeness**: Requirements' "invisible to callers"
+  guarantee contradicts the Amendment's documented behavioural difference
+  **Location**: Requirements; Amendment 2026-08-03, inheritance 3
+  Requirements states the goal is to preserve `vcs_adapters::facts`'s
+  semantics "so the change is invisible to callers," but Amendment
+  inheritance 3 documents a known caller-visible difference: after the
+  switch, deriving metadata stops having a write side effect on the user's
+  repository, and a `RepoFacts.revision` taken with unsnapshotted edits
+  present will name a different commit than today. The Requirements bullet
+  is never revised to acknowledge this exception.
+
+- 🟡 **Clarity**: Summary and Context attribute the library-backed adapter to
+  0169, contradicting Dependencies, frontmatter, and the item's own later
+  Amendment
+  **Location**: Summary; Context; Dependencies; Frontmatter: blocked_by
+  The Summary and Context both credit 0169 with introducing the
+  `gix`/`jj-lib` adapter, but the frontmatter's `blocked_by`, the
+  Dependencies section, and the Amendment's opening line ("Every reference
+  in this item that attributes the library-backed adapter or the zero-spawn
+  harness to 0169 is wrong. Both are 0188's.") all say otherwise. The
+  correction is a disclaimer appended at the bottom rather than an edit to
+  the Summary/Context sentences themselves.
+
+- 🟡 **Scope**: Unresolved open questions could expand this "task" well
+  beyond a wiring-plus-deletion change
+  **Location**: Open Questions; Amendment 2026-08-03, inheritances 2 and 5
+  The item is sized as a `task` — "a wiring change plus a deletion... with
+  no new behaviour and no user-visible change" — but its own Open Questions
+  describe decisions that, resolved one way, add substantial new work:
+  whether `InProcessProbe` needs an equivalent containment bound before it
+  runs inside `cli/visualiser/server` and the hook path, and whether the
+  MPL-2.0 exception this switch invalidates requires a new third-party
+  attribution artefact in the release pipeline. Neither is reflected in
+  Requirements or Acceptance Criteria.
+
+- 🟡 **Testability**: Licence re-check described as mandatory but not
+  captured as an Acceptance Criterion
+  **Location**: Amendment 2026-08-03, inheritance 5
+  The amendment instructs to "re-run 0188's check... as part of the switch,
+  not after it," but no Acceptance Criterion requires this check or records
+  what a pass/fail outcome looks like. A verifier working strictly from the
+  five listed ACs could mark the item complete without ever performing the
+  licence re-check.
+
+- 🟡 **Testability**: sha256 repository handling has no defined, verifiable
+  outcome
+  **Location**: Open Questions; Amendment 2026-08-03, inheritance 4
+  The item says revision validation "must accept both widths or record
+  sha256 as explicitly unsupported," and that this item's switch is what
+  exposes the gap, but no Acceptance Criterion states which outcome is
+  required. There is no way to write a test that conclusively confirms this
+  is "done correctly."
+
+- 🟡 **Dependency**: MPL-2.0 licence/attribution follow-up not captured as a
+  Dependency
+  **Location**: Open Questions; Amendment 2026-08-03, inheritance 5
+  A licence-compliance action with release-pipeline implications (a new
+  attribution artefact joining `_release_uploads()`, whose CI coverage
+  derives from `test_workflows.py`) lives only as a paragraph inside an
+  Open Questions amendment, not in the Dependencies section where planners
+  look for required actions.
+
+- 🟡 **Dependency**: New coupling to the `cli/visualiser/server` runtime not
+  referenced in Dependencies
+  **Location**: Open Questions
+  After this switch, `InProcessProbe` parses repository-controlled data with
+  no isolation inside a distributed, publicly-shipped binary for the first
+  time — a substantive new coupling to a subsystem owned elsewhere in the
+  epic (0168), but visible only by reading Open Questions prose rather than
+  as a Related entry.
+
+#### Minor
+
+- 🔵 **Clarity**: "Four inheritances" header is followed by five numbered
+  items
+  **Location**: Amendment 2026-08-03
+  The numbered list is introduced as "Four inheritances that change this
+  item's sizing" but five items follow.
+
+- 🔵 **Clarity**: File:line references for `CommandProbe` are likely stale
+  after the amendment's noted module move
+  **Location**: Requirements; Technical Notes; Amendment 2026-08-03,
+  inheritance 1
+  Requirements and Technical Notes cite `lib.rs` line numbers for
+  `CommandProbe`, but inheritance 1 states the subprocess pair now lives in
+  its own module, `subprocess.rs` — the original references are not updated
+  or flagged as stale.
+
+- 🔵 **Clarity**: "0169's own classifier port" is an undefined term not tied
+  to the ports named elsewhere in the document
+  **Location**: Amendment 2026-08-03
+  The document elsewhere names `RepoRoot` and `VcsProbe` as the relevant
+  ports, but "classifier port" is introduced without being reconciled
+  against either.
+
+- 🔵 **Completeness**: Technical Notes retains a premise the Amendment marks
+  stale
+  **Location**: Technical Notes
+  Technical Notes states "0169 will need to alter this anyway," which the
+  Amendment separately calls stale — the original bullet is left unedited
+  alongside the correction.
+
+- 🔵 **Completeness**: Frontmatter still shows draft/blocked despite the
+  recorded blocker having landed
+  **Location**: Frontmatter: status; blocked_by
+  Frontmatter records `status: draft` and `blocked_by: ["work-item:0188"]`,
+  but the Amendment states plainly that "0188 has landed" and the adapter
+  "exists and ships unwired."
+
+- 🔵 **Dependency**: Ordering relative to sibling Phase 11 item 0174 not
+  stated
+  **Location**: Dependencies
+  The parent epic groups this item with 0174 ("Retire Shell Tooling and CI
+  Guards") under Phase 11, sequenced first, but 0185 does not state whether
+  0174 depends on this item's completion.
+
+- 🔵 **Dependency**: sha256-repository handling is framed as this item's own
+  open question despite overlapping claims in 0169
+  **Location**: Open Questions
+  0169 (now done) records the identical sha256 finding about its own
+  shipped hook paths; treating the decision as local to each item risks
+  inconsistent handling across `vcs detect`/`guard`, this item's metadata
+  read, and future `vcs status`/`log` work.
+
+- 🔵 **Testability**: Containment-bound and snapshot-side-effect questions
+  left open with no criterion for how or whether they gate completion
+  **Location**: Open Questions
+  Both questions use language suggesting they must be resolved before the
+  switch ships, but neither is reflected as an Acceptance Criterion or given
+  a defined resolution procedure.
+
+- 🔵 **Testability**: Ambiguity over whether AC5 ("`mise run` is green")
+  covers the `check-zero-spawn` CI job referenced in the Amendment
+  **Location**: Acceptance Criteria
+  The Amendment describes a broader "strong form" assertion running in the
+  `check-zero-spawn` CI job; it is not stated whether that job is part of
+  the default `mise run` AC5 references.
+
+- 🔵 **Scope**: Licence-attribution follow-up is an orthogonal concern
+  spanning a different toolchain than the rest of this task
+  **Location**: Open Questions; Amendment 2026-08-03, inheritance 5
+  If triggered, the attribution-artefact work touches Python build-system
+  tooling (`_release_uploads()`, `test_workflows.py`), not the Rust
+  `vcs-adapters`/`corpus-adapters` crates the rest of this task is scoped
+  to.
+
+#### Suggestions
+
+- 🔵 **Clarity**: "the corpus writers" is used without a defined referent
+  **Location**: Open Questions; Amendment 2026-08-03, inheritance 3
+  Neither the Open Questions section nor the Amendment names the specific
+  module or call sites meant by "the corpus writers."
+
+- 🔵 **Clarity**: "§3.2's notice obligation" does not name which document it
+  refers to
+  **Location**: Amendment 2026-08-03, inheritance 5
+  Inferable from context as the MPL-2.0 licence, but never spelled out.
+
+- 🔵 **Completeness**: References entry points to anchors the Amendment
+  itself flags as no longer existing
+  **Location**: References
+  The first References bullet cites headings in 0169 that the Amendment
+  itself says are stale ("0169 has no 'Adapter-swap boundary' heading...").
+
+### Strengths
+
+- ✅ Requirements and Acceptance Criteria describe the same scope
+  one-to-one, with no drift between what the item asks for and how it will
+  be verified.
+- ✅ File:line anchors throughout Requirements and Technical Notes ground
+  abstract claims in specific, checkable locations.
+- ✅ Acceptance Criteria are concrete and multi-dimensional — grep-able
+  invariants, named test suites, and pinned boundary cases rather than
+  vague behavioural claims.
+- ✅ The adapter switch and `CommandProbe` deletion are explicitly framed as
+  "one atomic change" with a stated rationale, which is good scope
+  discipline rather than arbitrary bundling.
+- ✅ A closely related convergence effort (0125) is explicitly named and
+  deliberately kept out of scope, with reasoning given.
+- ✅ The Dependencies section states not just that 0188 blocks the work but
+  why, and documents the repointing history when 0169 was split.
+- ✅ The Amendment block is transparent about what it corrects, rather than
+  silently rewriting earlier sections — the underlying problem is that the
+  corrections were not also applied to those sections in place.
+
+### Recommended Changes
+
+1. **Edit the Summary, Context, and Requirements sections in place** to
+   reflect the Amendment's corrections (addresses: Summary/Context 0169
+   misattribution, Requirements "invisible to callers" contradiction)
+   rather than relying on a disclaimer appended at the end of the document.
+   Qualify the "invisible to callers" claim to the boundaries `detection.rs`
+   actually pins, and name the known snapshot-on-read exception inline.
+
+2. **Promote the MPL-2.0 licence re-check to a Dependency entry and an
+   Acceptance Criterion** (addresses: MPL-2.0 licence/attribution follow-up
+   not captured as a Dependency; Licence re-check not captured as an
+   Acceptance Criterion; Licence-attribution follow-up is orthogonal). State
+   explicitly what a pass/fail outcome looks like, and consider whether the
+   attribution-artefact work (if triggered) should be split into its own
+   follow-up item given it spans a different toolchain.
+
+3. **Resolve or explicitly scope the sha256-handling decision**, checking
+   first whether 0169 already decided how sha256 `HEAD` values are handled
+   for its own shipped paths (addresses: sha256 handling has no defined
+   outcome; sha256 framed as this item's own open question). If 0169's
+   decision exists, reference it rather than re-opening the question; if
+   not, record the decision in a shared location referenced by all
+   consumers.
+
+4. **Add a Related entry to the visualiser-owning work item** noting the new
+   call-graph reachability and the containment-bound decision that the
+   switch introduces (addresses: new coupling to `cli/visualiser/server`
+   not referenced in Dependencies; unresolved open questions could expand
+   this task).
+
+5. **Refresh stale frontmatter and cross-references**: clear or annotate
+   `blocked_by: ["work-item:0188"]` now that 0188 has landed, update the
+   `CommandProbe` file:line references to point at `subprocess.rs`, fix the
+   "Four inheritances" count, reconcile the "0169 will need to alter this
+   anyway" bullet in Technical Notes, and correct the stale References
+   anchor into 0169 (addresses: all remaining minor/suggestion findings).
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is detailed and mostly precise, with concrete
+file:line references and an explicit Assumptions/Open Questions structure.
+However, the 2026-08-03 amendment block corrects several claims made
+earlier in the document without editing the original text, leaving the
+document internally contradictory unless read end-to-end and manually
+reconciled. A handful of terms introduced only in the amendment
+("classifier port", "inheritance N", "corpus writers") are used without
+being tied back to concepts already defined in the body, and a numeric
+label mismatch ("Four inheritances" followed by five numbered items) is a
+small but concrete internal-consistency slip.
+
+**Strengths**:
+- File:line anchors throughout Technical Notes and Requirements ground
+  abstract claims in a specific, checkable location.
+- The amendment block explicitly flags that earlier attributions to 0169
+  are wrong rather than silently leaving them stale.
+- Assumptions and Open Questions are phrased as falsifiable, specific
+  claims rather than vague hedges.
+
+**Findings**: See Major/Minor/Suggestions above (Clarity-attributed items).
+
+### Completeness
+
+**Summary**: 0185 is a structurally complete task-kind work item: every
+expected section is present and substantively populated, Requirements and
+Technical Notes are anchored to specific file:line references, and the
+Amendment block transparently reconciles what changed once 0188 landed.
+The main completeness weakness is that the amendment corrects several
+claims made in the original Requirements, Technical Notes, and References
+sections without those sections themselves being updated, and frontmatter
+has not been refreshed to reflect that its sole recorded blocker has
+landed.
+
+**Strengths**:
+- Requirements and Technical Notes are anchored to specific file:line
+  references, making the work concretely actionable.
+- The Context section grounds the deliberate two-implementation boundary in
+  a specific, dated prior review decision.
+- Acceptance Criteria are specific and multi-dimensional.
+- The Open Questions are substantive and each tied to a concrete
+  pre-implementation decision.
+- The Amendment block explicitly separates corrections from new
+  inheritances rather than silently rewriting history.
+
+**Findings**: See Major/Minor/Suggestions above (Completeness-attributed
+items).
+
+### Dependency
+
+**Summary**: The Dependencies section captures the primary upstream
+blocker (0188) and two related items (0179, 0125) with clear rationale,
+and the Amendment block does real work surfacing hidden couplings that a
+lighter edit would have missed. However, two of the item's own Open
+Questions describe couplings that belong in Dependencies rather than
+buried in prose: the MPL-2.0 licence/attribution trigger, and the fact
+that this switch is what first links `vcs-adapters` into the distributed
+`accelerator-visualiser` binary's call graph.
+
+**Strengths**:
+- The Dependencies section states not just that 0188 blocks this work but
+  why, and documents the repointing history when 0169 was split.
+- The Related entries for 0179 and 0125 each carry a one-line rationale for
+  why the relationship matters.
+- The Amendment block proactively surfaces several couplings a less
+  careful revision would have left implicit.
+
+**Findings**: See Major/Minor above (Dependency-attributed items).
+
+### Scope
+
+**Summary**: This task is tightly and deliberately scoped: the Summary,
+Requirements, and Acceptance Criteria all describe one unit of work, and
+the item explicitly and correctly excludes an adjacent convergence effort
+(0125) rather than bundling it in. The main scope risk is not bundling
+within the stated Requirements, but four unresolved Open
+Questions/inheritances that could materially expand the work beyond
+"wiring plus deletion" without being reflected in the Requirements or
+Acceptance Criteria.
+
+**Strengths**:
+- Requirements and Acceptance Criteria describe the same scope
+  one-to-one.
+- The adapter switch and `CommandProbe` deletion are explicitly framed as
+  "one atomic change" with a stated rationale.
+- 0125 is explicitly named and deliberately kept out of scope, with
+  reasoning given.
+- The Drafting Notes give an explicit, checkable rationale for the
+  declared `task` kind.
+
+**Findings**: See Major/Minor above (Scope-attributed items).
+
+### Testability
+
+**Summary**: The Acceptance Criteria are unusually well-specified for a
+task-kind item — each is grounded in exact file:line references, named
+test suites, or grep-able invariants, giving a verifier a concrete
+pass/fail procedure. The main gap is that several decisions the Amendment
+frames in directive language (sha256 handling, the MPL licence re-check,
+the containment bound, the snapshot-on-read dependency) are left as Open
+Questions rather than being converted into measurable Acceptance Criteria.
+
+**Strengths**:
+- Acceptance Criteria are anchored to exact locations and named test
+  files.
+- AC1 ("no `Command::new` for `jj` or `git` remains in the crate's
+  non-test code") is mechanically checkable by grep with no interpretation
+  required.
+- AC4 enumerates exact boundary cases to preserve by reference to an
+  existing pinned test file.
+- The Requirements section explicitly bounds the surface to preserve
+  (`.name` and `.revision` only), preventing scope creep.
+
+**Findings**: See Major/Minor above (Testability-attributed items).
+
+## Re-Review (Pass 2) — 2026-08-10
+
+**Verdict:** APPROVE (overridden by reviewer from the suggested COMMENT
+verdict — the one remaining minor item, the MPL-2.0 attribution-artefact
+toolchain concern, was judged acceptable to track in-line rather than a
+blocker)
+
+### Previously Identified Issues
+
+- 🟡 **Clarity/Completeness**: Requirements' "invisible to callers" guarantee
+  contradicted the Amendment's documented behavioural difference — Resolved
+  (Requirements now qualifies the claim to `detection.rs`'s pinned boundaries
+  and names the snapshot-on-read exception inline)
+- 🟡 **Clarity**: Summary/Context attributed the adapter to 0169 instead of
+  0188 — Resolved (both sections edited in place)
+- 🟡 **Scope**: Unresolved open questions could expand this task beyond
+  wiring-plus-deletion — Partially resolved (the containment-bound and
+  licence decisions are now gated by explicit Acceptance Criteria and
+  Dependencies entries rather than left as free-floating prose, but the
+  decisions themselves remain open — see New Issues below)
+- 🟡 **Testability**: Licence re-check not captured as an Acceptance
+  Criterion — Resolved
+- 🟡 **Testability**: sha256 handling had no defined, verifiable outcome —
+  Resolved (AC added; decision now scoped to a shared, referenceable
+  location rather than resolved silently inline)
+- 🟡 **Dependency**: MPL-2.0 licence/attribution follow-up not captured as a
+  Dependency — Resolved
+- 🟡 **Dependency**: New coupling to `cli/visualiser/server` not referenced
+  in Dependencies — Resolved (0168 added to Dependencies and `relates_to`)
+- 🔵 **Clarity**: "Four inheritances" header followed by five items —
+  Resolved
+- 🔵 **Clarity**: Stale `CommandProbe` file:line references — Resolved
+- 🔵 **Clarity**: Undefined "classifier port" term — Resolved (renamed to
+  `VcsProbe`)
+- 🔵 **Completeness**: Technical Notes retained a stale premise — Resolved
+- 🔵 **Completeness**: Frontmatter `blocked_by`/`status` stale — Partially
+  resolved (`blocked_by` corrected; `status` intentionally left as `draft`
+  per the reviewer's constraint not to change status during review)
+- 🔵 **Dependency**: Ordering relative to 0174 not stated — Resolved
+- 🔵 **Dependency**: sha256 framed as a local decision despite 0169 overlap —
+  Resolved
+- 🔵 **Testability**: Containment-bound/snapshot questions ungated — Resolved
+  (both promoted to Acceptance Criteria)
+- 🔵 **Testability**: AC5/`check-zero-spawn` ambiguity — Resolved
+- 🔵 **Scope**: Licence-attribution follow-up spans a different toolchain —
+  Still present (accepted as an in-line Acceptance Criterion rather than
+  split into a separate item; see New Issues)
+- 🔵 **Clarity/Completeness**: "corpus writers"/"§3.2" undefined referents;
+  stale References anchor — Resolved
+
+### New Issues Introduced
+
+The edits addressing the pass-1 findings introduced their own inconsistencies,
+caught by this pass and fixed in the same edit session before this write:
+
+- 🟡 **Clarity**: the new `Blocks: 0174` bullet directly contradicted the
+  pre-existing Drafting Notes claim that this item "should not block" epic
+  0136's shell-retirement work — Fixed (Dependencies reworded from "Blocks"
+  to a hedged "Related" entry; Drafting Notes clarified that "should not
+  block" is a priority claim, not a sequencing one)
+- 🟡 **Clarity**: the Amendment block's corrections were partially stale
+  relative to the body they described, since several had already been
+  folded into the main sections — Fixed (added an editorial note marking
+  which inheritances are fully applied vs. still open)
+- 🟡 **Scope**: the new sha256 Acceptance Criterion required resolving the
+  policy locally, directly contradicting the Open Question's instruction to
+  decide it "in a location both consumers can reference... not... locally" —
+  Fixed (both the AC and Open Question now agree: this item decides the
+  policy and records it in the `vcs` crate's port-contract documentation,
+  since 0169 — the only other consumer — is closed)
+- 🟡 **Dependency**: `blocked_by` was cleared to `[]` on the assumption that
+  a landed blocker should be removed, contradicting the repo's own
+  convention (confirmed against 0169, which retains completed blockers) —
+  Fixed (restored to `["work-item:0188"]`)
+- 🔵 **Completeness/Dependency**: `relates_to` frontmatter was not updated
+  to match the new 0168 Dependencies entry — Fixed (added, along with 0198)
+
+One new substantive finding, not introduced by this pass's edits but
+surfaced by the dependency lens's re-review, independently verified against
+the codebase's own `meta/work/0198-*.md`:
+
+- 🟡 **Dependency**: Acceptance Criterion 1's claim that "no `Command::new`
+  for `jj` or `git` remains in the crate's non-test code" cannot be
+  satisfied crate-wide, because `cli/vcs-adapters/src/subprocess.rs` also
+  hosts `status`/`log`'s separate subprocess path (`run_vcs_text`), which
+  0198 owns and may retain indefinitely pending a feasibility
+  investigation. Verification of 0198's content further revealed that
+  `run_vcs_text` likely reuses the same capped-stdout/environment-scrubbing
+  helpers this item's Requirements assumed served `CommandProbe` "solely" —
+  Fixed (AC1, the zero-spawn Requirement, Technical Notes, and Dependencies
+  all reworded to scope the crate-wide claim to `facts` callers only and
+  flag the shared-helper risk explicitly)
+
+### Assessment
+
+The work item is now internally consistent: every claim traced back to the
+Amendment's corrections is applied in the body, the two previously-ungated
+prerequisite decisions (containment bound, snapshot-on-read dependency) are
+now checkable Acceptance Criteria, the sha256 and MPL-2.0 consequences are
+captured as both Dependencies and Acceptance Criteria, and the newly
+discovered 0198 coupling is scoped explicitly rather than left as a latent
+false-green risk in AC1. One minor, previously-identified concern remains
+open by design: the MPL-2.0 attribution artefact (if triggered) spans a
+different toolchain than the rest of this task, and the reviewer judged it
+better tracked as an in-line Acceptance Criterion than split into a
+separate item, since the licence *re-check* itself is cheap and the
+attribution-artefact work only materialises conditionally. The item is
+ready for implementation; no further revision is required before pickup.
+
+---
+*Review generated by /accelerator:review-work-item*

--- a/meta/validations/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-validation.md
+++ b/meta/validations/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-validation.md
@@ -1,0 +1,233 @@
+---
+type: plan-validation
+id: "2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-validation"
+title: "Validation Report: Converge corpus-adapters on the Library-Backed VCS Adapter"
+date: "2026-08-11T09:24:20+00:00"
+author: Toby Clemson
+producer: validate-plan
+status: complete
+result: pass
+parent: "work-item:0185"
+target: "plan:2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs"
+tags: [rust, vcs, cleanup, tech-debt]
+last_updated: "2026-08-11T09:24:20+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Validation Report: Converge corpus-adapters on the Library-Backed VCS Adapter
+
+Implemented across five changes on top of `27044ae3b3ce`:
+
+| Change | Phase |
+| --- | --- |
+| `aec43c3ae941` Record the VCS probe policy decisions the composition switch depends on | 1 |
+| `cbc4f0c4b695` Resolve repository facts in-process rather than by spawning jj or git | 2 |
+| `3a7dd0b4022f` Delete the subprocess-backed root and revision probes | 3 |
+| `4112316793c3` Record where the MPL-2.0 closure actually links across the sub-binaries | 4 |
+| `8bc00b20faa5` Strip comments that restate the code or name deleted implementations | (unplanned) |
+
+### Implementation Status
+
+✓ Phase 1: Record the pending policy decisions — fully implemented
+✓ Phase 2: Extend zero-spawn coverage, then repoint `facts` — fully implemented
+✓ Phase 3: Delete `CommandProbe` and collapse the dual-adapter comparison — fully implemented
+✓ Phase 4: Re-run the MPL-2.0 licence check — fully implemented (with a recorded methodology deviation)
+
+⚠️ Validation found one defect introduced by Phase 2 that no phase's
+verification set covered: the two new zero-spawn tests broke the
+`check-zero-spawn` CI job, a required dependency of the Main CI aggregate.
+**Fixed during validation** — see Potential Issues, item 1.
+
+### Automated Verification Results
+
+✓ `mise run check` passes (exit 0, 42.30s)
+✓ `cargo nextest run -p vcs-adapters -p corpus-adapters --features bash-parity`
+  — 201 tests run, 201 passed, 0 skipped
+✓ `cargo nextest run -p corpus-adapters --features bash-parity -E 'binary(zero_spawn)'`
+  — 2 passed (the metadata test covers both idioms in one body after the fix)
+✓ Simulated strong lane — the compiled `zero_spawn` binary run under
+  `env -i` with a `PATH` carrying no `git`/`jj` and the matrix handed over via
+  `ACCELERATOR_ZERO_SPAWN_MATRIX` — 2 passed. The same simulation reproduced
+  the original break first (both new tests erroring with
+  `git: No such file or directory`), so the fix is verified against a proven
+  red.
+✓ `grep -rn "CommandProbe" cli/ --include="*.rs"` — no matches
+✓ `grep -rn "MarkerWalkRoot" cli/ --include="*.rs"` — no matches
+✓ Surviving `Command::new` in `cli/vcs-adapters/src/` is confined to
+  `subprocess.rs`'s `status`/`log` path (`:68-95`) plus its own generic
+  shell-stand-in tests — no `facts`-serving spawn remains
+⚠️ `mise run test:integration:zero-spawn:strong` — not runnable locally (it
+  `sudo mv`s system `git`/`jj`, so it belongs on an ephemeral runner). Covered
+  by the simulation above instead, and by confirming that
+  `_compile_zero_spawn_targets`' `--no-run` step does build
+  `corpus-adapters-fixture` (checked by deleting it and rebuilding), so
+  everything the shadow window needs exists before it opens.
+✓ MPL-2.0 finding independently reproduced against the existing release
+  artefacts (`nm -a | grep -c`):
+
+  | Binary | `gix_` | `jj_lib` | `uluru` |
+  | --- | --- | --- | --- |
+  | accelerator-corpus | 546 | 238 | 3 |
+  | accelerator-vcs | 467 | 117 | 3 |
+  | accelerator-work | 547 | 274 | 3 |
+  | accelerator-collaboration | 464 | 0 | 3 |
+  | accelerator-migrate | 2163 | 2878 | 3 |
+  | accelerator-visualiser | 0 | 0 | 0 |
+
+  This matches `cli/deny.toml`'s recorded finding exactly: five binaries link
+  `uluru`, the visualiser links none of the three.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `cli/vcs-adapters/src/lib.rs:25` is now
+  `vcs::facts(start, &InProcessProbe, &InProcessProbe)`, exactly the shape
+  Phase 2 specified.
+- All three policy decisions are recorded where the plan placed them:
+  sha256 handling on `VcsProbe::revision` (`cli/vcs/src/lib.rs:72-75`), the
+  containment bound above `InProcessProbe` (`cli/vcs-adapters/src/library.rs:189-209`),
+  and the snapshot-on-read scope on `VcsBackedRepoFactsProbe`
+  (`cli/corpus-adapters/src/metadata.rs:205-210`).
+- Both backing tests the plan added for those decisions exist and pass: the
+  sha256 `revision` case (`cli/vcs-adapters/tests/queries.rs:575-577`) and the
+  git-side malformed-ref case
+  (`unreadable_git_ref_data_reports_absence_rather_than_a_wrong_commit`,
+  `cli/vcs-adapters/tests/library.rs:411-425`). The latter asserts the fixture
+  answers *before* it is broken, so it cannot pass vacuously.
+- The new reference binary sits at
+  `cli/corpus-adapters/tests/fixtures/corpus_adapters_fixture.rs`, declared as
+  a `[[bin]]` with no `required-features` gate, mirroring `vcs-adapters-fixture`
+  as specified. It is not in `_CLI_RELEASE_BINARIES` (`tasks/build.py:36-44`),
+  which is an explicit tuple rather than a glob, so it cannot reach release
+  staging.
+- Every deletion the plan enumerated landed cleanly, including the easy-to-miss
+  ones: the doc comment above `CommandProbe`, `run_checked`/`wait_capped_checked`,
+  the orphaned `origin_repo()` helper, the nested test-module imports
+  (`std::path::PathBuf` and `CommandProbe` at `subprocess.rs:414,421`), and
+  `detection.rs`'s `facts_via` indirection with its `RepoRoot`/`VcsProbe`
+  imports.
+- `run_capped`'s doc comment no longer intra-doc-links the deleted
+  `CommandProbe::revision`; the module-level comments in `subprocess.rs`,
+  `lib.rs`, `detection.rs` and `library.rs` were all retitled as the plan
+  required, and `library.rs`'s now names all three test groups rather than two.
+- `an_unsnapshotted_edit_is_the_one_documented_divergence` was reworked (not
+  deleted) to snapshot via `jj_revision_oracle` rather than `CommandProbe`, and
+  the new `git_revision_oracle` closes the git-side oracle gap the plan
+  identified in `a_plain_git_repository_reports_git_kind`.
+- The colocated test was renamed to `a_colocated_checkout_is_driven_as_jj_in_process`,
+  avoiding the name collision with `detection.rs` the plan warned about.
+- Work item `0203` was filed for the MPL-2.0 attribution artefact, as Phase 4
+  required, and carries the methodology caveat for whoever picks it up.
+
+#### Deviations from Plan:
+
+- **Phase 4 verification method changed, and is recorded as such.** The
+  plan's `extensions.objectFormat` / `There is no Jujutsu repo` string-literal
+  procedure proved unsound as an absence test. The implementation switched to
+  `nm -a` symbol counts and recorded the literals' unreliability in
+  `cli/deny.toml:91-95` and in `0203` itself. The plan's manual-verification
+  checkbox was annotated with the deviation rather than silently ticked. This
+  is the right call — my own reproduction confirms the symbol counts.
+- **An unplanned fifth commit (`8bc00b20faa5`) strips comments beyond the
+  plan's scope.** It rewrites the Phase 1 doc comments it had just added
+  (shorter, but the decisions survive) and additionally strips stale bash-port
+  references from `cli/corpus-adapters/src/work_item_pattern.rs`,
+  `tests/parity.rs` and `src/metadata.rs` — files the plan never named. The
+  change is consistent with the repo's comment policy and with the earlier
+  `d8776d652f6c` precedent, but it is scope this plan did not authorise and it
+  touched a parity suite the plan explicitly listed as "must keep passing
+  unchanged".
+- **`InProcessProbe` gained `Default`** (`#[derive(Debug, Clone, Copy, Default)]`)
+  where the plan's snippet showed a bare `pub struct InProcessProbe;`. Harmless.
+
+#### Potential Issues:
+
+1. **The two new zero-spawn tests failed the `check-zero-spawn` CI job.**
+   **Resolved during validation** — resolution at the end of this item.
+
+   `.github/workflows/main.yml:323-367` runs
+   `mise run test:integration:zero-spawn:strong`, which physically `sudo mv`s
+   every resolved `git` and `jj` aside (`tasks/test/integration.py:214-241`,
+   `_resolve_vcs_binaries` at `:279`) and then runs the whole `zero_spawn`
+   binary under `-E 'binary(zero_spawn)'`.
+
+   The pre-existing test survives that window because it *adopts* a matrix
+   built beforehand (`fixtures::matrix_root()` +
+   `Matrix::build_or_adopt`, honouring `ACCELERATOR_ZERO_SPAWN_MATRIX`). The
+   two new tests instead build their fixtures inline —
+   `environment.git(&["init", "--quiet"], &root)`
+   (`cli/corpus-adapters/tests/zero_spawn.rs:165-167`) and
+   `fixtures::pure_jj(...)` (`:179`) — both of which resolve their binary
+   through `Command::new("git")`/`Command::new("jj")`
+   (`cli/vcs-test-support/src/hermetic.rs:94,121`) and return `Err` when it
+   cannot be run. With the binaries moved, fixture construction fails and both
+   tests error out.
+
+   `check-zero-spawn` is a required dependency of the aggregate at
+   `.github/workflows/main.yml:436`, so this breaks Main CI. It is invisible
+   locally: the strong lane is deliberately out of every roll-up, so neither
+   `mise run check` nor the bare `mise run` exercises it.
+
+   **Resolution**: the two tests were replaced by a single
+   `the_metadata_read_resolves_both_idioms_without_spawning_them`, which draws
+   its start directories from the shared matrix (`PG-r` for plain git, `PJ` for
+   pure jj) exactly as the sibling test does, so the strong lane's existing
+   `_build_fixture_matrix` pre-build already covers them and no new CI wiring is
+   needed. Both idioms are still exercised, which was the plan's reason for
+   asking for two tests. Verified non-vacuous: both shapes resolve real facts
+   (`name=PG revision=1cbe1df0…`, `name=c revision=32922826…`) rather than
+   matching as "absent" twice.
+
+2. **The new tests did not fail closed on a malformed mode contract.**
+   **Resolved during validation.** The pre-existing test opens with
+   `Mode::from_environment()?` + `assert_shadowing_holds(mode)?` precisely so a
+   dropped export silently downgrades the run rather than passing; the new tests
+   skipped that, so they would have reported a strong-form pass in a path-only
+   environment. The replacement test now opens the same way.
+
+3. **The canonicalisation behaviour change is documented in the plan but not in
+   the code.** Phase 2 noted that `InProcessProbe::repository_root`
+   canonicalises where `MarkerWalkRoot`'s did not, and that this can change the
+   persisted `Repository Name:` when the repository directory itself is a
+   symlink. The plan judged it too narrow for new test infrastructure, which is
+   defensible, but nothing in the tree records it — the note lives only in the
+   plan document. A line on `VcsBackedRepoFactsProbe` alongside the staleness
+   note would keep it findable.
+
+### Manual Testing Required:
+
+1. Zero-spawn strong lane:
+  - [ ] Confirm the real lane is green now that issue 1 is fixed — push the
+        branch and watch `check-zero-spawn`. Do not run
+        `test:integration:zero-spawn:strong` on a developer machine; it
+        `sudo mv`s system `git`/`jj` and is meant for ephemeral runners.
+
+2. `corpus metadata derive` behaviour:
+  - [ ] Against a jj repository with unsnapshotted edits, confirm
+        `Current Revision:` names the last recorded commit (the accepted
+        divergence), not a freshly snapshotted one
+  - [ ] Against a bare repository, confirm it still reports no facts
+
+3. Hook path:
+  - [ ] `vcs detect` / `vcs guard` still behave — unchanged in principle, since
+        they already used `InProcessProbe`
+
+### Recommendations:
+
+- Issues 1 and 2 are fixed in `cli/corpus-adapters/tests/zero_spawn.rs`; the
+  branch is mergeable once `check-zero-spawn` is confirmed green on CI.
+- Consider recording the canonicalisation note in the code rather than only in
+  the plan (issue 3).
+- Worth a follow-up in its own right: the strong lane is the only place this
+  class of defect can surface, and nothing about writing a test in
+  `zero_spawn.rs` signals that building a fixture inline is forbidden. A note in
+  the module doc, or a helper that is the only sanctioned way to get a start
+  directory there, would stop the next person rediscovering this.
+- The unplanned comment-stripping commit is fine on its merits but would sit
+  more comfortably as its own change with its own justification, given it
+  touched a parity suite the plan had ring-fenced.
+- `0203` should be prioritised rather than parked: MPL-2.0 §3.2's notice
+  obligation is live today for five shipped binaries, and four of those were
+  already shipping before this plan.

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -5,14 +5,14 @@ title: "Converge corpus-adapters on the Library-Backed VCS Adapter"
 date: "2026-07-31T08:36:03+00:00"
 author: Toby Clemson
 producer: create-work-item
-status: draft
+status: ready
 kind: task
 priority: medium
 parent: "work-item:0136"
 blocked_by: ["work-item:0188"]
-relates_to: ["work-item:0125", "work-item:0179"]
+relates_to: ["work-item:0125", "work-item:0179", "work-item:0168", "work-item:0198"]
 tags: [rust, vcs, cleanup, tech-debt]
-last_updated: "2026-08-03T16:37:02+00:00"
+last_updated: "2026-08-10T02:08:00+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -20,23 +20,25 @@ schema_version: 1
 # 0185: Converge corpus-adapters on the Library-Backed VCS Adapter
 
 **Kind**: Task
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
 Migrate `cli/corpus-adapters` off the subprocess-based `CommandProbe` onto the
-library-backed (`gix` / `jj-lib`) VCS adapter that 0169 introduces, then delete
+library-backed (`gix` / `jj-lib`) VCS adapter that 0188 introduces, then delete
 `CommandProbe`. This closes the two-implementations state 0169 deliberately
 leaves behind, and extends the zero-`jj`/`git`-spawn guarantee from the four
-hook paths to every consumer of `vcs-adapters`.
+`vcs` subdomain paths (`detect`/`guard` — the two actual hooks — plus
+`status`/`log`, invoked by skills) to every consumer of `vcs-adapters`.
 
 ## Context
 
-0169 replaces `vcs-adapters`' subprocess probe with in-process `gix`/`jj-lib`
-bindings, but **bounds that swap to the `vcs detect|status|log|guard` paths**.
-The one production consumer outside those paths —
+0188 delivers a library-backed (`gix`/`jj-lib`) VCS adapter, `InProcessProbe`,
+and 0169 wires it for the `vcs detect|status|log|guard` paths only —
+**bounding that swap to those four paths**. The one production consumer
+outside those paths —
 `cli/corpus-adapters/src/metadata.rs:201`, which calls `vcs_adapters::facts` and
 reads `RepoFacts.name` and `.revision` to stamp artefact frontmatter — keeps
 using `CommandProbe`.
@@ -46,7 +48,8 @@ unanimous across the scope, completeness and testability lenses): converging the
 metadata path inside 0169 would have coupled a pre-1.0 `jj-lib` bet to an
 already-shipped consumer with its own parity suite, and nothing in the hooks
 migration required it. The cost is that `vcs-adapters` ships **two** probe
-implementations, and the zero-spawn property holds only for the hook paths.
+implementations, and the zero-spawn property holds only for those four `vcs`
+subdomain paths.
 
 This task pays that back once the library-backed adapter has proven itself on
 the four paths.
@@ -57,55 +60,147 @@ the four paths.
   adapter instead of `CommandProbe`. The call site is
   `cli/corpus-adapters/src/metadata.rs:201`; only `.name` and `.revision` are
   read (`:185-186`), so the required surface is narrow.
-- Delete `CommandProbe` (`cli/vcs-adapters/src/lib.rs:73`) and its supporting
-  subprocess machinery once it has no callers — including the capped-stdout
-  helper and environment scrubbing that exist solely to serve it, if nothing
-  else uses them.
-- Preserve `vcs_adapters::facts`'s existing signature and semantics
-  (`cli/vcs-adapters/src/lib.rs:225`) so the change is invisible to callers: a
-  repository with no commits still yields `revision: None`, a bare repository
-  still yields `None` facts, and a jj secondary workspace still reports the
-  repository's name rather than the workspace directory's.
+- Delete `CommandProbe` (`cli/vcs-adapters/src/subprocess.rs`, split out from
+  `lib.rs` on 2026-08-03 — confirm current line numbers at implementation
+  time) and its supporting subprocess machinery once it has no callers. Do
+  **not** assume the capped-stdout helper and environment scrubbing exist
+  solely to serve `CommandProbe`: 0198 describes its still-active
+  `status`/`log` subprocess path (`run_vcs_text`, same module) as running
+  "under a scrubbed environment and a 10-second cap," which reads as the
+  same machinery — confirm actual callers at implementation time before
+  deleting either helper.
+- Preserve `vcs_adapters::facts`'s existing signature and the boundary
+  behaviour `cli/vcs-adapters/tests/detection.rs` pins, so the switch is
+  invisible to callers at those boundaries: a repository with no commits
+  still yields `revision: None`, a bare repository still yields `None`
+  facts, and a jj secondary workspace still reports the repository's name
+  rather than the workspace directory's. One known exception is not
+  invisible: the switch drops the CLI's snapshot-on-read side effect (see
+  Amendment 2026-08-03, inheritance 3) — decide whether any consumer
+  depends on it before flipping `facts`.
 - Extend the zero-spawn assertion to cover the corpus metadata read, so the
-  guarantee is crate-wide rather than path-scoped.
+  guarantee covers every `vcs_adapters::facts` caller rather than only the
+  four `vcs` subdomain paths. This does **not** extend to `status`/`log`'s separate
+  subprocess path in the same crate (`subprocess.rs`'s `run_vcs_text`),
+  which 0198 owns and may retain indefinitely — the guarantee is
+  `facts`-wide, not literally crate-wide.
 
 ## Acceptance Criteria
 
 - [ ] `CommandProbe` no longer exists in `cli/vcs-adapters`, and no
-      `Command::new` for `jj` or `git` remains in the crate's non-test code.
+      `Command::new` for `jj` or `git` remains in the crate's non-test code
+      that serves `vcs_adapters::facts`. `status`/`log`'s separate subprocess
+      path (`run_vcs_text` in `subprocess.rs`) is explicitly out of scope —
+      it is owned by 0198 and may still spawn `jj`/`git` after this item
+      completes.
 - [ ] `cli/corpus-adapters` obtains `RepoFacts` through the library-backed
       adapter, and its existing suites pass unchanged —
       `cli/corpus-adapters/tests/parity.rs`,
       `cli/corpus-adapters/tests/metadata.rs`, and
       `cli/corpus-adapters/tests/work_item_pattern_parity.rs`.
-- [ ] The zero-spawn black-box assertion introduced by 0169 (fixture repos run
-      with `PATH` containing only marker-writing `git`/`jj` stubs) is extended
-      to a `corpus-adapters` metadata read: no marker is written and the read
-      still succeeds.
+- [ ] The zero-spawn black-box assertion — marker-writing `PATH` stubs plus
+      the platform-aware absolute-path shadow list plus the empty-config
+      environment, published from `cli/vcs-test-support` (Amendment
+      2026-08-03) — is extended to a `corpus-adapters` metadata read: no
+      marker is written and the read still succeeds. The `check-zero-spawn`
+      CI job runs this strong form; confirm it is part of the default `mise
+      run`/`mise run check` invocation, or add it as an explicit step if not.
 - [ ] Behaviour is unchanged at the boundaries that
       `cli/vcs-adapters/tests/detection.rs` already pins: no-commits →
       `revision: None`; bare repository → no facts; colocated → `VcsKind::Jj`;
       jj secondary workspace → the repository's name, not the workspace
       directory's.
+- [ ] The MPL-2.0 licence check 0188 recorded conditionally (`cli/deny.toml`'s
+      `uluru` exception) is re-run against an unstripped `--release` build now
+      that `facts` links `vcs-adapters` into the visualiser's call graph; if
+      the `gix`/`jj-lib` closure is reachable, a third-party attribution
+      artefact joins `_release_uploads()`.
+- [ ] A sha256 repository yields a defined, tested outcome from
+      `vcs_adapters::facts` — either `revision` accepting the 64-hex width or
+      an explicit unsupported-repository error — rather than an unhandled
+      `gix` `Err` propagating as a generic failure. The decision is recorded
+      in the `vcs` crate's port-contract documentation, not only inline in
+      `vcs-adapters`, so 0169's already-shipped `detect`/`status`/`log`/
+      `guard` paths (which hit the identical gix limitation without
+      deciding a policy) and any future consumer can reference the same
+      policy rather than each resolving it independently.
+- [ ] A containment-bound decision for `InProcessProbe` (timeout, memory
+      cap, or crash isolation — or an explicit decision that none is
+      needed) is made and recorded before `facts` is repointed, given it
+      now runs inside `cli/visualiser/server` and on the hook path with no
+      such bound today.
+- [ ] Confirmation that no `cli/corpus-adapters` write path depends on the
+      CLI's snapshot-on-read side effect is recorded, completed before or
+      as part of the switch.
 - [ ] `mise run` is green end to end.
+
+## Open Questions
+
+- Does `InProcessProbe` need an equivalent containment bound (timeout, memory
+  cap, crash isolation) before `facts` flips to it? `CommandProbe` parses in a
+  child process with a 10-second cap and kill-on-timeout; the in-process route
+  parses repository-controlled data in the caller's address space with no such
+  bound, and after the switch that runs inside `cli/visualiser/server` and on
+  the hook path. (Amendment 2026-08-03, inheritance 2)
+- Does any consumer depend on the CLI's snapshot-on-read side effect (writing
+  a new commit for unsnapshotted working-copy changes) that the in-process
+  route does not replicate? Nothing in the corpus writers (the `cli/corpus-adapters` write paths that persist
+   artefact frontmatter) appears to, but this
+  needs confirming before the switch. (Amendment 2026-08-03, inheritance 3)
+- How should revision validation handle sha256 repositories, which gix 0.85
+  does not support (every gix-backed query returns `Err`) and whose 64-hex
+  `HEAD` fails `detection.rs`'s 40-hex `is_full_revision_id` check — accept
+  both widths, or record sha256 as explicitly unsupported? This item's switch
+  is what first exposes a user on such a repository to the answer. 0169
+  recorded the identical gix limitation for its own shipped `vcs
+  detect|status|log|guard` paths (item 7 of its findings) without deciding a
+  handling policy, and 0169 is now closed — so this item makes the decision
+  and records it in the `vcs` crate's port-contract documentation (a location
+  0169's shipped behaviour and any future consumer can reference), rather
+  than resolving it silently inline in `vcs-adapters` alone. (Amendment
+  2026-08-03, inheritance 4)
+- Does the MPL-2.0 licence exception for `uluru` (via `gix-pack`'s LRU pack
+  cache) still hold once `vcs-adapters` actually links into the distributed
+  `accelerator-visualiser` binary through this switch? 0188 recorded the
+  exception conditionally on `vcs-adapters` being unreachable from the
+  visualiser's call graph; this switch is the expected trigger that
+  invalidates that finding and may require a third-party attribution
+  artefact. (Amendment 2026-08-03, inheritance 5)
 
 ## Dependencies
 
-- **Blocked by**: 0188 — the library-backed adapter does not exist until it
-  lands. (Originally recorded against 0169; repointed when 0169 was split and
-  the adapter work moved to 0188.)
+- **Blocked by**: 0188 — done; the library-backed adapter now exists,
+  unwired. (Originally recorded against 0169; repointed when 0169 was split
+  and the adapter work moved to 0188.)
 - **Related**: 0179 (delivered the `vcs`/`vcs-adapters` crate pair this
   modifies); 0125 (converge lexical VCS detection on the probe layer — a
   separate, shell-side convergence, but the same underlying "several detection
-  implementations coexist" problem, and worth sequencing consciously against).
+  implementations coexist" problem, and worth sequencing consciously against);
+  0168 (owns the visualiser's integration boundary — this switch is what
+  first makes `cli/visualiser/server` reachable into `vcs-adapters`'
+  `gix`/`jj-lib` closure, with no containment bound in place today; see
+  Amendment 2026-08-03, inheritance 2); 0198 (owns `status`/`log`'s separate
+  subprocess path in the same `subprocess.rs` module — this item's zero-spawn
+  and `CommandProbe`-deletion criteria are scoped to exclude it, and the two
+  items may share the capped-stdout/environment-scrubbing helpers, so verify
+  ownership of that machinery before deleting it); 0174 (Retire Shell Tooling
+  and CI Guards — sequenced after this item in the parent epic's Phase 11,
+  but not confirmed to depend on this item's completion; confirm at pickup
+  whether 0174 assumes `CommandProbe` and its subprocess machinery are
+  already gone before treating the two as independently schedulable).
+- **Process prerequisite**: re-run 0188's MPL-2.0 licence check (unstripped
+  `--release` build; grep for `extensions.objectFormat` and `There is no
+  Jujutsu repo`) as part of this switch, not after it — see Amendment
+  2026-08-03, inheritance 5.
 - **Parent**: epic 0136.
 
 ## Assumptions
 
-- 0169 lands the library-backed adapter behind the existing `RepoRoot` /
-  `VcsProbe` ports, so this task is a wiring change plus a deletion rather than
-  new adapter work. If 0169 instead builds a `vcs`-local adapter that does not
-  generalise, this task grows and should be re-estimated.
+- 0188 lands the library-backed adapter (`InProcessProbe`) behind the
+  existing `RepoRoot`/`VcsProbe` ports, so this task is a wiring change plus
+  a deletion rather than new adapter work. Confirmed by Amendment
+  2026-08-03, inheritance 3: `InProcessProbe` implements `VcsProbe` fully,
+  not partially, so this assumption now holds without qualification.
 - The corpus metadata path needs no VCS query beyond `name` and `revision`.
   Worth re-checking at implementation time — if `RepoFacts` has gained fields or
   consumers by then, the surface to preserve is wider.
@@ -116,17 +211,24 @@ the four paths.
   reading `.name` / `.revision` at `:185-186`; `use vcs::RepoFacts` at `:14`.
 - Composition root to change: `vcs_adapters::facts`
   (`cli/vcs-adapters/src/lib.rs:225-227`) currently hard-wires `MarkerWalkRoot`
-  + `CommandProbe::new()` with no injection variant. 0169 will need to alter
-  this anyway; this task finishes the job by removing the old probe rather than
-  leaving both wired.
-- `CommandProbe`'s subprocess surface is small — two commands (`jj log -r @ -T
-  commit_id` at `:110-120`, `git rev-parse HEAD` at `:124-125`) funnelling
-  through a single `spawn()` at `:168` — so the deletion is well-bounded.
+  + `CommandProbe::new()` with no injection variant. Repoint it at
+  `InProcessProbe` and delete the hard-wiring of the subprocess pair; see
+  Amendment 2026-08-03, inheritance 1 for the module-level deletion recipe.
+- `CommandProbe` and its subprocess machinery now live in their own module,
+  `cli/vcs-adapters/src/subprocess.rs` (split out 2026-08-03) — the crate
+  root holds no adapter code, only `facts` and the module declarations.
+  `CommandProbe`'s subprocess surface is small — two commands (`jj log -r @
+  -T commit_id`, `git rev-parse HEAD`) funnelling through a single `spawn()`
+  — so the deletion is well-bounded; confirm exact line numbers in
+  `subprocess.rs` at implementation time rather than relying on the
+  pre-split `lib.rs` references this item originally carried.
 - Watch the crate's own unit tests: several drive the private `capped_stdout`
-  and `scrub_environment` helpers directly
-  (`cli/vcs-adapters/src/lib.rs:229-322`) using generic shell binaries rather
-  than `jj`/`git`. They test machinery that exists only for `CommandProbe` and
-  should go with it, not be retargeted.
+  and `scrub_environment` helpers directly, using generic shell binaries
+  rather than `jj`/`git`. Do not assume these helpers exist only for
+  `CommandProbe` — 0198's `status`/`log` subprocess path (`run_vcs_text`,
+  also in `subprocess.rs`) reads as reusing the same scrubbed-environment/
+  capped-output pattern, so confirm actual callers before deleting either
+  helper or retargeting its tests.
 - The `bash-parity` feature gate on `cli/vcs-adapters/tests/detection.rs` means
   "needs real `jj`/`git` binaries to build fixtures", not "shells out in
   production" — it stays relevant after this change, since fixtures are still
@@ -136,12 +238,16 @@ the four paths.
 
 - Raised by 0169's downstream-hand-off acceptance criterion, which requires a
   follow-up item owning this convergence rather than leaving it as unowned debt.
-- Sized as a `task` rather than a story: it is a wiring change plus a deletion
-  behind an adapter another item delivers, with no new behaviour and no user-
-  visible change.
+- Sized as a `task` rather than a story: it is a wiring change plus a
+  deletion behind an adapter another item delivers, with one known,
+  narrowly-scoped user-visible exception (loss of the CLI's snapshot-on-read
+  write side effect — see Requirements) and otherwise no new behaviour.
 - Priority `medium`: nothing is broken while both implementations coexist — the
-  cost is a second code path and a narrower zero-spawn guarantee, not a defect.
-  It should not block epic 0136's shell-retirement work.
+  cost is a second code path and a narrower zero-spawn guarantee, not a
+  defect. "Should not block epic 0136's shell-retirement work" is a priority
+  claim, not a sequencing one — it means this item need not be rushed to
+  unblock 0136's critical path, not that 0174 can start before this item
+  finishes; see Dependencies for the open sequencing question with 0174.
 
 ## Amendment 2026-08-03 — 0188 has landed; corrections and inheritances
 
@@ -151,14 +257,24 @@ zero-spawn harness to 0169 is wrong.** Both are
 block raises the corrections rather than rewriting the sections above; where a
 statement is now false it is quoted and marked.
 
+*(Editorial note, 2026-08-10): the corrections listed below have since been
+applied to the Summary, Context, Requirements, Assumptions, Technical Notes,
+and References sections above. This block is retained as a historical record
+of what changed and why, not as a list of outstanding edits. The still-open
+decisions from the five inheritances below are inheritance 2 (containment
+bound — see Open Questions and Acceptance Criteria), inheritance 4 (sha256
+handling — see Open Questions and Acceptance Criteria), and inheritance 5
+(licence re-check — see Dependencies and Acceptance Criteria); inheritances
+1 and 3 are fully applied.)*
+
 - **The adapter exists and ships unwired.** `vcs_adapters::library::InProcessProbe`
   implements both `vcs` ports plus six inherent taxonomy queries.
   `vcs_adapters::facts` still names `MarkerWalkRoot`/`CommandProbe`, by design.
 - **0185 owns the `vcs_adapters::facts` switch**, and the switch and the
   `CommandProbe` deletion are **one atomic change** — the composition root
   cannot move until nothing else needs the subprocess pair. This closes the open
-  question 0188 recorded on the ordering; 0169 wires its own classifier port
-  without touching `facts`.
+  question 0188 recorded on the ordering; 0169 wires its own `VcsProbe`
+  implementation without touching `facts`.
 - **The harness criterion here describes `PATH` stubs only.** What it inherits
   is strictly larger: marker-writing stubs *plus* a platform-aware absolute-path
   shadow list *plus* the empty-config environment, published from
@@ -175,7 +291,7 @@ statement is now false it is quoted and marked.
   heading, and its Dependencies bullet is titled "Unowned debt this story
   creates".
 
-Four inheritances that change this item's sizing:
+Five inheritances that change this item's sizing:
 
 1. **The deletion is a file deletion.** `InProcessProbe` delegates to the
    crate-private `walk_up`/`marker_kind`/`carries_any_marker` helpers rather than
@@ -220,7 +336,8 @@ Four inheritances that change this item's sizing:
    deriving metadata stops having a write side effect on the user's repository,
    and a `RepoFacts.revision` taken with unsnapshotted edits present names the
    last recorded commit rather than a fresh one. Decide whether any consumer
-   depends on the snapshot semantics; nothing in the corpus writers appears to.
+   depends on the snapshot semantics; nothing in the corpus writers (the `cli/corpus-adapters` write paths that persist
+   artefact frontmatter) appears to.
 4. **sha256 repositories are unsupported by gix 0.85** (measured 2026-08-03):
    every gix-backed query returns `Err` on one, rather than misreading it.
    `detection.rs`'s `is_full_revision_id` also asserts 40 hex, and a sha256
@@ -232,7 +349,7 @@ Four inheritances that change this item's sizing:
    published `accelerator-visualiser` binary, but 0188 verified that dead-code
    elimination removes the whole `gix`/`jj-lib` closure from it — because nothing
    in the visualiser's reachable call graph enters `vcs-adapters` at all today,
-   not even `CommandProbe`. §3.2's notice obligation therefore does not bind, and
+   not even `CommandProbe`. MPL-2.0 §3.2's notice obligation therefore does not bind, and
    the `cli/deny.toml` exception comment records that finding **conditionally**.
    **This item's switch is the expected trigger that invalidates it.** Once the
    trees link into a distributed binary, distributing the Executable Form
@@ -246,8 +363,8 @@ Four inheritances that change this item's sizing:
 ## References
 
 - Boundary and rationale: `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
-  (Requirements → "Adapter-swap boundary"; Dependencies → "Unowned debt this
-  story creates or inherits", item 1)
+  (Dependencies → "Related", the 0185 entry; Dependencies → "Unowned debt this
+  story creates")
 - Review that recommended the boundary:
   `meta/reviews/work/0169-vcs-subdomain-and-hooks-migration-review-2.md` (Pass
   3, 2026-07-31)

--- a/meta/work/0203-ship-an-mpl-2-0-attribution-artefact-with-the-release.md
+++ b/meta/work/0203-ship-an-mpl-2-0-attribution-artefact-with-the-release.md
@@ -1,0 +1,100 @@
+---
+type: work-item
+id: "0203"
+title: "Ship an MPL-2.0 Attribution Artefact with the Release Uploads"
+date: "2026-08-10T18:40:00+00:00"
+author: Toby Clemson
+producer: implement-plan
+status: ready
+kind: task
+priority: medium
+relates_to: ["work-item:0185", "work-item:0188", "work-item:0165"]
+tags: [rust, licensing, release, vcs]
+last_updated: "2026-08-10T18:40:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0203: Ship an MPL-2.0 Attribution Artefact with the Release Uploads
+
+**Kind**: Task
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Five of the six dispatched sub-binaries link `uluru` (MPL-2.0), so MPL-2.0
+§3.2's notice obligation is live for the signed binaries we distribute today.
+The release upload set carries no artefact telling recipients how to obtain
+that source. Build one, and stage it alongside the binaries.
+
+## Context
+
+`cli/deny.toml`'s `uluru` exception was recorded on the basis that dead-code
+elimination removed the whole `gix`/`jj-lib` closure from every shipped
+binary, so §3.2 did not bind. 0185 re-ran that check across all six
+`DISPATCHED_SUBBINARIES` rather than the visualiser alone, and the premise
+turned out to hold only for the visualiser.
+
+Measured on unstripped `--release` builds for `aarch64-apple-darwin`, by
+counting `gix_`/`jj_lib`/`uluru` symbols:
+
+- `accelerator-vcs`, `accelerator-work`, `accelerator-collaboration` and
+  `accelerator-migrate` already linked `uluru` **before** 0185's switch. Each
+  constructs `InProcessProbe` directly, through call sites unrelated to the
+  metadata-read path, so directly-called code cannot be eliminated. This is a
+  pre-existing finding 0185 surfaced, not one it caused.
+- `accelerator-corpus` linked none of the three before and all of them after.
+  This one is caused by 0185 repointing `vcs_adapters::facts` onto the
+  library-backed probe.
+- `accelerator-visualiser` links none of the three, before or after, so its
+  original exception rationale is intact.
+
+`uluru` is `gix-pack`'s LRU pack cache, reached through `gix-odb`'s default
+features, so it cannot be feature-gated out of the closure.
+
+Note for whoever picks this up: the two string literals the original
+verification procedure used (`extensions.objectFormat` for gix, `There is no
+Jujutsu repo` for jj-lib) are unreliable as an absence test — both are missing
+from binaries that demonstrably link the closure. Count symbols with `nm -a`
+instead. Plain `grep` over a Mach-O binary also reports false positives here;
+`strings -a | grep` or `nm -a | grep` are the sound forms.
+
+## Requirements
+
+- Produce a third-party attribution artefact covering the MPL-2.0 components
+  linked into the distributed binaries, carrying the notice and the means of
+  obtaining the corresponding source.
+- Stage it into the release upload set (`_release_uploads()` in
+  `tasks/github.py`) so it ships with the signed manifest rather than
+  existing only in the repository.
+- Extend the release-workflow coverage assertion in `test_workflows.py` to
+  cover the new upload, so a future change to the upload set cannot silently
+  drop it.
+- Decide whether the artefact is generated (e.g. from the cargo metadata
+  graph) or hand-maintained, and record why. A generated artefact stays
+  correct as the closure moves; a hand-maintained one goes stale silently.
+- Update `cli/deny.toml`'s `uluru` exception comment to point at the shipped
+  artefact once it exists, replacing the current statement that the release
+  upload set carries none.
+
+## Acceptance Criteria
+
+- [ ] The attribution artefact exists and names every MPL-2.0 component in
+      the distributed closure, verified against the actual linked binaries
+      rather than against the dependency manifest alone.
+- [ ] It is present in the release upload set and covered by
+      `test_workflows.py`.
+- [ ] The generated-versus-maintained decision is recorded on this item.
+- [ ] `cli/deny.toml`'s comment reflects the shipped state.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- Relates to: work-item:0185 — surfaced the finding and made
+  `accelerator-corpus` reach the closure.
+- Relates to: work-item:0188 — delivered the library-backed adapter whose
+  closure carries `uluru`.
+- Relates to: work-item:0165 — owns the release manifest and upload set this
+  artefact has to join.


### PR DESCRIPTION

# [0185] Converge corpus-adapters on the Library-Backed VCS Adapter

## Summary

`vcs_adapters::facts` resolved repository facts by spawning `jj log -r @ -T commit_id` and `git rev-parse HEAD`. 0188 delivered a fully-implemented in-process alternative — `InProcessProbe`, backed by `gix` and `jj-lib` — but deliberately left it unwired, so the crate carried two complete implementations of the same ports. This PR repoints the composition root onto the library-backed probe, deletes the subprocess pair, extends the crate's zero-spawn guarantee to cover the corpus metadata-read path, and records the three policy decisions the switch depends on in the code itself. It also corrects a licensing finding that turned out to be wrong for five of the six shipped sub-binaries.

## Changes

- **Composition root repointed**: `vcs_adapters::facts` now composes `InProcessProbe` for both the `RepoRoot` and `VcsProbe` positions. No `Command::new` for `jj` or `git` remains anywhere on the `facts` path.
- **Subprocess probes deleted**: `CommandProbe`, `MarkerWalkRoot`, their private `jj_repository_root` helper, and the `OriginRemote`-only `run_checked`/`wait_capped_checked` pair are gone, along with the transitional dual-adapter comparisons in `tests/detection.rs` (`assert_implementations_agree`, `facts_via`) and `tests/library.rs` (`assert_parity`). `scrub_environment`/`run_capped` survive untouched — 0198's `status`/`log` subprocess path shares them, and `subprocess.rs` is now scoped to that alone.
- **Zero-spawn proof extended across the composition**: a new `corpus-adapters-fixture` reference binary drives the real `VcsBackedRepoFactsProbe` → `vcs_adapters::facts` → `InProcessProbe` chain as a black box, and `tests/zero_spawn.rs` proves it resolves both a plain-git and a pure-jj repository with `git`/`jj` stubbed off `PATH`. Previously only the individual taxonomy queries were proven; the metadata-read path the corpus actually uses was unproven. The fixture lives under `tests/fixtures/` rather than `src/bin/`, mirroring `vcs-adapters-fixture`, so it stays off the crate's normal build surface and out of release staging.
- **Three policy decisions recorded in code, not left open**: (1) a sha256-format repository is unsupported — `gix` 0.85 cannot read one at all, so `revision` folds to `None` through its existing fallible-to-`Option` contract rather than misreading; (2) no timeout, memory cap, or crash-isolation bound is added around `InProcessProbe`, with the decision naming what it *removes* (the old 10-second cap with kill-on-timeout) and the sharpest blast radius it exposes (`work create` holds a creation lock for the duration of the call, and its reclaim mechanism only reclaims a dead holder); (3) no `corpus-adapters` write path depends on jj's snapshot-on-read side effect, scoped explicitly so it does not imply the same for the authoring skills that copy `Current Revision:` into committed frontmatter.
- **New tests backing those decisions rather than asserting them**: a sha256 `revision()` case (the existing sha256 tests covered `is_bare`/`worktree`/`dual_roots`/`classify` but never `revision`), and a malformed-git-`HEAD` case giving the git dispatch path the graceful-failure proof the jj path already had.
- **Git-side revision oracle added**: deleting `assert_parity` removed the only place that cross-checked `InProcessProbe`'s git revision against the real `git` binary, leaving a 40-hex format check as the sole guard. A `git_revision_oracle` helper mirroring the existing `jj_revision_oracle` closes that, so the simplification stays symmetric.
- **MPL-2.0 finding corrected**: `cli/deny.toml`'s `uluru` exception was recorded on the premise that dead-code elimination stripped the whole `gix`/`jj-lib` closure from every shipped binary. Measured across all six `DISPATCHED_SUBBINARIES` on unstripped `--release` builds, the premise holds only for the visualiser. `accelerator-vcs`, `accelerator-work`, `accelerator-collaboration` and `accelerator-migrate` already linked it *before* this change (each constructs `InProcessProbe` directly through call sites unrelated to `facts`); `accelerator-corpus` is the one this switch causes. Follow-up `work-item:0203` filed for the attribution artefact the release upload set now owes.
- **Verification method corrected too**: the two string literals the original procedure relied on (`extensions.objectFormat`, `There is no Jujutsu repo`) are unsound as an absence test — both are missing from binaries that demonstrably link the closure. The recorded finding is now a `gix_`/`jj_lib`/`uluru` symbol count via `nm -a`, with the literals' unreliability recorded alongside it so the next person does not repeat the mistake.

## Context

Implements `work-item:0185` (Converge corpus-adapters on the Library-Backed VCS Adapter), researched in `meta/research/codebase/2026-08-10-0185-converge-corpus-adapters-library-backed-vcs.md`, planned in `meta/plans/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs.md`, reviewed at both the work-item and plan level (`meta/reviews/work/0185-...-review-1.md` and `meta/reviews/plans/2026-08-10-0185-...-review-1.md`, both APPROVE), and validated in `meta/validations/2026-08-10-0185-converge-corpus-adapters-on-library-backed-vcs-validation.md` (result: pass).

Completes the convergence 0169 deliberately deferred and `work-item:0188` set up: 0188 built and proved `InProcessProbe` without wiring it, so that the composition switch could be reviewed on its own merits. Bounded against `work-item:0198`, which owns the separate `status`/`log` subprocess path and is the reason `scrub_environment`/`run_capped` survive this deletion.

Surfaces `work-item:0203` as its own follow-up: MPL-2.0 §3.2's notice obligation is live today for five shipped binaries, four of them independently of this change.

## Testing

- [x] `mise run check` — the read-only CI-equivalent gate across frontend, server, cli, build-system and scripts — exits 0.
- [x] `mise run test:unit:cli` — 1486/1486 pass across the whole `cli/` workspace, including the reworked `detection.rs`/`library.rs` and both new decision-backing tests.
- [x] `mise run test:integration:zero-spawn` — passes. The metadata-read test is verified non-vacuous: both shapes resolve real facts (`name=PG revision=1cbe1df0…`, `name=c revision=32922826…`) rather than matching as "absent" twice.
- [x] The strong-form zero-spawn lane was simulated locally — the compiled `zero_spawn` binary run under `env -i` with a `PATH` carrying no `git`/`jj` and the fixture matrix handed over via `ACCELERATOR_ZERO_SPAWN_MATRIX`. This caught a real break in the first cut of the new tests (they built fixtures inside the test body, which the shadow window cannot support) and verified the fix against a proven red.
- [x] No `CommandProbe` or `MarkerWalkRoot` reference remains anywhere under `cli/`; the only surviving `std::process::Command` uses in `vcs-adapters` non-test code serve 0198's `status`/`log` path.
- [x] The MPL-2.0 finding reproduces independently by symbol count on the existing release artefacts, matching what `cli/deny.toml` now records.
- [ ] Not verified this session: the Linux CI lane, and the real `test:integration:zero-spawn:strong` job — it `sudo mv`s system `git`/`jj` and belongs on an ephemeral runner, so it was covered by the simulation above rather than run locally.

## Notes for Reviewers

- **The one user-visible behavioural change** is the loss of jj's snapshot-on-read side effect on `corpus metadata derive`. For `corpus-adapters`' own Rust write paths this is stdout-only (`work create` reads the derived timestamp, never the revision). It is *not* stdout-only for the authoring skills — `create-plan`, `research-issue`, `create-note` and others copy the printed `Current Revision:` into committed `meta/` frontmatter, so an artifact authored with unsnapshotted edits present now records the last recorded commit. Accepted as a best-effort provenance degradation rather than a correctness regression, and documented as such on `VcsBackedRepoFactsProbe`.
- **The containment decision deserves a second opinion.** It removes a 10-second cap with kill-on-timeout from the `facts()` call site and adds nothing in its place, on the grounds that the same unbounded exposure already runs on the hook path and no crash-isolation precedent exists in the workspace. The doc comment names the `work create` lock blast radius explicitly and states a structural revisit condition. If you disagree with the trade, this is the place to say so.
- **`work-item:0203` is a licensing obligation, not a nice-to-have.** It is filed but `ready`, not done. Four of the five affected binaries were already shipping the MPL-2.0 closure before this PR, so the obligation predates it — flagging so the finding is not read as introduced here, nor assumed closed by it.
- **One narrow behaviour is documented but untested**: `InProcessProbe::repository_root` canonicalises where `MarkerWalkRoot` did not, so if the repository directory itself is a symlink the canonicalised final path component can change the persisted `Repository Name:`. Judged too narrow to warrant new test infrastructure; say if you would rather it were pinned.
- **One commit exceeds the plan's stated scope**: "Strip comments that restate the code or name deleted implementations" also removes stale bash-port references from `corpus-adapters`' `work_item_pattern.rs` and `tests/parity.rs`, files the plan never named. Consistent with the repo's comment policy and with prior precedent, but called out rather than folded in silently.
- **History reviews commit by commit**: policy decisions → composition switch → deletion → licence finding → comment cleanup → zero-spawn lane fix → validation. The deletion commit is large but purely subtractive.
