### PR TITLE
Decompose the Jira and Linear integrations item into four children

### DIFF
--- a/meta/prs/68-description.md
+++ b/meta/prs/68-description.md
@@ -1,0 +1,71 @@
+---
+type: pr-description
+id: "68"
+title: "Decompose the Jira and Linear integrations item into four children"
+date: "2026-08-17T13:08:08+00:00"
+author: Toby Clemson
+producer: describe-pr
+status: complete
+work_item_id: "0171"
+parent: "work-item:0171"
+relates_to: ["work-item:0210", "work-item:0211", "work-item:0212", "work-item:0213", "work-item:0174"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/68"
+pr_number: 68
+tags: [work-items, reviews, decomposition, jira, linear]
+revision: "46d6fdb76f52528138233be1e956fc6d6a3e5d48"
+repository: "accelerator"
+last_updated: "2026-08-17T13:08:08+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Decompose the Jira and Linear integrations item into four children
+
+## Summary
+
+0171 (Jira and Linear Integrations) had grown to 28 requirements and 31 acceptance criteria covering two provider client crates, two dispatched binaries, three bash-retirement clusters, a fixture relocation, eleven test conversions and a conversational skill flow — epic-scale for a single story, and three review passes had failed to reduce its major-finding count. This PR turns it into an epic delivering through four children, each with its own status, requirements and acceptance criteria, and adds the five review artefacts that produced the decomposition.
+
+The substantive outcome is not the reshuffling: it is that reviewing the children caught a user-visible regression the parent's own criteria would have shipped, and that verifying the ordering rationale against the repository inverted it.
+
+## Changes
+
+- **0171 becomes an epic** (`kind: epic`, nested under 0136 following the 0145-under-0192 precedent) delivering through 0210 (provider client crates over the `RemoteTracker` port), 0212 (work-item script cutover), 0211 (integration binaries and bash cluster retirement) and 0213 (conversational conflict resolution flow). 0210–0212 are `story`, 0213 is `task`.
+- **Requirements and acceptance criteria move into the children, which are normative.** The parent keeps the narrative, the decomposition, the shared `## Decisions` register and the cross-child dependencies. It holds no duplicate copy, because it had one and it drifted within a single revision — losing a per-flow fixture-provenance obligation and the qualifier that a recorded assertion count is context rather than a bar. Both losses surfaced as review findings, which is the evidence for removing the duplication rather than annotating it.
+- **The cutover order is 0210 → 0212 → 0211**, with 0213 independent. Two constraints force it: 0210 is the only window in which the bash oracles still exist, so it precedes every deletion; and the coupling between the two deletion sets runs in one direction only, so the work suites must go first.
+- **Three port-less bridge capabilities are now owned by 0212** — the unkeyed discovery `search` mode of `work-item-fetch-remote.sh`, the create bridge's `--dry-run` field-resolution preview, and the update bridge's `--dry-run` payload validation. Each has no `RemoteTracker` operation and none survives the deletion by itself.
+- **0174's `blocked_by` re-points at 0211 and 0212**, the increments that actually clear its suite floors and `SHELL_LIBRARIES` entries, so a blocker lookup lands on the work rather than on a parent that performs none.
+- **Five review artefacts added** under `meta/reviews/work/`: 0171 across three passes and one per child across two, each through the clarity, completeness, dependency, scope and testability lenses. All five accepted with their remaining findings recorded rather than resolved.
+
+## Context
+
+Work item: [0171](../work/0171-jira-and-linear-integrations.md), under epic [0136](../work/0136-migrate-shell-scripts-to-rust-cli.md). Children: [0210](../work/0210-provider-client-crates-over-the-tracker-port.md), [0211](../work/0211-integration-binaries-and-bash-cluster-retirement.md), [0212](../work/0212-work-item-script-cutover.md), [0213](../work/0213-conversational-conflict-resolution-flow.md).
+
+Two findings from the review passes are worth reading in full, because both were latent defects rather than presentation problems.
+
+**The port-less capabilities had fallen through the decomposition.** 0171 spent a requirement, two acceptance criteria, one of three pickup-blocking open questions and three `## Decisions` entries on the fate of three bridge capabilities with no port operation. After the carve-out, no child mentioned any of them — `grep` for `dry-run`, `unkeyed` and `port-less` across all four returned nothing, while 0171 referenced them ten times — and 0212 deletes `work-item-fetch-remote.sh` and both remote bridges wholesale. All four children could have been accepted green while `/sync-work-items` silently lost the ability to list remote issues with no local work item, and `/sync-work-items --preview` lost live push validation against the tracker. Three lenses raised it independently. A full audit (28 requirements, 31 criteria) confirmed it was the only gap.
+
+**The ordering rationale was false, and verifying it inverted the order.** The decomposition originally placed 0211 before 0212 on the belief that `linear-create-flow.sh:304` and `jira-resolve-fields.sh:140` were live callers of `work-item-sync-label.sh`. They are comments noting that those scripts perform the same normalisation; grepping the clusters for invocations of any `work-item-*.sh`, with comment lines excluded, returns nothing. The real coupling runs the other way and is larger: four of the five suites 0212 deletes — `test-work-item-create-remote.sh`, `-update-remote.sh`, `-fetch-remote.sh` and `-sync-apply.sh` — resolve paths into `skills/integrations/{jira,linear}/scripts/test-helpers/` for the Python mock servers and `.../test-fixtures/` for their scenario fixtures. In the original order, 0211's wholesale cluster deletion would have broken all four suites and the `_EXPECTED_WORK_SUITES` floor at its own merge boundary. The 0211 and 0212 reviews carry a `## Correction` section recording that they endorsed that ordering and why the credit they gave it was misplaced.
+
+## Testing
+
+This change is eleven markdown files under `meta/`. No code, no tests, no build inputs.
+
+- [x] `accelerator corpus frontmatter validate` — structural and referential conformance across all eleven changed files: clean.
+- [x] Whole-corpus `accelerator corpus frontmatter validate`: one violation, pre-existing and unrelated (`meta/plans/2026-08-11-0196-...md` carries `status: superseded`, not in the plan vocab). None of the touched ids appear.
+- [x] The validator caught four dangling `relates_to` refs in the child reviews (`work-item-review:0171` resolves to no artifact; the correct form carries the review's full stem). Fixed and squashed into the commit that introduced them.
+- [x] Every touched item parses through `accelerator work show`, with `kind`, `status`, `parent`, `blocked_by` and `blocks` reading back as intended, and frontmatter `**Status**` body labels agreeing with the frontmatter.
+- [x] Dependency graph symmetry: 0210 blocks 0211 and 0212; 0212 is blocked by 0210 and blocks 0211 and 0174; 0211 is blocked by 0210 and 0212 and blocks 0174; 0213 free. 0174's `blocked_by` reciprocates from the other side.
+- [x] Frontmatter quoting restored to the repository convention on all five work items after `accelerator work update` stripped it (see Notes).
+- [ ] `mise run` end to end — not run. Nothing in this diff feeds the frontend, server, `cli/` or `scripts/` lanes, and `docs:check` builds `docs-site/`, which is untouched. CI covers it.
+
+## Notes for Reviewers
+
+The decomposition is the reviewable decision; the review artefacts are the evidence trail behind it and can be skimmed. If you read one thing, read 0171's `## Decomposition` section and the ordering note beneath it.
+
+**Five things must close before 0210, 0211 or 0212 can be picked up**, and they are recorded as such rather than resolved: the three open questions on 0171 (where the credentialed tracker target's secrets live, the fate of the three port-less capabilities, and whether `EXIT_CODES.md` is rewritten in place or folded into the CLI docs) and the two size-bounding assumptions in 0211 and 0212 (that the eight enumerated flows per provider are the whole bash surface, and that the Rust surface already covers the three previously-deferred scripts). Two of the five change what is in scope, so estimates are not meaningful until they are answered. 0213 is gated by none of them and fixes live degradation, so it can and should land first.
+
+**Three findings were accepted rather than fixed**, and are named in each review's `## Acceptance` section: 0210 carries no acceptance criterion for HTTP-status or GraphQL-level error classification or for auth (its four-table criterion covers `curl` transport codes, which the item stresses are not HTTP statuses); the non-port provider surface — `comment`, `transition`, provider `search`, `attach` and `init`, five of the eight flows, none with a port operation — is owned by neither 0210 nor 0211; and 0212 now bundles a mechanical deletion cutover with three capability re-sitings whose fates are still open. The first two are judged more cheaply closed by implementing 0210 than by further specification.
+
+**A CLI defect surfaced and is worth fixing separately.** `accelerator work update` re-serialises frontmatter and strips the repository's quoting convention from `title`, `date`, `parent` and `last_updated`, and unquotes typed-linkage list members. It hit all five items when their status moved to `ready`; I restored the quoting by hand in the first commit, but the next `work update` on any of these items will strip it again. Commit `88d2b760b2` ("Restore frontmatter quoting on the 0185 and 0197 work items") suggests this has bitten before.
+
+**On process, for what it is worth.** Across four review passes the severity ceiling fell — three criticals, then one, then none, then none — while the major count did not converge, and each fix round introduced two or three new majors of a single shape: a requirement updated without its criteria, or a criterion updated without its requirement. That pattern is why this stops at accepted-with-findings rather than at a clean pass.

--- a/meta/reviews/work/0171-jira-and-linear-integrations-review-1.md
+++ b/meta/reviews/work/0171-jira-and-linear-integrations-review-1.md
@@ -1,0 +1,991 @@
+---
+type: work-item-review
+id: "0171-jira-and-linear-integrations-review-1"
+title: "Work Item Review: Jira and Linear Integrations"
+date: "2026-08-17T10:13:53+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0136"
+target: "work-item:0171"
+work_item_id: "0171"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 3
+tags: [rust, jira, linear, integrations, cutover]
+last_updated: "2026-08-17T12:20:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Jira and Linear Integrations
+
+**Verdict:** REVISE
+
+0171 is exceptionally well specified on its cutover half — named files,
+exact counts, and criteria a verifier can settle with a single shell
+command — and the ownership split with 0174 is negotiated in both
+directions. The client-building half is specified to a materially lower
+standard: the integration-skill retirement is asserted only in
+Assumptions, its primary acceptance criterion names an oracle this same
+story deletes, and the two most failure-prone requirements (four
+per-operation exit-code tables, the timeout and page-cap bounds) have no
+criterion at all. Underneath both sits a sizing problem — three
+independently deliverable efforts share one `done` gate, in an epic that
+has already split two siblings for exactly this shape.
+
+### Cross-Cutting Themes
+
+- **The integration half is a second-class citizen** (flagged by:
+  clarity, completeness, scope, testability) — deletion of the 22 Jira
+  and 12 Linear scripts is never a requirement, no criterion asserts
+  their directories are gone, the `SKILL.md` bodies are never repointed
+  (only `allowed-tools`), and AC1 verifies against "the repointed
+  integration suites" — an artefact the same document withdraws.
+- **Requirements without criteria** (flagged by: completeness,
+  testability) — the four non-nested exit-code tables and the
+  timeout/page-cap bounding have no acceptance criterion, so the two
+  requirements most likely to be silently under-implemented have nothing
+  defining when they are done.
+- **Criteria that cannot fail** (flagged by: testability, scope) — AC5
+  accepts any fate for the four port-less capabilities as long as it is
+  recorded, including dropping the identifier-safety check the
+  Requirements mandate unconditionally.
+- **Real-tracker verification is unexecutable as written** (flagged by:
+  dependency, scope, testability) — provisioning a credentialed Jira
+  project and Linear team is an undischarged prerequisite behind the sole
+  Open Question, yet Dependencies asserts every blocker is discharged.
+- **Size** (flagged by: scope, and visible in the item's own Drafting
+  Notes) — each enrichment pass discovers material the previous scope
+  missed; 0136 records 0169 and 0173 being split on that same signature.
+
+### Findings
+
+#### Critical
+
+- 🔴 **Clarity / Completeness / Testability / Scope**: The integration-skill
+  half is unspecified, and AC1's oracle is deleted by this story
+  **Location**: Summary, Requirements, Acceptance Criteria (first)
+  The Summary limits the cutover to `work-item-*.sh`; the retirement of
+  `skills/integrations/{jira,linear}/scripts/`, their libraries, their
+  bash suites and their Python mock servers appears only obliquely (inside
+  the `_EXPECTED_INTEGRATIONS_SUITES` requirement) and once in
+  Assumptions — never as a requirement, never as a criterion. AC1 then
+  verifies eight flows per provider plus ADF↔markdown, JQL and GraphQL
+  "against the repointed integration suites", which cannot be the bash
+  suites if those retire and which no requirement establishes in the Rust
+  lane. The largest deliverable in the story therefore has no defined
+  pass condition, and an implementer following the checklist literally
+  can ship the Rust clients while leaving two live implementations per
+  provider.
+
+- 🔴 **Testability / Completeness**: Four exit-code tables and the
+  timeout/page-cap bounds have no acceptance criterion
+  **Location**: Requirements (exit-code tables; port call bounding)
+  The Requirements warn that the create and update provable sets are "not
+  nested in either direction" (Linear code 34 retryable on `create`,
+  terminal on `update`; codes 18, 23, 25, 27, 29 the other way) and that
+  the port must reproduce `--max-time 30`/`60` and `_WIFR_PAGE_CAP=20`
+  from inside because a caller cannot add them. Neither has a criterion.
+  A misclassified code silently retries an unretryable mutation or
+  terminates a retryable one, and an unbounded read path hangs
+  `/list-work-items` — both shippable with every criterion green.
+  Assumptions compound this by leaving table coverage conditional on what
+  `wiremock` can express.
+
+- 🔴 **Scope**: Two provider integrations and a large cutover bundled into
+  one story
+  **Location**: Summary
+  The Summary joins the efforts with a sequencing word — build the two
+  client crates and binaries, "Then perform the work-item cutover". The
+  two clients are independent of each other (different protocols, crates,
+  binaries, skill directories, mock scenarios, and separate non-nested
+  mapping tables) and neither is user-visible until the cutover flips the
+  callers. Three separately deliverable and revertible efforts share one
+  review, one branch and one `done` gate. Splitting does not recreate the
+  dead-window problem the 2026-08-10 note rejected, because the bash path
+  stays live until the cutover child lands.
+
+#### Major
+
+- 🟡 **Clarity / Testability**: The identifier-safety check is mandated,
+  then made droppable
+  **Location**: Requirements, Acceptance Criteria (fifth)
+  A requirement carries the check over unconditionally ("An unsafe
+  identifier is a `Terminal` failure, not an `Ok`"), yet AC5 lists it
+  among four capabilities that may be "re-sited, dropped or carried
+  forward as a recorded decision". The same requirement's list enumerates
+  only three capabilities plus a closing note. An implementer can satisfy
+  AC5 by recording a decision to drop the check, reintroducing control
+  characters and leading `---`/`#` into unquoted YAML frontmatter.
+
+- 🟡 **Testability / Scope**: The capability-gap criterion cannot fail, and
+  leaves delivered scope open-ended
+  **Location**: Acceptance Criteria (fifth), Requirements
+  AC5 is satisfied by dropping all four capabilities and writing that
+  down. It names no location for the record and no behavioural check per
+  outcome, despite two being load-bearing today: unkeyed `search` is how
+  `/sync-work-items` lists remote issues with no local item, and the
+  update `--dry-run` is what `--preview` validates pushes with (0194's
+  `--preview` explicitly does not discharge it). The third permitted
+  outcome — "carry it as an additive port item" — would reopen the port
+  0204 froze at six items and pull four crates into the change, so the
+  item's size is unknowable at planning time.
+
+- 🟡 **Dependency / Testability**: The credentialed-target gate is
+  unprovisioned, unexecutable, and narrower than the risk
+  **Location**: Dependencies, Acceptance Criteria (contract harness),
+  Open Questions
+  Dependencies opens "All blockers discharged as of 2026-08-17 … the item
+  is startable whole", but a scratch Jira project, a Linear team, API
+  tokens and (if CI) repository secrets do not exist, and the sole Open
+  Question decides where they live — and therefore whether a CI workflow
+  change is in scope. The criterion also names only `create` → `show` and
+  `update` → `show`, while Dependencies warns that a quietly dropped
+  operation is undetectable below a harness exercising all four against
+  the real client.
+
+- 🟡 **Scope**: Declared `kind: story` is inappropriate for epic-scale
+  scope
+  **Location**: Frontmatter: kind
+  22 requirement bullets and 17 criteria spanning two library crates, two
+  dispatched binaries, three retirement clusters, a fixture relocation,
+  eleven test conversions, four artefact repoints, build-system surgery, a
+  new conversational flow and external account provisioning. 0136's other
+  children are one CLI or one fix each; 0169 and 0173 were split on the
+  signature this item now shows — each pass discovering material the last
+  scope missed.
+
+- 🟡 **Scope**: The cutover half itself bundles three independent
+  retirement clusters
+  **Location**: Requirements
+  The work scripts (with fixtures, eleven tests, three SKILL repoints),
+  the integration scripts and suites, and the build-system floors and
+  `SHELL_LIBRARIES` entries retire on different prerequisites — cluster
+  (a) on both clients, (b) on the respective provider's client only, (c)
+  mechanically on whichever landed. Bundling forces each to wait on the
+  others across three test lanes and the CI shell gate at once.
+
+- 🟡 **Scope**: The conversational conflict flow is a separate user-facing
+  increment
+  **Location**: Requirements
+  Parsing the conflict report, rendering context, collecting choices and
+  re-invoking with `--resolve` shares no crate and no test lane with the
+  clients or the deletions, and its dependency (0194's report format and
+  exit codes) is already discharged. It cannot be reviewed or reverted on
+  its own.
+
+- 🟡 **Dependency**: Jira REST and Linear GraphQL are absent from
+  Dependencies
+  **Location**: Dependencies
+  The story is two HTTP clients against third-party APIs, yet neither
+  external system is recorded with its availability, rate-limit,
+  complexity-cap or API-versioning implications — while upstream 0204,
+  which only describes them, does exactly that. Two criteria can fail for
+  reasons entirely outside the change.
+
+- 🟡 **Dependency**: The 0174 blocking edge exists in one direction only
+  **Location**: Dependencies, Frontmatter: relates_to
+  0174 lists `work-item:0171` in `blocked_by`; 0171 records 0174 only
+  under "Relates to" and carries no `blocks` field. Anyone scheduling
+  from 0171 cannot see the downstream cleanup waiting on it, and a tracker
+  sync trusting this frontmatter drops the dependant.
+
+- 🟡 **Dependency**: 0194 is asserted complete but its record reads `ready`
+  **Location**: Dependencies, Drafting Notes
+  The prerequisite the whole cutover half rests on is, on the record, not
+  done — and the Drafting Notes concede it while Dependencies calls it
+  complete. Any readiness check reading statuses rather than prose will
+  disagree with this item about whether it can start.
+
+- 🟡 **Testability**: The baseline-corpus criterion has no seeding
+  procedure, and omits the dangerous case
+  **Location**: Acceptance Criteria (baseline corpus)
+  "Against matching remote records" gives no way to make a bash-generated
+  corpus match live tracker state, so the precondition is unreachable.
+  Nor does it require the absent-description case — literal `null` for
+  Jira, empty line for Linear — that Requirements single out as the one a
+  deserialiser gets wrong, with mass reclassification as the consequence.
+
+- 🟡 **Testability**: The conflict-rendering criterion rests on a
+  subjective threshold with no verification lane
+  **Location**: Acceptance Criteria (conflict flow), Requirements
+  "Enough local and remote context for the user to judge" enumerates no
+  fields, and nothing states whether a conversational SKILL flow is
+  checked by a test, a manual walkthrough, or inspection. The half that
+  makes conflict resolution possible at all can be argued complete with a
+  one-line render.
+
+- 🟡 **Clarity**: Bare numeric codes have no named namespace
+  **Location**: Requirements (exit-code tables)
+  "Linear code 34", "codes 18, 23, 25, 27 and 29", then "a single
+  status-to-class table is wrong" — the namespace is never named, and 34
+  is not a valid HTTP status, so "status" misdirects. An implementer could
+  key the Rust mapping off HTTP status instead of transport exit code,
+  producing exactly the misclassification the requirement exists to
+  prevent.
+
+#### Minor
+
+- 🔵 **Clarity**: "The rule they encode" is never stated, and "provable
+  set" / "provably pre-transmission" are undefined
+  **Location**: Requirements
+  The instruction "the tables win" is followable, but a reviewer cannot
+  judge whether a divergence found during porting is the intended
+  conservatism or a table bug.
+
+- 🔵 **Clarity**: "The tagged, network-touching filter" is referenced
+  before anything names it
+  **Location**: Requirements
+  No tag, nextest filter expression, cargo feature or `#[ignore]`
+  convention is named, leaving AC7's "the default `cargo test` makes no
+  network call" without a mechanism.
+
+- 🔵 **Clarity**: Cluster of unresolved referents
+  **Location**: Requirements
+  "Behind the seam", "the value returned" (by which operation?), "rely on
+  them" (the entries or `jq`/`curl`?), and "holding the two
+  implementations in step" (description or instruction?) each admit more
+  than one reading.
+
+- 🔵 **Clarity**: Two dirty-guard callers mapped onto three Rust paths
+  without pairing
+  **Location**: Requirements
+  The one behaviour whose loss means overwriting a user's uncommitted work
+  item is the part left implicit.
+
+- 🔵 **Completeness**: Open Questions is sparse relative to the decisions
+  the Requirements defer
+  **Location**: Open Questions
+  The four capability fates and the `EXIT_CODES.md` siting are deferred
+  inside prose requirements rather than surfaced where a planner looks;
+  the one recorded question has no owner and no deadline.
+
+- 🔵 **Completeness**: Status remains `draft` despite the item declaring
+  itself startable whole
+  **Location**: Frontmatter: status
+
+- 🔵 **Dependency**: Ordering between the client half and the cutover half
+  is not stated
+  **Location**: Requirements
+  An implementer could relocate the corpus or delete the bash surface
+  before projection fidelity is proven, losing the only oracle that would
+  have caught the regression.
+
+- 🔵 **Dependency**: New crate ingest is not captured as a coupling to the
+  Rust policy lanes
+  **Location**: Technical Notes
+  `wiremock-rs`, rustls and their trees must clear `deny.toml`'s licence
+  and advisory policy; no requirement expects a policy change.
+
+- 🔵 **Dependency**: Two new sub-binaries couple to the release and
+  attribution pipeline
+  **Location**: Dependencies
+  0165's upload set and signed `manifest.json`, and 0203's attribution
+  artefact, are unreferenced. A binary that registers locally but is
+  absent from the manifest is undiscoverable until a launcher fetches it.
+
+- 🔵 **Dependency**: The 0170 entry understates the repoint's dependency on
+  its command surface
+  **Location**: Dependencies
+  "No direct dependency" is inaccurate in the direction that matters: the
+  repoint consumes `accelerator work create`/`list`, which 0170 delivers.
+
+- 🔵 **Scope**: Credentialed tracker provisioning spans a different
+  ownership domain
+  **Location**: Open Questions
+
+- 🔵 **Scope**: Integrations-side scope stated by reference while
+  work-side is enumerated
+  **Location**: Requirements
+
+- 🔵 **Testability**: "No duplication of API logic" has no pass/fail
+  procedure
+  **Location**: Acceptance Criteria (second)
+  The structural guarantee the story exists to deliver is a judgement a
+  generous reader can always call satisfied.
+
+- 🔵 **Testability**: "Assertions unchanged in substance" is arguable
+  **Location**: Acceptance Criteria (eleven shellout tests)
+  A weakened assertion is the cheapest way to make a conversion pass, and
+  these tests are the cutover's only regression guard.
+
+- 🔵 **Testability**: Three cleanup requirements have no criterion beyond
+  the catch-all
+  **Location**: Requirements vs Acceptance Criteria
+  `_EXPECTED_INTEGRATIONS_SUITES`, the eight `SHELL_LIBRARIES` entries and
+  the cross-skill `jq`/`curl` audit — the first and third with nothing
+  covering them at all.
+
+#### Suggestions
+
+- 🔵 **Clarity**: Unnamed actor for `E_DISPATCH_*` taxonomy ownership, and
+  "a dispatch token" singular for two new commands
+  **Location**: Requirements, Dependencies
+
+- 🔵 **Completeness**: Story context describes the code surface, not whose
+  need is met
+  **Location**: Context
+  The user-facing motivation appears only incidentally, mid-requirement
+  ("until this lands no caller can resolve a conflict").
+
+### Strengths
+
+- ✅ Requirements and criteria name concrete, checkable artefacts —
+  thirteen production scripts, five suites, eleven Rust tests, eight
+  `SHELL_LIBRARIES` entries, `_EXPECTED_WORK_SUITES = 5` by symbol and
+  line — leaving little room for interpretation on the cutover half.
+- ✅ Cutover criteria are mechanically decidable rather than judgemental:
+  `ls skills/work/scripts/*.sh` matching nothing, the fixtures directory
+  not existing, a grep of `cli/` returning no hits.
+- ✅ The highest-risk fidelity case is pre-empted explicitly: the absent
+  description projecting as literal `null` for Jira and an empty line for
+  Linear, with the mass-reclassification consequence stated.
+- ✅ Where two sources of truth could conflict, the item says which wins
+  ("the tables win"), removing an interpretation choice from the
+  implementer.
+- ✅ Several criteria use precondition/action/outcome framing well,
+  including the awkward detail that `unresolved` lines must be read on
+  exit `71` as well as `4`.
+- ✅ The boundary with 0174 is negotiated in both directions and dated, so
+  no suite floor or library entry can be cleared twice or missed.
+- ✅ The four obligations inherited from 0194's deliberately unfinished
+  cutover are enumerated rather than left implicit, as is the guard gap
+  0204 handed over (a default-bodied trait method escaping `cargo
+  public-api`).
+- ✅ Drafting Notes carry a real decision log with dates and a rejected
+  alternative (an interim shim over the bridge scripts) and its reasoning.
+- ✅ Doc-comment updates are pinned to named sites, turning a normally
+  unverifiable tidy-up into a checklist.
+- ✅ Every template section is present and substantively populated, with
+  frontmatter valid for a story and empty linkage slots correctly omitted.
+
+### Recommended Changes
+
+1. **Decompose into siblings under 0136** (addresses: the bundling
+   critical, `kind: story`, the three-cluster and conflict-flow majors)
+   Three or four children: `jira-client` + `accelerator-jira`,
+   `linear-client` + `accelerator-linear`, the cutover (deletions, fixture
+   relocation, test conversions, skill repoints, floors), and optionally
+   the conversational conflict flow — which depends only on 0194 and could
+   land first. Attach each cluster's floor and `SHELL_LIBRARIES` edits to
+   the child that orphans them, preserving 0174's lockstep rule within
+   each child.
+
+2. **Specify the integration half to the same standard as the work half**
+   (addresses: the AC1-oracle critical, the integrations-by-reference
+   minor) Add a requirement naming the script directories, libraries and
+   bash suites to delete and the two `SKILL.md` bodies to repoint; add a
+   criterion asserting the directories are gone. Replace AC1's oracle with
+   one that outlives the bash suites — per flow, a `wiremock`-backed test
+   asserting the outgoing request (method, path or GraphQL document, body)
+   and the parsed response against a fixture captured from today's bash
+   flow — and name ADF↔markdown conversion explicitly.
+
+3. **Add criteria for the two uncovered requirements** (addresses: the
+   exit-code/timeout critical) A table-driven criterion enumerating every
+   code in all four bash tables and asserting the `TrackerError` class
+   *per operation*, with Linear 34 and 18/23/25/27/29 named as required
+   cases; and an observable-threshold criterion for the bounds — a
+   never-responding `wiremock` endpoint failing within ~35s (Jira) and
+   ~65s (Linear), and a 21-page fixture stopping at 20.
+
+4. **Remove the identifier-safety check from AC5 and give it its own
+   criterion** (addresses: the mandated-then-droppable major, the
+   enumerates-three clarity finding) Enumerate the four rejection cases —
+   control character, newline, leading `---`, leading `#` — each producing
+   a `Terminal` failure with no frontmatter written. Fix the
+   "four capabilities" list to enumerate four, and state that this one's
+   fate is already decided.
+
+5. **Close the four capability fates before pickup, and make AC5 fail if
+   behaviour is lost** (addresses: the self-certifying-criterion major)
+   Record each decision in a named location, and add outcome-conditional
+   behavioural criteria — `/sync-work-items` still lists remote issues
+   with no local item; `--preview` still surfaces an unresolvable Jira
+   project or an invalid payload before any mutation.
+
+6. **Resolve the secrets question and record the tracker target as a
+   prerequisite** (addresses: the credentialed-gate major) Name the runner
+   (a CI job with named secrets, or a documented manual step and where its
+   evidence lands), qualify the "all blockers discharged" sentence, add
+   the provisioning as an explicit prerequisite, and extend the criterion
+   to all four operations including `fetch_all` partition totality and the
+   read-never-`Terminal` rule.
+
+7. **Repair the dependency graph** (addresses: the 0174, 0194, 0204 and
+   0170 findings) Add `blocks: ["work-item:0174"]` and 0204 to the
+   frontmatter, flip 0194's status to `done` (or name its residue as a
+   live blocker here), record Jira REST and Linear GraphQL as external
+   systems with their rate and complexity limits, note the `deny.toml` and
+   release-manifest couplings, and reword the 0170 entry to record the
+   real discharged coupling.
+
+8. **Tighten the arguable criteria** (addresses: the "no duplication",
+   "unchanged in substance", conflict-rendering and cleanup findings)
+   Restate duplication structurally (no `reqwest` usage or provider
+   endpoint outside the client crates), make assertion parity countable
+   against the committed goldens, enumerate the minimum rendered conflict
+   fields, and extend the floor criterion to name
+   `_EXPECTED_INTEGRATIONS_SUITES` and the eight `SHELL_LIBRARIES`
+   entries.
+
+9. **Fix the local clarity defects** (addresses: the clarity minors and
+   suggestion) Name the exit-code namespace on first use, state the rule
+   the tables conservatively encode, name the network-lane filter, pair
+   each dirty-guard caller with its Rust path, resolve "behind the seam" /
+   "the value returned" / "rely on them", name the crate that owns
+   `E_DISPATCH_*`, and pluralise the dispatch tokens.
+
+10. **Advance `status` and enrich Context** (addresses: the two
+    completeness minors) Move `status` to `ready` for whichever children
+    are startable, drop the stale parenthetical about 0194, and add a
+    sentence naming the beneficiary and today's pain.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is unusually dense but mostly precise: it names
+concrete file paths, function names and counts, and states outcomes as
+observable system states rather than vague properties. Clarity breaks down
+in three places — a contradiction over the fate of the identifier-safety
+check (mandated as a requirement, yet listed among the four capabilities
+that may be "dropped"), an unstated scope boundary around the jira/linear
+bash scripts and suites (the Summary limits deletion to `work-item-*.sh`,
+while other sections and AC1 assume the integration suites both retire and
+remain as verification), and a set of bare numeric codes whose namespace is
+never named. Several noun phrases ("the tagged, network-touching filter",
+"behind the seam", "the rule they encode") are used before or without
+definition.
+
+**Strengths**:
+
+- Requirements and Acceptance Criteria overwhelmingly name concrete,
+  checkable artefacts, leaving little room for interpretation about what is
+  being changed.
+- Outcomes are stated as observable system states rather than desired
+  properties.
+- Potential misreadings are pre-empted explicitly: the absent-description
+  projection, and `RemoteTimestamp`'s "never `Reported("")`" rule.
+- Drafting Notes give a dated, reasoned audit trail of scope changes.
+- Where two sources of truth could conflict, the item states which wins.
+
+**Findings**:
+
+- **major / high** — *The "four bridge capabilities" list enumerates three,
+  and its fourth member contradicts a mandatory requirement*
+  (Requirements / Acceptance Criteria). An implementer reading AC5 can
+  legitimately record a decision to drop the identifier-safety check,
+  satisfying the criterion while violating an explicit requirement and
+  reintroducing unquoted control characters and leading `---`/`#` into a
+  work item's YAML frontmatter. List all four capabilities under the
+  requirement and state that this one's fate is already decided.
+- **major / high** — *Whether the jira and linear bash scripts and suites
+  are deleted here is never stated, and AC1 assumes suites that other
+  sections retire* (Summary / Requirements / Acceptance Criteria). The
+  single largest deletion sits in Assumptions rather than Requirements, and
+  AC1's verification points at an artefact whose existence the same
+  document withdraws.
+- **major / medium** — *Bare numeric codes have no named namespace, and the
+  sentence calling them "status" contradicts their likely origin*
+  (Requirements). 34 is not a valid HTTP status, so "status" misdirects; an
+  implementer could key the mapping off the wrong input domain.
+- **minor / high** — *"The rule they encode" is never stated, and "provable
+  sets" / "provably pre-transmission" are undefined* (Requirements). A
+  reviewer cannot judge whether a divergence found during porting is
+  intended conservatism or a table bug.
+- **minor / high** — *"The tagged, network-touching filter" is referenced
+  before anything named it* (Requirements). Leaves AC7's no-network claim
+  without a named mechanism.
+- **minor / medium** — *Cluster of unresolved referents: "the seam", "the
+  value returned", "them", "in step"* (Requirements).
+- **minor / medium** — *Two callers are mapped onto three Rust paths
+  without saying which discharges which* (Requirements). The guard whose
+  loss means overwriting uncommitted work is the part left implicit.
+- **suggestion / medium** — *Unnamed actor for taxonomy ownership, and "a
+  dispatch token" singular for two new commands* (Requirements /
+  Dependencies).
+
+### Completeness
+
+**Summary**: An unusually densely populated work item: every template
+section is present and substantively filled, the Requirements enumerate
+named files, counts and specific behaviours, and the Acceptance Criteria
+run to sixteen bullets including several in Given/When/Then form.
+Frontmatter is complete and valid for a story, with the omit-when-empty
+linkage slots correctly dropped. The completeness gaps that remain are
+asymmetries rather than absences — the integration-skill half of the
+cutover is never enumerated or asserted the way the work-script half is,
+two substantial requirements have no corresponding acceptance criterion,
+and Open Questions is thin relative to the number of decisions the
+Requirements explicitly defer.
+
+**Strengths**:
+
+- Every section of the template is present and substantively populated,
+  including the optional Technical Notes and Drafting Notes.
+- Requirements are exceptionally concrete — named crates, files with line
+  references, exact counts — so an implementer can start without follow-up
+  questions on the work-script cutover.
+- Several criteria use Given/When/Then form and pin observable outcomes
+  rather than activities.
+- Frontmatter is complete and correct for a story, with empty slots
+  correctly omitted.
+- Dependencies, Assumptions and Drafting Notes are richly populated,
+  including a rejected alternative and its reasoning.
+
+**Findings**:
+
+- **major / high** — *Integration-skill retirement is never enumerated or
+  asserted, unlike the work-script cutover* (Requirements / Acceptance
+  Criteria). No requirement deletes the 22 Jira and 12 Linear production
+  scripts or their suites, none repoints the jira/linear `SKILL.md` bodies
+  (only `allowed-tools`), and no criterion asserts the directories are
+  gone — while AC1 verifies against a test surface no requirement
+  establishes.
+- **major / high** — *Two substantive requirements have no corresponding
+  acceptance criterion* (Acceptance Criteria). The four per-operation
+  exit-code tables and the timeout/page-cap bounding — the two most likely
+  to be silently under-implemented — have nothing defining when they are
+  done.
+- **minor / medium** — *Open Questions is sparse relative to the decisions
+  the Requirements defer* (Open Questions). The four capability fates and
+  the `EXIT_CODES.md` siting sit inside prose; the one recorded question
+  has no owner or deadline.
+- **minor / medium** — *Status remains `draft` despite the item declaring
+  itself startable whole* (Frontmatter: status). The note that 0194's
+  status "is not yet updated" also contradicts Dependencies calling it
+  complete.
+- **suggestion / medium** — *Story context describes the code surface, not
+  whose need is met* (Context).
+
+### Dependency
+
+**Summary**: Dependency capture is unusually strong on the intra-repo,
+item-to-item axis: it inherits and enumerates 0194's four cutover
+obligations, records the frozen 0204 port surface in detail, and negotiates
+an explicit split of suite-floor and `SHELL_LIBRARIES` ownership with 0174.
+The gaps are on the axes that leave the repository: the two external
+trackers the whole story is built on are never named in Dependencies with
+their rate-limit and availability implications, and the credentialed tenant
+the contract criteria require is an undischarged prerequisite behind an
+unresolved Open Question — yet Dependencies asserts every blocker is
+discharged. The machine-readable graph is thinner than the prose: 0204 is
+absent from frontmatter, 0174 appears as a relation rather than a
+downstream block, and 0194's own record still reads `ready`.
+
+**Strengths**:
+
+- The four obligations inherited from 0194's unfinished cutover are
+  enumerated explicitly.
+- The ownership boundary with 0174 is negotiated in both directions and
+  dated, closing a real ordering hazard.
+- The eleven Rust tests resolving paths under `skills/work/scripts/` are
+  identified as a build-breaking coupling, forced into the same change.
+- The four port-less bridge capabilities are carried forward from 0204 as
+  an explicit decide-or-drop obligation.
+- The substantive shape of the frozen port is recorded, including the guard
+  gap 0204 handed over.
+
+**Findings**:
+
+- **major / high** — *Dependencies claims every blocker is discharged while
+  a credentialed Jira/Linear tenant remains unprovisioned* (Dependencies).
+  The item reads as schedulable, so it can be driven to its final gate
+  before anyone realises the tenant, tokens and secret-hosting decision do
+  not exist.
+- **major / high** — *Jira REST and Linear GraphQL are absent from
+  Dependencies as external systems* (Dependencies). The consumer that
+  actually calls them records less than the port that only describes them;
+  two criteria can fail for reasons outside the change.
+- **major / high** — *0174 is recorded as a relation, not a downstream
+  block, and the graph edge disagrees between the two items*
+  (Dependencies). A tracker sync trusting 0171's frontmatter drops the
+  dependant.
+- **major / high** — *0194 is asserted complete but its own record still
+  reads `ready`* (Dependencies). The prerequisite the cutover half rests on
+  is, on the record, not done.
+- **minor / high** — *0204, the most-cited upstream, is absent from the
+  frontmatter dependency fields* (Frontmatter: relates_to). 0204's own
+  Dependencies cross-references a `blocked_by` field this item does not
+  have.
+- **minor / medium** — *Ordering between the client half and the cutover
+  half is not stated* (Requirements). Deleting the bash surface before
+  projection fidelity is proven loses the only oracle.
+- **minor / medium** — *New third-party crate ingest is not captured as a
+  coupling to the Rust policy lanes* (Technical Notes). `wiremock-rs` and
+  rustls must clear `deny.toml`'s licence and advisory policy.
+- **minor / medium** — *Two new dispatched sub-binaries couple to the
+  release and attribution pipeline* (Dependencies). 0165's signed manifest
+  and upload set, and 0203's attribution artefact, are unreferenced.
+- **minor / medium** — *The 0170 relation understates the repoint's
+  dependency on its command surface* (Dependencies).
+
+### Scope
+
+**Summary**: Internally coherent in theme (finish the Rust migration of the
+tracker-facing surface) but not one unit of delivery: two independent
+provider client crates plus two binaries, a three-cluster bash cutover, an
+eleven-test fixture relocation and conversion, a new conversational flow in
+a SKILL, four unresolved design decisions, and the provisioning of
+credentialed external targets. The Summary itself joins the halves with
+"Then perform the work-item cutover", and 22 requirement bullets support 17
+criteria — a profile matching 0136's epic-level children far more than a
+story. 0136 records two precedents for splitting exactly this shape (0169
+on 2026-07-31, 0173 on 2026-08-05), and the same signature — each
+enrichment pass discovering material the previous scope missed — is visible
+in this item's own Drafting Notes.
+
+**Strengths**:
+
+- Boundaries with 0174 are stated with unusual precision and allocated
+  entry by entry.
+- The item refuses to defer residue and enumerates its work-cluster
+  deletion set exhaustively.
+- Requirements and criteria track each other closely, so both sections
+  describe the same scope.
+- Drafting Notes carry a real decision log including a rejected
+  alternative and its reasoning.
+
+**Findings**:
+
+- **critical / high** — *Two provider integrations and a large cutover
+  bundled into one story* (Summary). Three separately deliverable and
+  revertible efforts share one review, branch and `done` gate; a defect in
+  the Linear client blocks the Jira client and the entire bash retirement.
+  Splitting does not recreate the dead-window the 2026-08-10 note rejected,
+  because the bash path stays live until the cutover child lands.
+- **major / high** — *Declared kind `story` is inappropriate for epic-scale
+  scope* (Frontmatter: kind). The documented pattern is that each editing
+  pass at this size introduces as many defects as it fixes.
+- **major / medium** — *Cutover half itself bundles three independent
+  retirement clusters* (Requirements). The clusters depend on different
+  prerequisites and share no technical coupling.
+- **major / medium** — *Conversational conflict flow is a separate
+  user-facing increment* (Requirements). Its dependency is already
+  discharged; it shares no crate or test lane with the rest.
+- **major / medium** — *Four undecided capability fates leave the delivered
+  scope open-ended* (Requirements). "Carry it as an additive port item"
+  would reopen the frozen port and ripple across four crates.
+- **minor / medium** — *Credentialed tracker provisioning spans a different
+  ownership domain* (Open Questions). The unresolved CI-versus-local answer
+  silently adds or removes CI workflow work.
+- **minor / medium** — *Integrations-side scope stated by reference while
+  work-side is enumerated* (Requirements). Roughly half the deletion and
+  reimplementation surface has no enumerated in-scope set.
+
+### Testability
+
+**Summary**: The cutover half is exceptionally testable — mechanically
+checkable criteria leave a verifier almost nothing to interpret. The
+client-building half is not: the largest deliverable rests on an oracle
+this same story deletes, and three of the most failure-prone requirements —
+the four non-nested exit-code tables, the per-request timeouts and page
+cap, and the identifier-safety rejection — have no acceptance criterion at
+all, while AC5 actively permits dropping a behaviour the Requirements
+mandate. The credentialed-target criteria are unrunnable until the Open
+Question about secrets is closed.
+
+**Strengths**:
+
+- Cutover criteria are mechanically decidable single-command pass/fail
+  checks.
+- Enumeration replaces unbounded language where it matters, so "all" has a
+  closed, countable scope.
+- Requirements supply a genuine differentiating oracle for the
+  highest-risk fidelity concern, with the consequence stated.
+- Three criteria use precondition/action/outcome framing well, including
+  the `71`-as-well-as-`4` detail.
+- The negative criterion about Python and the test lane is verifiable as
+  stated.
+- Doc-comment updates are pinned to named sites.
+
+**Findings**:
+
+- **critical / high** — *Primary client criterion names an oracle the same
+  story deletes* (Acceptance Criteria, first). The largest deliverable can
+  be claimed as met by any implementation that exposes the eight subcommand
+  names. Replace with per-flow `wiremock` criteria asserting outgoing
+  request and parsed response against fixtures captured from today's bash
+  flow, and name ADF↔markdown explicitly.
+- **critical / high** — *Four exit-code tables and the timeout/page-cap
+  bounds have no acceptance criterion* (Requirements vs Acceptance
+  Criteria). A misclassified code retries an unretryable mutation; an
+  unbounded read path hangs `/list-work-items`. Both ship with every
+  criterion green.
+- **major / high** — *AC permits dropping the identifier-safety behaviour
+  the Requirements mandate* (Acceptance Criteria, fifth). Losing the check
+  writes tracker-controlled bytes unquoted into YAML frontmatter.
+- **major / high** — *Capability-gap criterion is self-certifying — any
+  outcome passes* (Acceptance Criteria, fifth). The one criterion guarding
+  against a user-visible regression cannot fail.
+- **major / high** — *Contract-run criterion has no defined execution
+  procedure and names only two of four operations* (Acceptance Criteria;
+  Open Questions).
+- **major / medium** — *No procedure for making remote records "match" the
+  corpus, and the dangerous case is not pinned* (Acceptance Criteria,
+  baseline corpus).
+- **major / medium** — *Conflict-rendering criterion relies on a subjective
+  threshold with no stated verification lane* (Acceptance Criteria;
+  Requirements).
+- **minor / high** — *"No duplication of API logic" has no pass/fail
+  procedure* (Acceptance Criteria, second).
+- **minor / medium** — *"Assertions unchanged in substance" is arguable*
+  (Acceptance Criteria, eleven shellout tests).
+- **minor / medium** — *Three cleanup requirements have no criterion beyond
+  the catch-all* (Requirements vs Acceptance Criteria):
+  `_EXPECTED_INTEGRATIONS_SUITES`, the eight `SHELL_LIBRARIES` entries, and
+  the cross-skill `jq`/`curl` audit.
+
+## Re-Review (Pass 2) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran against the revised item. All three criticals cleared;
+the verdict holds on major count (threshold: 2), not on severity. The scope
+critical was declined by the author and downgraded by the lens itself to major
+on re-read, with its recommendation restated once.
+
+### Previously Identified Issues
+
+- 🔴 → ✅ **Clarity/Completeness/Testability/Scope**: integration half
+  unspecified, AC1's oracle deleted — **Resolved**. Cluster retirement is a
+  requirement with an enumerated inventory; AC1 replaced by per-flow `wiremock`
+  fixtures captured pre-deletion.
+- 🔴 → ✅ **Testability/Completeness**: four exit-code tables and the
+  timeout/page-cap bounds uncovered — **Resolved**, then hardened in pass 2
+  (transcribed fixture, two-sided timeout window).
+- 🔴 → 🟡 **Scope**: three efforts in one story — **Still present, declined**.
+  Downgraded to major. Partially mitigated by the new `## Increments` section
+  naming four ordered, individually mergeable changes.
+- 🟡 → ✅ **Clarity/Testability**: identifier-safety mandated then droppable —
+  **Resolved**. Its own four-case criterion; the capability decision now covers
+  three.
+- 🟡 → ✅ **Testability/Scope**: self-certifying capability criterion —
+  **Resolved**. Outcome-conditional behavioural checks, and the drop branch must
+  state an observable replacement.
+- 🟡 → ✅ **Dependency/Testability**: credentialed gate unprovisioned and
+  narrow — **Resolved**. Prerequisite recorded, all four operations covered,
+  execution route required.
+- 🟡 → ✅ **Dependency**: Jira REST / Linear GraphQL absent; 0174 edge
+  one-directional; 0170 understated — **Resolved** in all three.
+- 🟡 → ✅ **Dependency**: 0194 asserted complete but reads `ready` —
+  **Resolved differently than recommended**. Verified that commit `c03f2448c6`
+  is not an ancestor of this workspace's working copy, so the record is
+  divergent rather than stale. Dependencies now directs confirmation against
+  0194's artefacts, not its status field.
+- 🟡 → ✅ **Testability**: corpus criterion unexecutable; conflict rendering
+  subjective — **Resolved**. Seeding procedure, absent-description case, six
+  enumerated fields, and a static plus manual verification split.
+- 🟡 → ✅ **Clarity**: exit-code namespace unnamed — **Resolved**. Keyed by
+  `curl` transport exit code, with the retry rule stated and the key domain
+  flagged for confirmation while porting.
+- 🔵 → ✅ Minors on referents, the network-lane filter, the dirty-guard
+  pairing, taxonomy ownership, Open Questions density, and Context framing —
+  **Resolved**.
+
+### New Issues Introduced
+
+Pass 2 surfaced fifteen findings, no criticals. Twelve were fixed in the same
+sitting; three remain.
+
+Fixed:
+
+- 🟡 **Testability**: the `jq`/`curl` audit criterion was tautological — any
+  surviving entry could be declared 0174's. Now an equality assertion against
+  0174's fourteen.
+- 🟡 **Testability**: "no longer hold any *migrated* production script" was
+  self-referentially escapable. Now `ls … matches nothing`.
+- 🟡 **Testability**: "every code in all four bash mapping tables" had no
+  oracle once the tables were deleted. Now transcribed verbatim to a committed
+  fixture pre-deletion, with a class assertion required per row.
+- 🟡 **Testability**: no criterion covered the three work `SKILL.md` bodies
+  being repointed. Added as a grep-shaped criterion.
+- 🟡 **Testability**: `~35s`/`~65s` gave no pass boundary and implied ~100s of
+  wall clock. Now a two-sided window plus a construction-time override.
+- 🟡 **Completeness**: registration, release-manifest and `deny.toml`
+  obligations appeared only in Dependencies. Now a requirement and a criterion.
+- 🟡 **Completeness**: nothing verified the two binaries' own CLI surface — the
+  layer the repointed skills invoke. Criterion added.
+- 🟡 **Completeness**: Requirements said provisioning was a prerequisite while
+  Drafting Notes said "during implementation". Aligned on prerequisite.
+- 🟡 **Dependency/Scope**: the additive-port-item branch was filed as a
+  dependency on 0204, which is done and frozen against exactly that. Now out of
+  scope — a new blocking item instead.
+- 🔵 Decisions preamble contradicted its own contents; two undefined states.
+  Reworded, states defined.
+- 🔵 "Drop the work suite floor to zero" contradicted "removed rather than
+  decremented" in the next sentence.
+- 🔵 Fixture-deletion and assertion-baseline escape clauses; ADF node-type
+  inventory; `RemoteTimestamp` blank/null rule; doc-comment criterion pointing
+  at two files this story deletes; ADF/JQL expanded on first use; "the caller"
+  and "the dispatcher" named; negative-space criteria given mechanical checks.
+
+Still present:
+
+- 🟡 **Scope**: the item remains four concerns in one `story` (26 requirements,
+  22 criteria) with `kind: story`. Declined by the author; `## Increments`
+  mitigates the delivery risk without changing the work-item boundary.
+- 🔵 **Scope**: several criteria are discharged by editing this document
+  (`## Decisions`) rather than by shipped behaviour. Two durable ones — the
+  contract-lane execution route and any port-less re-siting — are flagged in
+  `## Decisions` as belonging in `tasks/README.md` or an ADR, but not yet moved.
+- 🔵 **Dependency**: 0165 and 0203 are recorded in prose but not in
+  `relates_to`; `blocked_by` stays empty by design, with the five declared
+  upstreams enumerated in Dependencies instead.
+
+### Assessment
+
+The item is materially stronger than at pass 1: every criterion that could not
+fail now can, and the three oracles that existed only inside the code being
+deleted are captured before deletion. It is **not yet ready for planning**, for
+reasons that are now explicit rather than hidden — three Open Questions and two
+size-bounding assumptions must close before pickup, and `status` stays `draft`
+until they do. The residual scope concern is a recorded, deliberate decision
+rather than an unaddressed finding.
+
+## Re-Review (Pass 3) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran. No criticals; nineteen findings, of which nine are major.
+The verdict holds on major count. The defining result of this pass: the
+`## Increments` section added in pass 2 to mitigate the scope finding is now the
+single largest source of findings, and one of its defects is a live functional
+break.
+
+### Previously Identified Issues
+
+- 🟡 **Testability**: tautological `jq`/`curl` audit — **Resolved as a
+  criterion, reopened as an inconsistency**. The criterion now asserts set
+  equality against 0174's fourteen, but the requirement still says "no skill
+  outside this story's set", so the two sections state opposite expected
+  outcomes (zero versus fourteen).
+- 🟡 **Testability**: "any migrated production script" escapable — **Resolved**.
+- 🟡 **Testability**: exit-code tables without an oracle — **Resolved**.
+- 🟡 **Testability**: work `SKILL.md` repointing uncovered — **Resolved**.
+- 🟡 **Testability**: `~35s`/`~65s` unbounded — **Partially resolved, newly
+  self-contradictory**. The two-sided window (30–40s, 60–70s) and the
+  sub-second override cannot both hold as written; flagged by clarity and
+  testability independently.
+- 🟡 **Completeness**: registration and release obligations uncovered —
+  **Resolved**.
+- 🟡 **Completeness**: binaries' CLI surface uncovered — **Partially
+  resolved**. A criterion exists, but "its documented exit code" names no
+  document of record, and nothing pins the stdout the repointed skills consume.
+- 🟡 **Completeness**: provisioning contradiction — **Resolved**.
+- 🟡 **Dependency/Scope**: additive-port-item filed against frozen 0204 —
+  **Resolved**. Now out of scope, becoming a new blocking item.
+- 🔵 Decisions preamble, floor-to-zero contradiction, fixture-deletion and
+  drop-decision escape clauses, ADF inventory, `RemoteTimestamp` rule,
+  acronyms, named referents, negative-space checks — **Resolved**, bar the
+  Decisions state list (see below).
+- 🟡 **Scope**: four concerns in one `story` — **Still present, declined
+  again**. Stated once per instruction. The lens notes this is now two REVISE
+  passes deep on the trajectory 0136 recorded for 0169 before splitting it.
+
+### New Issues Introduced
+
+Nine majors, seven of them attributable to the pass-2 revision.
+
+Introduced by `## Increments`:
+
+- 🟡 **Dependency**: Increment 2 deletes `work-item-sync-label.sh` while two of
+  its live callers — `linear-create-flow.sh:304` and
+  `jira-resolve-fields.sh:140` — survive until increment 3. A merged increment 2
+  breaks the Jira field-resolution and Linear create flows. The criterion
+  asserting those references "vanish with their own files" is only true if both
+  clusters die in one change, which the increments forbid.
+- 🟡 **Dependency/Completeness/Scope**: the composition-root wiring is assigned
+  to no increment, yet increment 2 repoints the work skills at a binary whose
+  composition root may still resolve 0194's fakes.
+- 🟡 **Clarity**: the Requirements' four "in the same change" clauses contradict
+  a four-increment plan, and two "that same change" referents now dangle.
+- 🟡 **Scope**: no increment carries exit criteria and no criterion is
+  attributed to one, so "individually mergeable" is asserted, not verifiable.
+- 🟡 **Scope**: `deny.toml` clearance sits in increment 3 although both
+  dependency trees arrive in increment 1.
+- 🟡 **Dependency**: the credentialed-target prerequisite is timed to "before
+  the first deletion", but increment 1 already requires the harness green
+  against real clients — it gates increment 1, and has no named owner.
+- 🟡 **Scope**: increment 4 (the conflict flow) is orthogonal by the item's own
+  statement, fixes live user-visible degradation, and now inherits three Open
+  Questions and a credentialed-target gate it does not need.
+
+Independent of Increments:
+
+- 🟡 **Testability**: the contract-run execution-route criterion is discharged
+  by recording *either* answer — writing "a broken client can reach `main`"
+  passes it. Same shape on the fixture-capture-source and copyleft records.
+- 🟡 **Testability**: "consumer set swept to completion" names no query and
+  explicitly excludes the only two references it cites.
+- 🟡 **Testability**: no criterion pins the two binaries' stdout against the
+  bash output the repointed `SKILL.md` bodies consumed.
+- 🟡 **Testability**: the absent-description projection rule — the item's
+  highest-stated risk — is verified only in the credentialed lane, which
+  Dependencies records as unprovisioned.
+- 🟡 **Clarity**: "all four port operations" is followed by three operations
+  plus a rule, so a dropped `show` could satisfy the list.
+- 🔵 Minors: Decisions declares two states but uses three and omits two records
+  its criteria require; `tracker` attributed to both 0204 and 0194;
+  `work.integration` names and the read-never-`Terminal` rule undefined; two
+  different "fourteen"s; `linear-graphql.sh` classified inconsistently; Context
+  overstates 0194 and the prerequisite count; "over" ambiguous in the
+  dirty-guard pairing.
+
+### Assessment
+
+The criteria set is materially stronger than at pass 1 and most individual
+findings are shallower. But the pass-2 revision introduced seven majors while
+resolving eleven, and the mechanism is legible: `## Increments` added a second
+ordering model to a document whose Requirements already encoded atomicity, and
+the two now contradict each other in ways that produce a real functional break.
+
+That is the pattern 0136 recorded for 0169 — "three editing passes had not
+reduced its major-finding count … the signature of one work item carrying more
+than a single document can hold consistently." Pass 1: 3 critical, 12 major.
+Pass 2: 0 critical, 15 findings. Pass 3: 0 critical, 9 major. The severity
+ceiling is falling; the major count is not converging.
+
+Recommendation: rather than a fourth editing pass, either reify the four
+increments as child work items (the scope lens's suggestion — 0166 already
+parents 0178/0179/0180, so the epic has precedent for a child with children),
+or delete `## Increments` and restore the single-change atomicity the
+Requirements state. Both remove the contradiction at its source; further
+in-place editing is likely to trade one set of majors for another.
+
+## Acceptance — 2026-08-17
+
+**Accepted.** Verdict changed from REVISE to APPROVE by Toby Clemson, and the
+target work item moved to `ready`.
+
+The open findings recorded above were **accepted rather than resolved**. They are
+not withdrawn and remain the record of what is known to be imperfect; they carry
+into planning rather than blocking it. Specifically still open at acceptance:
+
+- The three Open Questions on 0171 — the credentialed target's secrets siting, the
+  fate of the three port-less bridge capabilities, and the `EXIT_CODES.md` siting —
+  plus the two ⚠️ size-bounding assumptions in 0211 and 0212.
+- Three self-contradictions introduced during the fix rounds: 0211's mock-server
+  deletion being simultaneously unconditional and deferrable, 0211's `jq`/`curl`
+  requirement asserting a survivor set its own criterion says the child cannot
+  reach, and 0213's stub-on-`PATH` seam defeating the one predicate item that would
+  catch a malformed `--resolve` template.
+- Two latent gaps better closed by implementation than by further specification:
+  the non-port provider surface (five of eight flows) being owned by neither 0210
+  nor 0211, and 0210 carrying no criterion for HTTP-status or GraphQL error
+  classification or auth.
+
+Rationale for accepting rather than iterating: across four review passes the
+severity ceiling fell (3 criticals → 1 → 0 → 0) while the major count did not
+converge, and each fix round introduced two or three new majors of one shape — a
+requirement updated without its criteria, or the reverse. The two correctness traps
+that mattered (the unowned port-less capabilities, and the `work-item-sync-label.sh`
+ordering break) are both closed. Further speculative specification was judged less
+valuable than starting 0210 and discovering the real shape of the client crates.

--- a/meta/reviews/work/0210-provider-client-crates-over-the-tracker-port-review-1.md
+++ b/meta/reviews/work/0210-provider-client-crates-over-the-tracker-port-review-1.md
@@ -1,0 +1,282 @@
+---
+type: work-item-review
+id: "0210-provider-client-crates-over-the-tracker-port-review-1"
+title: "Work Item Review: Provider Client Crates over the RemoteTracker Port"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0171"
+target: "work-item:0210"
+work_item_id: "0210"
+relates_to: ["work-item-review:0171-jira-and-linear-integrations-review-1"]
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: [rust, jira, linear, tracker, clients]
+last_updated: "2026-08-17T12:20:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Provider Client Crates over the RemoteTracker Port
+
+**Verdict:** REVISE
+
+0210 is the strongest of the four children on verification craft — the tripwire
+that tests itself by planting a violation, the T-relative timeout window, the
+every-row table assertion, the enforcing contract route that explicitly refuses
+"recording that no gate exists". Two gaps matter more than any of that: the
+projection recipes it is responsible for reproducing exactly have no criterion
+beyond the absent-description case, even though this child is the only window in
+which the bash corpus still exists as an oracle; and the three oracle
+transcriptions two siblings verify against name no path or format, so those
+sibling criteria cannot be checked when their children are accepted.
+
+This review was conducted as one pass over all four children of 0171. The
+cross-child critical — the three port-less bridge capabilities landing in no
+child — is stated in full in 0212's review, since 0212 owns the deleting change.
+
+### Findings
+
+#### Major
+
+- 🟡 **Testability**: Projection fidelity has no criterion beyond the
+  absent-description case
+  **Location**: Acceptance Criteria
+  The Requirements demand reproducing both recipes *exactly*, including Jira's
+  key-sorted ADF ordering, and 0171's parent requirement said projection is
+  "verified against the bash-generated baseline corpus 0194 committed" — a
+  clause 0210 dropped. No criterion in any child exercises the corpus offline
+  while it is still on disk. 0210 can be accepted with populated-description
+  projection unverified, and first detection would be 0212's credentialed run,
+  after every deletion has landed.
+
+- 🟡 **Testability**: The oracle-transcription criterion is forward-looking and
+  names no artefact for two of three oracles
+  **Location**: Acceptance Criteria
+  Only the exit-code fixture has a named form. The ADF node-type inventory and
+  the eleven-test baseline name no path, no format and no location, yet 0211's
+  "every entry in 0210's recorded node-type inventory" and 0212's "at least the
+  same fixture cases as 0210's recorded baseline" resolve to them. The criterion
+  is also stated against events that have not happened at 0210's acceptance —
+  "before 0211 or 0212 begins" — so it is vacuously satisfiable when checked and
+  only violable later.
+
+- 🟡 **Clarity / Scope**: "Leaves the production path unchanged" contradicts
+  wiring real providers into the composition root
+  **Location**: Summary
+  The same sentence says the child wires the sync engine to resolve real
+  providers rather than fakes *and* leaves the production path unchanged. One
+  reading is inert (the skills still call bash); the other puts live Jira and
+  Linear calls behind an already-shipped binary before any skill repointing or
+  contract gate exists. The two readings imply different merge risk.
+
+- 🟡 **Clarity / Scope**: ADF↔markdown is implemented here but its only
+  verification gate lives in 0211
+  **Location**: Requirements
+  The Requirements put ADF↔markdown inside `jira-client` and make this child
+  transcribe the node-type inventory, but no criterion here exercises the
+  conversion; 0211 carries it, despite being described as thin adapters over
+  these crates. The inventory this child pays to transcribe has no consumer
+  inside this child.
+
+#### Minor
+
+- 🔵 **Scope**: An acceptance criterion is phrased as a condition on when
+  siblings begin, so it cannot be closed by inspecting this child's own change.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Completeness**: The parent's instruction to *reuse* the existing
+  `tracker_contract` exclusion mechanism rather than introduce a second one was
+  not restated — only its outcome was.
+  **Location**: Requirements
+
+- 🔵 **Completeness / Clarity**: Pup rules and public-API snapshots for
+  `jira-client` and `linear-client` are claimed by 0211 ("the four crates"),
+  though this child creates them and demands `mise run` green at its own merge
+  boundary.
+  **Location**: Requirements
+
+- 🔵 **Testability**: The copyleft record is paired with a check that cannot
+  detect a wrong answer — `deny:check` goes green by committing allowances
+  regardless of what the recorded answer says, and that answer decides whether
+  0203 becomes a release-path dependency for 0211.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Clarity**: "It has no work item; 0171 names its owner" does not resolve —
+  0171 names an owner only for its Open Questions, not for the credentialed
+  target's provisioning.
+  **Location**: Dependencies
+
+### Strengths
+
+- ✅ The tripwire criterion tests the tripwire itself by planting a deliberate
+  violation — a rare falsifiable meta-assertion.
+- ✅ The timeout criterion is T-relative at two concrete values plus a separate
+  defaults assertion, so it is neither wall-clock-expensive nor waveable.
+- ✅ The exit-code criterion fails the build on a row with no assertion, and
+  names the divergent Linear cases explicitly.
+- ✅ The contract-run criterion demands an enforcing route and rules out
+  recording that no gate exists.
+- ✅ It states plainly that the credentialed target gates *this child's*
+  acceptance, not merely the eventual cutover.
+- ✅ The absent-description criterion is explicitly offline, so the
+  highest-risk behaviour does not depend on the unprovisioned lane.
+
+### Recommended Changes
+
+1. **Add an offline whole-corpus projection criterion** (addresses: projection
+   fidelity) For every record in `skills/work/scripts/test-fixtures/`, the
+   client's projection is byte-identical to the committed corpus entry for that
+   record, per provider, key ordering included — passing with no network target
+   and before any deletion.
+2. **Name the three transcription artefacts by path and format, and scope the
+   criterion to this merge** (addresses: forward-looking criterion) e.g. a
+   one-node-type-per-line inventory file and a per-test baseline listing fixture-
+   case identifiers, both committed as part of this child. Move the
+   "before any deletion" ordering to Dependencies, where the ordering rule lives.
+3. **Say what a user can reach after this merges** (addresses: the Summary
+   contradiction) State that the real clients become resolvable by
+   `accelerator work sync` while no skill invokes it until 0212 — or move the
+   composition-root binding to the child that repoints the skills.
+4. **Move the ADF, JQL and GraphQL construction criteria here** (addresses: the
+   split gate) They pin this child's code; leave 0211 the CLI-surface and
+   retirement criteria that match its thin-adapter role.
+5. **Apply the minors** — restate the reuse-the-existing-gate clause, claim the
+   two client crates' pup and public-API artefacts explicitly, require the
+   copyleft answer to be the committed output of a named reproducible command,
+   and name the provisioning owner directly.
+
+## Per-Lens Summaries
+
+- **Clarity**: precise sentence by sentence; the problems are at the seams — the
+  Summary contradiction, and ownership of ADF/JQL/GraphQL and the pup artefacts
+  stated in incompatible terms with 0211.
+- **Completeness**: complete as a `task` — Summary, Context, Requirements,
+  Acceptance Criteria, Dependencies, Assumptions, References all substantive.
+  Two parent clauses were lost in transcription.
+- **Dependency**: the strongest dependency record of the four — names the
+  credentialed target and both external services, states they gate this child's
+  own acceptance, and repeats the confirm-0194-by-artefact instruction.
+- **Scope**: correctly sequenced ahead of every deletion and correctly made
+  responsible for the oracles. Still story-scale despite `kind: task`.
+- **Testability**: the tightest criteria set of the four, undermined by the two
+  majors above.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran over the four children as a set. **No criticals.** The
+pass-1 critical is resolved and independently confirmed: the completeness lens
+verified that every obligation the parent's Scope narrative and `## Decisions`
+register still names resolves to a child requirement or criterion, including the
+three port-less bridge capabilities now owned by 0212.
+
+The verdict holds on major count. Three of the majors are defects the fix round
+introduced; the rest are pre-existing gaps the tightened criteria exposed.
+
+### Previously Identified Issues
+
+- 🟡 → ✅ **Projection fidelity had no criterion beyond absent-description** —
+  **Resolved**. The whole-corpus offline criterion now pins every record in
+  `skills/work/scripts/test-fixtures/`, including Jira's key-sorted ADF ordering,
+  with no network target.
+- 🟡 → 🟡 **Oracle transcriptions named no artefact** — **Half-resolved, and now
+  a defect of its own.** The requirement and criterion both promise all three
+  land "each at a named committed path", but only one path is written down
+  (`cli/jira-client/tests/fixtures/adf-node-types.txt`). Flagged independently by
+  clarity, completeness and testability.
+- 🟡 → ✅ **"Leaves the production path unchanged" contradiction** —
+  **Resolved**. The Summary now states the user-visible delta is nothing, and why.
+- 🟡 → ✅ **ADF↔markdown verified in the wrong child** — **Resolved**. The
+  ADF/JQL/GraphQL assertions moved here, where the code lives.
+- 🔵 → ✅ Minors on the reuse-the-gate clause, pup ownership, the copyleft
+  command, the provisioning owner, and the sibling-dated criterion — **all
+  resolved**.
+
+### New Issues Introduced
+
+- 🟡 **Testability / Clarity / Completeness**: Two of three transcriptions still
+  have no path (introduced by the fix round). The requirement's own stated failure
+  mode applies to its own bullets — "a transcription with no path is a criterion
+  neither sibling can check" — and 0212's fixture-count and fixture-case criteria
+  resolve to those files after the source directory is deleted.
+- 🟡 **Testability**: No criterion covers HTTP-status or GraphQL-level error
+  classification, or auth. Pre-existing. The four-`curl`-table criterion covers
+  transport exit codes, and the item stresses those are *not* HTTP statuses —
+  so nothing pins a 401, 404, 429 or a `200`-carrying-`errors` GraphQL body to a
+  `TrackerError` class, and nothing pins auth-header construction. A client that
+  misclassifies an auth failure as retryable passes every criterion.
+- 🟡 **Testability**: The ADF criterion is scoped by an inventory this child
+  authors, with no anchor to the bash source. Coverage is total by construction:
+  an inventory omitting a node type yields a passing fixture set while that node
+  type regresses at cutover — and the bash oracle dies in 0211.
+- 🟡 **Scope**: The non-port provider surface is owned by neither this child nor
+  0211 — see the cross-child note below.
+- 🔵 **Testability**: The identifier-safety criterion asserts "no value is written
+  to a work item's frontmatter", an observation point below the port where this
+  child's crates write no files.
+- 🔵 **Clarity**: `accelerator-work` is never tied to a crate directory, though
+  siblings name `cli/work/`, `cli/work-cli/` and `cli/work-adapters/` distinctly
+  and the pup/public-API criterion needs to know which.
+- 🔵 **Clarity**: The projection recipe shifts between "summary line" and "title
+  line", and describes output via the `jq -S` invocation being deleted; how the
+  no-blank-line rule composes with Linear's absent-description golden "ending in
+  an empty line" is left to inference.
+- 🔵 **Suggestion**: The 1.35×T timeout window at T = 200ms leaves ~70ms of
+  headroom — precise enough to flake under parallel CI load.
+
+### Cross-Child
+
+- 🟡 **Scope**: **The non-port provider surface is unowned.** This child scopes
+  its crates to the four port operations and forbids `reqwest::` use outside them;
+  0211 declares *thin* adapters exposing eight flows, of which `comment`,
+  `transition`, provider `search`, `attach` and `init` have no port operation. Their
+  request construction must therefore live in crates whose Requirements never asked
+  for it. Either this child is materially larger than it states, or 0211 must extend
+  and re-snapshot crates it does not own while calling itself thin.
+
+### Assessment
+
+The strongest child in the set, and the criteria that were rewritten did close
+their holes — bar the transcription paths, which are a half-fix. The two
+substantive gaps are pre-existing rather than introduced: error classification
+beyond transport codes has never had a criterion, and the ADF inventory has no
+anchor to the source it transcribes.
+
+## Acceptance — 2026-08-17
+
+**Accepted.** Verdict changed from REVISE to APPROVE by Toby Clemson, and the
+target work item moved to `ready`.
+
+The open findings recorded above were **accepted rather than resolved**. They are
+not withdrawn and remain the record of what is known to be imperfect; they carry
+into planning rather than blocking it. Specifically still open at acceptance:
+
+- The three Open Questions on 0171 — the credentialed target's secrets siting, the
+  fate of the three port-less bridge capabilities, and the `EXIT_CODES.md` siting —
+  plus the two ⚠️ size-bounding assumptions in 0211 and 0212.
+- Three self-contradictions introduced during the fix rounds: 0211's mock-server
+  deletion being simultaneously unconditional and deferrable, 0211's `jq`/`curl`
+  requirement asserting a survivor set its own criterion says the child cannot
+  reach, and 0213's stub-on-`PATH` seam defeating the one predicate item that would
+  catch a malformed `--resolve` template.
+- Two latent gaps better closed by implementation than by further specification:
+  the non-port provider surface (five of eight flows) being owned by neither 0210
+  nor 0211, and 0210 carrying no criterion for HTTP-status or GraphQL error
+  classification or auth.
+
+Rationale for accepting rather than iterating: across four review passes the
+severity ceiling fell (3 criticals → 1 → 0 → 0) while the major count did not
+converge, and each fix round introduced two or three new majors of one shape — a
+requirement updated without its criteria, or the reverse. The two correctness traps
+that mattered (the unowned port-less capabilities, and the `work-item-sync-label.sh`
+ordering break) are both closed. Further speculative specification was judged less
+valuable than starting 0210 and discovering the real shape of the client crates.

--- a/meta/reviews/work/0211-integration-binaries-and-bash-cluster-retirement-review-1.md
+++ b/meta/reviews/work/0211-integration-binaries-and-bash-cluster-retirement-review-1.md
@@ -1,0 +1,400 @@
+---
+type: work-item-review
+id: "0211-integration-binaries-and-bash-cluster-retirement-review-1"
+title: "Work Item Review: Integration Binaries and Bash Cluster Retirement"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0171"
+target: "work-item:0211"
+work_item_id: "0211"
+relates_to: ["work-item-review:0171-jira-and-linear-integrations-review-1"]
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: [rust, jira, linear, cli, cutover, registration]
+last_updated: "2026-08-17T12:40:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Integration Binaries and Bash Cluster Retirement
+
+**Verdict:** REVISE
+
+0211 attracted more findings than any other child. Three of them are structural
+rather than editorial: its exit-code criterion measures the implementation
+against a document the same child authors, so it can never fail; the per-flow
+fixture *capture-source* recording was lost in the carve-out, so all sixteen
+fixtures could be captured from the mock servers this child deletes and every
+criterion would read green; and its `allowed-tools` equality criterion can only
+be satisfied by 0212's work, inverting the declared order. It also blocks 0174
+without declaring the edge, and the cross-cluster coupling analysis that justified
+the 0210 → 0211 → 0212 order was done in one direction only.
+
+This review was conducted as one pass over all four children of 0171. The
+cross-child critical — the three port-less bridge capabilities landing in no
+child — is stated in full in 0212's review.
+
+### Findings
+
+#### Major
+
+- 🟡 **Testability**: The exit-code contract criterion is circular
+  **Location**: Acceptance Criteria
+  It asserts that every failure class maps to "the integer the named document of
+  record specifies", while that document is a deliverable of this same child.
+  Any integers the implementation emits can be written into the document, after
+  which the table-driven test passes. The repointed `SKILL.md` bodies branch on
+  these values, so a mapping that silently differs from the bash exit codes they
+  previously branched on breaks skill behaviour with the criterion green. 0171's
+  anchor — that these be pinned by CLI-level tests at the layer the skills invoke
+  — was also dropped.
+
+- 🟡 **Testability / Completeness / Dependency**: The per-flow fixture
+  capture-source recording was lost
+  **Location**: Acceptance Criteria
+  0171 requires `## Decisions` to record, per flow, whether each fixture came
+  from the credentialed target or the retiring mock server, naming the blocker
+  where the real target was unreachable. 0211 keeps the per-flow assertion and
+  drops the provenance obligation entirely, while 0171's `## Decisions` still
+  lists that entry as *pending* with no child owning it. All sixteen fixtures
+  could pin the new clients to a test double this child deletes.
+
+- 🟡 **Dependency**: The `allowed-tools` equality criterion depends on 0212's
+  outcome, inverting the declared order
+  **Location**: Acceptance Criteria
+  It asserts the surviving set contains "no jira, linear or work skill" — but the
+  three work skills are backed by `skills/work/scripts/*.sh` and are repointed
+  only in 0212, which this child blocks. Either 0211 cannot be accepted at its own
+  merge boundary, or the criterion is a silent no-op.
+
+- 🟡 **Dependency**: 0211 blocks 0174 but declares no edge
+  **Location**: Frontmatter: blocks
+  This child retires `_EXPECTED_INTEGRATIONS_SUITES` and seven of the eight
+  orphaned `SHELL_LIBRARIES` entries that 0174 waits on, yet declares only
+  `blocks: 0212`. 0174 can appear unblocked while a live integrations floor and
+  seven orphaned entries still exist.
+
+- 🟡 **Dependency**: Cross-cluster coupling was analysed in one direction only
+  **Location**: Dependencies
+  The ordering rationale covers jira/linear scripts calling
+  `work-item-sync-label.sh`. The reverse coupling is unexamined: the work-item
+  remote bridges and their three suites survive until 0212, and the two Python
+  mock servers those suites may use are deleted *here*. If any surviving work
+  script or suite reaches into the clusters or the mock servers, this child's
+  blanket deletion breaks the still-live work-item bash path — the mirror image
+  of the break the ordering was chosen to avoid, created rather than prevented
+  by the chosen order.
+
+- 🟡 **Clarity / Completeness**: "The four crates'" pup rules and public-API
+  snapshots
+  **Location**: Requirements
+  This child introduces two crates; the other two are 0210's. Neither child
+  states unambiguously where `jira-client` and `linear-client` get their pup
+  rules and public-API snapshots, and "the four crates" has no antecedent here.
+
+- 🟡 **Clarity**: ADF↔markdown, JQL and GraphQL construction — verified here,
+  implemented in 0210, owned explicitly by neither
+  **Location**: Requirements / Acceptance Criteria
+  This child carries the only criterion for that behaviour while its Requirements
+  never state it implements any of it. A 0210 implementer can read the conversion
+  as in scope with no criterion; a 0211 implementer as already delivered.
+
+- 🟡 **Clarity**: "Library entry" carries two meanings and the seven-versus-eight
+  count cannot be reconciled
+  **Location**: Requirements / Acceptance Criteria
+  "All seven library entries" and "the seven jira and linear entries are gone
+  from `SHELL_LIBRARIES`" sit beside a requirement to classify
+  `linear-graphql.sh` as possibly "an eighth library entry". The term is used
+  both for a sourced-only file on disk and for a frozenset member, and the
+  outcome determines whether a lint guard passes.
+
+- 🟡 **Testability**: The eight-flow enumeration's completeness has no coverage
+  criterion
+  **Location**: Acceptance Criteria
+  Every behavioural criterion is scoped to "the eight flows" while the child's own
+  ⚠️ assumption says that enumeration is unconfirmed against 34 production
+  scripts — and another criterion empties both directories outright. A flow that
+  exists in bash but is absent from the eight can be deleted with everything
+  green.
+
+- 🟡 **Scope**: Three separately deliverable concerns behind an "and" in the
+  title
+  **Location**: Summary / Requirements
+  Sixteen subcommands with stdout goldens and an exit-code contract; end-to-end
+  registration through 0165's signed manifest with 0203 as a conditional
+  dependency; and two whole-cluster deletions. Only "capture goldens before
+  deleting" couples them. Folding release-pipeline registration into a cutover
+  child means a manifest or licence problem blocks the bash retirement.
+
+#### Minor
+
+- 🔵 **Dependency**: The fixture capture step may need the credentialed target,
+  which this child's Dependencies never names.
+  **Location**: Dependencies
+
+- 🔵 **Dependency**: The conditional 0203 release-path dependency has no edge, no
+  trigger mechanism and no owner for converting it when the copyleft check fires.
+  **Location**: Dependencies
+
+- 🔵 **Testability**: The stdout-golden criterion's "shape deliberately changed"
+  branch has a judgement-based pass condition and requires no golden for the new
+  shape, so any inconvenient subcommand can be routed down it.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Clarity**: `search` names both a migrated flow here and the parent's
+  still-undecided unkeyed-discovery capability, with no disambiguation.
+  **Location**: Requirements
+
+- 🔵 **Clarity**: ADF and JQL are used unexpanded in the child whose criteria pin
+  their fidelity, though 0210 and the parent both expand them.
+  **Location**: Context / Requirements
+
+### Strengths
+
+- ✅ The `allowed-tools` criterion is an equality assertion against a named
+  survivor set, not a "no unexpected entries" formulation.
+- ✅ Ownership of the mechanical surfaces is split explicitly and exhaustively —
+  seven `SHELL_LIBRARIES` entries here, one in 0212; one suite floor each — with
+  each child stating what it does *not* own.
+- ✅ It carries a `mise run` green criterion scoped to its own merge boundary,
+  "not only after the whole of 0171".
+- ✅ It restates the ⚠️ size-bounding assumption it inherits, naming what happens
+  to the child if it fails to hold.
+- ✅ The `work-item-sync-label.sh` ordering rationale is stated from this side as
+  well as 0212's, in mutually consistent terms.
+
+### Recommended Changes
+
+1. **Anchor the exit-code mapping externally** (addresses: the circular
+   criterion) Require each class's integer to equal the value the retiring bash
+   flow returned for the same condition, captured pre-deletion, or to reuse
+   `tracker`'s existing `E_DISPATCH_*` integers — and restore the CLI-level
+   pinning at the layer the skills invoke.
+2. **Restore the capture-source clause** (addresses: lost provenance) Per flow,
+   record provenance in 0171's `## Decisions` as credentialed-target or
+   mock-served, with each mock-served entry naming the blocker.
+3. **Move the whole-repository `allowed-tools` equality to 0212** (addresses: the
+   inverted dependency) Leave 0211 the jira and linear subset plus a recorded
+   enumeration of residual declarers.
+4. **Add `blocks: 0174`** and a Dependencies bullet naming what 0174 waits on
+   from this child (addresses: the missing edge).
+5. **Sweep the reverse cross-cluster coupling before deleting** (addresses:
+   one-directional analysis) Enumerate every reference from
+   `skills/work/scripts/` into the two clusters and into the mock servers, with
+   the recorded result; where references exist, either keep the work path green
+   explicitly or move the mock-server deletion to 0212.
+6. **Add a flow-coverage criterion** (addresses: enumeration completeness) Each
+   of the 22 Jira and 12 Linear production scripts maps to a named subcommand or
+   a recorded internal-helper classification, with the count reconciling to the
+   pre-deletion file list.
+7. **Resolve the ownership and terminology defects** — name the four crates and
+   split the pup/public-API claim with 0210, state which child implements
+   ADF/JQL/GraphQL, distinguish sourced-only library file from `SHELL_LIBRARIES`
+   member and state the expected count under each `linear-graphql.sh` branch,
+   disambiguate `search`, and expand both acronyms on first use.
+8. **Consider splitting the child** (addresses: the bundle) A "binaries and
+   registration" child blocking a "cluster retirement" child, or fold retirement
+   into per-provider children if the provider seam is cut.
+
+## Per-Lens Summaries
+
+- **Clarity**: individually precise, but ownership of three shared obligations
+  (pup artefacts, ADF/JQL/GraphQL, `search`) is stated in terms incompatible with
+  0210 or the parent.
+- **Completeness**: complete as a `task`, bar the lost capture-source clause.
+- **Dependency**: two real graph defects (the missing 0174 edge, the inverted
+  `allowed-tools` criterion) plus the one-directional cluster analysis.
+- **Scope**: the largest child and the most easily reduced; three concerns behind
+  an "and".
+- **Testability**: two criteria that cannot fail as written, and a coverage
+  measure scoped to an unconfirmed enumeration.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran over the four children as a set. **No criticals.** The
+pass-1 critical is resolved and independently confirmed: the completeness lens
+verified that every obligation the parent's Scope narrative and `## Decisions`
+register still names resolves to a child requirement or criterion, including the
+three port-less bridge capabilities now owned by 0212.
+
+The verdict holds on major count. Three of the majors are defects the fix round
+introduced; the rest are pre-existing gaps the tightened criteria exposed.
+
+### Previously Identified Issues
+
+- 🟡 → 🟡 **Exit-code criterion was circular** — **Improved, not closed.** The
+  anchor now points at "the value the retiring bash flow returned … captured
+  pre-deletion", but no criterion requires that capture to be committed, and the
+  free choice between it and `tracker`'s `E_DISPATCH_*` value (qualified only by
+  "genuinely the same taxonomy") restores the unfalsifiability. Flagged by both
+  clarity and testability.
+- 🟡 → ✅ **Per-flow fixture provenance was lost** — **Resolved**. Provenance is
+  recorded per flow, each mock-served entry naming its blocker.
+- 🟡 → ✅ **`allowed-tools` equality depended on 0212's work** — **Resolved** by
+  moving the equality assertion to 0212 — but the Requirements bullet was not
+  updated to match, so the two now contradict each other (below).
+- 🟡 → ✅ **Blocked 0174 without declaring the edge** — **Resolved**; `blocks`
+  names it and 0174's `blocked_by` reciprocates.
+- 🟡 → 🟡 **Cross-cluster coupling analysed one direction only** — **Addressed but
+  self-contradictory.** The reverse sweep is now a requirement, but its deferral
+  branch collides with two of this child's own criteria (below).
+- 🟡 → ✅ **"The four crates'" pup artefacts** — **Resolved**; two binary crates
+  here, two client crates in 0210, stated on both sides.
+- 🟡 → ✅ **ADF ownership ambiguity** — **Resolved**; the assertions moved to 0210.
+- 🟡 → ✅ **"Library entry" two senses** — **Resolved** in the `SHELL_LIBRARIES`
+  requirement, though Context and the deletion bullet were not updated to match
+  (below).
+- 🟡 → ✅ **Flow enumeration had no coverage criterion** — **Resolved in form**,
+  but the new criterion has an unconstrained escape (below).
+- 🟡 → 🟡 **Three concerns behind an "and"** — **Still present.** Declined at the
+  set level; this child remains the heaviest.
+- 🔵 → ✅ Acronyms, `search` disambiguation, the 0203 trigger, the stdout escape
+  branch — **all resolved**. The stdout branch now demands a new golden plus a
+  recorded diff.
+
+### New Issues Introduced
+
+- 🟡 **Clarity / Dependency / Testability**: **The mock-server deletion is
+  simultaneously unconditional and deferrable** (introduced by the fix round).
+  The reverse-sweep requirement permits deferring mock-server deletion to 0212;
+  two criteria here assert the servers do not exist, and 0212 carries no
+  requirement or criterion mentioning them. If the sweep finds references — the
+  outcome it exists to detect — the permitted resolution makes two of this child's
+  own criteria unpassable, and the deletion lands in no child.
+- 🟡 **Clarity**: **The `jq`/`curl` requirement asserts a survivor set its own
+  criterion says this child cannot reach** (introduced by the fix round). The
+  requirement still expects "no jira, linear or work skill among them"; at this
+  child's boundary the three work skills have not been repointed, so they must
+  still declare `jq`/`curl`.
+- 🟡 **Clarity**: **Context settles the `linear-graphql.sh` partition the
+  Requirements leave open.** Context states "12 production scripts plus
+  `linear-common` and `linear-auth`" as exhaustive, while the requirement makes the
+  classification an open decision that would change both counts — and the
+  flow-coverage criterion asserts "the 22 Jira and 12 Linear production scripts"
+  as a fixed denominator.
+- 🟡 **Testability**: **The flow-coverage criterion is total by construction.**
+  Any script not mapping to one of the eight flows can be declared an
+  internal helper by fiat, and the count still reconciles — so the case it exists
+  to catch is the case it cannot catch.
+- 🟡 **Testability / Clarity**: The exit-code anchor names two authorities with no
+  precedence rule, and never requires the bash capture to be committed.
+- 🟡 **Dependency**: **0165 is treated as an existing artefact with no
+  confirmation instruction**, unlike 0194. 0165's record shows the same status
+  divergence (frontmatter `done` against a body reading In Progress, no criteria
+  ticked) *and* names an undischarged privileged prerequisite — a minisign secret
+  key installed by a repository administrator. The registration criterion could be
+  undischargeable for reasons outside this change.
+- 🔵 **Dependency**: No External systems entry, though its fixtures are captured
+  against the real providers "wherever reachable" — the one child whose work is
+  provider-by-provider records no availability coupling.
+- 🔵 **Completeness**: No before-pickup marker for the exit-code contract, which
+  the parent's register still lists as *open*; siblings carry such markers.
+- 🔵 **Testability**: The reverse sweep names no search procedure, so
+  enumeration completeness is unverifiable — unlike 0212's sweep, which names its
+  grep and records the command.
+- 🔵 **Testability**: "At minimum" leaves the failure-class set open, so per-class
+  coverage is satisfied by the five-class floor regardless of what the binaries
+  can actually exit on.
+- 🔵 **Clarity**: "Mock server" denotes both `wiremock` and the Python servers in
+  adjacent sentences.
+
+### Assessment
+
+This child absorbed the most fixes and now carries the most residue. Two of its
+three new contradictions were introduced by the fix round — the mock-server
+deferral and the `jq`/`curl` survivor set — and both are the same shape: a
+requirement updated without its criteria, or vice versa. The exit-code anchor
+moved the hole rather than closing it: anchoring to an uncommitted capture is not
+an anchor.
+
+## Acceptance — 2026-08-17
+
+**Accepted.** Verdict changed from REVISE to APPROVE by Toby Clemson, and the
+target work item moved to `ready`.
+
+The open findings recorded above were **accepted rather than resolved**. They are
+not withdrawn and remain the record of what is known to be imperfect; they carry
+into planning rather than blocking it. Specifically still open at acceptance:
+
+- The three Open Questions on 0171 — the credentialed target's secrets siting, the
+  fate of the three port-less bridge capabilities, and the `EXIT_CODES.md` siting —
+  plus the two ⚠️ size-bounding assumptions in 0211 and 0212.
+- Three self-contradictions introduced during the fix rounds: 0211's mock-server
+  deletion being simultaneously unconditional and deferrable, 0211's `jq`/`curl`
+  requirement asserting a survivor set its own criterion says the child cannot
+  reach, and 0213's stub-on-`PATH` seam defeating the one predicate item that would
+  catch a malformed `--resolve` template.
+- Two latent gaps better closed by implementation than by further specification:
+  the non-port provider surface (five of eight flows) being owned by neither 0210
+  nor 0211, and 0210 carrying no criterion for HTTP-status or GraphQL error
+  classification or auth.
+
+Rationale for accepting rather than iterating: across four review passes the
+severity ceiling fell (3 criticals → 1 → 0 → 0) while the major count did not
+converge, and each fix round introduced two or three new majors of one shape — a
+requirement updated without its criteria, or the reverse. The two correctness traps
+that mattered (the unowned port-less capabilities, and the `work-item-sync-label.sh`
+ordering break) are both closed. Further speculative specification was judged less
+valuable than starting 0210 and discovering the real shape of the client crates.
+
+## Correction — 2026-08-17
+
+**A premise this review relied on was false, and the finding built on it is
+withdrawn.**
+
+Both the pass-1 and pass-2 reviews treated `linear-create-flow.sh:304` and
+`jira-resolve-fields.sh:140` as **live callers** of `work-item-sync-label.sh`, and
+the pass-3 dependency finding on the parent described them the same way. They are
+not callers. Both lines are comments:
+
+```bash
+# (Same normalisation as the Jira guard and work-item-sync-label.sh.)
+# guard and work-item-sync-label.sh).
+```
+
+Verified by grepping `skills/integrations/*/scripts/*.sh` for invocations of
+`work-item-*.sh` with comment lines excluded: no matches. The clusters invoke no
+work script at all.
+
+What the coupling actually is, and it runs the other way: **four** of the five
+suites 0212 deletes — `test-work-item-create-remote.sh`, `-update-remote.sh`,
+`-fetch-remote.sh` and `-sync-apply.sh` — resolve paths into
+`skills/integrations/{jira,linear}/scripts/test-helpers/` for the Python mock
+servers and `.../test-fixtures/` for their scenario fixtures.
+
+Consequences for this review:
+
+- The **0211-before-0212 ordering it endorsed was wrong.** In that order, 0211's
+  wholesale cluster deletion would have broken all four suites and the
+  `_EXPECTED_WORK_SUITES` floor at 0211's own merge boundary. The order is now
+  0210 → 0212 → 0211.
+- The pass-2 major *"the mock-server deferral branch has no receiving requirement
+  in 0212 and contradicts 0211's own criteria"* is **resolved by the reordering
+  rather than by the patch this review recommended**. With the work suites deleted
+  first, nothing outside the clusters consumes their test assets, so 0211 deletes
+  the mock servers unconditionally as its criteria always stated. The deferral
+  branch has been removed from 0211 entirely; no conditional criteria were added
+  to either child.
+- The pass-2 major on 0211's `jq`/`curl` survivor set is **resolved as a side
+  effect**: with 0211 landing last, the work skills are already repointed at its
+  boundary, so its expectation of no surviving work-skill declarer is correct as
+  written. 0211 now owns the whole-repository equality assertion and 0212 asserts
+  only that no work skill declares `jq` or `curl`.
+- The reverse-coupling sweep 0211 gained in the previous round survives in reduced
+  form: a confirmation at its boundary that nothing outside the clusters still
+  references `test-helpers/` or `test-fixtures/`, expected to be empty.
+
+The reviews' strengths sections credit the 0211-before-0212 ordering as
+"justified by a concrete, named break". That credit was misplaced — the break was
+named but not verified, and verifying it would have inverted the order three
+passes earlier.

--- a/meta/reviews/work/0212-work-item-script-cutover-review-1.md
+++ b/meta/reviews/work/0212-work-item-script-cutover-review-1.md
@@ -1,0 +1,351 @@
+---
+type: work-item-review
+id: "0212-work-item-script-cutover-review-1"
+title: "Work Item Review: Work-Item Script Cutover"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0171"
+target: "work-item:0212"
+work_item_id: "0212"
+relates_to: ["work-item-review:0171-jira-and-linear-integrations-review-1"]
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: [rust, cutover, work-items, fixtures]
+last_updated: "2026-08-17T12:40:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Work-Item Script Cutover
+
+**Verdict:** REVISE
+
+0212's deletion criteria are the most mechanically checkable in the set — `ls`
+matching nothing, a repository-wide grep with the command and empty output as the
+recorded result, relocated-count-plus-deletions equalling the pre-change file
+count. It carries one critical, found independently by three lenses: the three
+port-less bridge capabilities that 0171 spent a requirement, two criteria and an
+Open Question on land in no child, and this is the child that deletes the scripts
+carrying them. Secondarily, it inherits two live-tracker criteria without
+inheriting the credentialed-target prerequisite that gates them, so it can be
+scheduled as needing nothing external and then strand mid-cutover.
+
+### Findings
+
+#### Critical
+
+- 🔴 **Completeness / Scope / Testability**: The three port-less bridge
+  capabilities are owned by no child, and this child deletes the scripts carrying
+  them
+  **Location**: Requirements / Acceptance Criteria
+  0171 carries a requirement, two acceptance criteria, one of three
+  pickup-blocking Open Questions and three *open* `## Decisions` entries covering
+  the fate of the unkeyed discovery `search` mode of `work-item-fetch-remote.sh`,
+  the create bridge's `--dry-run` field-resolution preview, and the update
+  bridge's `--dry-run` payload validation. No child mentions any of them: 0210
+  addresses only the out-of-scope branch, 0211's `search` is the standalone
+  provider search flow rather than the unkeyed discovery mode, 0213 is unrelated,
+  and this child deletes `work-item-fetch-remote.sh` and both remote bridges
+  wholesale with no requirement to re-site, drop or replace the behaviour.
+
+  Verified directly: grepping the four children for `dry-run`, `unkeyed` and
+  `port-less` returns nothing, while 0171 references them ten times.
+
+  **Impact**: If the children are the acceptance gates, every one of the four can
+  pass green while `/sync-work-items` silently loses its ability to list remote
+  issues with no local work item and `/sync-work-items --preview` loses live push
+  validation — the exact user-visible regression 0171 warns against. The Open
+  Question also now has no child in which it can be discharged. This is the same
+  partition failure that caused the superseded `## Increments` section to be
+  replaced.
+
+#### Major
+
+- 🟡 **Dependency / Testability / Clarity**: Two live-tracker criteria with no
+  credentialed-target dependency, and "the scratch project and team" has no
+  antecedent
+  **Location**: Dependencies / Acceptance Criteria
+  The corpus criterion creates "one remote issue per relocated corpus record on
+  the scratch project and team" and runs sync "through the real clients", yet
+  Dependencies lists only 0210, 0211 and 0194 — no credentialed target, no Jira
+  REST or Linear GraphQL entry, unlike 0210 which spells both out. The child that
+  performs the irreversible deletions carries an unsatisfiable-without-
+  provisioning criterion invisible in its own dependency record.
+
+- 🟡 **Dependency**: 0212 → 0174 is a dangling half-edge
+  **Location**: Frontmatter: blocks
+  This child declares `blocks: 0174`, but 0174's `blocked_by` names 0171, not
+  0212, while 0171 still declares `blocks: 0174` too. The edge now exists in
+  three places with two different tails and no reciprocal entry for the new one.
+  Anyone resolving blockers from 0174 lands on a parent that performs no work
+  directly.
+
+- 🟡 **Testability**: The dirty-guard and corpus criteria name no procedure
+  **Location**: Acceptance Criteria
+  "A work item carrying an uncommitted edit is not overwritten by a pull that
+  would otherwise apply, with the evidence location recorded" names no harness,
+  no way to stage such a pull, and no automated home. A verifier cannot
+  distinguish a genuine failure from an unprovisioned environment, so both slide
+  into recorded evidence of an unrepeatable run.
+
+- 🟡 **Clarity / Testability**: "0210's recorded baseline" is ambiguous between
+  the assertion count and the fixture-case list
+  **Location**: Acceptance Criteria
+  0210 records both, and this child dropped 0171's disambiguating clause that
+  "the recorded assertion count is context for that comparison, not the bar". A
+  reviewer can hold a faithful pure-Rust rewrite to a count it need not match.
+
+#### Minor
+
+- 🔵 **Testability**: The fixture-relocation criterion compares against "the
+  pre-change file count under that directory" — a number that exists nowhere once
+  the directory is gone, recoverable only by VCS archaeology.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Testability**: The `EXIT_CODES.md` "rewritten for the Rust surface" branch
+  has no check that the documented codes match what the CLI emits.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Dependency**: The shared-file coupling on `sync-work-items/SKILL.md` is
+  recorded only on 0213's side, though this child sits at the end of the chain
+  and is more likely to land second.
+  **Location**: Dependencies
+
+- 🔵 **Clarity**: Several criteria say evidence is "recorded" without naming the
+  record, inconsistently with sibling criteria that name 0171's `## Decisions`
+  explicitly.
+  **Location**: Acceptance Criteria
+
+### Strengths
+
+- ✅ The deletion criteria are mechanically checkable end to end: `ls` matching
+  nothing, a repository-wide grep excluding `meta/` with the command and empty
+  output as the recorded result, and count arithmetic on relocated fixtures.
+- ✅ The consumer sweep explicitly covers `hooks/`, `templates/`, `docs-site/`,
+  `tasks/` and agent definitions rather than only `skills/`.
+- ✅ It labels its half of the absent-description guarantee and points at 0210
+  for the other half, so neither reader mistakes a half for the whole.
+- ✅ The dirty guard's two-part verification separates the static call-site check
+  from the behavioural one.
+- ✅ It restates the ⚠️ size-bounding assumption it inherits and names the
+  consequence — that a missing Rust replacement turns deletion into new
+  behaviour.
+- ✅ It repeats the confirm-0194-by-artefact instruction rather than trusting the
+  parent's judgement.
+
+### Recommended Changes
+
+1. **Assign the three port-less capabilities here** (addresses: the critical)
+   Add 0171's fate-decision requirement and both verification criteria verbatim,
+   including the *drop* branch's obligation to state the replacement outcome in
+   observable terms and verify that outcome in place of the original behaviour.
+   Size the child for it, and update 0171's `## Decomposition` table so the
+   partition is provably total against the parent's Requirements. If the
+   re-siting is large enough to unbalance this child, carve a fifth child
+   blocking it instead.
+2. **Name the credentialed target and both external services in Dependencies**
+   (addresses: the invisible gate) With the same explicitness 0210 uses, saying
+   which criterion each gates, and introduce "the scratch project and team" as a
+   defined referent inside this child.
+3. **Settle the 0174 edge convention** (addresses: the half-edge) Either move it
+   to the children — adding 0211 and 0212 to 0174's `blocked_by` and recording in
+   0171 that the edge is discharged by its children — or keep it at parent level
+   and drop it from 0212.
+4. **Specify the dirty-guard check as a named test** (addresses: no procedure) A
+   fixture work item with an uncommitted edit plus a remote-modified counterpart,
+   asserting the file's bytes are unchanged and the refusal diagnostic emitted,
+   rather than recorded evidence.
+5. **Restore the assertion-count-is-context clause**, have 0210's baseline record
+   the pre-change fixture file count as a committed number, pin the rewritten
+   `EXIT_CODES.md` branch with a test asserting each documented integer against
+   the CLI's emitted value, add 0213 to `relates_to` with the shared-file note,
+   and name the record location in every criterion that requires recording.
+
+## Per-Lens Summaries
+
+- **Clarity**: precise on the deletion inventory; the defects are an undefined
+  referent ("the scratch project and team"), an ambiguous baseline, and
+  inconsistent "recorded" phrasing.
+- **Completeness**: complete as a `task`, and explicit about what it does not own
+  — but the port-less capabilities were dropped in the carve-out.
+- **Dependency**: correctly blocked by 0210 and 0211, with the sync-label
+  rationale stated; missing the credentialed target and carrying a dangling 0174
+  half-edge.
+- **Scope**: coherent as the cutover unit, still story-scale despite
+  `kind: task`.
+- **Testability**: the strongest deletion criteria in the set, weakest on the two
+  behavioural checks that need a live tracker or a staged pull.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran over the four children as a set. **No criticals.** The
+pass-1 critical is resolved and independently confirmed: the completeness lens
+verified that every obligation the parent's Scope narrative and `## Decisions`
+register still names resolves to a child requirement or criterion, including the
+three port-less bridge capabilities now owned by 0212.
+
+The verdict holds on major count. Three of the majors are defects the fix round
+introduced; the rest are pre-existing gaps the tightened criteria exposed.
+
+### Previously Identified Issues
+
+- 🔴 → ✅ **The three port-less bridge capabilities were owned by no child** —
+  **Resolved.** They are now a Requirements bullet here with two dedicated
+  criteria, one for the recorded fate and one demanding the behaviour be verified
+  against whichever option was taken. Independently confirmed by the completeness
+  lens against the parent's register.
+- 🟡 → ✅ **Two live-tracker criteria with no credentialed-target dependency** —
+  **Resolved**; the prerequisite and both external systems are named, with the
+  owner and the criterion each gates.
+- 🟡 → ✅ **0174 dangling half-edge** — **Resolved**; the edge sits at child level
+  and 0174's `blocked_by` reciprocates. (0174's *prose* still names 0171 — see
+  cross-child.)
+- 🟡 → ✅ **Dirty-guard criterion named no procedure** — **Resolved**, and now
+  exemplary: a static half plus a named automated test asserting the file's bytes
+  unchanged and the refusal diagnostic emitted, with recorded manual evidence
+  explicitly ruled out.
+- 🟡 → ✅ **"0210's recorded baseline" ambiguity** — **Resolved**; the fixture-case
+  list is the bar and the assertion count is context.
+- 🔵 → ✅ The pre-change file count, the `EXIT_CODES.md` pin, the 0213 shared-file
+  edge, and the record locations — **resolved**, bar the branch asymmetry below.
+
+### New Issues Introduced
+
+- 🟡 **Completeness**: **The two `--dry-run` capabilities are specified more
+  thinly than the discovery-`search` one beside them** (introduced by the fix
+  round). `search` names its carrier script, its consumer and why `fetch_all`
+  cannot express it; the two `--dry-run` capabilities name neither carrier script
+  nor flag, the create one is attributed to two different callers in two places
+  (the confirm gate in the requirement, `--preview` in the criterion), and the
+  criterion requires "each emitting its named diagnostic" while no diagnostic is
+  named anywhere.
+- 🟡 **Scope**: **This child now bundles a mechanical deletion cutover with three
+  unsettled net-new re-sitings.** Every other obligation here is migration
+  bookkeeping resting on the assumption that the Rust surface already covers the
+  deleted behaviour. The three capabilities are different in kind: fates still
+  `open`, and one permitted fate is net-new design of unknown size. The child
+  performing the irreversible deletions now has a size unbounded by three
+  undecided questions.
+- 🟡 **Testability**: **The `create-work-item` and `list-work-items` repoints have
+  only a static criterion**, while this change deletes the five
+  `test-work-item-*.sh` suites and the work suite floor — the only executable
+  checks on them. A repointed invocation with a wrong subcommand name, flag or
+  argument passes everything, `mise run` included.
+- 🔵 **Scope**: The Summary omits both obligations that most recently moved in —
+  the port-less capabilities and the repository-wide `jq`/`curl` equality
+  assertion.
+- 🔵 **Scope**: One of 0210's three transcriptions (the parity-test baseline) is
+  destroyed by *this* child, in the same change that consumes it, so it could sit
+  here instead and be closed by inspecting one change.
+- 🔵 **Testability**: The preferred `EXIT_CODES.md` branch carries the weaker gate
+  — folding into the CLI docs drops the doc-versus-emitted-value test that the
+  non-preferred branch requires.
+- 🔵 **Testability**: The drop branch of the port-less criterion verifies a
+  replacement outcome defined by the same decision under test.
+- 🔵 **Completeness**: Alone among the children that consume 0194, this one
+  carries no confirm-the-artefacts-not-the-status instruction — and it is the
+  child whose deletions are irreversible.
+- 🔵 **Clarity**: The corpus criterion points at a project and team "named in
+  Dependencies", which describes them generically without naming either.
+- 🔵 **Clarity**: The "preserve the guard" requirement also carries an unrelated
+  normalisation repoint, outside its own stated rationale.
+
+### Assessment
+
+The pass-1 critical is genuinely closed and the dirty-guard criterion is now the
+best-specified behavioural check in the set. The cost of closing the critical is
+that this child inherited three undecided capability fates, which the scope lens
+reads as unbounding its size — worth weighing against carving them into their own
+child that blocks this one.
+
+## Acceptance — 2026-08-17
+
+**Accepted.** Verdict changed from REVISE to APPROVE by Toby Clemson, and the
+target work item moved to `ready`.
+
+The open findings recorded above were **accepted rather than resolved**. They are
+not withdrawn and remain the record of what is known to be imperfect; they carry
+into planning rather than blocking it. Specifically still open at acceptance:
+
+- The three Open Questions on 0171 — the credentialed target's secrets siting, the
+  fate of the three port-less bridge capabilities, and the `EXIT_CODES.md` siting —
+  plus the two ⚠️ size-bounding assumptions in 0211 and 0212.
+- Three self-contradictions introduced during the fix rounds: 0211's mock-server
+  deletion being simultaneously unconditional and deferrable, 0211's `jq`/`curl`
+  requirement asserting a survivor set its own criterion says the child cannot
+  reach, and 0213's stub-on-`PATH` seam defeating the one predicate item that would
+  catch a malformed `--resolve` template.
+- Two latent gaps better closed by implementation than by further specification:
+  the non-port provider surface (five of eight flows) being owned by neither 0210
+  nor 0211, and 0210 carrying no criterion for HTTP-status or GraphQL error
+  classification or auth.
+
+Rationale for accepting rather than iterating: across four review passes the
+severity ceiling fell (3 criticals → 1 → 0 → 0) while the major count did not
+converge, and each fix round introduced two or three new majors of one shape — a
+requirement updated without its criteria, or the reverse. The two correctness traps
+that mattered (the unowned port-less capabilities, and the `work-item-sync-label.sh`
+ordering break) are both closed. Further speculative specification was judged less
+valuable than starting 0210 and discovering the real shape of the client crates.
+
+## Correction — 2026-08-17
+
+**A premise this review relied on was false, and the finding built on it is
+withdrawn.**
+
+Both the pass-1 and pass-2 reviews treated `linear-create-flow.sh:304` and
+`jira-resolve-fields.sh:140` as **live callers** of `work-item-sync-label.sh`, and
+the pass-3 dependency finding on the parent described them the same way. They are
+not callers. Both lines are comments:
+
+```bash
+# (Same normalisation as the Jira guard and work-item-sync-label.sh.)
+# guard and work-item-sync-label.sh).
+```
+
+Verified by grepping `skills/integrations/*/scripts/*.sh` for invocations of
+`work-item-*.sh` with comment lines excluded: no matches. The clusters invoke no
+work script at all.
+
+What the coupling actually is, and it runs the other way: **four** of the five
+suites 0212 deletes — `test-work-item-create-remote.sh`, `-update-remote.sh`,
+`-fetch-remote.sh` and `-sync-apply.sh` — resolve paths into
+`skills/integrations/{jira,linear}/scripts/test-helpers/` for the Python mock
+servers and `.../test-fixtures/` for their scenario fixtures.
+
+Consequences for this review:
+
+- The **0211-before-0212 ordering it endorsed was wrong.** In that order, 0211's
+  wholesale cluster deletion would have broken all four suites and the
+  `_EXPECTED_WORK_SUITES` floor at 0211's own merge boundary. The order is now
+  0210 → 0212 → 0211.
+- The pass-2 major *"the mock-server deferral branch has no receiving requirement
+  in 0212 and contradicts 0211's own criteria"* is **resolved by the reordering
+  rather than by the patch this review recommended**. With the work suites deleted
+  first, nothing outside the clusters consumes their test assets, so 0211 deletes
+  the mock servers unconditionally as its criteria always stated. The deferral
+  branch has been removed from 0211 entirely; no conditional criteria were added
+  to either child.
+- The pass-2 major on 0211's `jq`/`curl` survivor set is **resolved as a side
+  effect**: with 0211 landing last, the work skills are already repointed at its
+  boundary, so its expectation of no surviving work-skill declarer is correct as
+  written. 0211 now owns the whole-repository equality assertion and 0212 asserts
+  only that no work skill declares `jq` or `curl`.
+- The reverse-coupling sweep 0211 gained in the previous round survives in reduced
+  form: a confirmation at its boundary that nothing outside the clusters still
+  references `test-helpers/` or `test-fixtures/`, expected to be empty.
+
+The reviews' strengths sections credit the 0211-before-0212 ordering as
+"justified by a concrete, named break". That credit was misplaced — the break was
+named but not verified, and verifying it would have inverted the order three
+passes earlier.

--- a/meta/reviews/work/0213-conversational-conflict-resolution-flow-review-1.md
+++ b/meta/reviews/work/0213-conversational-conflict-resolution-flow-review-1.md
@@ -1,0 +1,268 @@
+---
+type: work-item-review
+id: "0213-conversational-conflict-resolution-flow-review-1"
+title: "Work Item Review: Conversational Conflict Resolution Flow for Sync"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0171"
+target: "work-item:0213"
+work_item_id: "0213"
+relates_to: ["work-item-review:0171-jira-and-linear-integrations-review-1"]
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: [skills, sync, conflicts]
+last_updated: "2026-08-17T12:20:00+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Conversational Conflict Resolution Flow for Sync
+
+**Verdict:** REVISE
+
+0213 is the best-scoped child by a distance — one coherent flow in one SKILL.md
+body, gated by none of 0171's prerequisites, independently valuable, correctly
+identified as landing first. Every lens said so. Its problems are all about
+verification and standalone readability: the manual walkthrough that is its only
+behavioural check names no fixture path, no injection seam and no pass predicate
+beyond field presence; exit `0` is described as "clean" yet required to carry
+unresolved lines, and is never exercised; and it is the only child with neither
+Context nor Assumptions, so its motivation and its one size-bounding unknown are
+both discoverable only from the parent.
+
+This review was conducted as one pass over all four children of 0171. The
+cross-child critical — the three port-less bridge capabilities landing in no
+child — is stated in full in 0212's review and does not touch this child.
+
+### Findings
+
+#### Major
+
+- 🟡 **Testability**: The manual walkthrough specifies no fixture, no injection
+  seam and no pass predicate
+  **Location**: Acceptance Criteria
+  The only behavioural criterion names no path for the two-conflict fixture
+  report, no content for it (which fields, which conflict shapes, which ids), and
+  — critically — no mechanism by which the SKILL body's `accelerator work sync`
+  invocation yields that fixture and the stated exit code instead of a live run.
+  The child simultaneously claims it needs no credentialed target, so the seam (a
+  stub binary on `PATH`, an `ACCELERATOR_*` override, a recorded transcript) is
+  load-bearing and unspecified. Nothing asserts the re-invocation it constructs
+  is actually *accepted* by the binary, so a malformed `--resolve` id would pass
+  both the static template check and the walkthrough. Two verifiers can reach
+  opposite verdicts.
+
+- 🟡 **Clarity / Testability**: Exit `0` is described as clean yet required to
+  carry unresolved lines, and is never exercised
+  **Location**: Requirements / Acceptance Criteria
+  The Requirements demand reading `unresolved` lines "on exits `0`, `4` and `71`
+  alike" and in the same sentence say "`sync` exits `0` clean". The walkthrough
+  then runs only `4` and `71`. An implementer cannot tell whether exit `0` can
+  genuinely carry conflicts — in which case "clean" is wrong and a case is
+  missing — or whether reading on `0` is merely defensive.
+
+- 🟡 **Completeness**: No Assumptions section, so the child's one size bound is
+  unstated
+  **Location**: Assumptions
+  Both substantive criteria assume 0194's shipped conflict report already carries
+  all six render fields on all three exit codes. Dependencies only says to
+  confirm the artefacts *exist*, not that they carry those fields. Its siblings
+  each carry a ⚠️-marked unconfirmed assumption naming the consequence; this
+  child states nothing equivalent. If the report omits a field — the title or
+  either timestamp are the plausible candidates — the child stops being a
+  SKILL.md-only change and grows into 0194's binary, invalidating its stated
+  independence and its ability to land first.
+
+#### Minor
+
+- 🔵 **Testability**: `mise run` exits 0 is the only non-manual criterion, and it
+  is unrelated to the added behaviour — a SKILL.md body edit passes it whether or
+  not the conflict loop works. The child ships with no automated regression
+  guard, and 0212 edits the same file.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Completeness / Clarity**: No Context section; the motivation sits as a
+  subordinate clause inside a Dependencies bullet, and the child does not state
+  its position in the parent's ordering or why it is high priority under a
+  medium-priority parent.
+  **Location**: Context
+
+- 🔵 **Completeness**: The walkthrough criterion does not name where its evidence
+  is recorded, though 0171's `## Decisions` already holds a matching *pending*
+  entry awaiting exactly this.
+  **Location**: Acceptance Criteria
+
+- 🔵 **Dependency**: The sole prerequisite carries no edge — `relates_to: 0194`
+  only, no `blocked_by` — while 0194's record as visible from this workspace reads
+  `ready`. The contingency instruction lives only in the parent, and this child
+  declares no `blocks` despite discharging one of 0171's criteria outright.
+  **Location**: Dependencies
+
+- 🔵 **Clarity**: "Six fields" versus seven enumerated values — the Requirements
+  list id, title, differing field, local value, remote value "and both
+  timestamps", and say "at least", while the criterion asserts an exact six.
+  **Location**: Acceptance Criteria
+
+### Strengths
+
+- ✅ Genuinely well-scoped: one conversational flow, one file, no crate, no
+  fixture corpus, no deletion — the only child every lens called right-sized.
+- ✅ Its Dependencies affirmatively records what it is *not* gated by (no
+  credentialed target, no client crate, none of the three Open Questions), which
+  is a stronger statement than an empty section.
+- ✅ Correctly identified as landing first, with the reason given — the conflict
+  report is unactionable today.
+- ✅ The static half of its verification is a real mechanical check: the
+  invocation template, the three exit codes, the named render fields.
+- ✅ The overlap with 0212 on `sync-work-items/SKILL.md` is anticipated and
+  localised rather than left as a hidden collision.
+- ✅ It records the `--resolve` token set and the conflict-carrying exit codes as
+  corrected against `cli/work-cli/src/cli.rs`, so the invocation shape is sourced
+  rather than assumed.
+
+### Recommended Changes
+
+1. **Specify the walkthrough completely** (addresses: the verification major)
+   Name the fixture path and its two conflict records, name the injection seam and
+   the exact command sequence, state the pass predicate as a checklist (six fields
+   present per conflict, one prompt per item, one `--resolve <id>=<choice>` per
+   collected choice with ids matching the fixture), and assert the constructed
+   re-invocation is accepted by `accelerator work sync` rather than rejected as a
+   usage error.
+2. **Settle exit `0`** (addresses: the contradiction) Either add a third
+   walkthrough case with an empty `unresolved` set and the expected outcome
+   stated — report no conflicts, issue no re-invocation — or drop `0` from the
+   static assertion if a clean run genuinely carries no report.
+3. **Add an Assumptions section** with a ⚠️-marked entry: the existing conflict
+   report already carries all six fields on all three exit codes, to be confirmed
+   against the report format before planning, with the consequence named.
+4. **Add an automated guard** (addresses: no regression protection) A test
+   asserting the SKILL body contains the `--resolve <id>=<remote|local|skip>`
+   template and the three exit codes, wired into the existing skills test lane, so
+   the static half survives as a guard rather than a one-off inspection —
+   particularly since 0212 edits the same file.
+5. **Add a short Context** stating the problem inline (a detected conflict cannot
+   be resolved because the binary is non-interactive), its position in the
+   ordering, and that it can land first.
+6. **Record the evidence location in 0171's `## Decisions`**, add the concrete
+   0194 artefact check with the action if it fails, add 0212 to `relates_to`, and
+   reconcile the six-versus-seven field count.
+
+## Per-Lens Summaries
+
+- **Clarity**: the exit-`0` contradiction and the field-count mismatch; motivation
+  reachable only through the parent.
+- **Completeness**: proportionate to its size, but missing Context and Assumptions
+  where its siblings carry both, and the second hides a real size bound.
+- **Dependency**: correctly records what does *not* gate it; its one real
+  prerequisite carries no edge.
+- **Scope**: the best-scoped child in the set — no findings against its
+  boundaries.
+- **Testability**: the weakest verification of the four, and the only child whose
+  sole automated criterion is unrelated to what it delivers.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-17
+
+**Verdict:** REVISE
+
+All five lenses re-ran over the four children as a set. **No criticals.** The
+pass-1 critical is resolved and independently confirmed: the completeness lens
+verified that every obligation the parent's Scope narrative and `## Decisions`
+register still names resolves to a child requirement or criterion, including the
+three port-less bridge capabilities now owned by 0212.
+
+The verdict holds on major count. Three of the majors are defects the fix round
+introduced; the rest are pre-existing gaps the tightened criteria exposed.
+
+### Previously Identified Issues
+
+- 🟡 → 🟡 **The walkthrough specified no fixture, seam or pass predicate** —
+  **Largely resolved, one item self-defeating.** Three named fixtures, a
+  stub-on-`PATH` seam and a four-part checklist now exist. But the predicate's last
+  item — that the re-invocation be "accepted by `accelerator work sync` rather
+  than rejected as a usage error" — cannot fail under the stated seam, because the
+  stub *is* `accelerator work sync` and validates nothing.
+- 🟡 → ✅ **Exit `0` described as clean yet required to carry unresolved lines** —
+  **Resolved**; the flow branches on whether the report carries `unresolved`
+  lines, `0` is stated to carry none, and a `clean-exit-0.txt` fixture exercises
+  it.
+- 🟡 → ✅ **No Assumptions section** — **Resolved**; the six-field premise is
+  recorded as ⚠️ unconfirmed with its consequence named.
+- 🔵 → ✅ **No automated guard** — **Resolved**; the static half is now an
+  automated skills-lane assertion, explicitly because 0212 edits the same file.
+- 🔵 → ✅ Context, the evidence location, the 0194 artefact check with its
+  remedial edge, and the `relates_to` link — **all resolved**.
+
+### New Issues Introduced
+
+- 🟡 **Testability**: **The stub seam prevents the one predicate item that would
+  catch a malformed `--resolve` template** (introduced by the fix round). This is
+  the most likely defect in a `SKILL.md`-only change, and the check for it cannot
+  fail. The fix is to split the predicate: render/prompt/emit against the stub,
+  argument acceptance against the real binary with the stub off `PATH`.
+- 🟡 **Clarity**: **The loop's unit alternates between "conflict" and "item".**
+  Requirements say "collect a choice per item"; the predicate says "one prompt per
+  conflict" and one `--resolve` order per choice, while `--resolve` is keyed by
+  work-item id. These coincide only if a work item can carry at most one
+  conflicting field, and the fixtures — two conflicts with *distinct* ids — avoid
+  the case where they diverge. One reading silently drops a choice.
+- 🔵 **Clarity / Completeness**: "The walkthrough" is introduced with a definite
+  article, no antecedent and no actor — a committed harness, a documented manual
+  procedure, or an automated test are all consistent with the text, and they imply
+  different scope.
+- 🔵 **Clarity**: Exit `71`'s meaning is never stated — only that a `71` run "may
+  carry conflicts alongside its failure" — and its fixture's predicate is
+  identical to exit `4`'s, so the two test the same path under two codes.
+- 🔵 **Testability**: The walkthrough's evidence is a Decisions entry with no
+  artefact at a named path, unlike 0210's contract-run criterion which requires a
+  committed evidence file.
+- 🔵 **Scope**: This child is `priority: high` and fixes live degradation, yet sits
+  inside an epic held at `draft` by three Open Questions it does not depend on.
+  Either state in 0171 that it may be picked up regardless, or re-parent it to
+  0136.
+
+### Assessment
+
+Still the best-scoped child, and every pass-1 finding was addressed. The one
+regression is instructive: adding the stub seam made the walkthrough deterministic
+and simultaneously neutered its sharpest assertion. The conflict-versus-item unit
+question is the more consequential open point — it decides whether the flow can
+silently drop a user's choice.
+
+## Acceptance — 2026-08-17
+
+**Accepted.** Verdict changed from REVISE to APPROVE by Toby Clemson, and the
+target work item moved to `ready`.
+
+The open findings recorded above were **accepted rather than resolved**. They are
+not withdrawn and remain the record of what is known to be imperfect; they carry
+into planning rather than blocking it. Specifically still open at acceptance:
+
+- The three Open Questions on 0171 — the credentialed target's secrets siting, the
+  fate of the three port-less bridge capabilities, and the `EXIT_CODES.md` siting —
+  plus the two ⚠️ size-bounding assumptions in 0211 and 0212.
+- Three self-contradictions introduced during the fix rounds: 0211's mock-server
+  deletion being simultaneously unconditional and deferrable, 0211's `jq`/`curl`
+  requirement asserting a survivor set its own criterion says the child cannot
+  reach, and 0213's stub-on-`PATH` seam defeating the one predicate item that would
+  catch a malformed `--resolve` template.
+- Two latent gaps better closed by implementation than by further specification:
+  the non-port provider surface (five of eight flows) being owned by neither 0210
+  nor 0211, and 0210 carrying no criterion for HTTP-status or GraphQL error
+  classification or auth.
+
+Rationale for accepting rather than iterating: across four review passes the
+severity ceiling fell (3 criticals → 1 → 0 → 0) while the major count did not
+converge, and each fix round introduced two or three new majors of one shape — a
+requirement updated without its criteria, or the reverse. The two correctness traps
+that mattered (the unowned port-less capabilities, and the `work-item-sync-label.sh`
+ordering break) are both closed. Further speculative specification was judged less
+valuable than starting 0210 and discovering the real shape of the client crates.

--- a/meta/work/0171-jira-and-linear-integrations.md
+++ b/meta/work/0171-jira-and-linear-integrations.md
@@ -5,15 +5,15 @@ title: "Jira and Linear Integrations"
 date: "2026-06-28T17:01:56+00:00"
 author: Toby Clemson
 producer: extract-work-items
-status: draft
-kind: story
+status: ready
+kind: epic
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0187", "work-item:0194"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
-relates_to: ["work-item:0170", "work-item:0194", "work-item:0174"]
+blocks: ["work-item:0174"]
+relates_to: ["work-item:0170", "work-item:0194", "work-item:0204", "work-item:0174", "work-item:0165", "work-item:0203"]
 tags: [rust, jira, linear, integrations, reqwest, sync]
-last_updated: "2026-08-12T00:40:00+00:00"
+last_updated: "2026-08-17T11:52:00+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-192"
@@ -21,237 +21,353 @@ external_id: "PP-192"
 
 # 0171: Jira and Linear Integrations
 
-**Kind**: Story
-**Status**: Draft
+**Kind**: Epic
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
-Build the `jira-client` and `linear-client` adapter crates (`reqwest`/serde
-replacing `jq`/`curl`, each implementing the `RemoteTracker` port) and the thin
-`accelerator-jira` / `accelerator-linear` binaries over them, so the standalone
+Build the `jira-client` and `linear-client` adapter crates over the frozen
+`RemoteTracker` port (`reqwest`/serde replacing `jq`/`curl`) and the thin
+`accelerator-jira` / `accelerator-linear` binaries above them, so the standalone
 integration skills and the work-item sync engine share one implementation per
-provider — and, because these clients are the last thing the Rust sync engine
-needs to be usable, perform the work-item cutover: retire the nine migrated
-sync and bridge scripts, repoint the work skills at `accelerator work …`, and
-give `/sync-work-items` its conversational conflict flow.
+provider.
+
+Then retire both bash surfaces those clients replace — the jira and linear
+script clusters under `skills/integrations/`, and the work-item cutover 0194
+deliberately left undone — and give `/sync-work-items` the conversational
+conflict flow that makes its conflict report actionable. The four children carry
+the inventory and the acceptance criteria; see Scope and Decomposition.
 
 ## Context
 
 `skills/integrations/jira/scripts/` (22 prod) and `linear/scripts/` (12 prod)
-implement create/update/comment/transition/search/show/attach/init flows, ADF↔markdown
-conversion, JQL/GraphQL, and auth, shelling out to `jq`/`curl`. Both have Python
-mock HTTP servers for tests. Resolved Q2: provider clients are shared crates reused
-by both the standalone binaries and the `tracker` sync engine (0194 — split off
-from 0170 on 2026-08-05; the `tracker` crate and `RemoteTracker` port now live
-there, not in 0170). May be split into separate Jira and Linear stories if finer
-granularity is wanted.
+implement create/update/comment/transition/search/show/attach/init flows,
+Atlassian Document Format (ADF)↔markdown conversion, Jira Query Language (JQL)
+and GraphQL, and auth, shelling out to `jq`/`curl`. Both have Python mock HTTP
+servers for tests. The intended shape is one shared client crate per provider,
+consumed by both the standalone binary and the `tracker` sync engine — neither
+crate exists yet.
 
-## Requirements
+Two things are degraded for plugin users until this lands. `/sync-work-items`
+can detect a conflict but cannot resolve one, because 0194's binary is
+non-interactive and nothing yet closes the report → prompt → resolve loop. And
+every provider behaviour — auth, projection, error classification — exists twice
+per provider, once in bash and once in Rust, so a fix to either drifts from the
+other until the bash half is gone.
 
-- Implement `jira-client` (Jira REST + ADF↔markdown + auth) and `linear-client`
-  (Linear GraphQL + auth) as adapter crates over `reqwest` + rustls + serde, each
-  `impl RemoteTracker` (the port from 0204's `tracker` crate).
-- Implement `accelerator-jira` and `accelerator-linear` as thin inbound CLI adapters
-  exposing the user-facing flows (create/update/comment/transition/search/show/
-  attach/init).
-- Carry over the Python mock servers (`mock-jira-server.py`, `mock-linear-server.py`)
-  as integration-test scaffolding for the Rust clients.
-- Remove the `jq`/`curl` `allowed-tools` entries from the integration skills once
-  migrated; confirm no other skill relies on them.
-- Run 0194's shared `RemoteTracker` contract test — the harness it delivers,
-  parameterised over implementations — against both real clients under the
-  tagged, network-touching filter, so the fake 0194 verified against and the
-  real clients are held to one contract. That harness asserts
-  `fetch_all`'s partition totality and the read-never-`Terminal` rule as
-  well as the create/update round trips; both are port obligations no
-  test in `tracker` can hold.
-- Port **four** exit-code mapping tables, not two, and derive each
-  operation's classification from its own: `_wicr_map_jira` and
-  `_wiur_map_jira` for Jira, `_wiur_map_linear` and
-  `_linear_map_no_file_failure` (inside `linear-create-flow.sh`) for
-  Linear. The two operations' provable sets are **not nested in either
-  direction** — Linear code 34 is retryable on `create` and terminal on
-  `update`, while codes 18, 23, 25, 27 and 29 run the other way — so a
-  single status-to-class table is wrong in both directions.
+Every repository input this story consumes is on disk; its non-repository
+prerequisites — the credentialed tracker target and the two provider services —
+are listed in Dependencies. 0204 introduced the `tracker` crate and froze the
+`RemoteTracker` port inside it; 0194 added the sync engine to the same crate and
+left three artefacts behind for this story (confirm they exist rather than
+trusting 0194's status field — see Dependencies): the contract harness at `cli/tracker-test-support/src/contract.rs`
+(parameterised over implementations via `ContractSubject`, run by `mise run
+test:integration:tracker-contract`), the bash-generated baseline corpus under
+`skills/work/scripts/test-fixtures/`, and `accelerator work sync` with its
+machine-parseable conflict report. The bash path stays the production path until
+this story lands.
 
-  The tables are deliberately more conservative than the rule they
-  encode: several codes are provably pre-transmission yet mapped
-  terminal. Where the two disagree, **the tables win** — port them rather
-  than reasoning from `TrackerError`'s doc comment and arriving somewhere
-  more precise.
-- Carry over the identifier-safety check the create bridge performs
-  (`work-item-create-remote.sh:62-87,238-246`): reject a returned
-  identifier carrying control characters, a newline, or a leading `---`
-  or `#`, because the value is written unquoted into a work item's YAML
-  frontmatter. It is the one tracker-agnostic check the dispatcher does,
-  and the dispatcher dissolves at the port — `ExternalId::new` is
-  infallible by freeze, so the type cannot carry it. An unsafe identifier
-  is a `Terminal` failure, not an `Ok`.
-- Bound the port's calls from inside. `RemoteTracker` is synchronous with
-  no deadline or cancellation, so the per-request timeouts the bridges
-  carry today (`curl --max-time 30` for Jira, `--max-time 60` for the
-  Linear flows) and the `_WIFR_PAGE_CAP=20` pagination backstop must be
-  reproduced behind the seam. A caller has no way to add them, and
-  `/list-work-items` relies on the read path not hanging.
-- Decide the fate of four bridge capabilities that have **no port
-  operation**, each deliberately left above the port by 0204 rather than
-  overlooked. For each: re-site it above the port, drop it, or carry it
-  as an additive port item.
-  - The unkeyed discovery `search` mode of `work-item-fetch-remote.sh` —
-    used by `/sync-work-items` to list remote issues with no local work
-    item. `fetch_all(ids)` is key-scoped and cannot express it.
-  - The create bridge's `--dry-run` field-resolution preview, which
-    surfaces an unresolvable Jira project *before* the confirm gate.
-  - The update bridge's `--dry-run` payload validation, which is what
-    `/sync-work-items --preview` uses to validate every push against the
-    live tracker today. 0194's `--preview` routes mutations to no-ops and
-    makes no port call, so it does not discharge this.
-  - Dropping any of them silently is a user-visible regression at
-    cutover.
-- Reproduce the existing per-provider projection recipes exactly (jira —
-  summary line then the description in Atlassian Document Format through
-  key-sorted `jq -S`; linear — title line then Markdown description
-  verbatim), verified against the bash-generated baseline corpus 0194
-  commits under `test-fixtures/`. Title line, then description, with **no
-  blank line between them** and a trailing newline. The value returned is
-  the *un-normalised* projection; the caller normalises before hashing.
+## Scope
 
-  The case a JSON deserialiser will get wrong: an **absent** description
-  projects as the literal token `null` for Jira (`jq -cS '… // null'`)
-  and as an empty line for Linear (`// ""`). Neither is what `serde` would
-  naturally produce, and either wrong choice reclassifies every such item
-  as `remotely-modified` on the first run after cutover.
-- **Perform the work-item cutover**, which 0194 deliberately left undone because
-  the flows cannot resolve a real tracker until these clients exist. In one
-  change: remove `work-item-sync-{apply,baseline,classify,decide}.sh`,
-  `work-item-{fetch,project,create,update}-remote.sh`,
-  `work-item-push-decide.sh` and their `test-*.sh` suites plus the superseded
-  sections of `test-work-item-scripts.sh`; repoint
-  `skills/work/sync-work-items/SKILL.md`,
-  `skills/work/create-work-item/SKILL.md`,
-  `skills/work/list-work-items/SKILL.md` and `skills/work/scripts/EXIT_CODES.md`
-  at `accelerator work …`; and decrement the work suite floor
-  (`_EXPECTED_WORK_SUITES`, `tasks/test/integration.py`). Leave
-  `work-item-sync-label.sh` and `work-item-normalise.sh` in place — their
-  consumers sit outside the sync engine and retire under 0174.
-- Add the conversational half of 0194's two-invocation conflict flow to
-  `skills/work/sync-work-items/SKILL.md`: invoke `accelerator work sync`, parse
-  its machine-parseable conflict report, render each conflict with enough local
-  and remote context for the user to judge, collect a choice per item, and
-  re-invoke with the matching `--resolve <id>=<remote|local>` orders. The binary
-  is non-interactive by 0194's requirement, so until this lands no caller can
-  resolve a conflict.
-- Take single ownership of the `E_DISPATCH_*` exit-code taxonomy once the bash
-  bridges are gone, deleting `work-item-bridge-codes.sh` and the fixture holding
-  the two implementations in step.
+This item is the unit of value — **one Rust implementation per provider, in
+production** — and it is delivered entirely by its four children. Requirements and
+acceptance criteria live in them.
 
-## Acceptance Criteria
+**Precedence: the children are normative.** Each child's Requirements and
+Acceptance Criteria are the contract its implementer builds to and its reviewer
+accepts against. This item deliberately holds no duplicate copy, because it had
+one and it drifted: two clauses were silently lost between the parent and a child
+within a single revision (a per-flow fixture-provenance obligation, and the
+qualifier that a recorded assertion count is context rather than a bar). One
+normative home per obligation removes that failure mode.
 
-- [ ] `accelerator jira …` and `accelerator linear …` reproduce the standalone flows,
-      verified against the repointed integration suites and the mock servers.
-- [ ] Both client crates implement `RemoteTracker` and are consumable by
-      `accelerator-work`'s sync engine (0194) with no duplication of API logic.
-- [ ] No production `jq`/`curl` dependency remains for the migrated integration
-      skills; their `allowed-tools` entries are removed.
-- [ ] The integration suite floor is decremented in lockstep as the shell scripts
-      are removed.
-- [ ] Each of the four bridge capabilities with no port operation — unkeyed
-      `search`, both `--dry-run` modes, and the identifier-safety check — is
-      re-sited, dropped or carried forward as a recorded decision, and none
-      is lost silently at cutover.
-- [ ] The doc comments in `tracker` that name bash artefacts are updated in
-      the same change that deletes them: `RemoteIssue.body`'s projection
-      reference, `errors.rs`'s module doc, `show`'s `# Errors` note about
-      the read bridge, and `RemoteTimestamp::Reported`'s note about the
-      bash-written baseline. The contracts they state outlive the scripts;
-      the references do not.
-- [ ] 0194's shared `RemoteTracker` contract test passes against both real
-      clients under the tagged filter, asserting round-trip `create` → `show`
-      and whole-content `update` → `show`; the default
-      `cargo test`/`cargo nextest run` invocation still makes no network call.
-- [ ] Given the bash-generated baseline corpus 0194 committed, when
-      `accelerator work sync` runs against matching remote records through the
-      real clients, then every item classifies as `synced` and neither a push
-      nor a pull is issued — so the cutover cannot mass-reclassify a user's
-      synced items.
-- [ ] The nine migrated scripts and their `test-*.sh` suites are removed, the
-      superseded sections of `test-work-item-scripts.sh` are deleted, the four
-      work-skill callers are repointed at `accelerator work …`, and
-      `_EXPECTED_WORK_SUITES` is decremented — all in the same change.
-      `work-item-sync-label.sh` and `work-item-normalise.sh` remain in place and
-      their consumers still pass.
-- [ ] Given a `sync` run reporting two conflicts, then
-      `skills/work/sync-work-items/SKILL.md` renders both with their local and
-      remote context, collects a choice per item, and re-invokes with
-      `--resolve` orders matching those choices — closing the report →
-      prompt → resolve loop without the binary reading stdin.
-- [ ] After the cutover the `E_DISPATCH_*` taxonomy has one implementation:
-      `work-item-bridge-codes.sh` and its parity fixture are gone, and no
-      surviving script sources the removed definition.
+What the whole delivers, as narrative rather than contract:
+
+- `jira-client` and `linear-client` over the frozen `RemoteTracker` port, each
+  reproducing its provider's projection recipe, error classification and request
+  bounds, wired into `accelerator-work`'s composition root — **0210**.
+- `accelerator-jira` and `accelerator-linear` exposing the eight flows per
+  provider, registered as dispatched sub-binaries, replacing both bash script
+  clusters — **0211**.
+- The work-item cutover: eighteen scripts deleted, the fixture corpus relocated,
+  eleven parity tests converted, the three work skills repointed, both suite
+  floors removed, the dirty guard preserved, the three port-less bridge
+  capabilities discharged — **0212**.
+- The conversational conflict loop that makes `accelerator work sync`'s conflict
+  report actionable — **0213**.
+
+Every parent obligation was audited into exactly one child before this section
+replaced the duplicated lists: 28 requirements and 31 criteria, all assigned. The
+audit found exactly one gap — the three port-less bridge capabilities, which no
+child had claimed — now owned by 0212.
+
+## Decomposition
+
+This item stays the single coherent unit of value — one Rust implementation per
+provider, in production — and delegates delivery to four children, each with its
+own status, requirements and acceptance criteria. The Requirements and Acceptance
+Criteria above remain the whole picture; each child owns the subset named here
+and restates it, so an increment can be planned, merged and accepted on its own.
+
+| Child | Carries | Blocked by |
+|---|---|---|
+| 0210 | Client crates, composition root, oracle transcriptions, contract run | — |
+| 0212 | Work-item cutover, fixtures, tests, floors, guard, port-less capabilities | 0210 |
+| 0211 | Provider binaries, registration, integration cluster retirement | 0210, 0212 |
+| 0213 | Conversational conflict flow | — |
+
+- **0210 — Provider Client Crates over the RemoteTracker Port.** `jira-client`,
+  `linear-client`, the composition-root wiring, `deny.toml` clearance, the four
+  mapping tables, bounded calls, the identifier-safety check, whole-corpus offline
+  projection fidelity, the ADF/JQL/GraphQL construction assertions (they pin this
+  child's code, so they moved here from 0211), and the contract harness against
+  both real clients. Deletes nothing, and transcribes at named paths the three
+  oracles the later children destroy: the four `curl` tables, the ADF node-type
+  inventory, and the baseline carrying the eleven tests' fixture cases, their
+  assertion counts and the pre-change fixture file count.
+- **0212 — Work-Item Script Cutover.** The eighteen `work-item-*.sh` files, the
+  fixture relocation, the eleven test conversions, the three work-skill
+  repoints, the work suite floor, the dirty guard, the `E_DISPATCH_*`
+  consolidation, the `tracker` doc-comment sweep — and the **three port-less
+  bridge capabilities**, since this is the child that deletes the scripts
+  carrying them. It also owns the whole-repository `jq`/`curl` equality
+  assertion, because the work skills are repointed here.
+- **0211 — Integration Binaries and Bash Cluster Retirement.**
+  `accelerator-jira` and `accelerator-linear` with eight flows each, their exit-
+  code contract, per-flow request and **stdout** goldens, registration and the
+  release manifest, then both script clusters, their suites, the mock servers,
+  the integrations floor and the seven jira/linear `SHELL_LIBRARIES` entries.
+- **0213 — Conversational Conflict Resolution Flow.** The conversational half in
+  `sync-work-items/SKILL.md`. Gated by none of this item's Open Questions and by
+  no credentialed target, so it can land first — and should, since
+  `/sync-work-items` cannot resolve a conflict today.
+
+**Ordering.** 0210 → 0212 → 0211, with 0213 free. Two constraints force it.
+
+First, 0210's bash is the only oracle for projection and classification fidelity,
+so it precedes every deletion.
+
+Second, 0212 precedes 0211 because the coupling between the two deletion sets runs
+in **one direction only**. Four of the five suites 0212 deletes —
+`test-work-item-create-remote.sh`, `-update-remote.sh`, `-fetch-remote.sh` and
+`-sync-apply.sh` — reach into
+`skills/integrations/{jira,linear}/scripts/test-helpers/` and `.../test-fixtures/`
+for the Python mock servers and their scenario fixtures. The clusters invoke no
+`work-item-*.sh` in return: verified by grep, the two references to
+`work-item-sync-label.sh` at `linear-create-flow.sh:304` and
+`jira-resolve-fields.sh:140` are comments about shared normalisation, not calls.
+Deleting the work suites first removes the only outside consumers of the clusters'
+test assets, after which 0211 retires both clusters whole.
+
+⚠️ This ordering was **reversed on 2026-08-17** after the earlier rationale proved
+false. The decomposition originally put 0211 first on the belief that those two
+comment references were live callers; in that order 0211 would have broken all
+four suites and the `_EXPECTED_WORK_SUITES` floor at its own merge boundary.
+
+Each child's boundary is its own atomicity unit: an "in the same change" clause in
+a child's Requirements binds that child's change, not the set. Each child must
+leave `mise run` green at its own merge point, per epic 0136's stay-functional
+rule, and each carries a criterion saying so.
 
 ## Open Questions
 
-- Whether to split into separate Jira and Linear work items — left grouped here;
-  split if implementation granularity warrants.
+Five things must be settled before pickup, each changing what is in scope: the
+three questions below, plus the two ⚠️-marked assumptions that bound the size of
+0211 and 0212 respectively. Owner: Toby Clemson.
+
+- Where the credentialed Jira/Linear target's secrets live — CI secrets or
+  local-only. This decides whether the real-client contract run is a CI gate or
+  a manual pre-merge check, and therefore whether a broken client can reach
+  `main`. The CI answer also adds a workflow change to the scope; the local-only
+  answer does not.
+- The fate of the three open port-less bridge capabilities: unkeyed discovery
+  `search`, the create `--dry-run` field-resolution preview, the update
+  `--dry-run` payload validation. Re-site above the port, drop, or file as an
+  additive port item. Only the first two are options **inside** this story:
+  0204 is done and frozen, and its own protocol says a later surface need lands
+  as a **new** additive work item, so choosing that fate for any capability
+  means filing that item (parented to 0136, blocking this one) and holding this
+  story at `draft` until it exists. The identifier-safety check is **not**
+  among these three; it is decided.
+- Whether `skills/work/scripts/EXIT_CODES.md` is rewritten in place for the Rust
+  exit codes or folded into the CLI's own docs. The latter is preferred and
+  removes `skills/work/scripts/` entirely; the former keeps a directory holding
+  one file.
+
+## Decisions
+
+One entry per decision, each carrying its state. Several acceptance criteria are
+discharged in part by an entry here — always paired with an independent
+assertion, never by the entry alone. Three states appear: *open* means blocked on
+an Open Question and must be answered **before pickup**; *pending* means the
+answer is produced by doing the work and is recorded as it lands; *decided* means
+settled and closed.
+
+- Unkeyed discovery `search` — *open*.
+- Create `--dry-run` field-resolution preview — *open*.
+- Update `--dry-run` payload validation — *open*.
+- Contract-run execution route (CI job and secrets, or manual step and evidence
+  location) — *open*. Durable beyond this story: site the answer in
+  `tasks/README.md` and point here.
+- `EXIT_CODES.md` siting: rewritten in place, or folded into the CLI docs with
+  `skills/work/scripts/` removed — *open*.
+- The two binaries' exit-code contract and its document of record — *open*.
+  Durable: it belongs in the CLI's own docs, not here.
+- Copyleft status of the `wiremock-rs` and `rustls` dependency trees, and
+  whether 0203 therefore becomes a release-path dependency — *pending*.
+- `linear-graphql.sh` classified as a production script or a library entry —
+  *pending*.
+- Consumer sweep result for the eighteen deleted work scripts (the grep command
+  and its empty output) — *pending*.
+- Reverse cross-cluster sweep result: references from `skills/work/scripts/` into
+  either integration cluster or into the two Python mock servers, with each one's
+  resolution — *pending* (0211).
+- Flow-coverage mapping: each of the 22 Jira and 12 Linear production scripts to a
+  named subcommand or a recorded internal-helper classification — *pending*
+  (0211).
+- Conflict-flow walkthrough evidence, one run per fixture including the clean
+  exit-`0` case — *pending* (0213).
+- Pre-deletion transcriptions: the four `curl` exit-code tables, the ADF node-type
+  inventory, and the per-test assertion-count and fixture-case baseline for the
+  eleven converted tests — *pending*.
+- Fixtures deleted for having no consumer, with the reason each has none —
+  *pending*.
+- Per-flow fixture capture source (credentialed target or mock-served) —
+  *pending*.
+- Cross-skill `jq`/`curl` `allowed-tools` audit result — *pending*.
+- Conflict-flow walkthrough evidence — *pending*.
+- Identifier-safety check — **decided**: carried forward, an unsafe identifier
+  is a `Terminal` failure.
 
 ## Dependencies
 
-- No longer blocked by 0204 (the `RemoteTracker` port) — split out of
-  0194 on 2026-08-10 precisely so the client crates would wait on a
-  trait and its vocabulary rather than on a whole sync engine, and
-  accepted and implemented on 2026-08-12. The frozen signature is six
-  items, not four value types and an error type as this story previously
-  understood: the trait, `ExternalId`, `RemoteIssue`, `RemoteTimestamp`,
-  `FetchOutcome` and `TrackerError`. One consequence for this story's own
-  Requirements: `fetch_all` returns `FetchOutcome.found` as
-  `Vec<(ExternalId, RemoteTimestamp)>`, a stamp per key rather than a
-  projected issue, so each client's bulk-mode query needs no
-  `description`/body field at all — Linear's selection set in particular
-  can stay as narrow as `linear-search-flow.sh`'s today, with no need to
-  widen it against Linear's complexity cap. The client work needs
-  nothing else from 0194.
-
-  One further shape settled on 0204's implementation review (2026-08-12):
-  `RemoteTimestamp` is a three-variant enum, not a `String` newtype. A
-  client maps a tracker's stamp to `Reported(bytes)` verbatim and a blank
-  or null one to `NotReported` — never to `Reported("")`, which means
-  nothing. The third variant, `NotRead`, is unreachable through the port:
-  a client cannot return it, because `show` and `fetch_all` either answer
-  or fail.
-- Blocked by: 0194 (the sync engine) for the **cutover half only** — the
-  script removal, skill repointing, conversational conflict flow and
-  contract-suite run all need the binary that story delivers. The client
-  crates and the two thin binaries do not, and can proceed in parallel
-  with it once 0204 lands.
-- Blocked by: 0187 (generalises the sub-binary registration surface). This story
-  adds a dispatch token; it does not generalise the surface. Registration
-  follows the checklist 0187 adds at
-  `tasks/README.md#registering-a-dispatched-sub-binary`. (2026-08-01)
-- Relates to: 0170 (the work-item lifecycle subdomain — no direct
-  dependency on these clients or the `RemoteTracker` port itself; 0194
-  wires `--push` onto its `create`/`update` commands separately, using
-  0194's own port).
-- Relates to: 0194 (the sync engine consumes these clients).
-- Carries 0194's cutover. 0194 ships the Rust sync engine beside the live bash
-  path without retiring it, because `sync` and `create`/`update --push` can only
-  resolve fakes until these clients exist — and 0194 blocks this story, so it
-  could not have waited. This story therefore inherits four obligations from it:
-  the script removal and skill repointing, the sync SKILL's conversational
-  conflict flow, running the shared contract suite against real clients, and
-  per-provider projection fidelity against 0194's committed corpus. Until this
-  story lands, the bash path remains the production path and nothing regresses.
-  (2026-08-10)
-- Relates to: 0174 (Retire Shell Tooling and CI Guards) — inherits the
-  residual `work-item-sync-label.sh` / `work-item-normalise.sh`
-  duplication that neither this story nor 0194 removes.
+- `blocked_by` is deliberately empty because every declared upstream is `done`.
+  Five items declare an edge into this one: 0166 (shared config, corpus and
+  store crates), 0169 (VCS subdomain and hooks migration), 0187 (sub-binary
+  registration surface) and 0204 (the `RemoteTracker` port) all carry `blocks:
+  work-item:0171` and all read `done`; 0194 (the `tracker` crate and sync
+  engine) blocks the cutover half in prose only. Registration follows the
+  checklist at `tasks/README.md#registering-a-dispatched-sub-binary`; this
+  story adds **two** dispatch tokens (`jira` and `linear`), it does not
+  generalise the surface.
+- ⚠️ **0194's status needs confirming at pickup, not assuming.** This item
+  treats 0194 as complete, but the 0194 record visible from the `build-system`
+  workspace reads `status: ready` with no criteria ticked — the flip to `done`
+  is in commit `c03f2448c6`, which is not an ancestor of this workspace's
+  working copy. Confirm against the artefacts themselves (does
+  `cli/tracker-test-support/src/contract.rs` exist, does `accelerator work
+  sync` run) rather than against a status field, since the whole cutover half
+  consumes them. If 0194 is genuinely incomplete, restore an explicit
+  `blocked_by` edge for that half.
+- Two non-work-item prerequisites remain open — see the next two entries.
+- **Prerequisite, not yet discharged**: a credentialed tracker target. A
+  scratch Jira project, a Linear team and API tokens must exist, and — if the
+  Open Question resolves to CI — the secrets must be installed on the
+  repository, which is an action outside this change. **Toby Clemson owns
+  provisioning it** — it is external account administration with no work item of
+  its own, and it gates 0210's contract run and 0212's corpus run alike. It gates more than two
+  criteria: the ordering rule below requires the contract harness to pass
+  before any bash is deleted, so an unprovisioned target blocks **every**
+  deletion, relocation and repointing in the story. Provision it before the
+  first deletion, or the change strands with both implementations live — the
+  half-migrated state 0194 was restructured to avoid.
+- **External systems**: Jira REST and Linear GraphQL. The network-touching
+  contract lane's success is contingent on both services being reachable, and
+  on staying inside per-tenant rate limits, Linear's query-complexity cap and
+  its 250-issue bulk truncation. A red contract run is therefore not
+  automatically a defect in the change, and an API deprecation on either side
+  can break a passing client later.
+- **Ordering within the change**: the clients must implement `RemoteTracker`,
+  reproduce the projection recipes and pass the contract harness *before* the
+  bash scripts are deleted, the corpus relocated or the skills repointed. The
+  bash scripts and their generated corpus are the only oracle for projection
+  and classification fidelity; deleting them first discards the guard that
+  makes the cutover safe.
+- **New dependency trees**: `wiremock-rs`, `rustls` and their transitive
+  dependencies must clear `deny.toml`'s licence and advisory policy. Any
+  allowance or exception needed is part of this change, not a follow-up.
+- **Release pipeline**: two new dispatched binaries join the per-platform
+  upload set and the minisign-signed `manifest.json` contract 0165 owns. A
+  binary that builds and registers locally but is absent from the manifest is
+  undiscoverable until a user's launcher tries to fetch it. If the copyleft
+  check in the registration requirement fires, 0203 (MPL-2.0 attribution
+  artefact, still `ready`) becomes a release-path dependency — a licence
+  failure, not a build one, so it must be settled at planning rather than at
+  release.
+- **Blocks 0174** (Retire Shell Tooling and CI Guards), but the edge is now held
+  at **child** level: 0211 clears the integrations floor and seven library
+  entries, 0212 clears the work floor and the eighth, so 0174's `blocked_by` names
+  0211 and 0212 rather than this item. A blocker lookup from 0174 therefore lands
+  on the increments that do the work instead of on a parent that performs none.
+  This item retains its own `blocks: 0174` as the rolled-up view.
+- The frozen port signature is six items: the trait, `ExternalId`,
+  `RemoteIssue`, `RemoteTimestamp`, `FetchOutcome` and `TrackerError`.
+  `fetch_all` returns `FetchOutcome.found` as `Vec<(ExternalId,
+  RemoteTimestamp)>` — a stamp per key rather than a projected issue — so each
+  client's bulk-mode query needs no `description`/body field at all. Linear's
+  selection set in particular can stay as narrow as `linear-search-flow.sh`'s
+  today, with no need to widen it against Linear's complexity cap.
+- `RemoteTimestamp` is a three-variant enum, not a `String` newtype. A client
+  maps a tracker's stamp to `Reported(bytes)` verbatim and a blank or null one to
+  `NotReported` — never to `Reported("")`, which means nothing. The third
+  variant, `NotRead`, is unreachable through the port: a client cannot return it,
+  because `show` and `fetch_all` either answer or fail.
+- A client that quietly drops an operation once the trait gains a
+  default-bodied method is undetectable by 0204's own guards (`cargo public-api`
+  and the signature-probe test). Nothing catches that mistake below the shared
+  contract harness actually exercising all four operations against the real
+  client.
+- Carries 0194's cutover. 0194 shipped the Rust sync engine beside the live bash
+  path without retiring it, because `sync` and `create`/`update --push` could only
+  resolve fakes until these clients existed. This story inherits four obligations
+  from it: the script removal and skill repointing, the sync SKILL's
+  conversational conflict flow, running the shared contract harness against real
+  clients, and per-provider projection fidelity against the committed corpus.
+- 0170 (the work-item lifecycle subdomain) is a **discharged** dependency, not
+  merely a relation: the skill repointing consumes `accelerator work create`
+  and `list`, which 0170 delivers, and `/list-work-items` is why the read path
+  must stay bounded. 0170 is `done`, so nothing is blocked; it carries no
+  dependency on these clients or the port, and 0194 wires `--push` onto its
+  `create`/`update` commands separately.
+- 0174 (Retire Shell Tooling and CI Guards) also relates in the other
+  direction: this story now clears the whole `work-item-*.sh` surface itself,
+  so 0174 inherits none of it. 0174 was updated on 2026-08-17 to say so and to
+  record the split of floor and `SHELL_LIBRARIES` ownership between the two, so
+  neither a floor nor a library entry can be cleared twice or missed.
 - Parent: epic 0136.
 
 ## Assumptions
 
-- The existing Python mock servers port over as Rust integration-test scaffolding
-  with minimal change.
+- `wiremock` can express both providers' error shapes faithfully enough to
+  exercise all four exit-code mapping tables — including Linear's
+  partial-success GraphQL responses, where a `200` carries an `errors` array.
+  If it cannot, the affected cases move to the credentialed target rather than
+  going uncovered — the transcribed-fixture criterion requires a class
+  assertion for every row whichever lane provides it.
+- The async-to-sync bridge in the test layer is a one-off pattern, not a
+  per-test cost, and does not force the production clients async.
+- The four bash exit-code mapping tables are the authority over
+  `TrackerError`'s doc comment wherever the two disagree.
+- The committed goldens are a sufficient oracle once their bash generators are
+  gone — no case in the corpus depends on regenerating it.
+- The Rust surface already covers everything the three previously-deferred
+  scripts do (`sync-label` → `cli/work/src/sync/label.rs`, `normalise` →
+  `cli/work/src/normalise.rs`, `file-dirty` → `working_copy_status.rs` /
+  `dirty_paths.rs`), so blanket deletion needs repointing rather than new
+  behaviour.
+
+  ⚠️ This assumption and the flow-enumeration one below each **bound the size**
+  of one half of the item, and neither is confirmed. Both must be checked before
+  planning, alongside the three Open Questions: if the flow list is short, more
+  flows need migrating and fixturing; if a Rust replacement is missing, blanket
+  deletion means new behaviour rather than repointing.
+- The eight flows per provider are the whole user-facing surface of the two
+  integration script clusters — no flow exists in bash that the enumerated
+  eight plus ADF↔markdown, JQL and GraphQL construction do not cover. Worth
+  confirming against both script directories before planning commits to the
+  per-flow fixture criterion.
 
 ## Technical Notes
 
@@ -260,52 +376,198 @@ granularity is wanted.
   `skills/integrations/linear/scripts/` (`linear-common`, `linear-auth`,
   `linear-graphql.sh`, flows).
 - `reqwest` + rustls keeps the clients musl-static-friendly; no native-tls.
+- `wiremock-rs` is the mock layer: `MockServer::start()` binds a random local
+  port in-process, servers are pooled across tests and shut down on drop, and
+  instances must not be shared between tests. `tokio` and `reqwest` are already
+  workspace dependencies and `cli/github` already uses tokio, so no new runtime
+  enters the workspace.
+- Crate ownership, stated once: 0204 introduced the `tracker` crate together
+  with the frozen port; 0194 added the sync engine inside it. References to "the
+  `tracker` crate" throughout mean that one crate.
+- Contract harness: `cli/tracker-test-support/src/contract.rs`, parameterised
+  via `ContractSubject`; excluded from the default test run and driven by
+  `mise run test:integration:tracker-contract` (`tasks/test/integration.py`,
+  `tracker_contract`).
+- Baseline corpus currently at `skills/work/scripts/test-fixtures/`; its Rust
+  consumers resolve it by repo-root-relative path today, which is what the
+  relocation removes.
 
 ## Drafting Notes
 
-- Treated as the Phase 8 story; kept as one grouped item per the user's selection,
-  with a noted split option.
+- Treated as the Phase 8 story; kept as one grouped item.
 - Updated 2026-08-05: 0170 split into 0170 (lifecycle CRUD) and 0194
-  (`tracker` crate and remote sync engine) following a work item review. All
-  references to "the tracker port from 0170" now point at 0194, which is
-  where the `RemoteTracker` port actually lives.
-- Updated 2026-08-10, absorbing the cutover from 0194 after review 2 pass 2
-  raised it as a critical finding against that item. 0194's original final phase
-  retired the bash sync and bridge scripts, but the real clients replacing them
-  are this story's deliverable and this story is blocked by 0194 — so the
-  user-facing `sync` and `--push` flows would have been dead between the two,
-  against epic 0136's rule that the plugin stays functional at every step. The
-  cutover moved here, where the clients exist. An interim adapter shelling
-  out to the existing bridge scripts was weighed and rejected: throwaway
-  work needing its own retirement, for a window this story closes anyway.
-  This item grew materially as a result, and its Open Question about
-  splitting Jira from Linear is worth re-taking with the cutover in scope —
-  a natural third slice.
-- Updated 2026-08-10: the `RemoteTracker` port moved out of 0194 into its
-  own item, 0204. This story's `blocked_by` now names 0204 for the client
-  work and 0194 only for the cutover half, so the client crates and thin
-  binaries can start as soon as the port lands rather than waiting on a
-  whole sync engine they do not use.
-- Updated 2026-08-12: 0204 was accepted and implemented, and cleared from
-  `blocked_by` — the client work can now start. Its final signature grew
-  by one item during plan review (`FetchOutcome`, a total three-way
-  partition over a bulk `fetch_all`), which this story's description had
-  not caught up with; corrected above, along with the resulting change to
-  what a bulk-mode query needs to request. 0204's own review also
-  confirmed a real gap this story should be aware of when implementing
-  `impl RemoteTracker`: a client that quietly drops an operation once the
-  trait gains a default-bodied method is undetectable by either of
-  0204's own guards (`cargo public-api` and the signature-probe test),
-  so nothing catches that mistake below the level of 0194's shared
-  contract test actually exercising all four operations against the real
-  client.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+  (`tracker` crate and remote sync engine). All references to "the tracker port
+  from 0170" point at 0194's line of work.
+- Updated 2026-08-10: absorbed the cutover from 0194, whose original final phase
+  retired the bash sync and bridge scripts — but the real clients replacing them
+  are this story's deliverable, so the user-facing `sync` and `--push` flows
+  would have been dead between the two, against epic 0136's rule that the plugin
+  stays functional at every step. An interim adapter shelling out to the bridge
+  scripts was weighed and rejected: throwaway work needing its own retirement,
+  for a window this story closes anyway.
+- Updated 2026-08-10: the port moved out of 0194 into 0204 so the client crates
+  would wait on a trait and its vocabulary rather than a whole sync engine.
+- Updated 2026-08-17, enrichment pass. 0194 is complete, so every work-item
+  blocker is discharged.
+  Five decisions taken: keep Jira, Linear and the cutover as one item now that
+  sequencing no longer argues for a split; test with `wiremock-rs` and keep
+  Python out of the `cli/` lane; relocate the fixture corpus into the Rust test
+  tree rather than leaving it beside the skills; delete **every**
+  `work-item-*.sh` and `test-work-item-*.sh` by the end of this story rather
+  than deferring three to 0174; and provision the credentialed tracker target
+  before the cutover lands. (That last decision originally read "during
+  implementation"; the 2026-08-17 review pass re-sited it as a prerequisite,
+  since it is external-account administration with no work item of its own.)
+- The enrichment found eleven Rust tests resolving paths under
+  `skills/work/scripts/`, which no requirement or criterion had accounted for.
+  Deleting the scripts breaks the build; deleting the tests discards the
+  cutover's only regression guard. Converting them is now explicit, and the
+  count is eleven rather than seven precisely because deletion went blanket —
+  `normalise_parity`, `sync_label_parity`, `cli_diff_parity` and
+  `diff_shellout_parity` pin against scripts the earlier scope retained.
+- Blanket deletion also promoted three things from footnotes to requirements:
+  the suite floor is removed outright rather than decremented,
+  `test-work-item-scripts.sh` dies whole rather than in part, and the
+  dirty-work-item overwrite guard at `sync-work-items/SKILL.md:137` needs an
+  explicit Rust replacement rather than quietly vanishing.
+- `--resolve` takes three tokens (`remote|local|skip`), not the two this item
+  previously specified, and `sync` reports conflicts on exit `4` and `71` alike.
+  Corrected against `cli/work-cli/src/cli.rs`.
+- `producer` left as `extract-work-items`: it records where the item came from,
+  and this pass enriched it rather than created it.
+- Reviewed 2026-08-17 (review 1, verdict REVISE) and revised in place. The
+  review's scope critical — split the two clients and the cutover into
+  siblings — was considered and **declined**: the item stays whole. Everything
+  else was applied. The substantive changes: the integration script clusters are
+  now a requirement rather than an assumption, with the eight flows per provider
+  enumerated and both `SKILL.md` sets repointed in the body, not just their
+  frontmatter; the primary client criterion no longer verifies against the bash
+  suites it deletes, but against committed request/response fixtures captured
+  from those flows before deletion; the four exit-code tables and the
+  timeout/page-cap bounds gained criteria with named threshold values; the
+  identifier-safety check was lifted out of the four-capability decision (whose
+  list enumerated three) into its own four-case criterion, leaving three genuinely
+  open fates; the contract run now covers all four port operations and needs a
+  named execution route; the corpus criterion gained a seeding procedure and the
+  absent-description case; and Dependencies gained the credentialed-target
+  prerequisite, both external systems, the intra-change ordering rule, the
+  `deny.toml` and release-manifest couplings and an explicit `blocks: 0174`.
+- The review reported 0194's status as `ready`, contradicting this item. That is
+  workspace divergence: the flip to `done` is in commit `c03f2448c6`, verified
+  not to be an ancestor of this workspace's working copy. Dependencies now says
+  to confirm 0194 against its artefacts rather than its status field, since a
+  divergence in either direction is possible.
+- Children 0210-0213 reviewed 2026-08-17 (one pass, five lenses over all four as a
+  set). Every finding was applied. The pass found one **critical**, raised
+  independently by three lenses and verified directly: the three port-less bridge
+  capabilities — unkeyed discovery `search` and the two `--dry-run` behaviours —
+  had landed in no child, while 0212 deletes the scripts carrying them. All four
+  children could have been accepted green while `/sync-work-items` lost remote-issue
+  discovery and `--preview` lost live push validation. That is the same
+  partition failure that killed `## Increments`, reproduced in a second structure;
+  it is now 0212's, and a full audit (28 requirements, 31 criteria) confirmed it was
+  the only gap.
+- Other fixes from that pass. 0211's exit-code mapping is now anchored to the
+  retiring bash flow's codes or `tracker`'s existing values rather than to a
+  document the same child authors — it previously could not fail. The per-flow
+  fixture *provenance* obligation, silently dropped in the carve-out, is restored,
+  so sixteen fixtures cannot quietly pin the new clients to the mock servers 0211
+  deletes. The whole-repository `jq`/`curl` equality assertion moved to 0212, since
+  0211 could not satisfy it before the work skills were repointed. The
+  ADF/JQL/GraphQL assertions moved to 0210, where the code they pin lives. 0210
+  gained a whole-corpus offline projection criterion — the only window in which the
+  bash corpus exists — and its three transcriptions now have named paths and are
+  scoped to its own merge, so the siblings' "verify against 0210's baseline"
+  criteria resolve to files. 0213 gained a Context, an Assumptions entry, a
+  stub-on-`PATH` walkthrough with a stated pass predicate and three named fixtures
+  (including the clean exit-`0` case), and an automated skills-lane guard — 0212
+  edits the same file, so a manual-only check would not have survived it.
+- 0211 also gained a **reverse** cross-cluster sweep. The pass-3 reordering was
+  justified by references running from the integration clusters into
+  `skills/work/scripts/`; nobody had checked the other direction, where the
+  surviving work-item bridges and their three suites may drive the two Python mock
+  servers 0211 deletes. Unswept, the chosen order could create the mirror of the
+  break it was chosen to prevent.
+- Structural changes from that pass: this item is now `kind: epic` (nested under
+  0136, following the 0145-under-0192 precedent) with 0210-0212 as `story` and 0213
+  as `task`, since three children are multi-week efforts that `task` mis-sizes. The
+  duplicated Requirements and Acceptance Criteria were removed in favour of a
+  `## Scope` section stating that **the children are normative** — the duplication
+  had already drifted twice in one revision, losing a provenance clause and an
+  assertion-count qualifier, and both losses surfaced as findings. The 0174 edge
+  moved to child level: 0174's `blocked_by` now names 0211 and 0212, the increments
+  that actually clear its floors and library entries.
+- Not applied, and deliberately: the scope lens's recommendation to split 0210 and
+  0211 along the **provider seam** (jira and linear as separate children). It would
+  halve the two largest children and let the providers proceed in parallel, and the
+  seam is real — separate crates, binaries, clusters and skill sets, sharing only
+  the port, the composition root and the async-to-sync test pattern. It is not
+  applied because it doubles the child count on a decomposition the author has
+  already ruled on twice, and because the shared items would need an arbitrary home
+  in whichever provider lands first. Worth revisiting if 0211's unconfirmed
+  flow-enumeration assumption comes back short.
+- Reviewed a third time 2026-08-17 (review 1, pass 3, REVISE on major count with
+  no criticals). The decisive finding was that `## Increments`, added in pass 2 to
+  mitigate the scope critical, had become the largest single source of majors: it
+  contradicted the Requirements' "in the same change" clauses, did not partition
+  the requirement set, left the composition-root wiring unassigned, and — the
+  live break — put the deletion of `work-item-sync-label.sh` in an increment
+  before the one retiring the two integration-cluster scripts that still call it.
+  Resolved at the source by reifying the four increments as children 0210–0213
+  parented to this item, each with its own status, requirements and criteria,
+  following the 0166 → 0178/0179/0180 precedent. Ordering is now 0210 → 0211 →
+  0212 with 0213 free, and 0211 precedes 0212 precisely so the sync-label callers
+  die before the script does. The independent pass-3 findings were applied too:
+  the contract-run criterion demands an enforcing route rather than a recorded
+  one (writing down "a broken client can reach `main`" used to satisfy it); the
+  consumer sweep names a definite repository-wide grep instead of excluding the
+  only two references it cited; the binaries gained an exit-code contract with a
+  document of record and stdout goldens for the sixteen subcommands; the
+  absent-description rule gained an offline criterion so the item's highest risk
+  is not verified only in the unprovisioned credentialed lane; the timeout
+  criterion's self-contradictory window became a T-relative assertion plus a
+  defaults check; and "all four port operations" now enumerates four operations
+  with the two cross-operation obligations listed separately.
+- The scope lens's position, stated across all three passes, was that this item
+  is epic-scale for a `story`. Splitting into siblings was declined twice; the
+  child decomposition is the third answer, and it keeps 0171 as the single unit
+  of value while giving each increment its own acceptance gate.
+- Reviewed again 2026-08-17 (review 1, pass 2, still REVISE — no criticals
+  remained, but the major count kept the verdict). Applied: the four mapping
+  tables now pair to a named provider and operation and are transcribed to a
+  committed fixture before deletion, alongside the ADF node-type inventory and
+  the per-test assertion baseline — three oracles that previously existed only
+  in the code being deleted; the tautological `jq`/`curl` audit and the
+  escapable "any migrated production script" both became equality assertions;
+  the work-skill repointing, the two binaries' own CLI surface, sub-binary
+  registration with the release manifest, and the `RemoteTimestamp` blank/null
+  rule each gained the criterion they lacked; the timeout criterion gained a
+  two-sided window and an override seam so it cannot be waved through or turn
+  into 100s of wall clock; the fixture-deletion and drop-decision escape
+  clauses were closed; and the additive-port-item branch was moved out of scope
+  entirely — 0204 is frozen, so that fate means a new blocking item, not a
+  dependency on a done one. An `## Increments` section named four ordered,
+  individually mergeable changes — superseded by the pass-3 child decomposition
+  above, which reifies those four as 0210–0213.
+- Three Open Questions must close before pickup — the secrets siting, the three
+  port-less capability fates, and the `EXIT_CODES.md` siting. Each of the first two
+  changes what is in scope, so sizing is not settled until they are answered. That
+  originally held this item at `draft`.
+- Superseded 2026-08-17: the five items were moved to `ready` with those three
+  questions **still open**, alongside the two ⚠️ size-bounding assumptions in 0211
+  and 0212. They are carried into planning rather than treated as pickup gates, so
+  the first planning session must answer them before committing to a shape. The
+  five reviews were accepted at the same time with their open findings recorded
+  rather than resolved — see each review's Acceptance section for what remains
+  known-imperfect, including three self-contradictions introduced during the fix
+  rounds (0211's mock-server deferral, 0211's `jq`/`curl` survivor set, 0213's stub
+  seam) and two latent gaps better closed by implementing 0210 than by more
+  specification.
 
 ## References
 
 - Source: `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
 - Parent: `meta/work/0136-migrate-shell-scripts-to-rust-cli.md`
+- Related: 0194, 0204, 0170, 0174
+- Review: `meta/reviews/work/0171-jira-and-linear-integrations-review-1.md`
 - ADRs: ADR-0045, ADR-0046, ADR-0053

--- a/meta/work/0174-retire-shell-tooling-and-ci-guards.md
+++ b/meta/work/0174-retire-shell-tooling-and-ci-guards.md
@@ -9,10 +9,10 @@ status: draft
 kind: story
 priority: medium
 parent: "work-item:0136"
-blocked_by: ["work-item:0167", "work-item:0168", "work-item:0169", "work-item:0170", "work-item:0171", "work-item:0172", "work-item:0195", "work-item:0196", "work-item:0197"]
+blocked_by: ["work-item:0167", "work-item:0168", "work-item:0169", "work-item:0170", "work-item:0172", "work-item:0195", "work-item:0196", "work-item:0197", "work-item:0211", "work-item:0212"]
 derived_from: ["codebase-research:2026-06-28-0136-rust-cli-migration-scope-and-architecture"]
 tags: [shell, tooling, ci, cleanup]
-last_updated: "2026-06-28T17:01:56+00:00"
+last_updated: "2026-08-17T08:44:49+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 external_id: "PP-195"
@@ -59,6 +59,18 @@ Playwright executor) and stays under the bash-3.2 floor.
 - Keep the surviving thin shell (launcher bootstrap, hook wrapper, Playwright
   executor) bash-3.2-safe; decide whether a reduced bashisms check still guards
   them or whether the surviving set is small enough to review by hand.
+- Do **not** carry the work-item or integration clusters. 0171 was widened on
+  2026-08-17 to delete every `work-item-*.sh` and `test-work-item-*.sh` outright
+  — including `work-item-sync-label.sh`, `work-item-normalise.sh` and
+  `work-item-file-dirty.sh`, which earlier drafts of both stories deferred here —
+  and to migrate the jira and linear integration scripts. It therefore owns the
+  removal of `_EXPECTED_WORK_SUITES` (floor and `_require_suite_floor` call
+  alike, not a decrement), the `_EXPECTED_INTEGRATIONS_SUITES` retirement, and
+  eight of the twenty-two `SHELL_LIBRARIES` entries: the
+  `skills/work/scripts/work-item-bridge-codes.sh` entry plus all seven jira and
+  linear library entries. This story's lockstep obligation covers only what
+  remains — the fourteen `scripts/*.sh` entries and the config, hooks, decisions
+  and github floors.
 
 ## Acceptance Criteria
 
@@ -97,6 +109,20 @@ Playwright executor) and stays under the bash-3.2 floor.
   `tasks/format/scripts.py:9` (shfmt); `tasks/lint/scripts.py:70` (shellcheck);
   `tasks/shared/sources.py:60` (`shell_sources`); `.shellcheckrc`;
   `.editorconfig:36-39`; `.github/workflows/main.yml:99` (`check-scripts`).
+- Floor ownership as of 2026-08-17. `tasks/test/integration.py` declares six:
+  `_EXPECTED_CONFIG_SUITES = 15` (:45), `_EXPECTED_WORK_SUITES = 5` (:51),
+  `_EXPECTED_INTEGRATIONS_SUITES = 32` (:57), `_EXPECTED_HOOKS_SUITES = 1` (:76),
+  `_EXPECTED_DECISIONS_SUITES = 0` (:77) and `_EXPECTED_GITHUB_SUITES = 0` (:78).
+  0171 removes the work and integrations pair; the other four are this story's,
+  alongside whichever the config and hooks clusters' own stories decrement.
+- `SHELL_LIBRARIES` ownership: 0171 clears the single `skills/work/scripts/`
+  entry and the seven `skills/integrations/{jira,linear}/scripts/` entries. The
+  fourteen `scripts/*.sh` entries — `fs-common`, `hash-common`, `log-common`,
+  `work-common`, `config-defaults`, `config-common`, `atomic-common`,
+  `vcs-common`, `doc-type-table`, `doc-type-inference`,
+  `frontmatter-emission-rules`, `frontmatter-fixtures`, `test-helpers` and
+  `accelerator-scaffold` — retire under their own subdomain stories, and the
+  frozenset itself disappears here once the last is gone.
 
 ## Drafting Notes
 
@@ -104,6 +130,15 @@ Playwright executor) and stays under the bash-3.2 floor.
   incrementally inside the subdomain stories (lockstep floor decrements), with the
   final checker/CI-job removals gated on all clusters retiring — hence the broad
   `blocked_by`.
+- Updated 2026-08-17: scope moved out to 0171. Earlier drafts of 0171 retained
+  `work-item-sync-label.sh` and `work-item-normalise.sh` and left
+  `work-item-file-dirty.sh` undecided, all three landing here as residue; 0171
+  now deletes the whole `work-item-*.sh` surface itself. This story's generic
+  lockstep language did not name the residue, so nothing here was wrong — but it
+  did leave ownership of the work and integrations floors and eight
+  `SHELL_LIBRARIES` entries ambiguous between the two items. Both are now stated
+  explicitly in Requirements and Technical Notes, so a floor cannot be
+  decremented twice or missed entirely.
 
 > Extracted from source documents without interactive enrichment.
 > Acceptance criteria, dependencies, and kind may need refinement before

--- a/meta/work/0210-provider-client-crates-over-the-tracker-port.md
+++ b/meta/work/0210-provider-client-crates-over-the-tracker-port.md
@@ -1,0 +1,272 @@
+---
+type: work-item
+id: "0210"
+title: "Provider Client Crates over the RemoteTracker Port"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0171"
+blocks: ["work-item:0211", "work-item:0212"]
+relates_to: ["work-item:0194", "work-item:0204"]
+tags: [rust, jira, linear, integrations, reqwest, tracker]
+last_updated: "2026-08-17T11:17:18+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0210: Provider Client Crates over the RemoteTracker Port
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Build `jira-client` and `linear-client` as adapter crates over `reqwest` +
+rustls + serde, each implementing the `RemoteTracker` port 0204 froze, and wire
+both into `accelerator-work`'s composition root so the sync engine resolves real
+providers rather than fakes. This child touches no bash, so every bash oracle the later
+children delete is still available to verify against.
+
+Precisely what changes for a user when this merges: **nothing**. No skill invokes
+the new binaries or the sync engine's new provider resolution — the jira, linear
+and work skills all still shell out to bash until 0211 and 0212 repoint them. What
+does change is that `accelerator work sync`, already shipped by 0194, becomes
+*able* to resolve real clients instead of fakes when invoked directly.
+
+## Context
+
+First of four children of 0171, and the blocker for two of them. Everything the
+later children delete — the projection recipes, the four exit-code mapping
+tables, the ADF node-type inventory, the eleven parity tests' baselines — is
+still on disk while this lands, which is the only window in which those oracles
+can be transcribed and verified against.
+
+`RemoteTracker` is synchronous and six items wide (the trait, `ExternalId`,
+`RemoteIssue`, `RemoteTimestamp`, `FetchOutcome`, `TrackerError`). A capability
+needing a new port operation is out of scope here — it becomes a new work item
+blocking 0171, not an amendment to a done and frozen 0204.
+
+## Requirements
+
+- Implement `jira-client` (Jira REST + Atlassian Document Format (ADF)↔markdown
+  + auth) and `linear-client` (Linear GraphQL + auth) as adapter crates over
+  `reqwest` + rustls + serde, each `impl RemoteTracker`. No native-tls, so the
+  clients stay musl-static-friendly.
+- Wire both clients into `accelerator-work`'s composition root under the
+  `work.integration` config values 0194 exercised against fakes (`jira` and
+  `linear`). This edits 0194's binary and adds crate-graph edges, so its
+  `cli/pup.ron` rules and public-API snapshot must accept them.
+- Test against `wiremock` (`wiremock-rs`), which runs an in-process HTTP server
+  on a random local port. No Python enters `cli/`'s test dependencies; the mock
+  servers retire with the bash suites in 0211.
+- Bridge `wiremock`'s async API to the synchronous port once, in the test layer
+  — runtime for setup, the client call outside `block_on` or via
+  `spawn_blocking` — and reuse that pattern rather than solving it per test.
+- **Transcribe the three oracles that later children destroy**, as part of this
+  child's own change, each at a named committed path in a diffable format:
+  - the four `curl` exit-code mapping tables, verbatim, into a fixture keyed by
+    (code, provider, operation, class);
+  - the inventory of ADF node types the bash conversion handles, as a
+    one-node-type-per-line list at
+    `cli/jira-client/tests/fixtures/adf-node-types.txt`;
+  - a baseline file recording, for each of the eleven parity tests 0212 converts,
+    its fixture-case identifiers and its pre-conversion assertion count, plus the
+    pre-change file count under `skills/work/scripts/test-fixtures/` as a
+    committed number.
+
+  0211 and 0212 verify against these files, so a transcription with no path is a
+  criterion neither sibling can check.
+- Port **four** exit-code mapping tables, not two, each pairing one provider
+  with one operation: Jira `create` is `_wicr_map_jira`, Jira `update` is
+  `_wiur_map_jira`, Linear `update` is `_wiur_map_linear`, Linear `create` is
+  `_linear_map_no_file_failure` (inside `linear-create-flow.sh`), whose name
+  understates what it covers.
+
+  The tables are keyed by **`curl` transport exit code**, not HTTP status — 34,
+  18, 23, 25, 27 and 29 are all `curl` exit values and none is a valid HTTP
+  status. Confirm the key domain against each table while porting. Within a
+  provider, `create`'s and `update`'s retryable sets are **not nested in either
+  direction**: for Linear, 34 is retryable on `create` and terminal on
+  `update`, while 18, 23, 25, 27 and 29 run the other way. Confirm whether the
+  Jira pair diverges too.
+
+  The rule the tables encode: a failure that **provably occurred before the
+  request left the client** is retryable; anything that may have reached the
+  tracker is terminal. The tables are deliberately more conservative than that
+  rule. Where the two disagree, **the tables win**.
+- Carry over the identifier-safety check the create bridge performs
+  (`work-item-create-remote.sh:62-87,238-246`): reject a returned identifier
+  carrying control characters, a newline, or a leading `---` or `#`, because the
+  value is written unquoted into a work item's YAML frontmatter.
+  `ExternalId::new` is infallible by freeze, so the type cannot carry it, and
+  the bash dispatcher that did has no counterpart once the port replaces it. An
+  unsafe identifier is a `Terminal` failure, not an `Ok`.
+- Bound the port's calls from inside each client crate, below its
+  `RemoteTracker` impl — configured on the `reqwest` client, overridable at
+  construction for tests. Reproduce `curl --max-time 30` for Jira,
+  `--max-time 60` for the Linear flows, and the `_WIFR_PAGE_CAP=20` pagination
+  backstop. A caller above the port cannot add them, and `/list-work-items`
+  relies on the read path not hanging.
+- Reproduce the per-provider projection recipes exactly, verified against the
+  bash-generated baseline corpus 0194 committed at
+  `skills/work/scripts/test-fixtures/` while it is still on disk — this child is
+  the only window in which that oracle exists. Jira: summary line then the
+  description in ADF through key-sorted `jq -S`; linear: title line then Markdown
+  description verbatim. Title line, then description, with **no
+  blank line between them** and a trailing newline, for both providers; Jira's
+  `summary` field supplies its title line. What `show` and the projection helper
+  place in `RemoteIssue.body` is the *un-normalised* projection; 0194's sync
+  engine normalises before hashing, above the port.
+
+  The case a JSON deserialiser will get wrong: an **absent** description
+  projects as the literal token `null` for Jira (`jq -cS '… // null'`) and as an
+  empty line for Linear (`// ""`). Neither is what `serde` produces naturally,
+  and either wrong choice reclassifies every such item as `remotely-modified`
+  on the first run after cutover.
+- Map `RemoteTimestamp` per 0204's contract: a tracker's stamp to
+  `Reported(bytes)` verbatim, a blank or null one to `NotReported` — never
+  `Reported("")`. `NotRead` is unreachable through the port.
+- Implement `ContractSubject` for both clients and run 0194's shared harness
+  (`cli/tracker-test-support/src/contract.rs`, driven by `mise run
+  test:integration:tracker-contract`) against both, so the fake 0194 verified
+  against and the real clients are held to one contract.
+- Gate the credentialed contract lane out of the default test run by **reusing**
+  whatever already excludes `tracker_contract` — the nextest filter expression,
+  cargo feature or `#[ignore]` convention wired in `tasks/test/integration.py` —
+  and name it in the implementation. Do not introduce a second mechanism; two
+  ways to gate the network lane leaves a later maintainer unsure which is
+  authoritative.
+- Own the `cli/pup.ron` import rules and public-API snapshots for the two crates
+  this child creates, `jira-client` and `linear-client`. 0211 owns them for the
+  two binary crates it creates. The composition-root edit additionally requires
+  `accelerator-work`'s existing pup rules and public-API snapshot to accept the
+  new crate-graph edges.
+- Clear `wiremock-rs`, `rustls` and their transitive trees through `deny.toml`'s
+  licence and advisory policy, committing any allowance needed. Record whether
+  either tree carries copyleft components; if it does, 0203's attribution
+  artefact becomes a release-path dependency for 0211.
+
+## Acceptance Criteria
+
+- [ ] Both client crates implement `RemoteTracker`, and the composition root of
+      `accelerator-work` binds each real client under its `work.integration`
+      value — verified by a test constructing the sync engine with each real
+      client, not by the crates merely compiling.
+- [ ] Request construction for a provider appears only in its client crate,
+      checked mechanically: no `use reqwest` or `reqwest::` outside the two
+      client crates, and no string literal matching `/rest/api/`, `/rest/agile/`
+      or a leading `query ` / `mutation ` GraphQL document outside them. The
+      tripwire itself is tested by planting a deliberate violation and observing
+      it fail.
+- [ ] The four tables are transcribed verbatim into a committed fixture (code,
+      provider, operation, class), and a table-driven test asserts a
+      `TrackerError` class for **every row** — a row with no assertion fails the
+      build. Classification is per operation, and the divergent Linear cases are
+      covered: 34 retryable on `create` and terminal on `update`, 18, 23, 25, 27
+      and 29 the other way.
+- [ ] With an injected timeout T, a never-responding `wiremock` endpoint causes
+      `show` and `fetch_all` to fail no earlier than T and no later than 1.35×T,
+      verified at T = 200ms and T = 400ms; and a unit assertion confirms the
+      constructed defaults are exactly 30s for Jira, 60s for Linear, and a page
+      cap of 20. A paginated fixture offering 21 or more pages stops after 20.
+- [ ] Given a `create` response whose returned identifier carries (a) a control
+      character, (b) a newline, (c) a leading `---`, or (d) a leading `#`, the
+      client returns a `Terminal` failure and no value is written to a work
+      item's frontmatter.
+- [ ] **Offline, whole corpus**: for every record in
+      `skills/work/scripts/test-fixtures/`, the client's projection is
+      byte-identical to that record's committed corpus entry, per provider,
+      including Jira's key-sorted ADF ordering. Runs with no network target and
+      before any deletion, so populated-description fidelity is pinned while the
+      oracle still exists.
+- [ ] ADF↔markdown conversion has a committed fixture set exercising both
+      directions and covering every entry in the node-type inventory this child
+      records; JQL composition and Linear's GraphQL document construction are each
+      pinned by request-body assertions. These verify this child's client code, so
+      they sit here rather than in 0211.
+- [ ] **Offline**: given a `RemoteIssue` fixture with an absent description, the
+      Jira projection is byte-identical to a committed golden ending in the
+      literal `null`, and the Linear projection to a golden ending in an empty
+      line — both with no blank line before the description and a trailing
+      newline. This does not depend on any network target.
+- [ ] Given a response whose timestamp field is absent, `null` or an empty
+      string, each client returns `RemoteTimestamp::NotReported` — never
+      `Reported("")`; given a populated stamp it returns `Reported` with the
+      bytes unaltered.
+- [ ] `ContractSubject` is implemented for both real clients and `mise run
+      test:integration:tracker-contract` exercises all four port operations —
+      `create`, `update`, `show` and `fetch_all` — against each, plus the two
+      cross-operation obligations: `fetch_all`'s partition totality (every
+      requested key lands in exactly one of found or missing) and the rule that
+      a read operation never returns a `Terminal` failure.
+- [ ] The contract run has an enforcing route, not merely a recorded one:
+      **either** a committed CI workflow whose job is required on the pull
+      request, **or** a committed evidence file at a named path holding the
+      harness output for both providers, dated no earlier than the final client
+      commit. Recording that no gate exists does not satisfy this.
+- [ ] The default `cargo test` / `cargo nextest run` invocation makes no network
+      call, verified by running the default suite green in a network-disabled
+      environment rather than by reading the filter expression.
+- [ ] The three oracle transcriptions are committed **as part of this child's
+      change**, each at its named path: the four-table fixture, the ADF node-type
+      inventory, and the baseline file carrying the eleven tests' fixture-case
+      identifiers, their pre-conversion assertion counts, and the pre-change
+      fixture file count. Verifiable by inspecting this change alone.
+- [ ] `deny:check` is green with any needed allowance committed, and the copyleft
+      question is answered by the committed verbatim output of a named
+      reproducible command (a `cargo deny list` or `cargo about` licence listing
+      over the `wiremock-rs` and `rustls` trees), not by a summary judgement — so
+      a verifier can re-run it. The answer is recorded in 0171's `## Decisions`,
+      and if it is positive, 0203 is added to 0211's `blocked_by` per 0211's
+      trigger.
+- [ ] `jira-client` and `linear-client` carry `cli/pup.ron` import rules and
+      public-API snapshots, and `accelerator-work`'s existing pup rules and
+      snapshot accept the new composition-root edges.
+- [ ] The credentialed contract lane is gated by the **existing**
+      `tracker_contract` exclusion mechanism, named in the implementation, with no
+      second mechanism introduced.
+- [ ] No Python enters `cli/`'s dev-dependencies, and `mise run` exits 0
+      end-to-end at this child's merge boundary.
+
+## Dependencies
+
+- Blocked in practice by the **credentialed tracker target**: a scratch Jira
+  project, a Linear team, API tokens, and repository secrets if 0171's secrets
+  Open Question resolves to CI. Two criteria here — the contract run and its
+  enforcing route — are unsatisfiable without it, so it gates *this* child's
+  acceptance, not merely the eventual cutover. It has no work item of its own and
+  is external account administration rather than a code change; **Toby Clemson
+  owns provisioning it**, per 0171's Open Questions, and the secrets-siting answer
+  decides whether a CI workflow change joins this child's scope.
+- **External systems**: Jira REST and Linear GraphQL. Reachability, per-tenant
+  rate limits, Linear's query-complexity cap and its 250-issue bulk truncation
+  all bear on the contract lane; a red run is not automatically a defect in this
+  change.
+- Consumes 0204's frozen port and 0194's contract harness. Confirm 0194's
+  artefacts exist rather than trusting its status field — see 0171.
+- Blocks 0211 and 0212: both delete bash this child must first be verified
+  against. The ordering obligation is that no deletion in either sibling begins
+  before this child's three transcriptions and its offline corpus criterion have
+  landed — recorded here rather than inside an acceptance criterion, so this
+  child's own gate can be closed by inspecting its own change.
+- Parent: 0171.
+
+## Assumptions
+
+- `wiremock` can express both providers' error shapes faithfully enough to
+  exercise all four tables, including Linear's partial-success GraphQL
+  responses where a `200` carries an `errors` array. If it cannot, the affected
+  cases move to the credentialed target rather than going uncovered.
+- The async-to-sync bridge is a one-off test-layer pattern and does not force
+  the production clients async.
+
+## References
+
+- Parent: `meta/work/0171-jira-and-linear-integrations.md`
+- Related: 0194, 0204
+- ADRs: ADR-0045, ADR-0046, ADR-0053

--- a/meta/work/0211-integration-binaries-and-bash-cluster-retirement.md
+++ b/meta/work/0211-integration-binaries-and-bash-cluster-retirement.md
@@ -1,0 +1,235 @@
+---
+type: work-item
+id: "0211"
+title: "Integration Binaries and Bash Cluster Retirement"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0171"
+blocked_by: ["work-item:0210", "work-item:0212"]
+blocks: ["work-item:0174"]
+relates_to: ["work-item:0165", "work-item:0203"]
+tags: [rust, jira, linear, integrations, cli, cutover]
+last_updated: "2026-08-17T11:17:18+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0211: Integration Binaries and Bash Cluster Retirement
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Ship `accelerator-jira` and `accelerator-linear` as thin inbound CLI adapters
+over 0210's client crates, repoint the jira and linear skill bodies at them, then
+delete both bash script clusters, their suites and their Python mock servers.
+Register the two dispatch tokens end to end, including the release manifest.
+
+## Context
+
+Last of the three sequenced children of 0171, ordered **after** the work-item
+cutover (0212). The clusters this child deletes carry the shared test assets four
+of 0212's suites consume — `test-helpers/` holding the Python mock servers, and
+`test-fixtures/` holding their scenario fixtures — so those suites must be gone
+before the clusters can be retired whole. The coupling is one-directional:
+verified by grep, the clusters invoke no `work-item-*.sh`, and the two references
+to `work-item-sync-label.sh` in `linear-create-flow.sh:304` and
+`jira-resolve-fields.sh:140` are comments about shared normalisation, not calls.
+Landing this child first would break `test-work-item-{create,update,fetch}-remote.sh`
+and `-sync-apply.sh` along with the `_EXPECTED_WORK_SUITES` floor.
+
+`skills/integrations/jira/scripts/` (22 production scripts plus the
+`jira-common`, `jira-auth`, `jira-jql`, `jira-body-input` and
+`jira-custom-fields` libraries) and `skills/integrations/linear/scripts/` (12
+production scripts plus `linear-common` and `linear-auth`) implement the eight
+flows per provider, Atlassian Document Format (ADF)↔markdown conversion, Jira
+Query Language (JQL) and GraphQL, and auth.
+
+## Requirements
+
+- Implement `accelerator-jira` and `accelerator-linear` as thin inbound CLI
+  adapters over 0210's client crates, each exposing the eight flows its cluster
+  implements: `create`, `update`, `comment`, `transition`, `search`, `show`,
+  `attach`, `init`. This `search` is the provider-side issue search the bash flow
+  exposes; it is **not** the unkeyed discovery `search` mode of
+  `work-item-fetch-remote.sh`, which 0212 discharges separately.
+- Define and document the exit-code contract for the two binaries. Enumerate the
+  failure classes — at minimum auth-invalid, target-not-found, payload-rejected,
+  transport-failure and usage-error — and **anchor each integer externally rather
+  than choosing it**: it equals the value the retiring bash flow returned for the
+  same condition, captured pre-deletion, or `tracker`'s existing `E_DISPATCH_*`
+  value where that is genuinely the same taxonomy. Name the document of record
+  (the CLI's own exit-code documentation). Choosing the integers freely and then
+  writing them down would make the mapping unfalsifiable, and the repointed skill
+  bodies branch on these values, so a silent divergence from the bash codes breaks
+  skill behaviour.
+- Capture, before deleting each bash flow, a golden of its **stdout** as well as
+  its request and response. The repointed `SKILL.md` bodies consume that output
+  the way they consume the scripts' output today, including any `!`-preprocessor
+  interpolation.
+- Record the **provenance** of every captured fixture in 0171's `## Decisions`:
+  per flow, whether it was captured against the credentialed target or the
+  retiring Python mock server, and for each mock-served entry the blocker that
+  prevented a real capture. A mock-captured fixture pins the new client to a test
+  double this child deletes, so an unrecorded provenance hides that substitution.
+- Confirm the shared test assets have no surviving consumer before deleting them.
+  `test-helpers/` (both Python mock servers) and `test-fixtures/` (scenarios, and
+  Jira's `adf-samples` and `api-responses`) were consumed by four of 0212's
+  suites, which that child deletes first. Re-run the sweep at this child's
+  boundary — every reference into
+  `skills/integrations/{jira,linear}/scripts/{test-helpers,test-fixtures}` from
+  outside the clusters themselves — and record the result. It should be empty; if
+  anything survives, repoint or remove it here rather than deleting an asset still
+  in use.
+- Register both dispatch tokens per
+  `tasks/README.md#registering-a-dispatched-sub-binary`, add the **two binary
+  crates'** `cli/pup.ron` import rules and public-API snapshots — `jira-client`
+  and `linear-client` carry theirs in 0210, which creates them — and add both
+  binaries to the per-platform release upload set and the minisign-signed
+  `manifest.json` 0165 owns. If 0210's copyleft check fired, 0203's attribution artefact is a
+  release-path dependency.
+- Repoint the **bodies** of every jira and linear `SKILL.md` at
+  `accelerator jira …` / `accelerator linear …`, not merely their frontmatter,
+  and remove the `jq`/`curl` `allowed-tools` entries.
+- Delete both clusters whole: all production scripts, all seven library entries,
+  the bash integration suites, and `mock-jira-server.py` /
+  `mock-linear-server.py`.
+- Enumerate every skill whose frontmatter declares `jq` or `curl` in
+  `allowed-tools` after the change, and record the enumeration. This child lands
+  last, so the expected survivors are exactly the skills still backed by repo-root
+  `scripts/*.sh`, which 0174 owns — no jira, linear or work skill among them (0212
+  repointed the work skills before this child began). This is where the
+  whole-repository equality assertion is checkable.
+- Retire `_EXPECTED_INTEGRATIONS_SUITES = 32` (`tasks/test/integration.py:57`)
+  outright rather than decrementing it, and remove the seven jira and linear
+  library entries from `SHELL_LIBRARIES` (`tasks/lint/scripts.py:18`):
+  `jira-common`, `jira-auth`, `jira-jql`, `jira-body-input`,
+  `jira-custom-fields`, `linear-common`, `linear-auth`. Two senses of
+  "library" are in play and must not be conflated: a **sourced-only library file**
+  on disk (governed by the exec-bit invariant) and a **`SHELL_LIBRARIES` member**
+  in `tasks/lint/scripts.py`. Classify `linear-graphql.sh` explicitly as either
+  one of Linear's twelve production scripts (executable, no `SHELL_LIBRARIES`
+  member, so the expected removal count stays seven) or a sourced-only library
+  (an eighth member, so the expected count becomes eight). Record which — an
+  orphaned member fails the exec-bit invariant guard with no story left to fix
+  it.
+
+## Acceptance Criteria
+
+- [ ] For each of the eight flows per provider, a `wiremock`-backed test asserts
+      the outgoing request (method, path or GraphQL document, and body) and the
+      parsed response against a fixture captured from the bash flow before
+      deletion. Where a flow issues no single provider request — `init` if it
+      only validates credentials and writes config — the criterion is replaced by
+      a named observable outcome for that flow; for `attach`, the fixture file
+      and expected transport shape (multipart or link-based) are named. Every
+      fixture's provenance is recorded in 0171's `## Decisions` as
+      credentialed-target or mock-served, each mock-served entry naming the
+      blocker that prevented a real capture.
+- [ ] Each of the sixteen subcommands' stdout is asserted byte-for-byte against
+      a golden captured from the corresponding bash flow. Where the shape
+      deliberately changed, that branch commits a golden of the **new** stdout
+      plus a recorded diff against the bash golden, and a CLI-level test asserts
+      the specific tokens the repointed `SKILL.md` body instructs the model to
+      read — so the branch is not an escape from the byte-for-byte half.
+- [ ] Each binary's eight subcommands parse and dispatch, and every enumerated
+      failure class maps to an integer **equal to the value the retiring bash flow
+      returned for the same condition** (captured pre-deletion) or to `tracker`'s
+      existing `E_DISPATCH_*` value — asserted table-driven at the CLI level, in
+      `accelerator-jira` and `accelerator-linear`, the layer the repointed skills
+      invoke. The document of record states the same mapping, so it records the
+      contract rather than defining it.
+- [ ] Every one of the 22 Jira and 12 Linear production scripts maps either to a
+      named subcommand of its binary or to a recorded internal-helper
+      classification, with the mapping committed and its count reconciling to the
+      pre-deletion file list — so a flow present in bash but absent from the
+      enumerated eight cannot be deleted unnoticed.
+- [ ] The shared-asset sweep is recorded and empty: grepping the repository,
+      excluding `meta/`, for
+      `skills/integrations/jira/scripts/test-helpers`,
+      `.../jira/scripts/test-fixtures`, `.../linear/scripts/test-helpers`,
+      `.../linear/scripts/test-fixtures`, `mock-jira-server` and
+      `mock-linear-server` returns hits only from inside the clusters being
+      deleted. The grep command and its output are the recorded result. Anything
+      surviving is repointed or removed here, not deleted from under a live
+      consumer.
+- [ ] `ls skills/integrations/jira/scripts/*.sh` and
+      `ls skills/integrations/linear/scripts/*.sh` each match nothing (or both
+      directories are absent); `mock-jira-server.py` and
+      `mock-linear-server.py` do not exist; and every jira and linear
+      `SKILL.md` body invokes `accelerator jira …` or `accelerator linear …`.
+- [ ] The set of `skills/` frontmatter entries declaring `jq` or `curl` in
+      `allowed-tools` after this change is **exactly** the set belonging to skills
+      still backed by repo-root `scripts/*.sh`, all of which 0174 owns — with no
+      jira, linear or work skill among them. This child lands last, so it is the
+      one that can assert the whole-repository equality; 0212 asserted only that no
+      work skill declares them. The enumerated result is recorded in 0171's
+      `## Decisions`.
+- [ ] Both dispatch tokens are registered per the sub-binary checklist, both
+      binaries appear in the per-platform upload set and the signed
+      `manifest.json`, and the two binary crates carry pup rules and public-API
+      snapshots — `jira-client` and `linear-client` carried theirs in 0210.
+- [ ] `_EXPECTED_INTEGRATIONS_SUITES` is removed from
+      `tasks/test/integration.py`, the seven jira and linear entries are gone
+      from `SHELL_LIBRARIES` — eight if `linear-graphql.sh` was classified as a
+      sourced-only library, seven if as a production script —
+      `linear-graphql.sh`'s classification is recorded in 0171's `## Decisions`,
+      and `lint:scripts:exec-bits:check` is green.
+- [ ] No Python remains in the `cli/` test lane: the mock servers are gone and
+      neither client crate's dev-dependencies nor `tasks/` reference them.
+- [ ] `mise run` exits 0 end-to-end at this child's merge boundary, not only
+      after the whole of 0171.
+
+## Dependencies
+
+- Blocked by 0210: these binaries are thin adapters over its client crates, and
+  the per-flow fixtures must be captured while the bash flows still exist (they
+  are deleted by this child, so the capture happens inside it).
+- Blocked by 0212. The clusters carry `test-helpers/` and `test-fixtures/`, which
+  four of 0212's suites consume; those suites must be deleted before these
+  directories can be. Verified by grep in both directions: the clusters invoke no
+  `work-item-*.sh`, so nothing here waits on 0212 for any other reason.
+- **Conditionally requires the credentialed tracker target.** Response shapes
+  should be captured from the real Jira project and Linear team wherever
+  reachable, since a mock-served fixture pins the new client to a test double this
+  child deletes. Where the target is unreachable for a flow, the mock is
+  acceptable and the blocker is recorded. The target has no work item; 0171 names
+  the owner.
+- **Blocks 0174**, as the last of the three: 0174 cannot remove the
+  `SHELL_LIBRARIES` frozenset or the exec-bit guard while this child's seven (or
+  eight) orphaned
+  entries and the live `_EXPECTED_INTEGRATIONS_SUITES` floor still exist. Recorded
+  in this child's `blocks` and in 0174's `blocked_by`.
+- Blocks 0212: the two `work-item-sync-label.sh` callers in these clusters must
+  be gone before 0212 deletes that script.
+- 0165 owns the signed `manifest.json` and upload set both binaries join. 0203
+  (still `ready`) becomes a release-path dependency if 0210's copyleft check
+  fired — a licence failure rather than a build one. **The trigger is explicit**:
+  if 0210 records a copyleft component, whoever records it adds
+  `work-item:0203` to this child's `blocked_by` and `work-item:0211` to 0203's
+  `blocks` before this child leaves `draft`.
+- 0174 owns the fourteen repo-root `scripts/*.sh` `SHELL_LIBRARIES` entries and
+  the skills backed by them; this child owns only the seven jira and linear
+  entries.
+- Parent: 0171.
+
+## Assumptions
+
+- ⚠️ **Unconfirmed, and it bounds this child's size**: the eight enumerated
+  flows plus ADF↔markdown, JQL and GraphQL construction are the whole
+  user-facing surface of both clusters. Confirm against both script directories
+  before planning — if the list is short, more flows need migrating, fixturing
+  and stdout goldens.
+
+## References
+
+- Parent: `meta/work/0171-jira-and-linear-integrations.md`
+- Blocked by: `meta/work/0210-provider-client-crates-over-the-tracker-port.md`
+- Related: 0165, 0174, 0203

--- a/meta/work/0212-work-item-script-cutover.md
+++ b/meta/work/0212-work-item-script-cutover.md
@@ -1,0 +1,269 @@
+---
+type: work-item
+id: "0212"
+title: "Work-Item Script Cutover"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: story
+priority: medium
+parent: "work-item:0171"
+blocked_by: ["work-item:0210"]
+blocks: ["work-item:0211", "work-item:0174"]
+relates_to: ["work-item:0194", "work-item:0213"]
+tags: [rust, cutover, work-items, fixtures, cli]
+last_updated: "2026-08-17T11:17:18+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0212: Work-Item Script Cutover
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Finish the cutover 0194 deliberately left undone: delete all eighteen
+`work-item-*.sh` and `test-work-item-*.sh` files, relocate their fixture corpus
+into the Rust test tree, convert the eleven parity tests to read those fixtures,
+repoint the three work skills at `accelerator work …`, remove the work suite
+floor, and consolidate the `E_DISPATCH_*` taxonomy on the `tracker` crate.
+
+## Context
+
+Second of the three sequenced children of 0171, and the first that deletes
+anything. It runs **before** 0211 because the coupling between the work scripts
+and the integration clusters runs in only one direction: four of the five suites
+deleted here reach into `skills/integrations/{jira,linear}/scripts/test-helpers/`
+and `.../test-fixtures/` for the Python mock servers and their scenario fixtures
+— `test-work-item-create-remote.sh`, `-update-remote.sh`, `-fetch-remote.sh` and
+`-sync-apply.sh`. The clusters, by contrast, invoke no `work-item-*.sh` at all;
+the two references to `work-item-sync-label.sh` in `linear-create-flow.sh:304`
+and `jira-resolve-fields.sh:140` are comments noting that those scripts perform
+the same normalisation, not calls.
+
+Deleting the work suites first therefore removes the only consumers of the
+clusters' shared test assets, so 0211 can then retire both clusters whole. The
+reverse order would break all four suites and the `_EXPECTED_WORK_SUITES` floor
+the moment 0211 landed.
+
+All eighteen files: thirteen production scripts (`work-item-bridge-codes`,
+`-create-remote`, `-fetch-remote`, `-file-dirty`, `-normalise`,
+`-project-remote`, `-push-decide`, `-sync-apply`, `-sync-baseline`,
+`-sync-classify`, `-sync-decide`, `-sync-label`, `-update-remote`) and five
+suites (`test-work-item-create-remote`, `-fetch-remote`, `-scripts`,
+`-sync-apply`, `-update-remote`). `test-work-item-scripts.sh` goes in its
+entirety, not merely its superseded sections.
+
+## Requirements
+
+- Delete all eighteen files. By the end of this child no `work-item-*.sh` or
+  `test-work-item-*.sh` script remains.
+- Repoint `skills/work/sync-work-items/SKILL.md`,
+  `skills/work/create-work-item/SKILL.md` and
+  `skills/work/list-work-items/SKILL.md` at `accelerator work …`, and re-site
+  `skills/work/scripts/EXIT_CODES.md` — either rewritten in place for the Rust
+  exit codes, or folded into the CLI's own docs, in which case
+  `skills/work/scripts/` disappears entirely. Prefer the latter; see 0171's
+  Open Questions.
+- Preserve the dirty-work-item overwrite guard. `sync-work-items/SKILL.md:137`
+  invokes `work-item-file-dirty.sh` as a precondition and `SKILL.md:312` pipes
+  `work-item-project-remote.sh` through `work-item-normalise.sh --stdin`. The
+  dirtiness precondition resolves to
+  `cli/work-adapters/src/sync/working_copy_status.rs`, which reads dirtiness
+  through `cli/vcs-adapters/src/library/dirty_paths.rs`; the normalisation pipe
+  resolves to `cli/work/src/normalise.rs`. Deleting the guard without a
+  replacement means overwriting a user's uncommitted work item.
+- Relocate the whole of `skills/work/scripts/test-fixtures/` into the Rust test
+  tree. Each fixture goes beside its consumer —
+  `work-item-{push-decide,sync-classify,sync-decide,normalise,sync-label}` into
+  `cli/work/tests/fixtures/`, `work-item-{project-remote,sync-baseline}` into
+  `cli/work-adapters/tests/fixtures/`, the rest beside whichever Rust test reads
+  it — and any fixture with no remaining consumer is deleted with its reason
+  recorded. No bash reader survives, so nothing needs repointing.
+- Convert all **eleven** Rust tests that resolve paths under
+  `skills/work/scripts/` into pure-Rust tests reading their relocated fixtures:
+  `cli/work/tests/sync_push_decide.rs`, `sync_classify.rs`, `sync_decide.rs`,
+  `normalise_parity.rs`, `sync_label_parity.rs`,
+  `cli/work-cli/tests/exit_codes_parity.rs`, `cli_diff_parity.rs`,
+  `cli/work-adapters/tests/project_remote_parity.rs`,
+  `sync_baseline_corpus.rs`, `sync_baseline_shellout_parity.rs` and
+  `diff_shellout_parity.rs`. They are the oracles pinning the Rust engine to the
+  bash one; deleting the scripts without converting them breaks the build, and
+  deleting the tests instead discards the only guard against a projection or
+  classification regression.
+- Remove the work suite floor outright. `_EXPECTED_WORK_SUITES = 5`
+  (`tasks/test/integration.py:51`) counts exactly the five deleted suites, so
+  the floor and its `_require_suite_floor` call are removed rather than
+  decremented. Remove `skills/work/scripts/work-item-bridge-codes.sh` from
+  `SHELL_LIBRARIES` (`tasks/lint/scripts.py:18`).
+- **Discharge the three port-less bridge capabilities** before deleting the
+  scripts that carry them. Each has no `RemoteTracker` operation, so none
+  survives the deletion by itself, and each is load-bearing today:
+  - the unkeyed discovery `search` mode of `work-item-fetch-remote.sh`, which
+    `/sync-work-items` uses to list remote issues with no local work item —
+    `fetch_all(ids)` is key-scoped and cannot express it. This is **not** the
+    provider `search` subcommand 0211 ships;
+  - the create bridge's `--dry-run` field-resolution preview, which surfaces an
+    unresolvable Jira project *before* the confirm gate;
+  - the update bridge's `--dry-run` payload validation, which is what
+    `/sync-work-items --preview` uses to validate every push against the live
+    tracker today. 0194's `--preview` routes mutations to no-ops and makes no
+    port call, so it does not discharge this.
+
+  For each, implement the fate recorded in 0171's `## Decisions`: re-site it
+  above the port, or drop it with the replacement outcome stated in observable
+  terms. A capability needing a new port operation is out of scope — it becomes a
+  new work item blocking this one, since 0204 is done and frozen. All three fates
+  must be settled before pickup; see 0171's Open Questions.
+- Leave the `tracker` crate as the single owner of the `E_DISPATCH_*` exit-code
+  taxonomy. Delete `work-item-bridge-codes.sh` and
+  `cli/tracker/tests/fixtures/dispatch-codes.txt` — the fixture exists only to
+  pin the bash and Rust definitions to each other, so it has no purpose once one
+  is gone.
+- Update the doc comments and code comments in `tracker` that name deleted bash
+  artefacts: `RemoteIssue.body`'s projection reference, `errors.rs`'s module
+  doc, `show`'s `# Errors` note about the read bridge, and
+  `RemoteTimestamp::Reported`'s note about the bash-written baseline. The
+  contracts they state outlive the scripts; the references do not.
+
+## Acceptance Criteria
+
+- [ ] `ls skills/work/scripts/*.sh` matches nothing: all thirteen production
+      scripts and all five `test-work-item-*.sh` suites are deleted, and
+      `EXIT_CODES.md` is either rewritten for the Rust surface or re-sited with
+      the directory removed. Under the rewritten-in-place branch, a test asserts
+      each documented integer equals the value the CLI actually emits for that
+      condition.
+- [ ] Grepping the whole repository, excluding `meta/`, for each of the eighteen
+      deleted basenames and for `skills/work/scripts` returns no hits. The grep
+      command and its empty output are the recorded result — this is the
+      consumer sweep, and it covers `hooks/`, `templates/`, `docs-site/`,
+      `tasks/` and agent definitions, not only `skills/`.
+- [ ] `sync-work-items/SKILL.md`, `create-work-item/SKILL.md` and
+      `list-work-items/SKILL.md` each invoke `accelerator work …` for every flow
+      they previously shelled out to.
+- [ ] Given a work item with uncommitted local changes, when a pull would
+      overwrite it, then the sync flow still refuses. Verified in two parts:
+      statically, `sync-work-items/SKILL.md` invokes the named Rust surface at
+      the same precondition point the bash guard occupied; behaviourally, a named
+      automated test stages a fixture work item carrying an uncommitted edit
+      alongside a remote-modified counterpart whose pull would otherwise apply,
+      and asserts the file's bytes are unchanged and the refusal diagnostic
+      emitted. Not recorded evidence of a manual run.
+- [ ] `skills/work/scripts/test-fixtures/` no longer exists. Every fixture it
+      held sits under a `cli/**/tests/fixtures/` directory beside its consumer,
+      or is listed in 0171's `## Decisions` with the reason it has none.
+      Relocated count plus enumerated deletions equals the pre-change file count
+      that 0210's baseline artefact records as a committed number (so the
+      comparison survives the directory's removal without VCS archaeology), and grepping `cli/` for `skills/work/scripts`
+      returns no hits.
+- [ ] All eleven shellout tests are pure Rust — `sync_push_decide`,
+      `sync_classify`, `sync_decide`, `normalise_parity`, `sync_label_parity`,
+      `exit_codes_parity`, `cli_diff_parity`, `project_remote_parity`,
+      `sync_baseline_corpus`, `sync_baseline_shellout_parity` and
+      `diff_shellout_parity` — reading committed fixtures from their own crate's
+      test tree and invoking no bash script. Each covers at least the same
+      fixture cases as 0210's recorded **fixture-case list**, with expected values
+      byte-identical to the committed goldens. 0210 also records a pre-conversion
+      assertion count per test; that figure is context for the comparison, not the
+      bar, since a faithful pure-Rust rewrite may legitimately restructure
+      assertions.
+- [ ] Given a fixture-driven setup that creates one remote issue per relocated
+      corpus record on the credentialed scratch Jira project and Linear team
+      named in Dependencies, when `accelerator work
+      sync` runs against them through the real clients, then every item
+      classifies as `synced` and neither a push nor a pull is issued. The
+      exercised set includes at least one item with an absent description per
+      provider. (0210 carries the offline half of this guarantee.)
+- [ ] Each of the three port-less bridge capabilities — unkeyed discovery
+      `search`, the create `--dry-run` field-resolution preview, the update
+      `--dry-run` payload validation — has its decided fate implemented, with the
+      decision recorded in 0171's `## Decisions` naming the option taken.
+- [ ] The behaviour behind each is verified against whichever option was taken,
+      not merely recorded: `/sync-work-items` still lists remote issues with no
+      matching local work item, and `/sync-work-items --preview` still surfaces an
+      unresolvable Jira project key and a payload missing a required field before
+      any mutation is issued — each emitting its named diagnostic. Where a
+      decision was *drop*, it states the replacement outcome in observable terms
+      and that outcome is verified in place of the original behaviour. No branch
+      is discharged by prose alone.
+- [ ] No work `SKILL.md` declares `jq` or `curl` in `allowed-tools`, and the full
+      set of remaining declarers across `skills/` is enumerated and recorded in
+      0171's `## Decisions`. The whole-repository **equality** assertion belongs
+      to 0211, which lands last — the jira and linear skills still declare both at
+      this child's boundary.
+- [ ] `_EXPECTED_WORK_SUITES` and its `_require_suite_floor` call are removed
+      from `tasks/test/integration.py`, no task references a deleted suite, and
+      `work-item-bridge-codes.sh` is gone from `SHELL_LIBRARIES`.
+- [ ] The `E_DISPATCH_*` taxonomy has one implementation:
+      `work-item-bridge-codes.sh` and `cli/tracker/tests/fixtures/dispatch-codes.txt`
+      are gone, and no surviving script or Rust test sources the removed
+      definition.
+- [ ] The four named doc and code comments in `tracker` no longer reference
+      deleted bash artefacts, with the contracts they state preserved.
+- [ ] `mise run` exits 0 end-to-end at this child's merge boundary.
+
+## Dependencies
+
+- Blocked by 0210 alone: the clients and the transcribed oracles. Nothing in this
+  child needs 0211 — the work skills repoint at `accelerator work …`, not at
+  `accelerator jira` or `accelerator linear`.
+- **Blocks 0211.** Four of the five suites deleted here are the only consumers of
+  `skills/integrations/{jira,linear}/scripts/test-helpers/` and
+  `.../test-fixtures/` outside the integration suites themselves. Until they are
+  gone, 0211's wholesale cluster deletion would break them and the
+  `_EXPECTED_WORK_SUITES` floor. Verified by grep: the clusters invoke no
+  `work-item-*.sh`, so the coupling is one-directional and this is the safe
+  order.
+- **Prerequisite, not discharged by this change**: the credentialed tracker
+  target — a scratch Jira project, a Linear team and API tokens, plus repository
+  secrets if 0171's secrets Open Question resolves to CI. It gates the corpus
+  classification criterion below, exactly as it gates 0210's contract run. It has
+  no work item of its own; 0171 names the owner. This child performs the
+  irreversible deletions, so an unprovisioned target here strands the cutover
+  half-migrated.
+- **External systems**: Jira REST and Linear GraphQL. The corpus criterion runs
+  through the real clients, so reachability, per-tenant rate limits and Linear's
+  query-complexity cap bear on it; a red run is not automatically a defect in
+  this change.
+- Shares `skills/work/sync-work-items/SKILL.md` with 0213, which adds the
+  conflict loop while this child changes the invocations. Different parts of the
+  body; whichever lands second rebases onto the other.
+- **Blocks 0174**: it cannot remove the bashisms linter, the exec-bit guard or
+  the `SHELL_LIBRARIES` frozenset until this child's deletions land, and 0211's
+  after them. 0174 owns only the fourteen repo-root `scripts/*.sh` entries. The
+  0174 edge is held at child level — 0174's `blocked_by` names 0211 and 0212, and
+  0171 records that its own edge is discharged by these children — so a blocker
+  lookup from 0174 lands on the increments that do the work rather than on a
+  parent that performs none.
+- Consumes 0194's baseline corpus at `skills/work/scripts/test-fixtures/` and
+  `accelerator work sync`. Confirm both artefacts exist rather than trusting
+  0194's status field, which reads `ready` from this workspace: the corpus
+  directory is populated, and `accelerator work sync --help` runs. If either is
+  absent, add `blocked_by: [work-item:0194]` before planning — this child's
+  deletions are irreversible and its corpus criterion depends on both.
+- Parent: 0171.
+
+## Assumptions
+
+- ⚠️ **Unconfirmed, and it bounds this child's size**: the Rust surface already
+  covers everything the three previously-deferred scripts do (`sync-label` →
+  `cli/work/src/sync/label.rs`, `normalise` → `cli/work/src/normalise.rs`,
+  `file-dirty` → `working_copy_status.rs` over `dirty_paths.rs`), so blanket
+  deletion needs repointing rather than new behaviour. Confirm the dirty guard
+  is reachable from the CLI before planning — if a replacement is missing, this
+  child grows new behaviour.
+- The committed goldens are a sufficient oracle once their bash generators are
+  gone — no case in the corpus depends on regenerating it.
+
+## References
+
+- Parent: `meta/work/0171-jira-and-linear-integrations.md`
+- Blocked by: `meta/work/0210-provider-client-crates-over-the-tracker-port.md`,
+  `meta/work/0211-integration-binaries-and-bash-cluster-retirement.md`
+- Related: 0194, 0174

--- a/meta/work/0213-conversational-conflict-resolution-flow.md
+++ b/meta/work/0213-conversational-conflict-resolution-flow.md
@@ -1,0 +1,149 @@
+---
+type: work-item
+id: "0213"
+title: "Conversational Conflict Resolution Flow for Sync"
+date: "2026-08-17T11:17:18+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: ready
+kind: task
+priority: high
+parent: "work-item:0171"
+relates_to: ["work-item:0194", "work-item:0212"]
+tags: [skills, sync, work-items, conflicts]
+last_updated: "2026-08-17T11:17:18+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0213: Conversational Conflict Resolution Flow for Sync
+
+**Kind**: Task
+**Status**: Ready
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+Add the conversational half of 0194's two-invocation conflict flow to
+`skills/work/sync-work-items/SKILL.md`: invoke `accelerator work sync`, parse its
+machine-parseable conflict report, render each conflict with enough context for
+the user to judge, collect a choice per item, and re-invoke with matching
+`--resolve` orders.
+
+## Context
+
+`/sync-work-items` can detect a conflict today but cannot resolve one. 0194's
+binary is non-interactive by requirement, so it reports conflicts and exits; until
+something closes the report → prompt → resolve loop, a user who hits a conflict
+has no way through it. This is live, user-visible degradation.
+
+Fourth of four children of 0171 and the only one gated by none of its
+prerequisites — no credentialed tracker target, no client crate, none of the three
+Open Questions. It can therefore land first, ahead of 0210, which is why it
+carries a higher priority than its siblings.
+
+## Requirements
+
+- Invoke `accelerator work sync`, parse its machine-parseable conflict report,
+  render each conflict, collect a choice per item, and re-invoke with the
+  matching `--resolve <id>=<remote|local|skip>` orders — three permitted
+  resolutions (`remote`, `local`, `skip`), not two.
+- Read the report on exits `0`, `4` and `71` — the only codes it can accompany —
+  and branch on whether it carries `unresolved` lines rather than on the code
+  alone. `4` means items await a human; a `71` run may carry conflicts alongside
+  its failure; `0` is a clean run, so its report carries **no** `unresolved`
+  lines and the flow must report no conflicts and issue no `--resolve`
+  re-invocation. Parsing `0` defensively is what stops a clean run from prompting
+  against an empty list.
+- Render each conflict with at least these six fields: the work-item id, its
+  title, the differing field, the local value, the remote value, and the local and
+  remote timestamps as a pair. More is allowed; fewer is not.
+- Resolve **per work item, not per field**, because `--resolve` is keyed by id and
+  can carry only one choice per id. Where one item conflicts on several fields,
+  render every differing field for that item, then collect a single choice
+  covering all of them. Prompting per field would collect choices that cannot all
+  be expressed, silently dropping one — confirm against the report format whether
+  it can emit multiple differing fields for a single id, and if it can, add a
+  fixture exercising that case.
+- The binary is non-interactive by 0194's requirement, so the SKILL body must
+  never expect it to read stdin.
+- Deliver the walkthrough as a **committed harness** under
+  `skills/work/sync-work-items/test-fixtures/`, not as an undocumented manual
+  procedure: a script that puts the stub `accelerator` on `PATH`, drives the flow
+  against one fixture, captures the transcript, then replays the emitted argv
+  against the real binary with the stub removed. Whoever runs it produces the
+  evidence artefact by running one command, so the check is repeatable rather
+  than a one-off inspection.
+
+## Acceptance Criteria
+
+- [ ] Statically: `sync-work-items/SKILL.md` contains the
+      `--resolve <id>=<remote|local|skip>` invocation template, instructs reading
+      the report on exits `0`, `4` and `71`, and names all six render fields.
+      Asserted by an automated test in the existing skills test lane, not by
+      inspection — 0212 edits the same file, so this is the guard that survives.
+- [ ] Three committed fixture reports exist at
+      `skills/work/sync-work-items/test-fixtures/`: `conflicts-exit-4.txt` and
+      `conflicts-exit-71.txt`, each carrying two conflict records populated in all
+      six fields with distinct work-item ids, and `clean-exit-0.txt` carrying no
+      `unresolved` lines.
+- [ ] **Behaviour, against the stub.** The walkthrough is run once per fixture,
+      driven through a stub `accelerator` on `PATH` that emits the fixture and
+      exits with its code, so no credentialed target or live tracker is involved.
+      Its pass predicate is a checklist: both conflicts render with all six
+      fields; exactly one prompt is issued per conflict; and exactly one
+      `--resolve <id>=<choice>` order is emitted per collected choice, with ids
+      matching the fixture's. For `clean-exit-0.txt`, the predicate is that no
+      conflict is reported and no re-invocation is issued.
+- [ ] **Argv acceptance, against the real binary.** The argv the flow emitted in
+      each conflict-bearing run is replayed against the real `accelerator work
+      sync` with the stub **off** `PATH`, and its exit code is not the
+      usage-error code. A configuration or tracker failure is a pass — it proves
+      the parser accepted the flags — while a usage error means the invocation
+      template is malformed, which is the likeliest defect in a `SKILL.md`-only
+      change and the one the stub cannot catch. Name the usage-error code in the
+      test so the assertion is not merely "some non-zero exit".
+- [ ] Both halves' evidence — the per-fixture transcripts (rendered conflicts,
+      prompts issued, emitted argv) and the replay exit codes — is committed at
+      `skills/work/sync-work-items/test-fixtures/walkthrough-evidence/`, one file
+      per fixture, with 0171's `## Decisions` entry pointing at the directory.
+- [ ] `mise run` exits 0, including the new skills-lane assertion above.
+
+## Dependencies
+
+- Depends only on 0194, which already ships `accelerator work sync`, its
+  machine-parseable conflict report and the `--resolve` flag. 0194's record as
+  visible from this workspace reads `status: ready`, so confirm the artefacts
+  themselves rather than the status field: `accelerator work sync --help` lists
+  `--resolve`, and a conflicting pair produces a report carrying `unresolved`
+  lines. If either check fails, add `blocked_by: ["work-item:0194"]` to this child
+  before planning — its entire deliverable rests on that one upstream.
+- **Gated by none of 0171's other prerequisites**: it needs no credentialed
+  tracker target, no client crate, and none of the three Open Questions. It can
+  land before its siblings, and should — Context in 0171 records that
+  `/sync-work-items` can detect a conflict but cannot resolve one today.
+- Touches `sync-work-items/SKILL.md`, which 0212 also repoints. Whichever lands
+  second rebases onto the other; the edits are in different parts of the body
+  (0212 changes the invocations, this child adds the conflict loop).
+- Parent: 0171.
+
+## Assumptions
+
+- ⚠️ **Unconfirmed, and it bounds this child's size**: 0194's shipped conflict
+  report already carries all six render fields — work-item id, title, differing
+  field, local value, remote value, and both timestamps — on every exit code that
+  can carry a report. Confirm against the report format before planning. If a
+  field is absent (the title and either timestamp are the plausible candidates),
+  this stops being a `SKILL.md`-only change and grows into 0194's binary,
+  invalidating both its stated independence and its ability to land first.
+- The stub-on-`PATH` seam is sufficient to drive the walkthrough deterministically
+  without a live tracker, so the flow can be verified while 0210 is still
+  outstanding.
+
+## References
+
+- Parent: `meta/work/0171-jira-and-linear-integrations.md`
+- Related: 0194, 0212 (shares `sync-work-items/SKILL.md`)
+- Corrected against `cli/work-cli/src/cli.rs` for the `--resolve` token set and
+  the exit codes carrying a conflict report.


### PR DESCRIPTION

# Decompose the Jira and Linear integrations item into four children

## Summary

0171 (Jira and Linear Integrations) had grown to 28 requirements and 31 acceptance criteria covering two provider client crates, two dispatched binaries, three bash-retirement clusters, a fixture relocation, eleven test conversions and a conversational skill flow — epic-scale for a single story, and three review passes had failed to reduce its major-finding count. This PR turns it into an epic delivering through four children, each with its own status, requirements and acceptance criteria, and adds the five review artefacts that produced the decomposition.

The substantive outcome is not the reshuffling: it is that reviewing the children caught a user-visible regression the parent's own criteria would have shipped, and that verifying the ordering rationale against the repository inverted it.

## Changes

- **0171 becomes an epic** (`kind: epic`, nested under 0136 following the 0145-under-0192 precedent) delivering through 0210 (provider client crates over the `RemoteTracker` port), 0212 (work-item script cutover), 0211 (integration binaries and bash cluster retirement) and 0213 (conversational conflict resolution flow). 0210–0212 are `story`, 0213 is `task`.
- **Requirements and acceptance criteria move into the children, which are normative.** The parent keeps the narrative, the decomposition, the shared `## Decisions` register and the cross-child dependencies. It holds no duplicate copy, because it had one and it drifted within a single revision — losing a per-flow fixture-provenance obligation and the qualifier that a recorded assertion count is context rather than a bar. Both losses surfaced as review findings, which is the evidence for removing the duplication rather than annotating it.
- **The cutover order is 0210 → 0212 → 0211**, with 0213 independent. Two constraints force it: 0210 is the only window in which the bash oracles still exist, so it precedes every deletion; and the coupling between the two deletion sets runs in one direction only, so the work suites must go first.
- **Three port-less bridge capabilities are now owned by 0212** — the unkeyed discovery `search` mode of `work-item-fetch-remote.sh`, the create bridge's `--dry-run` field-resolution preview, and the update bridge's `--dry-run` payload validation. Each has no `RemoteTracker` operation and none survives the deletion by itself.
- **0174's `blocked_by` re-points at 0211 and 0212**, the increments that actually clear its suite floors and `SHELL_LIBRARIES` entries, so a blocker lookup lands on the work rather than on a parent that performs none.
- **Five review artefacts added** under `meta/reviews/work/`: 0171 across three passes and one per child across two, each through the clarity, completeness, dependency, scope and testability lenses. All five accepted with their remaining findings recorded rather than resolved.

## Context

Work item: [0171](../work/0171-jira-and-linear-integrations.md), under epic [0136](../work/0136-migrate-shell-scripts-to-rust-cli.md). Children: [0210](../work/0210-provider-client-crates-over-the-tracker-port.md), [0211](../work/0211-integration-binaries-and-bash-cluster-retirement.md), [0212](../work/0212-work-item-script-cutover.md), [0213](../work/0213-conversational-conflict-resolution-flow.md).

Two findings from the review passes are worth reading in full, because both were latent defects rather than presentation problems.

**The port-less capabilities had fallen through the decomposition.** 0171 spent a requirement, two acceptance criteria, one of three pickup-blocking open questions and three `## Decisions` entries on the fate of three bridge capabilities with no port operation. After the carve-out, no child mentioned any of them — `grep` for `dry-run`, `unkeyed` and `port-less` across all four returned nothing, while 0171 referenced them ten times — and 0212 deletes `work-item-fetch-remote.sh` and both remote bridges wholesale. All four children could have been accepted green while `/sync-work-items` silently lost the ability to list remote issues with no local work item, and `/sync-work-items --preview` lost live push validation against the tracker. Three lenses raised it independently. A full audit (28 requirements, 31 criteria) confirmed it was the only gap.

**The ordering rationale was false, and verifying it inverted the order.** The decomposition originally placed 0211 before 0212 on the belief that `linear-create-flow.sh:304` and `jira-resolve-fields.sh:140` were live callers of `work-item-sync-label.sh`. They are comments noting that those scripts perform the same normalisation; grepping the clusters for invocations of any `work-item-*.sh`, with comment lines excluded, returns nothing. The real coupling runs the other way and is larger: four of the five suites 0212 deletes — `test-work-item-create-remote.sh`, `-update-remote.sh`, `-fetch-remote.sh` and `-sync-apply.sh` — resolve paths into `skills/integrations/{jira,linear}/scripts/test-helpers/` for the Python mock servers and `.../test-fixtures/` for their scenario fixtures. In the original order, 0211's wholesale cluster deletion would have broken all four suites and the `_EXPECTED_WORK_SUITES` floor at its own merge boundary. The 0211 and 0212 reviews carry a `## Correction` section recording that they endorsed that ordering and why the credit they gave it was misplaced.

## Testing

This change is eleven markdown files under `meta/`. No code, no tests, no build inputs.

- [x] `accelerator corpus frontmatter validate` — structural and referential conformance across all eleven changed files: clean.
- [x] Whole-corpus `accelerator corpus frontmatter validate`: one violation, pre-existing and unrelated (`meta/plans/2026-08-11-0196-...md` carries `status: superseded`, not in the plan vocab). None of the touched ids appear.
- [x] The validator caught four dangling `relates_to` refs in the child reviews (`work-item-review:0171` resolves to no artifact; the correct form carries the review's full stem). Fixed and squashed into the commit that introduced them.
- [x] Every touched item parses through `accelerator work show`, with `kind`, `status`, `parent`, `blocked_by` and `blocks` reading back as intended, and frontmatter `**Status**` body labels agreeing with the frontmatter.
- [x] Dependency graph symmetry: 0210 blocks 0211 and 0212; 0212 is blocked by 0210 and blocks 0211 and 0174; 0211 is blocked by 0210 and 0212 and blocks 0174; 0213 free. 0174's `blocked_by` reciprocates from the other side.
- [x] Frontmatter quoting restored to the repository convention on all five work items after `accelerator work update` stripped it (see Notes).
- [ ] `mise run` end to end — not run. Nothing in this diff feeds the frontend, server, `cli/` or `scripts/` lanes, and `docs:check` builds `docs-site/`, which is untouched. CI covers it.

## Notes for Reviewers

The decomposition is the reviewable decision; the review artefacts are the evidence trail behind it and can be skimmed. If you read one thing, read 0171's `## Decomposition` section and the ordering note beneath it.

**Five things must close before 0210, 0211 or 0212 can be picked up**, and they are recorded as such rather than resolved: the three open questions on 0171 (where the credentialed tracker target's secrets live, the fate of the three port-less capabilities, and whether `EXIT_CODES.md` is rewritten in place or folded into the CLI docs) and the two size-bounding assumptions in 0211 and 0212 (that the eight enumerated flows per provider are the whole bash surface, and that the Rust surface already covers the three previously-deferred scripts). Two of the five change what is in scope, so estimates are not meaningful until they are answered. 0213 is gated by none of them and fixes live degradation, so it can and should land first.

**Three findings were accepted rather than fixed**, and are named in each review's `## Acceptance` section: 0210 carries no acceptance criterion for HTTP-status or GraphQL-level error classification or for auth (its four-table criterion covers `curl` transport codes, which the item stresses are not HTTP statuses); the non-port provider surface — `comment`, `transition`, provider `search`, `attach` and `init`, five of the eight flows, none with a port operation — is owned by neither 0210 nor 0211; and 0212 now bundles a mechanical deletion cutover with three capability re-sitings whose fates are still open. The first two are judged more cheaply closed by implementing 0210 than by further specification.

**A CLI defect surfaced and is worth fixing separately.** `accelerator work update` re-serialises frontmatter and strips the repository's quoting convention from `title`, `date`, `parent` and `last_updated`, and unquotes typed-linkage list members. It hit all five items when their status moved to `ready`; I restored the quoting by hand in the first commit, but the next `work update` on any of these items will strip it again. Commit `88d2b760b2` ("Restore frontmatter quoting on the 0185 and 0197 work items") suggests this has bitten before.

**On process, for what it is worth.** Across four review passes the severity ceiling fell — three criticals, then one, then none, then none — while the major count did not converge, and each fix round introduced two or three new majors of a single shape: a requirement updated without its criteria, or a criterion updated without its requirement. That pattern is why this stops at accepted-with-findings rather than at a clean pass.
