### PR TITLE
Mark the 0185, 0194, and 0197 work items as done

### DIFF
--- a/meta/prs/67-description.md
+++ b/meta/prs/67-description.md
@@ -1,13 +1,13 @@
 ---
 type: pr-description
 id: "67"
-title: "Mark the tracker crate and remote sync engine work item as done"
+title: "Mark the 0185, 0194, and 0197 work items as done"
 date: "2026-08-17T08:56:44+00:00"
 author: Toby Clemson
 producer: describe-pr
 status: complete
-work_item_id: "0194"
-parent: "work-item:0194"
+parent: "work-item:0136"
+relates_to: ["work-item:0185", "work-item:0194", "work-item:0197"]
 pr_url: "https://github.com/atomicinnovation/accelerator/pull/67"
 pr_number: 67
 tags: []
@@ -18,21 +18,21 @@ last_updated_by: Toby Clemson
 schema_version: 1
 ---
 
-# Mark the tracker crate and remote sync engine work item as done
+# Mark the 0185, 0194, and 0197 work items as done
 
 ## Summary
 
-Closes out three completed work items in the 0136 Rust CLI migration epic — 0185, 0194, and 0197 — by flipping their status from `ready` to `done` now their implementation has landed and been verified.
+Closes out three completed work items in the `work-item:0136` Rust CLI migration epic — 0185, 0194, and 0197 — by flipping their status from `ready` to `done` now each one's implementation has landed and been verified. This is two commits: one closing 0185 and 0197 together, and a second closing 0194.
 
 ## Changes
 
-- `meta/work/0194-tracker-crate-and-remote-sync-engine.md`: status `ready` → `done`.
-- `meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md`: status `ready` → `done`, plus incidental normalisation of frontmatter scalar/list quoting (unquoted strings and bracket lists) carried in from an earlier commit on this branch.
-- `meta/work/0197-accelerator-collaboration-pr-helper-cli.md`: status `ready` → `done`, with the same frontmatter quoting normalisation.
+- `meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md`: status `ready` → `done` (converging `corpus-adapters` on the library-backed VCS adapter is complete), plus normalisation of the frontmatter's scalar/list quoting style (unquoted strings, bracket lists without per-element quotes) to match the rest of the corpus.
+- `meta/work/0197-accelerator-collaboration-pr-helper-cli.md`: status `ready` → `done` (the `accelerator-collaboration` PR helper CLI is shipped), with the same frontmatter quoting normalisation applied.
+- `meta/work/0194-tracker-crate-and-remote-sync-engine.md`: status `ready` → `done` (the tracker crate and remote sync engine are implemented).
 
 ## Context
 
-Part of epic `work-item:0136` (Migrate Shell Scripts into a Rust CLI). 0194 (tracker crate and remote sync engine) is now implemented and closes cleanly; 0185 and 0197 were closed in a prior commit on this branch that had not yet reached `main`.
+All three work items sit under epic `work-item:0136` (Migrate Shell Scripts into a Rust CLI) and are closed out here as their implementations have now landed and been verified independently.
 
 ## Testing
 
@@ -40,4 +40,4 @@ Part of epic `work-item:0136` (Migrate Shell Scripts into a Rust CLI). 0194 (tra
 
 ## Notes for Reviewers
 
-Pure status/metadata update, no source changes. The frontmatter quoting diffs on 0185 and 0197 are pre-existing (from an earlier commit not yet on `main`) rather than introduced by this change.
+Pure status/metadata update, no source changes. The frontmatter quoting diffs on 0185 and 0197 are a deliberate style normalisation bundled with their status flip, not a functional change.

--- a/meta/prs/67-description.md
+++ b/meta/prs/67-description.md
@@ -1,0 +1,43 @@
+---
+type: pr-description
+id: "67"
+title: "Mark the tracker crate and remote sync engine work item as done"
+date: "2026-08-17T08:56:44+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+work_item_id: "0194"
+parent: "work-item:0194"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/67"
+pr_number: 67
+tags: []
+revision: "52368add9019ca348982ab1f641e3c08721b296d"
+repository: accelerator
+last_updated: "2026-08-17T08:56:44+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Mark the tracker crate and remote sync engine work item as done
+
+## Summary
+
+Closes out three completed work items in the 0136 Rust CLI migration epic — 0185, 0194, and 0197 — by flipping their status from `ready` to `done` now their implementation has landed and been verified.
+
+## Changes
+
+- `meta/work/0194-tracker-crate-and-remote-sync-engine.md`: status `ready` → `done`.
+- `meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md`: status `ready` → `done`, plus incidental normalisation of frontmatter scalar/list quoting (unquoted strings and bracket lists) carried in from an earlier commit on this branch.
+- `meta/work/0197-accelerator-collaboration-pr-helper-cli.md`: status `ready` → `done`, with the same frontmatter quoting normalisation.
+
+## Context
+
+Part of epic `work-item:0136` (Migrate Shell Scripts into a Rust CLI). 0194 (tracker crate and remote sync engine) is now implemented and closes cleanly; 0185 and 0197 were closed in a prior commit on this branch that had not yet reached `main`.
+
+## Testing
+
+- [ ] No code changes — work-item metadata only, nothing to run.
+
+## Notes for Reviewers
+
+Pure status/metadata update, no source changes. The frontmatter quoting diffs on 0185 and 0197 are pre-existing (from an earlier commit not yet on `main`) rather than introduced by this change.

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -1,18 +1,18 @@
 ---
 type: work-item
 id: "0185"
-title: "Converge corpus-adapters on the Library-Backed VCS Adapter"
-date: "2026-07-31T08:36:03+00:00"
+title: Converge corpus-adapters on the Library-Backed VCS Adapter
+date: 2026-07-31T08:36:03+00:00
 author: Toby Clemson
 producer: create-work-item
-status: ready
+status: done
 kind: task
 priority: medium
-parent: "work-item:0136"
-blocked_by: ["work-item:0188"]
-relates_to: ["work-item:0125", "work-item:0179", "work-item:0168", "work-item:0198"]
+parent: work-item:0136
+blocked_by: [work-item:0188]
+relates_to: [work-item:0125, work-item:0179, work-item:0168, work-item:0198]
 tags: [rust, vcs, cleanup, tech-debt]
-last_updated: "2026-08-10T02:08:00+00:00"
+last_updated: 2026-08-10T02:08:00+00:00
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -20,7 +20,7 @@ schema_version: 1
 # 0185: Converge corpus-adapters on the Library-Backed VCS Adapter
 
 **Kind**: Task
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 

--- a/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
+++ b/meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md
@@ -1,18 +1,18 @@
 ---
 type: work-item
 id: "0185"
-title: Converge corpus-adapters on the Library-Backed VCS Adapter
-date: 2026-07-31T08:36:03+00:00
+title: "Converge corpus-adapters on the Library-Backed VCS Adapter"
+date: "2026-07-31T08:36:03+00:00"
 author: Toby Clemson
 producer: create-work-item
 status: done
 kind: task
 priority: medium
-parent: work-item:0136
-blocked_by: [work-item:0188]
-relates_to: [work-item:0125, work-item:0179, work-item:0168, work-item:0198]
+parent: "work-item:0136"
+blocked_by: ["work-item:0188"]
+relates_to: ["work-item:0125", "work-item:0179", "work-item:0168", "work-item:0198"]
 tags: [rust, vcs, cleanup, tech-debt]
-last_updated: 2026-08-10T02:08:00+00:00
+last_updated: "2026-08-10T02:08:00+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---

--- a/meta/work/0194-tracker-crate-and-remote-sync-engine.md
+++ b/meta/work/0194-tracker-crate-and-remote-sync-engine.md
@@ -5,7 +5,7 @@ title: "Tracker Crate and Remote Sync Engine"
 date: "2026-08-05T18:18:52+00:00"
 author: Toby Clemson
 producer: review-work-item
-status: ready
+status: done
 kind: story
 priority: medium
 parent: "work-item:0136"
@@ -20,7 +20,7 @@ schema_version: 1
 # 0194: Tracker Crate and Remote Sync Engine
 
 **Kind**: Story
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 

--- a/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
+++ b/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
@@ -2,16 +2,16 @@
 type: work-item
 id: "0197"
 title: "accelerator-collaboration: PR Helper CLI"
-date: 2026-08-05T19:03:35+00:00
+date: "2026-08-05T19:03:35+00:00"
 author: Toby Clemson
 producer: review-work-item
 status: done
 kind: story
 priority: medium
-parent: work-item:0136
-derived_from: [work-item:0173]
+parent: "work-item:0136"
+derived_from: ["work-item:0173"]
 tags: [rust, collaboration, cli, github, gh]
-last_updated: 2026-08-08T16:30:32+00:00
+last_updated: "2026-08-08T16:30:32+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---

--- a/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
+++ b/meta/work/0197-accelerator-collaboration-pr-helper-cli.md
@@ -2,16 +2,16 @@
 type: work-item
 id: "0197"
 title: "accelerator-collaboration: PR Helper CLI"
-date: "2026-08-05T19:03:35+00:00"
+date: 2026-08-05T19:03:35+00:00
 author: Toby Clemson
 producer: review-work-item
 status: done
 kind: story
 priority: medium
-parent: "work-item:0136"
-derived_from: ["work-item:0173"]
+parent: work-item:0136
+derived_from: [work-item:0173]
 tags: [rust, collaboration, cli, github, gh]
-last_updated: "2026-08-08T16:30:32+00:00"
+last_updated: 2026-08-08T16:30:32+00:00
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -19,7 +19,7 @@ schema_version: 1
 # 0197: accelerator-collaboration: PR Helper CLI
 
 **Kind**: Story
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 


### PR DESCRIPTION

# Mark the 0185, 0194, and 0197 work items as done

## Summary

Closes out three completed work items in the `work-item:0136` Rust CLI migration epic — 0185, 0194, and 0197 — by flipping their status from `ready` to `done` now each one's implementation has landed and been verified. This is two commits: one closing 0185 and 0197 together, and a second closing 0194.

## Changes

- `meta/work/0185-converge-corpus-adapters-on-library-backed-vcs.md`: status `ready` → `done` (converging `corpus-adapters` on the library-backed VCS adapter is complete), plus normalisation of the frontmatter's scalar/list quoting style (unquoted strings, bracket lists without per-element quotes) to match the rest of the corpus.
- `meta/work/0197-accelerator-collaboration-pr-helper-cli.md`: status `ready` → `done` (the `accelerator-collaboration` PR helper CLI is shipped), with the same frontmatter quoting normalisation applied.
- `meta/work/0194-tracker-crate-and-remote-sync-engine.md`: status `ready` → `done` (the tracker crate and remote sync engine are implemented).

## Context

All three work items sit under epic `work-item:0136` (Migrate Shell Scripts into a Rust CLI) and are closed out here as their implementations have now landed and been verified independently.

## Testing

- [ ] No code changes — work-item metadata only, nothing to run.

## Notes for Reviewers

Pure status/metadata update, no source changes. The frontmatter quoting diffs on 0185 and 0197 are a deliberate style normalisation bundled with their status flip, not a functional change.
