### PR TITLE
Claim built binaries out of cargo's uplift path

### DIFF
--- a/meta/prs/66-description.md
+++ b/meta/prs/66-description.md
@@ -1,0 +1,60 @@
+---
+type: pr-description
+id: "66"
+title: "Claim built binaries out of cargo's uplift path"
+date: "2026-08-17T08:05:56+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/66"
+pr_number: 66
+tags: [tests, cargo, build-system, flakiness]
+revision: "d94680ab79164e5781c732694803655cda938cea"
+repository: "accelerator"
+last_updated: "2026-08-17T08:05:56+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Claim built binaries out of cargo's uplift path
+
+## Summary
+
+`test:integration:entrypoint` intermittently failed its whole module-scoped shim fixture — 52 errors from one `pytest.fail("not built: cli/target/debug/accelerator-verify")` against a binary that plainly existed, after a `cargo build` that had exited 0.
+
+Cargo unlinks and re-hardlinks `cli/target/debug/<bin>` at the end of **every** build, a no-op one included, so that path is intermittently absent whenever anything else builds in the same workspace. Measured directly: five successive no-op `cargo build -p accelerator-verify` invocations left the path missing on 290 consecutive stat attempts, across 6 distinct inodes. `_cargo_build` released cargo's target lock and then stat-ed that shared path, so a sibling cargo invocation blocked on the very same lock proceeded and re-linked precisely into the check — a correlated race, not a uniformly unlikely one.
+
+Suites now copy each freshly built binary into a per-process directory and run that copy. Nothing was wrong with the shim, the launcher, or the entry point.
+
+## Changes
+
+- **`claim_artefact` copies a freshly built binary out of cargo's uplift path, retrying while the source sits in the re-link window.** Only the `open` has to land while the link is live — unix unlink semantics keep an in-flight read valid — so a vanished source is retried rather than fatal, and no lock or barrier over cargo is needed. The 5-second deadline is three orders of magnitude above the millisecond window it covers, so anything approaching it means the binary was never built at all; `not built` survives as the terminal message for that case.
+- **The claim also closes a wider latent failure the original check only hinted at.** The entrypoint suite execs the shim repeatedly over minutes, so a sibling re-link could have broken an exec mid-run, not merely fixture setup. A private copy cannot be pulled out from under a running test.
+- **`_cargo_build` memoises per binary name, so a pytest process invokes cargo once.** The entrypoint suite dropped from 156s to 28s, because it no longer queues behind cargo's target lock per fixture. The accepted consequence: editing `cli/` mid-process will not rebuild — pytest processes are short-lived and the next run rebuilds.
+- **Three sibling suites carried the identical racy pattern and are now routed through the shared build.** `tests/unit/tasks/test_signing.py`, `tests/unit/tasks/test_manifest.py` and `tests/integration/tasks/test_github.py` each hand-copied the build-then-stat sequence, and all three run concurrently with the entrypoint lane under `mise run` — fixing one lane would have left the same failure live in three others.
+- **The shared apparatus is extracted to `tests/support/`, split by concern.** `artefacts.py` owns binaries built from `cli/` (`build_shim`, `build_launcher`, `claim_artefact`); `tools.py` owns external-tool preconditions (`require`, `in_ci`). Dependencies now point one way — suites and `tests/integration/support/installation.py` both depend on `tests/support`, and no unit suite imports integration support. `installation.py` keeps only what it is documented to own: the bootstrap fixture apparatus.
+- **Four hand-copied `require`/`in_ci` pairs collapse into one.** They were behaviourally identical, differing only in message ordering in `test_github.py`.
+- **`tests/integration/entrypoint/test_built_artefacts.py` pins the three properties.** The claimed path lies outside `cli/target`, is stable across calls, and the claim retries through a source that vanishes — the last driven by patching `shutil.copy2` to raise `FileNotFoundError` twice before delegating, so the retry is proved deterministically rather than by timing.
+
+## Context
+
+No work item: this is a test-infrastructure defect found by a failing `mise run` rather than planned work. It touches only files under `tests/`, and no shipped skill, script, hook, or crate.
+
+## Testing
+
+- [x] `mise run` (the bare default) exits 0 end-to-end, with zero `ERROR task failed` lines.
+- [x] The entrypoint suite passes 57/57 **while a concurrent `cargo build` loop hammers the workspace** — the exact condition that produced the failure. Against the old code that same condition is what the 290-miss measurement describes.
+- [x] The affected suites together: 123 passed across entrypoint, signing, manifest and github; `test:integration:skill-invocation` 128 passed.
+- [x] `mise run build-system:check` clean (ruff, formatting, pyrefly).
+- [ ] CI's own parallelism and the linux lane are unverified locally — the fix removes a dependency on inter-process timing rather than adding one, so CI should be strictly less exposed, but only a CI run proves it.
+- [ ] Not investigated: whether other suites read binaries straight out of `cli/target` by paths this change does not cover. The four that build via `cargo build` are covered; a path-literal reader elsewhere would still be exposed.
+
+## Notes for Reviewers
+
+**The first full run was not green, and the two failures are unrelated to this change.** `test:integration:dev` failed `test_orphan_reach_with_only_server_recorded` and `test_sigterm_ignoring_frontend_is_sigkilled` on a server readiness timeout; both pass in isolation (17/17), and the dev suite imports neither support module. Contributing factor: five orphaned `circusd` processes were alive on the machine from earlier sessions, four of them roughly four days old and two owned by a different jj workspace. They have been reaped, and the re-run was green.
+
+**One trap worth knowing.** The first full run reported exit 0 while a task had failed, because the invocation was piped to `tail` — the pipeline's status is `tail`'s. Verification here captured `mise run`'s own exit code instead.
+
+**Where the new suite lives is a judgement call open to review.** `test_built_artefacts.py` sits under `tests/integration/entrypoint/` because that is the lane the defect broke and the lane that runs it; `tests/support/` has no collected home of its own. If a suite per support module is preferred, it would need a task edge to be run at all.
+
+**`build_launcher`'s documented constraint is unchanged and still load-bearing.** A suite calling it must not also gain a `build:cli:dev` dependency, or the two contend on cargo's target lock and the asserted edge goes inert. The claim removes the *stat* race, not that contention.

--- a/tests/integration/entrypoint/test_accelerator_entrypoint.py
+++ b/tests/integration/entrypoint/test_accelerator_entrypoint.py
@@ -33,8 +33,6 @@ from tests.integration.support.installation import (
     Installation as Harness,
 )
 from tests.integration.support.installation import (
-    build_launcher,
-    build_shim,
     copy_bootstrap,
     download_log,
     dumped_env,
@@ -47,6 +45,7 @@ from tests.integration.support.installation import (
 from tests.integration.support.installation import (
     host_platform as _resolve_host_platform,
 )
+from tests.support.artefacts import build_launcher, build_shim
 
 _HERE = Path(__file__).resolve().parent
 

--- a/tests/integration/entrypoint/test_built_artefacts.py
+++ b/tests/integration/entrypoint/test_built_artefacts.py
@@ -1,0 +1,52 @@
+"""Isolation of the binaries these suites build from cargo's uplift path.
+
+Cargo unlinks and re-hardlinks `cli/target/debug/<bin>` at the end of every
+build — including a no-op one — so the shared path is intermittently absent
+whenever any other cargo invocation touches the workspace. Several suites and
+build tasks do exactly that, concurrently, under a full `mise run`.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from tests.support import artefacts
+from tests.support.artefacts import CLI_TARGET_DIR, build_shim, claim_artefact
+
+
+def test_a_built_shim_is_claimed_out_of_cargos_uplift_path() -> None:
+    shim = build_shim()
+
+    assert CLI_TARGET_DIR not in shim.parents
+    assert os.access(shim, os.X_OK)
+    assert subprocess.run(
+        [str(shim)], check=False, capture_output=True, text=True
+    ).stderr.startswith("accelerator-verify: usage:")
+
+
+def test_a_claimed_shim_is_stable_across_calls() -> None:
+    assert build_shim() == build_shim()
+
+
+def test_claiming_retries_while_the_uplift_path_is_absent(
+    mocker, tmp_path: Path
+) -> None:
+    built = tmp_path / "artefact"
+    built.write_bytes(b"payload")
+    built.chmod(0o755)
+    copy = shutil.copy2
+    attempts: list[Path] = []
+
+    def vanishing(source: Path, destination: Path) -> object:
+        attempts.append(source)
+        if len(attempts) < 3:
+            raise FileNotFoundError(source)
+        return copy(source, destination)
+
+    mocker.patch.object(artefacts.shutil, "copy2", side_effect=vanishing)
+
+    claimed = claim_artefact(built)
+
+    assert claimed.read_bytes() == b"payload"
+    assert len(attempts) == 3

--- a/tests/integration/skill-invocation/test_skill_invocation_conformance.py
+++ b/tests/integration/skill-invocation/test_skill_invocation_conformance.py
@@ -34,8 +34,6 @@ from tests.integration.support.installation import (
     REPO_BIN,
     REPO_ROOT,
     Installation,
-    build_launcher,
-    build_shim,
     copy_bootstrap,
     generate_keys,
     host_platform,
@@ -43,6 +41,7 @@ from tests.integration.support.installation import (
     run_bootstrap,
     write_downloader,
 )
+from tests.support.artefacts import build_launcher, build_shim
 
 _SKILLS = REPO_ROOT / "skills"
 

--- a/tests/integration/support/installation.py
+++ b/tests/integration/support/installation.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.support.tools import require
+
 REPO_ROOT = Path(__file__).resolve().parents[3]
 REPO_BOOTSTRAP = REPO_ROOT / "bin/accelerator"
 REPO_BIN = REPO_ROOT / "bin"
@@ -90,20 +92,6 @@ sys.exit(22)
 """
 
 
-def in_ci() -> bool:
-    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
-
-
-def require(name: str) -> None:
-    """Skip locally, fail in CI: a missing tool there is a provisioning bug."""
-    if shutil.which(name):
-        return
-    message = f"{name} not on PATH"
-    if in_ci():
-        pytest.fail(f"{message} — provisioning regression in CI")
-    pytest.skip(message)
-
-
 def host_platform() -> str:
     """The running host's release-asset alias, e.g. ``darwin-arm64``."""
     arch = {
@@ -118,43 +106,6 @@ def host_platform() -> str:
             f"unsupported host: {platform.system()}/{platform.machine()}"
         )
     return f"{system}-{arch}"
-
-
-def _cargo_build(package: str, binary: str) -> Path:
-    require("cargo")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "--quiet",
-            *package.split(),
-            "--manifest-path",
-            str(REPO_ROOT / "cli/Cargo.toml"),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    built = REPO_ROOT / "cli/target/debug" / binary
-    if not (built.exists() and os.access(built, os.X_OK)):
-        pytest.fail(f"not built: {built}")
-    return built
-
-
-def build_shim() -> Path:
-    """Build and return the real `accelerator-verify` shim from `cli/`."""
-    return _cargo_build("-p accelerator-verify", "accelerator-verify")
-
-
-def build_launcher() -> Path:
-    """Build and return the real launcher from `cli/`.
-
-    Built here rather than behind a `mise` build edge so a suite using it still
-    runs standalone under a bare `uv run pytest`. A suite that calls this must
-    therefore *not* also gain a `build:cli:dev` dependency: the two would
-    contend on cargo's target lock and the asserted edge would be inert.
-    """
-    return _cargo_build("--bin accelerator", "accelerator")
 
 
 def generate_keys(key_dir: Path) -> Path:

--- a/tests/integration/tasks/test_github.py
+++ b/tests/integration/tasks/test_github.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import subprocess
 from collections.abc import Mapping
@@ -24,6 +23,8 @@ from tasks.github import (
 from tasks.shared.errors import InvalidVersionError
 from tasks.shared.paths import DEBUG_ARCHIVE_DIRS, DISPATCHED_SUBBINARIES
 from tasks.shared.targets import TARGETS
+from tests.support.artefacts import build_shim
+from tests.support.tools import require
 
 _PLATFORMS = tuple(platform for _, platform in TARGETS)
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -258,18 +259,6 @@ class TestIsPreReleaseVersion:
 
 
 # ── upload_and_verify_release() (unified single-gate publish) ─────────
-
-
-def _in_ci() -> bool:
-    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
-
-
-def _require(name: str) -> None:
-    if shutil.which(name):
-        return
-    if _in_ci():
-        pytest.fail(f"{name} not on PATH — provisioning regression in CI")
-    pytest.skip(f"{name} not on PATH")
 
 
 def _setup_release(mocker, tmp_path: Path, *, create: bool = True) -> None:
@@ -555,28 +544,10 @@ class TestBuilderSeams:
 class TestReverifyViaShim:
     @pytest.fixture(scope="class")
     def shim_bin(self) -> Path:
-        _require("cargo")
-        subprocess.run(
-            [
-                "cargo",
-                "build",
-                "--quiet",
-                "-p",
-                "accelerator-verify",
-                "--manifest-path",
-                str(_REPO_ROOT / "cli/Cargo.toml"),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        shim = _REPO_ROOT / "cli/target/debug/accelerator-verify"
-        if not (shim.exists() and os.access(shim, os.X_OK)):
-            pytest.fail(f"shim not built: {shim}")
-        return shim
+        return build_shim()
 
     def _keypair(self, tmp_path: Path, name: str) -> tuple[Path, Path]:
-        _require("minisign")
+        require("minisign")
         pub = tmp_path / f"{name}.pub"
         sec = tmp_path / f"{name}.sec"
         subprocess.run(

--- a/tests/support/artefacts.py
+++ b/tests/support/artefacts.py
@@ -1,0 +1,93 @@
+"""Binaries built from `cli/` for a suite to run.
+
+Cargo unlinks and re-hardlinks `cli/target/debug/<bin>` at the end of every
+build, a no-op one included, so that path is intermittently absent whenever
+anything else builds in the same workspace — which several suites and build
+tasks do concurrently under a full `mise run`. A suite therefore never runs the
+uplifted binary directly: it claims its own copy, which no later build can pull
+out from under it.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.support.tools import require
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_TARGET_DIR = REPO_ROOT / "cli/target"
+CLI_MANIFEST = REPO_ROOT / "cli/Cargo.toml"
+
+# How long a claim keeps retrying while cargo's uplift path is absent. The gap
+# between the unlink and the re-link is milliseconds; anything approaching this
+# bound means the binary was never built at all.
+CLAIM_TIMEOUT_SECONDS = 5.0
+
+# Every claimed binary lives here for the life of the process, out of reach of
+# any concurrent cargo invocation.
+_ARTEFACTS = tempfile.TemporaryDirectory(prefix="accelerator-artefacts-")
+_CLAIMED: dict[str, Path] = {}
+
+
+def claim_artefact(built: Path) -> Path:
+    """Copy a freshly built binary out of cargo's uplift path.
+
+    Only the `open` has to land while the link is live, so a source that has
+    vanished into the re-link window is retried rather than fatal.
+    """
+    claimed = Path(_ARTEFACTS.name) / built.name
+    deadline = time.monotonic() + CLAIM_TIMEOUT_SECONDS
+    while True:
+        try:
+            shutil.copy2(built, claimed)
+        except FileNotFoundError:
+            if time.monotonic() >= deadline:
+                pytest.fail(f"not built: {built}")
+            time.sleep(0.05)
+            continue
+        return claimed
+
+
+def _cargo_build(package: str, binary: str) -> Path:
+    if binary in _CLAIMED:
+        return _CLAIMED[binary]
+    require("cargo")
+    subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--quiet",
+            *package.split(),
+            "--manifest-path",
+            str(CLI_MANIFEST),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    claimed = claim_artefact(CLI_TARGET_DIR / "debug" / binary)
+    if not os.access(claimed, os.X_OK):
+        pytest.fail(f"not executable: {claimed}")
+    _CLAIMED[binary] = claimed
+    return claimed
+
+
+def build_shim() -> Path:
+    """Build and return the real `accelerator-verify` shim from `cli/`."""
+    return _cargo_build("-p accelerator-verify", "accelerator-verify")
+
+
+def build_launcher() -> Path:
+    """Build and return the real launcher from `cli/`.
+
+    Built here rather than behind a `mise` build edge so a suite using it still
+    runs standalone under a bare `uv run pytest`. A suite that calls this must
+    therefore *not* also gain a `build:cli:dev` dependency: the two would
+    contend on cargo's target lock and the asserted edge would be inert.
+    """
+    return _cargo_build("--bin accelerator", "accelerator")

--- a/tests/support/tools.py
+++ b/tests/support/tools.py
@@ -1,0 +1,25 @@
+"""External tools a suite needs on PATH.
+
+Absence is a contributor's missing toolchain locally and a provisioning
+regression in CI, so the same call has to skip in one place and fail in the
+other.
+"""
+
+import os
+import shutil
+
+import pytest
+
+
+def in_ci() -> bool:
+    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
+
+
+def require(name: str) -> None:
+    """Skip locally, fail in CI: a missing tool there is a provisioning bug."""
+    if shutil.which(name):
+        return
+    message = f"{name} not on PATH"
+    if in_ci():
+        pytest.fail(f"{message} — provisioning regression in CI")
+    pytest.skip(message)

--- a/tests/unit/tasks/test_manifest.py
+++ b/tests/unit/tasks/test_manifest.py
@@ -11,8 +11,6 @@ together cover the full parse → verify → resolve path against producer bytes
 
 import hashlib
 import json
-import os
-import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -33,6 +31,8 @@ from tasks.shared.errors import ManifestError
 from tasks.shared.paths import CLI_DIR, load_toml
 from tasks.shared.targets import TARGETS
 from tasks.signing import generate, sign_file
+from tests.support.artefacts import build_shim
+from tests.support.tools import require
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _SCHEMA = _REPO_ROOT / "cli/launcher/tests/fixtures/manifest.schema.json"
@@ -42,44 +42,13 @@ _REAL_VERSION = json.loads(
 _PLATFORMS = tuple(platform for _, platform in TARGETS)
 
 
-def _in_ci() -> bool:
-    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
-
-
-def _require(name: str) -> None:
-    if shutil.which(name):
-        return
-    message = f"{name} not on PATH"
-    if _in_ci():
-        pytest.fail(f"{message} — provisioning regression in CI")
-    pytest.skip(message)
-
-
 @pytest.fixture(scope="module")
 def shim_bin() -> Path:
-    _require("cargo")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "--quiet",
-            "-p",
-            "accelerator-verify",
-            "--manifest-path",
-            str(_REPO_ROOT / "cli/Cargo.toml"),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    shim = _REPO_ROOT / "cli/target/debug/accelerator-verify"
-    if not (shim.exists() and os.access(shim, os.X_OK)):
-        pytest.fail(f"shim not built: {shim}")
-    return shim
+    return build_shim()
 
 
 def _keypair(tmp_path: Path) -> tuple[Path, Path]:
-    _require("minisign")
+    require("minisign")
     pub = tmp_path / "release.pub"
     sec = tmp_path / "release.sec"
     generate(MagicMock(spec=Context), pub_path=str(pub), sec_path=str(sec))
@@ -147,7 +116,7 @@ class TestBuildManifest:
 
 class TestCollectEntries:
     def test_sources_description_and_signature(self, tmp_path):
-        _require("minisign")
+        require("minisign")
         _, sec = _keypair(tmp_path)
         staging = tmp_path / "dist"
         payloads = _stage_and_sign(staging, "foo", sec)
@@ -165,7 +134,7 @@ class TestCollectEntries:
             assert payloads[platform]  # staged
 
     def test_missing_description_raises(self, tmp_path):
-        _require("minisign")
+        require("minisign")
         _, sec = _keypair(tmp_path)
         staging = tmp_path / "dist"
         _stage_and_sign(staging, "foo", sec)

--- a/tests/unit/tasks/test_signing.py
+++ b/tests/unit/tasks/test_signing.py
@@ -5,8 +5,6 @@ The sign → verify round-trips run against the real `minisign` CLI and the real
 missing tool is a CI provisioning regression (fail) rather than a local skip.
 """
 
-import os
-import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -25,21 +23,10 @@ from tasks.signing import (
     resolve_secret_key,
     sign_file,
 )
+from tests.support.artefacts import build_shim
+from tests.support.tools import require
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def _in_ci() -> bool:
-    return bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
-
-
-def _require(name: str) -> None:
-    if shutil.which(name):
-        return
-    message = f"{name} not on PATH"
-    if _in_ci():
-        pytest.fail(f"{message} — provisioning regression in CI")
-    pytest.skip(message)
 
 
 @pytest.fixture
@@ -51,30 +38,11 @@ def ctx():
 
 @pytest.fixture(scope="module")
 def shim_bin() -> Path:
-    """Build and return the real `accelerator-verify` shim from `cli/`."""
-    _require("cargo")
-    subprocess.run(
-        [
-            "cargo",
-            "build",
-            "--quiet",
-            "-p",
-            "accelerator-verify",
-            "--manifest-path",
-            str(_REPO_ROOT / "cli/Cargo.toml"),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    shim = _REPO_ROOT / "cli/target/debug/accelerator-verify"
-    if not (shim.exists() and os.access(shim, os.X_OK)):
-        pytest.fail(f"shim not built: {shim}")
-    return shim
+    return build_shim()
 
 
 def _keypair(tmp_path: Path, name: str = "release") -> tuple[Path, Path]:
-    _require("minisign")
+    require("minisign")
     pub = tmp_path / f"{name}.pub"
     sec = tmp_path / f"{name}.sec"
     generate(MagicMock(spec=Context), pub_path=str(pub), sec_path=str(sec))


### PR DESCRIPTION
# Claim built binaries out of cargo's uplift path

## Summary

`test:integration:entrypoint` intermittently failed its whole module-scoped shim fixture — 52 errors from one `pytest.fail("not built: cli/target/debug/accelerator-verify")` against a binary that plainly existed, after a `cargo build` that had exited 0.

Cargo unlinks and re-hardlinks `cli/target/debug/<bin>` at the end of **every** build, a no-op one included, so that path is intermittently absent whenever anything else builds in the same workspace. Measured directly: five successive no-op `cargo build -p accelerator-verify` invocations left the path missing on 290 consecutive stat attempts, across 6 distinct inodes. `_cargo_build` released cargo's target lock and then stat-ed that shared path, so a sibling cargo invocation blocked on the very same lock proceeded and re-linked precisely into the check — a correlated race, not a uniformly unlikely one.

Suites now copy each freshly built binary into a per-process directory and run that copy. Nothing was wrong with the shim, the launcher, or the entry point.

## Changes

- **`claim_artefact` copies a freshly built binary out of cargo's uplift path, retrying while the source sits in the re-link window.** Only the `open` has to land while the link is live — unix unlink semantics keep an in-flight read valid — so a vanished source is retried rather than fatal, and no lock or barrier over cargo is needed. The 5-second deadline is three orders of magnitude above the millisecond window it covers, so anything approaching it means the binary was never built at all; `not built` survives as the terminal message for that case.
- **The claim also closes a wider latent failure the original check only hinted at.** The entrypoint suite execs the shim repeatedly over minutes, so a sibling re-link could have broken an exec mid-run, not merely fixture setup. A private copy cannot be pulled out from under a running test.
- **`_cargo_build` memoises per binary name, so a pytest process invokes cargo once.** The entrypoint suite dropped from 156s to 28s, because it no longer queues behind cargo's target lock per fixture. The accepted consequence: editing `cli/` mid-process will not rebuild — pytest processes are short-lived and the next run rebuilds.
- **Three sibling suites carried the identical racy pattern and are now routed through the shared build.** `tests/unit/tasks/test_signing.py`, `tests/unit/tasks/test_manifest.py` and `tests/integration/tasks/test_github.py` each hand-copied the build-then-stat sequence, and all three run concurrently with the entrypoint lane under `mise run` — fixing one lane would have left the same failure live in three others.
- **The shared apparatus is extracted to `tests/support/`, split by concern.** `artefacts.py` owns binaries built from `cli/` (`build_shim`, `build_launcher`, `claim_artefact`); `tools.py` owns external-tool preconditions (`require`, `in_ci`). Dependencies now point one way — suites and `tests/integration/support/installation.py` both depend on `tests/support`, and no unit suite imports integration support. `installation.py` keeps only what it is documented to own: the bootstrap fixture apparatus.
- **Four hand-copied `require`/`in_ci` pairs collapse into one.** They were behaviourally identical, differing only in message ordering in `test_github.py`.
- **`tests/integration/entrypoint/test_built_artefacts.py` pins the three properties.** The claimed path lies outside `cli/target`, is stable across calls, and the claim retries through a source that vanishes — the last driven by patching `shutil.copy2` to raise `FileNotFoundError` twice before delegating, so the retry is proved deterministically rather than by timing.

## Context

No work item: this is a test-infrastructure defect found by a failing `mise run` rather than planned work. It touches only files under `tests/`, and no shipped skill, script, hook, or crate.

## Testing

- [x] `mise run` (the bare default) exits 0 end-to-end, with zero `ERROR task failed` lines.
- [x] The entrypoint suite passes 57/57 **while a concurrent `cargo build` loop hammers the workspace** — the exact condition that produced the failure. Against the old code that same condition is what the 290-miss measurement describes.
- [x] The affected suites together: 123 passed across entrypoint, signing, manifest and github; `test:integration:skill-invocation` 128 passed.
- [x] `mise run build-system:check` clean (ruff, formatting, pyrefly).
- [ ] CI's own parallelism and the linux lane are unverified locally — the fix removes a dependency on inter-process timing rather than adding one, so CI should be strictly less exposed, but only a CI run proves it.
- [ ] Not investigated: whether other suites read binaries straight out of `cli/target` by paths this change does not cover. The four that build via `cargo build` are covered; a path-literal reader elsewhere would still be exposed.

## Notes for Reviewers

**The first full run was not green, and the two failures are unrelated to this change.** `test:integration:dev` failed `test_orphan_reach_with_only_server_recorded` and `test_sigterm_ignoring_frontend_is_sigkilled` on a server readiness timeout; both pass in isolation (17/17), and the dev suite imports neither support module. Contributing factor: five orphaned `circusd` processes were alive on the machine from earlier sessions, four of them roughly four days old and two owned by a different jj workspace. They have been reaped, and the re-run was green.

**One trap worth knowing.** The first full run reported exit 0 while a task had failed, because the invocation was piped to `tail` — the pipeline's status is `tail`'s. Verification here captured `mise run`'s own exit code instead.

**Where the new suite lives is a judgement call open to review.** `test_built_artefacts.py` sits under `tests/integration/entrypoint/` because that is the lane the defect broke and the lane that runs it; `tests/support/` has no collected home of its own. If a suite per support module is preferred, it would need a task edge to be run at all.

**`build_launcher`'s documented constraint is unchanged and still load-bearing.** A suite calling it must not also gain a `build:cli:dev` dependency, or the two contend on cargo's target lock and the asserted edge goes inert. The claim removes the *stat* race, not that contention.
