### PR TITLE
[0190] Classify acquire_lock mkdir failures and bound the reclaim arm

### DIFF
--- a/bin/accelerator
+++ b/bin/accelerator
@@ -15,7 +15,8 @@
 # cache directory may be read-only.
 #
 # Test seams (unset in production): ACCELERATOR_UNAME_S/_M override host
-# detection; ACCELERATOR_BOOTSTRAP_DOWNLOADER injects a `downloader <url> <dest>`.
+# detection; ACCELERATOR_BOOTSTRAP_DOWNLOADER injects a `downloader <url> <dest>`;
+# ACCELERATOR_LOCK_MAX_WAIT caps the lock-wait iteration ceiling (default 300).
 #
 # Local-build override (contributor-only): with ACCELERATOR_ALLOW_UNVERIFIED_LAUNCHER=1,
 # the untracked .accelerator-dev-launcher marker, and ACCELERATOR_LAUNCHER_BIN
@@ -323,6 +324,11 @@ release_lock() {
 }
 
 acquire_lock() {
+	max_wait="${ACCELERATOR_LOCK_MAX_WAIT:-300}"
+	case "${max_wait}" in
+	*[!0-9]*) max_wait=300 ;;
+	*) max_wait=$((10#${max_wait})) ;;
+	esac
 	waited=0
 	while true; do
 		if mkdir "${lock_dir}" 2>/dev/null; then
@@ -331,6 +337,10 @@ acquire_lock() {
 			trap release_lock EXIT INT TERM
 			return 0
 		fi
+		if [[ -L "${lock_dir}" ]] ||
+			[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]; then
+			fail "cannot create the launcher cache lock: ${lock_dir}"
+		fi
 		owner=$(cat "${lock_dir}/pid" 2>/dev/null)
 		if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
 			# A live owner is fetching, bounded by curl's --max-time; reset the
@@ -338,13 +348,12 @@ acquire_lock() {
 			# waiter. The budget elapses only while no live owner is seen — a
 			# dead owner is reclaimed immediately below.
 			waited=0
-		elif [[ -n "${owner}" ]]; then
-			rm -f "${lock_dir}/pid" 2>/dev/null
-			rmdir "${lock_dir}" 2>/dev/null
+		elif [[ -n "${owner}" ]] && rm -f "${lock_dir}/pid" 2>/dev/null &&
+			rmdir "${lock_dir}" 2>/dev/null; then
 			continue
 		else
 			waited=$((waited + 1))
-			if [[ "${waited}" -gt 300 ]]; then
+			if [[ "${waited}" -gt "${max_wait}" ]]; then
 				fail "timed out acquiring the launcher cache lock: ${lock_dir}"
 			fi
 		fi

--- a/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
+++ b/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
@@ -444,7 +444,7 @@ regardless of the guard — making such a test vacuous rather than a tripwire).
 
 #### Automated Verification:
 
-- [ ] All five new tests red against current `main` and pass after the fix
+- [x] All five new tests red against current `main` and pass after the fix
       (`uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "lock or leading_zero"`).
       Against current `main` neither the classifier nor the
       `ACCELERATOR_LOCK_MAX_WAIT` seam exists, so the injected `=3`/`=08`
@@ -456,25 +456,27 @@ regardless of the guard — making such a test vacuous rather than a tripwire).
       sub-second on the wrong lock-timeout message; the empty-pid test is green
       once the seam is present, guarding that the classifier left the `else` arm
       intact.)
-- [ ] Existing lock guards stay green (AC3):
+- [x] Existing lock guards stay green (AC3):
       `uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "stale_lock or slow_downloader or readonly_cache_fails_fast"`
-- [ ] The `macos-latest` integration leg exercises the new tests under bash 3.2
+- [x] The `macos-latest` integration leg exercises the new tests under bash 3.2
       automatically — the harness pins `/bin/bash` (`installation.py:43`, bash
       3.2 on macOS) and `test-integration` runs that leg — so the 3.2 floor is a
       CI gate, not only a manual replay.
-- [ ] Shell lint clean (AC5): `mise run scripts:check`
+- [x] Shell lint clean (AC5): `mise run scripts:check`
       (`scripts/lint-bashisms.sh`, shfmt, ShellCheck)
-- [ ] Read-only CI mirror passes: `mise run check`
-- [ ] Full local gate exits 0 end-to-end (AC6): `mise run`
+- [x] Read-only CI mirror passes: `mise run check`
+- [x] Full local gate exits 0 end-to-end (AC6): `mise run`
+      (one unrelated pre-existing flake in the parallel integrations shell suite;
+      passes clean on a standalone `mise run test:integration:integrations`).
 
 #### Manual Verification:
 
-- [ ] Optional `/bin/bash` spot-check on macOS as a supplementary backstop (the
+- [x] Optional `/bin/bash` spot-check on macOS as a supplementary backstop (the
       bashisms linter is documented KNOWN-INCOMPLETE); the automated bash-3.2
       gate is the `macos-latest` integration leg above. The fix uses only
       3.2-safe constructs — `[[ -d/-e/-L/-n ]]`, `{ …; }` grouping, `case`,
       `kill -0`, `$(( ))`, and `${VAR:-default}` — no bash-4 construct.
-- [ ] The dead-owner test terminates in well under a second on a green run
+- [x] The dead-owner test terminates in well under a second on a green run
       (not near the `timeout=15` ceiling), confirming the bound, not the
       tripwire, is what ends it.
 

--- a/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
+++ b/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
@@ -1,0 +1,533 @@
+---
+type: plan
+id: "2026-08-21-0190-classify-lock-mkdir-failures"
+title: "acquire_lock mkdir classification and bounded reclaim Implementation Plan"
+date: "2026-08-21T15:21:54+00:00"
+author: Toby Clemson
+producer: create-plan
+status: draft
+work_item_id: "work-item:0190"
+parent: "work-item:0190"
+derived_from: ["codebase-research:2026-08-21-0190-acquire-lock-mkdir-classification"]
+tags: [bug, shell, bootstrap, bash-3.2, locking]
+revision: "4390192c1d375fa7646436166b422a1268f6ea42"
+repository: "accelerator"
+last_updated: "2026-08-21T15:21:54+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# acquire_lock mkdir classification and bounded reclaim Implementation Plan
+
+## Overview
+
+Fix two defects in `acquire_lock` (`bin/accelerator:317-345`): a failed `mkdir`
+on an unusable lock path is misclassified as contention and reported as a lock
+timeout after the full ~30 s budget, and the dead-owner reclaim arm `continue`s
+past the loop's shared budget tail so a `rmdir` that keeps failing spins
+unbounded. Three coupled edits to one function — a classification branch, a
+bounded reclaim arm, and an env-injectable iteration ceiling that makes the
+bounded arm testable sub-second — plus five deterministic integration tests.
+
+## Current State Analysis
+
+The loop `mkdir`s the lock directory and, on any failure, unconditionally
+assumes contention: it reads `${lock_dir}/pid` and branches three ways on owner
+liveness.
+
+```bash
+acquire_lock() {
+	waited=0
+	while true; do
+		if mkdir "${lock_dir}" 2>/dev/null; then
+			printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null
+			lock_held=1
+			trap release_lock EXIT INT TERM
+			return 0
+		fi
+		owner=$(cat "${lock_dir}/pid" 2>/dev/null)
+		if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
+			# ... live owner: reset budget
+			waited=0
+		elif [[ -n "${owner}" ]]; then
+			rm -f "${lock_dir}/pid" 2>/dev/null
+			rmdir "${lock_dir}" 2>/dev/null
+			continue
+		else
+			waited=$((waited + 1))
+			if [[ "${waited}" -gt 300 ]]; then
+				fail "timed out acquiring the launcher cache lock: ${lock_dir}"
+			fi
+		fi
+		sleep 0.1
+	done
+}
+```
+
+The `sleep 0.1` at `:343` is **outside** the `if/elif/else` — a shared tail run
+by the live-owner and `else` arms but skipped by the reclaim arm's `continue`.
+That `continue`, bypassing the loop's single budget-and-sleep tail, is the
+unbounded-spin mechanism.
+
+- **Defect 1 — misclassification.** A failed `mkdir` whose directory is absent
+  (a non-directory occupies the path, or the parent is unwritable) yields
+  `owner=""`, routing to the `else` arm, which advances the budget toward a
+  lock-timeout `fail`. Wrong diagnostic, and only after 300 × `sleep 0.1`.
+- **Defect 2 — unbounded reclaim.** A dead owner on a lock directory that
+  cannot be removed (`rm -f`/`rmdir` both fail) fires `continue` with `waited`
+  untouched and no sleep. A busy spin with no timeout — the more severe defect.
+
+## Desired End State
+
+`acquire_lock` classifies the `mkdir` failure before assuming contention. The
+three failure-classification arms — fail-fast, dead-owner-unremovable, and
+empty-pid — terminate within a bounded budget. Two arms are *not* bounded by
+`max_wait`: the live-owner reset (which sleeps 0.1 s per iteration) is bounded by
+the owner completing, and the reclaim-*success* `continue` is a no-sleep
+fast-retry bounded only by an external process ceasing to recreate a removable
+dead-owner directory. See What We're NOT Doing. Verify by:
+
+- `bin/.accelerator-lock-<platform>` occupied by a **file or symlink** → fails
+  fast with `cannot create the launcher cache lock: <path>`, not a lock timeout.
+- A dead-owner lock directory whose pid cannot be removed → terminates with the
+  existing lock-timeout message within the budget, never spins.
+- An empty-pid lock directory → still advances the budget to the same timeout
+  (the genuine-race `else` arm is intact).
+- A competitor that releases its lock mid-wait → the waiter retries and acquires,
+  never fails fast (guarded by the concurrent-cold-cache test).
+- Existing reclaim and concurrent-cold-cache tests stay green.
+
+### Key Discoveries:
+
+- Both defects and the fix live in one function: `bin/accelerator:317-345`.
+- The `continue` at `:336` is the unbounded-spin mechanism — it skips the shared
+  `sleep 0.1`+budget tail at `:343` (`bin/accelerator:333-343`).
+- ⚠️ The 0186 gate `require_exec_capable_cache` (`bin/accelerator:386`) probes
+  **`cache_dir`**, not the lock **subdirectory**, so a `chmod`-unwritable cache
+  dir is caught before `acquire_lock`. AC1's fail-fast branch is therefore
+  reachable in a test only via a **non-directory (or symlink) at the lock path**
+  — no `chmod`, no root guard. The branch's *unwritable-parent* trigger stays
+  masked by this gate, so its coverage is coupled to gate retention: a future
+  change removing or refactoring the gate must add a direct test for that
+  trigger. AC2's precondition (`chmod` the lock dir `0o555`) is unaffected and
+  keeps the root guard.
+- `bin/accelerator` runs under `set -uo pipefail` — **no `-e`** (`:25`). The
+  ceiling is validated to an all-digit string and normalised to base 10
+  (`$((10#…))`) at read time, so `[[ "${waited}" -gt "${max_wait}" ]]` always
+  compares two decimal integers: a non-numeric `ACCELERATOR_LOCK_MAX_WAIT` falls
+  back to 300 and a leading-zero value (`08`, `09`) is read decimally, not as an
+  invalid-octal literal. This closes the arithmetic-injection surface (`-gt`
+  evaluates operands as arithmetic, which re-expands `a[$(cmd)]` subscript
+  syntax) and the silent loss-of-bound — whether from a bare non-integer or an
+  octal error — that would otherwise return non-zero every iteration under
+  no-`-e` so the timeout `fail` never fires. `"${VAR:-300}"` still covers the
+  `set -u` unset case.
+- `run_bootstrap` converts a subprocess `timeout=` into a hard `pytest.fail`
+  (`tests/integration/support/installation.py:333-334`), so an unbounded
+  regression reds the suite rather than hanging it.
+- Precedent for the fail-fast writability pre-check: `atomic-common.sh:104-109`.
+  Precedent for the env ceiling: `jira-common.sh:146-151` (gated on
+  `ACCELERATOR_TEST_MODE`; this file has no such gate, so we go always-on).
+
+## What We're NOT Doing
+
+- Not re-wording the existing lock-timeout message.
+- Not redesigning the mkdir+pid locking scheme.
+- Not removing the 0186 probe gate — retained as defence-in-depth with its own
+  guard `test_unverifiable_launcher_in_readonly_cache_fails_fast`.
+- Not making `sleep 0.1` injectable — only the iteration ceiling; a low ceiling
+  already yields sub-second tests.
+- Not gating the ceiling behind `ACCELERATOR_TEST_MODE`. The override stays
+  always-on to match this file's plain `"${VAR:-default}"` convention; the value
+  is instead validated and base-10 normalised, which is what actually closes the
+  injection and bound-loss risks. Recorded in Migration Notes.
+- Not making the reclaim single-winner. `rm -f pid; rmdir` is non-atomic, so two
+  waiters that read the same dead owner can both reclaim, and a reclaim can
+  destroy a live holder's freshly-created directory (a plain TOCTOU, distinct
+  from the reused-pid case below). This is safe **only** because the critical
+  section is idempotent — `fetch_and_verify` writes per-PID temp files and
+  commits via atomic rename of identical verified content, so a double-entry
+  cannot corrupt the cache. Revisit before the lock ever guards a non-idempotent
+  op; `atomic-common.sh` linearises this via an atomic `mv` of a nonce'd
+  sentinel. `release_lock` (`:310-315`) is the same non-owner-gated
+  `rm -f pid; rmdir`, so a future single-winner change must cover both call
+  sites.
+- Not adding a `sleep`/budget step to the reclaim-*success* `continue`. It is a
+  deliberate no-sleep fast-retry (to grab a just-freed lock quickly), so a
+  co-writer repeatedly recreating a *removable* dead-owner directory in the
+  `rmdir`→`mkdir` window can hot-spin it — a pre-existing, tight-race,
+  low-probability path unchanged by this fix, distinct from the sleeping
+  live-owner reset.
+- Not closing the shared-cache denial-of-service. On a shared
+  `ACCELERATOR_CACHE_DIR` a co-writer can repeatedly plant a dead-owner `0o555`
+  directory to bounce a victim to a bounded failure; the fix bounds the worst
+  case (no more unbounded spin) but does not eliminate denial on a predictably
+  named, shared lock path. A co-writer could also swap the lock path for a
+  symlink between the `-L` check and the reclaim `rm`, a narrow
+  delete-a-`pid`-file primitive against an attacker-chosen target. Both rest on
+  `ACCELERATOR_CACHE_DIR` pointing at a shared, world-writable directory; the
+  supported cache is the per-user `${plugin_root}/bin`, which is not
+  attacker-writable.
+- Not fixing the live-owner-resets-forever-on-reused-pid concern: a foreign
+  process at a reused pid keeps resetting the budget — a residual *unbounded
+  wait*, the same availability class 0190 otherwise closes. `jira-common.sh`
+  solves the analogue with a `holder.start` check; 0190 scopes it out.
+
+## Implementation Approach
+
+One phase. The three code changes edit the same 10-line region and share the
+ceiling test seam, so splitting them would leave either a dead env knob or a
+half-fix whose tests cannot run sub-second. The additional-instructions rule
+("phases independently mergeable") is satisfied trivially by a single
+self-contained, green phase; 0191 edits a different region of the file, so there
+is no merge coupling.
+
+TDD sequence within the phase: the bounded-arm test (Defect 2) is written first
+because it is red against the current code as a hang, then the ceiling seam and
+reclaim bound turn it green; the classification tests (Defect 1 — a file and a
+symlink at the lock path) follow the same red-green step; the empty-pid and
+leading-zero-ceiling tests land last as guards that the `else` arm survived and
+that the ceiling is read as base 10.
+
+---
+
+## Phase 1: Classify the mkdir failure and bound the reclaim arm
+
+### Overview
+
+Add a classification branch, fold the reclaim into a compound condition so any
+`rm`/`rmdir` failure falls to the budget-advancing `else`, and replace the
+literal `300` with a validated `"${ACCELERATOR_LOCK_MAX_WAIT:-300}"` ceiling.
+
+### Changes Required:
+
+#### 1. `acquire_lock` — classification, bounded reclaim, injectable ceiling
+
+**File**: `bin/accelerator`
+**Changes**: Rewrite the loop body. A classification branch sits between the
+`mkdir`-success block and the pid read: it fails fast only on a **permanent**
+condition — a symlink at the lock path, or a non-directory occupying it — while a
+merely-*absent* directory (a competitor that released its lock between this
+waiter's failed `mkdir` and the check) falls through to the retry loop, so a
+released competitor is retried rather than misclassified. The `-L` guard also
+stops the reclaim `rm`/`rmdir` following an attacker-planted symlink. The reclaim
+arm becomes a compound `elif` whose `continue` fires only when both `rm -f` and
+`rmdir` succeed; any failure falls through to the `else` — whose contract is thus
+wider than empty-pid alone, also absorbing a dead owner whose lock could not be
+removed. `max_wait` is read once at the top, validated to an all-digit string,
+and normalised to base 10 with `$((10#…))`, so a non-numeric
+`ACCELERATOR_LOCK_MAX_WAIT` falls back to 300 and a leading-zero value (e.g.
+`08`) is read decimally — the value can never reach the `[[ -gt ]]` arithmetic
+operand as an unchecked string or as an octal literal.
+
+```bash
+acquire_lock() {
+	max_wait="${ACCELERATOR_LOCK_MAX_WAIT:-300}"
+	case "${max_wait}" in
+		*[!0-9]*) max_wait=300 ;;
+		*) max_wait=$((10#${max_wait})) ;;
+	esac
+	waited=0
+	while true; do
+		if mkdir "${lock_dir}" 2>/dev/null; then
+			printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null
+			lock_held=1
+			trap release_lock EXIT INT TERM
+			return 0
+		fi
+		if [[ -L "${lock_dir}" ]] ||
+			[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]; then
+			fail "cannot create the launcher cache lock: ${lock_dir}"
+		fi
+		owner=$(cat "${lock_dir}/pid" 2>/dev/null)
+		if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
+			# A live owner is fetching, bounded by curl's --max-time; reset the
+			# abort budget so a slow-but-progressing cold fetch never fails a
+			# waiter.
+			waited=0
+		elif [[ -n "${owner}" ]] && rm -f "${lock_dir}/pid" 2>/dev/null &&
+			rmdir "${lock_dir}" 2>/dev/null; then
+			continue
+		else
+			waited=$((waited + 1))
+			if [[ "${waited}" -gt "${max_wait}" ]]; then
+				fail "timed out acquiring the launcher cache lock: ${lock_dir}"
+			fi
+		fi
+		sleep 0.1
+	done
+}
+```
+
+Post-fix arm order: `mkdir` ok → hold; `mkdir` fails + symlink or non-directory
+at the path → fail fast; `mkdir` fails + path absent (a competitor just
+released) → fall through and retry; live owner → reset budget; dead owner +
+`rm`+`rmdir` ok → reclaim and retry; dead owner + `rm`/`rmdir` fails, or
+empty/unreadable pid → advance budget then shared `sleep`.
+
+#### 2. Document the new env seam
+
+**File**: `bin/accelerator`
+**Changes**: Extend the header "Test seams" note (`:17-18`) so the knob is
+discoverable alongside the existing seams.
+
+```diff
+ # Test seams (unset in production): ACCELERATOR_UNAME_S/_M override host
+-# detection; ACCELERATOR_BOOTSTRAP_DOWNLOADER injects a `downloader <url> <dest>`.
++# detection; ACCELERATOR_BOOTSTRAP_DOWNLOADER injects a `downloader <url> <dest>`;
++# ACCELERATOR_LOCK_MAX_WAIT caps the lock-wait iteration ceiling (default 300).
+```
+
+#### 3. Integration tests
+
+**File**: `tests/integration/entrypoint/test_accelerator_entrypoint.py`
+**Changes**: Add five tests near `test_stale_lock_is_reclaimed` (`:311-323`),
+reusing its default-cache lock path (`bin/.accelerator-lock-<platform>`),
+`_require_unprivileged`, and `_restricted`.
+
+```python
+def test_uncreatable_lock_dir_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    # A file at the lock path: mkdir fails and the path is a non-directory.
+    (root / f"bin/.accelerator-lock-{host_platform}").write_text("")
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "cannot create the launcher cache lock" in output, output
+    assert "timed out" not in output, output
+
+
+def test_unremovable_dead_owner_lock_terminates_within_budget(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text("999999\n")  # dead PID, unreadable-to-rm below
+    with _restricted(lock, 0o555):  # rm of pid fails; the pid persists
+        result = _run_bootstrap(
+            root,
+            server,
+            downloader,
+            extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+            timeout=15,
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+
+
+def test_empty_pid_lock_advances_budget(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text("")  # competitor made the dir, no pid written yet
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+    assert "cannot create the launcher cache lock" not in output, output
+
+
+def test_symlink_lock_path_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    target = root / "foreign-lock-target"
+    target.mkdir()
+    (target / "pid").write_text("999999\n")  # a dead owner: reclaim would rm this
+    (root / f"bin/.accelerator-lock-{host_platform}").symlink_to(target)
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "cannot create the launcher cache lock" in output, output
+    assert "timed out" not in output, output
+    assert (target / "pid").read_text() == "999999\n", "reclaim followed symlink"
+
+
+def test_leading_zero_ceiling_is_decimal_not_octal(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text("")  # empty pid → else arm, bounded by the ceiling
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        # 08: invalid octal; base-10 makes it a ceiling of 8, not an error
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "08"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+```
+
+Why each is deterministic and sub-second, and what each pins:
+
+| Test | Precondition | Discriminates | Root guard |
+| --- | --- | --- | --- |
+| `test_uncreatable_lock_dir_fails_fast` | file at lock path | fail-fast vs timeout (AC1) | none |
+| `test_symlink_lock_path_fails_fast` | symlink at lock path | `-L` guard, no-follow | none |
+| `test_unremovable_dead_owner_lock_terminates_within_budget` | dead pid, dir `0o555` | bounded vs unbounded (AC2) | `_require_unprivileged` |
+| `test_empty_pid_lock_advances_budget` | empty pid file | `else` arm intact (AC4) | none |
+| `test_leading_zero_ceiling_is_decimal_not_octal` | empty pid, ceiling `08` | base-10 not octal | none |
+
+The dead-owner test is the tripwire: against the current `continue`, `rm -f`
+fails on the `0o555` directory so the pid persists, the dead-owner arm fires
+every iteration and busy-spins, and the `timeout=15` (well above the injected
+`3 × 0.1 s` budget, far below the default ~30 s) trips `pytest.fail`. After the
+fix the failed `rm` drops the compound `elif`, control reaches the `else`, and
+the loop exits in ~0.4 s with the timeout message. The 15 s value matches the
+`test_unverifiable_launcher_in_readonly_cache_fails_fast` precedent, leaving
+headroom for a correctly-bounded run under parallel CI load rather than a tight
+`timeout=5` a loaded runner could trip on a passing fix. The other four tests
+also pass `timeout=15` as a hang net, so a regression of the ceiling comparison
+itself reds cleanly instead of hanging the suite. Root would remove the pid and
+void the dead-owner case, so it hard-fails rather than skips.
+
+The symlink test pins the `-L` guard — a regression to a bare
+`[[ -e && ! -d ]]` would let a symlink-to-directory through, and reclaim would
+then follow the link and delete the dead-owner pid planted inside the target; the
+test asserts that pid survives, so it reds on such a regression. The leading-zero
+test pins the base-10 normalisation, since `08` reaches `[[ -gt ]]` as an octal
+error and hangs without it. Neither plants a `chmod`, so neither needs a root
+guard. Two branches cannot be pinned by a fast behavioural test and are covered
+by inspection plus ShellCheck instead: the absent-path fall-through (the next
+`mkdir` would win the race, so it is only incidentally exercised by the
+concurrent-cold-cache test), and the non-numeric ceiling fallback (any rejected
+value falls back to the 300-iteration ~30 s default and a fail-fast setup never
+reaches the `[[ -gt ]]` operand, so a rejected injection payload never executes
+regardless of the guard — making such a test vacuous rather than a tripwire).
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] All five new tests red against current `main` and pass after the fix
+      (`uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "lock or leading_zero"`).
+      Against current `main` neither the classifier nor the
+      `ACCELERATOR_LOCK_MAX_WAIT` seam exists, so the injected `=3`/`=08`
+      ceilings are inert: every new test either burns the literal 300×0.1 s≈30 s
+      budget or busy-spins, exceeds its `timeout=15` net, and reds as a
+      hang→`pytest.fail`. After the fix each terminates in well under a second
+      with its asserted message. (In the TDD-ordered intermediate — seam landed,
+      classifier not yet — the fail-fast and symlink tests instead red
+      sub-second on the wrong lock-timeout message; the empty-pid test is green
+      once the seam is present, guarding that the classifier left the `else` arm
+      intact.)
+- [ ] Existing lock guards stay green (AC3):
+      `uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "stale_lock or slow_downloader or readonly_cache_fails_fast"`
+- [ ] The `macos-latest` integration leg exercises the new tests under bash 3.2
+      automatically — the harness pins `/bin/bash` (`installation.py:43`, bash
+      3.2 on macOS) and `test-integration` runs that leg — so the 3.2 floor is a
+      CI gate, not only a manual replay.
+- [ ] Shell lint clean (AC5): `mise run scripts:check`
+      (`scripts/lint-bashisms.sh`, shfmt, ShellCheck)
+- [ ] Read-only CI mirror passes: `mise run check`
+- [ ] Full local gate exits 0 end-to-end (AC6): `mise run`
+
+#### Manual Verification:
+
+- [ ] Optional `/bin/bash` spot-check on macOS as a supplementary backstop (the
+      bashisms linter is documented KNOWN-INCOMPLETE); the automated bash-3.2
+      gate is the `macos-latest` integration leg above. The fix uses only
+      3.2-safe constructs — `[[ -d/-e/-L/-n ]]`, `{ …; }` grouping, `case`,
+      `kill -0`, `$(( ))`, and `${VAR:-default}` — no bash-4 construct.
+- [ ] The dead-owner test terminates in well under a second on a green run
+      (not near the `timeout=15` ceiling), confirming the bound, not the
+      tripwire, is what ends it.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+Shell has no unit harness here; behaviour is exercised end-to-end through the
+bootstrap subprocess. The five integration tests above are the unit-equivalent,
+each isolating one arm of the post-fix `if/elif/else`.
+
+### Integration Tests:
+
+The five new tests plus the three retained guards
+(`test_stale_lock_is_reclaimed`,
+`test_concurrent_cold_cache_slow_downloader_all_succeed`,
+`test_unverifiable_launcher_in_readonly_cache_fails_fast`) cover every arm:
+fail-fast (file and symlink), base-10 ceiling, live-owner reset, dead-owner
+reclaim, dead-owner bounded, empty-pid race, and the 0186 gate.
+
+### Manual Testing Steps:
+
+1. On macOS, run the five new tests under the system bash 3.2 to confirm no
+   4.x construct slipped in.
+2. Temporarily revert the reclaim bound (restore the bare `continue`) and
+   confirm the dead-owner test flips to a `pytest.fail` hang — proving the test
+   is a genuine tripwire, not a tautology.
+
+## Performance Considerations
+
+⏱️ None on the warm or cold happy path: `max_wait` is read once per
+`acquire_lock` call, and the new `[[ ! -d ]]` test runs only after a `mkdir`
+failure. The fix removes an unbounded busy spin, so worst-case behaviour
+strictly improves.
+
+## Migration Notes
+
+None. `ACCELERATOR_LOCK_MAX_WAIT` is unset in production, so the default `300`
+ceiling and existing timing are unchanged; when set, it is validated to an
+all-digit value, normalised to base 10 (so a leading-zero value is read
+decimally, never as octal), and otherwise falls back to `300`, with the override
+active in all environments (not gated behind `ACCELERATOR_TEST_MODE`). No on-disk
+lock format change — the `owner.<nonce>` / pid contract is untouched.
+
+## References
+
+- Work item: `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`
+- Research: `meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md`
+- Defect site: `bin/accelerator:317-345`
+- 0186 gate and guard: `bin/accelerator:380-396`,
+  `tests/integration/entrypoint/test_accelerator_entrypoint.py:1290-1318`
+- Harness hang→fail: `tests/integration/support/installation.py:333-334`
+- Precedents: `scripts/atomic-common.sh:104-109`,
+  `skills/integrations/jira/scripts/jira-common.sh:146-151`

--- a/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
+++ b/meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md
@@ -5,7 +5,7 @@ title: "acquire_lock mkdir classification and bounded reclaim Implementation Pla
 date: "2026-08-21T15:21:54+00:00"
 author: Toby Clemson
 producer: create-plan
-status: draft
+status: done
 work_item_id: "work-item:0190"
 parent: "work-item:0190"
 derived_from: ["codebase-research:2026-08-21-0190-acquire-lock-mkdir-classification"]

--- a/meta/prs/74-description.md
+++ b/meta/prs/74-description.md
@@ -1,0 +1,54 @@
+---
+type: pr-description
+id: "74"
+title: "Classify acquire_lock mkdir failures and bound the reclaim arm"
+date: "2026-08-22T19:25:05+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "work-item:0190"
+parent: "work-item:0190"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/74"
+pr_number: 74
+tags: [bug, shell, bootstrap, bash-3.2, locking]
+revision: "70175a80a981c370bfa1d89d5ba87802e23474f7"
+repository: "accelerator"
+last_updated: "2026-08-22T19:25:05+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0190] Classify acquire_lock mkdir failures and bound the reclaim arm
+
+## Summary
+
+Fixes two defects in `acquire_lock` (`bin/accelerator`): a failed `mkdir` on an unusable lock path was misclassified as contention and reported as a ~30 s lock timeout, and the dead-owner reclaim arm could spin unbounded when the lock directory could not be removed. The production change is 19 lines in one function, guarded by five deterministic integration tests; the remaining files are the 0190 lifecycle artefacts (work item, research, reviews, plan, validation).
+
+## Changes
+
+- **Classify the mkdir failure before assuming contention.** A symlink or non-directory occupying the lock path now fails fast with `cannot create the launcher cache lock: <path>` instead of burning the wait budget and reporting a lock timeout. A merely-absent directory (a competitor that just released) falls through and retries, so a released competitor is never misclassified. The `-L` guard also stops the reclaim `rm`/`rmdir` from following an attacker-planted symlink.
+- **Bound the dead-owner reclaim arm.** The reclaim `continue` now fires only when both `rm -f` and `rmdir` succeed; any failure falls through to the budget-advancing `else`, so an unremovable foreign lock terminates within the ceiling rather than busy-spinning with no timeout — the more severe of the two defects.
+- **Make the iteration ceiling env-injectable and injection-safe.** `max_wait` is read once from `ACCELERATOR_LOCK_MAX_WAIT` (default 300), validated to an all-digit string, and normalised to base 10 via `$((10#…))`. A non-numeric value falls back to 300 and a leading-zero value (`08`) is read decimally, not as an invalid octal literal — closing the arithmetic-injection surface and the silent loss-of-bound under `set -uo pipefail` (no `-e`). The knob also lets the bounded arm test sub-second.
+- **Five integration tests** in `test_accelerator_entrypoint.py`, one per post-fix arm: fail-fast on a file and on a symlink at the lock path, bounded termination on an unremovable dead owner, the empty-pid `else` arm, and the base-10 ceiling.
+
+## Context
+
+- Work item: `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`
+- Research: `meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md`
+- Plan: `meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md`
+- Validation: `meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md`
+
+## Testing
+
+- [x] New lock tests pass: `uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "lock or leading_zero"` (6 passed).
+- [x] Retained lock guards stay green: `-k "stale_lock or slow_downloader or readonly_cache_fails_fast"` (3 passed).
+- [x] Shell lint clean: `mise run scripts:check` (bashisms, exec-bits, shfmt, ShellCheck).
+- [x] Read-only CI mirror passes: `mise run check` (exit 0).
+- [ ] Full default gate `mise run` not re-run locally this session — the outstanding delta is the docs CI lane, untouched by this change; CI covers it.
+- [x] bash 3.2 floor: the `macos-latest` integration leg exercises the tests under system bash 3.2; the fix uses only 3.2-safe constructs.
+
+## Notes for Reviewers
+
+- The reclaim remains intentionally non-single-winner and the reclaim-*success* `continue` stays a no-sleep fast-retry — both scoped out in the plan's "What We're NOT Doing", safe because the guarded critical section is idempotent. Residual availability classes (reused-pid live-owner reset, shared-cache DoS) are documented there and unchanged.
+- ⚠️ The AC1 fail-fast branch is reachable in tests only via a non-directory/symlink at the lock path, because the 0186 gate `require_exec_capable_cache` probes `cache_dir` (not the lock subdirectory). If that gate is ever removed, add a direct test for the unwritable-parent trigger.
+- Follow-up 0191 edits a different region of the same file, so there is no merge coupling.

--- a/meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md
+++ b/meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md
@@ -1,0 +1,228 @@
+---
+type: codebase-research
+id: "2026-08-21-0190-acquire-lock-mkdir-classification"
+title: "Research: acquire_lock mkdir misclassification and unbounded reclaim (0190)"
+date: "2026-08-21T14:47:24+00:00"
+author: Toby Clemson
+producer: research-codebase
+status: complete
+work_item_id: "0190"
+parent: "work-item:0190"
+topic: "acquire_lock cannot classify an unusable lock directory and can spin unbounded on reclaim"
+tags: [research, codebase, shell, bootstrap, bash-3.2, locking, acquire_lock]
+revision: "8c5eebef10dd63b532d9113e13b37b572456147e"
+repository: "accelerator"
+last_updated: "2026-08-21T14:47:24+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# Research: acquire_lock mkdir misclassification and unbounded reclaim (0190)
+
+**Date**: 2026-08-21T14:47:24+00:00
+**Author**: Toby Clemson
+**Git Commit**: 8c5eebef10dd63b532d9113e13b37b572456147e
+**Branch**: working copy `8c5eebef` (no 0190 bookmark yet; nearest named bookmark on ancestry is `0213-refine-conflict-flow`, parent commit `c25fbd1b` "Add the 0190 review and tighten its lock-failure criteria")
+**Repository**: accelerator
+
+## Research Question
+
+How does `acquire_lock` in `bin/accelerator` currently classify a failed `mkdir`, where exactly are the two defects in work item 0190 (misclassification of an unusable lock directory, and an unbounded dead-owner reclaim arm), and what does the fix need — the live control flow, the test harness that must exercise it, the bash-3.2 and env-knob conventions to mirror, and the historical thread through 0186/0164?
+
+## Summary
+
+Both defects live in one 29-line loop, `acquire_lock` at `bin/accelerator:317-345`. The loop `mkdir`s a lock directory and, on any failure, unconditionally assumes contention — it reads a pid file and branches three ways on process liveness. It has no notion of an `mkdir` that can never succeed (unwritable parent, foreign lock directory), and its dead-owner reclaim arm `continue`s without advancing the budget, so a `rmdir` that keeps failing spins forever.
+
+**The work item's two-part fix is well-founded and the code confirms it.** Add a classification branch — after a failed `mkdir`, `[[ -d "${lock_dir}" ]]` distinguishes `EEXIST` (a real competitor) from an absent directory (unwritable parent → fail fast); and bound the reclaim arm by gating its `continue` on `rmdir` succeeding, so a failed `rmdir` advances the shared budget instead of looping free. A third change — an env-injectable iteration ceiling — makes the bounded arm testable sub-second.
+
+One correction to the work item's framing surfaced. The `sleep 0.1` it attributes to the `else` arm is actually a **shared loop tail** at `bin/accelerator:343`, run by the live-owner and empty-pid arms but skipped by the reclaim arm's `continue`. That `continue` skipping the shared sleep-and-budget tail is precisely the unbounded-spin mechanism, which makes the fix cleaner than the work item states: on `rmdir` failure, drop the `continue` and let control fall to the shared tail after incrementing the budget.
+
+The repo already contains the exact structural precedent the fix needs — `atomic-common.sh:104-109` is a fail-fast parent-writability pre-check guarding the identical "burn the whole timeout on an `mkdir` that can never recover" bug class, with a comment saying so. The env-injectable-ceiling template is the Jira lock at `jira-common.sh:146-151`. The test harness converts a hang into a red test via `pytest.fail`, and the permission-rule helpers (`_require_unprivileged`, `_restricted`) already exist.
+
+## Detailed Findings
+
+### The defect: `acquire_lock` control flow (`bin/accelerator:317-345`)
+
+The loop, verbatim:
+
+```bash
+acquire_lock() {
+	waited=0
+	while true; do
+		if mkdir "${lock_dir}" 2>/dev/null; then
+			printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null
+			lock_held=1
+			trap release_lock EXIT INT TERM
+			return 0
+		fi
+		owner=$(cat "${lock_dir}/pid" 2>/dev/null)
+		if [[ -n "${owner}" ]] && kill -0 "${owner}" 2>/dev/null; then
+			waited=0
+		elif [[ -n "${owner}" ]]; then
+			rm -f "${lock_dir}/pid" 2>/dev/null
+			rmdir "${lock_dir}" 2>/dev/null
+			continue
+		else
+			waited=$((waited + 1))
+			if [[ "${waited}" -gt 300 ]]; then
+				fail "timed out acquiring the launcher cache lock: ${lock_dir}"
+			fi
+		fi
+		sleep 0.1
+	done
+}
+```
+
+The `mkdir` is line 320. On success it writes `$$` to the pid file, sets `lock_held=1`, installs the cleanup trap, and returns. On failure it reads the owning pid (line 326) and takes one of three arms:
+
+| Arm | Lines | Condition | Action | Budget effect |
+| --- | --- | --- | --- | --- |
+| Live owner | 327-332 | pid present and `kill -0` succeeds | `waited=0` (reset), then shared `sleep` | Resets — never advances |
+| Dead-owner reclaim | 333-336 | pid present, `kill -0` fails | `rm -f` pid, `rmdir` dir, `continue` | None — skips sleep and budget |
+| `else` (empty/absent/unreadable pid) | 337-342 | `owner` empty | `waited++`, `fail` if `> 300`, then shared `sleep` | Advances — the only bounded arm |
+
+The `sleep 0.1` at line 343 is **outside** the `if/elif/else` — a shared tail run by the live-owner and `else` arms, but not the reclaim arm, which `continue`s past it.
+
+**Defect 1 — misclassification (the bounded-but-wrong arm).** A failed `mkdir` on an *unwritable parent* leaves no directory, so `cat` yields `""`, so control takes the `else` arm and advances the budget toward a lock-timeout `fail`. The diagnostic is wrong (it reports contention on a directory that can never be created), and it arrives only after the full 300 × `sleep 0.1` ≈ 30 s budget.
+
+**Defect 2 — unbounded reclaim (the more severe arm).** When the pid file names a dead process on a lock directory that *cannot be removed* (foreign owner, or a writable cache dir whose lock subdir is not writable), `rm -f` and `rmdir` both fail silently, `continue` fires, and the loop re-enters with `waited` untouched and no sleep. It spins **unbounded, with no timeout at all** — a hang, not a slow wrong answer.
+
+**Correction to the work item's `300` framing.** `waited` advances only in the `else` arm (line 338); the live-owner arm resets it and the reclaim arm never touches it. So `300` bounds *consecutive empty-pid observations*, not total iterations — the wait for a lock directory that exists but whose pid file never appears or reads. The `300` at line 339 and the `0.1` at line 343 are bare literals; nothing in the loop is env-injectable.
+
+**The pid file** is `${lock_dir}/pid` (`lock_dir="${cache_dir}/.accelerator-lock-${platform}"`, line 307). Written after a successful `mkdir` (line 321), so a competitor can momentarily see the directory with no pid file yet — the genuine-race window the `else` arm exists to cover. Read via `owner=$(cat ... 2>/dev/null)` (line 326), which collapses absent, empty, and unreadable pid files into the same empty string, all routed to the `else` arm.
+
+**`fail`** (`bin/accelerator:48-51`) prints `accelerator: <msg>` to stderr and `exit "${abort_status}"` (1 normally, 0 under `--fail-safe`). **`release_lock`** (lines 310-315) `rm -f`s the pid and `rmdir`s the directory; the trap installed at line 323 fires it on EXIT/INT/TERM. The **only caller** is line 387.
+
+### The 0186 probe gate does not cover either 0190 case fully
+
+The gate above the single `acquire_lock` call site is `require_exec_capable_cache` at `bin/accelerator:386`, inside the cold `else` branch (lines 380-396). Its comment (lines 381-385) names the exact hazard:
+
+```bash
+# Staging was skipped (the staged shim already matched) but verification
+# failed. Without this, an unwritable cache dir reaches acquire_lock, whose
+# mkdir can never succeed and whose loop treats a missing pid file as an
+# imminent competitor — burning its whole timeout budget and reporting a
+# lock timeout instead of the real cause.
+require_exec_capable_cache
+acquire_lock
+```
+
+`require_exec_capable_cache` (lines 258-267) calls `probe_exec_capable` (lines 180-191), which writes/chmods/execs/removes a probe file **in `cache_dir`** and maps the result to `fail_no_cache_dir`.
+
+- ✅ **Unwritable `cache_dir` — prevented.** The probe fails, `acquire_lock` is never reached. This is what the gate is for.
+- ⚠️ **Foreign / pre-existing `lock_dir` — not prevented.** The probe writes a *file* into `cache_dir`, which succeeds even when the `.accelerator-lock-*` *subdirectory* already exists and is foreign. Control reaches `acquire_lock`, `mkdir` fails on `EEXIST`, and the loop engages. This is the only realistic residual reason `mkdir` still fails after the gate — precisely the case the gate cannot catch, and the entry point for Defect 2's unbounded spin.
+
+The work item retains this gate as defence-in-depth; it does not remove it. The gate's regression guard is `test_unverifiable_launcher_in_readonly_cache_fails_fast`.
+
+### The fix shape, reconciled against the live structure
+
+Three changes, all bash-3.2-safe (`[[ -d ]]`, `[[ -n ]]`, `kill -0`, `$(( ))` are all permitted — confirmed against the linter below, and all four idioms already appear in this file):
+
+1. **Classification branch (new fail-fast).** After the failed `mkdir`, before reading the pid file, test `[[ -d "${lock_dir}" ]]`. Absent directory → the parent is unwritable and `mkdir` can never succeed → `fail` immediately naming the lock path and a permission-or-I/O cause. Directory present → `EEXIST` → fall through to the existing wait logic. `mkdir` exposes no shell-portable errno, so directory-presence is the only portable `EEXIST` discriminator.
+
+2. **Bound the reclaim arm.** Gate the `continue` on `rmdir` succeeding. On `rmdir` failure, advance the budget (`waited=$((waited + 1))` + ceiling check) and fall to the shared `sleep 0.1` tail rather than `continue`-ing. Because the `continue` is exactly what skips the shared budget-and-sleep tail, the minimal fix is: on `rmdir` failure, do not `continue`. The arm then shares the `else` arm's cap and terminates with the existing lock-timeout `fail` — which is why the work item specifies "terminates within budget" for this arm, not a new fail-fast path.
+
+3. **Env-injectable ceiling.** Replace the literal `300` with `"${ACCELERATOR_...:-300}"` so a test can inject a low value and exercise the bounded arm sub-second. Default stays 300.
+
+❓ **Open design point for the plan.** Change 2 needs the `rmdir`-failure path to increment `waited` *and* run the ceiling check, then reach the shared sleep. The current `if/elif/else` puts the increment+check only in the `else` body. The implementer must either restructure so the reclaim arm's failure path reaches that logic, or duplicate the two lines into the elif. This is the one place the fix is not a pure insertion; worth pinning in the plan to keep the `else` arm (the genuine-race window) intact.
+
+### Post-fix arm order (from the work item, mapped to line regions)
+
+`mkdir` succeeds → hold (320-324); `mkdir` fails + directory absent → **fail fast (new)**; directory + live owner → reset budget (327-332); directory + dead owner + `rmdir` ok → reclaim and retry (333-336); directory + dead owner + `rmdir` fails → **advance budget (new)**; directory + empty/unreadable pid (`else`) → advance budget (337-342).
+
+### Test harness: how the new tests attach (`tests/integration/entrypoint/test_accelerator_entrypoint.py` + `tests/integration/support/installation.py`)
+
+The subprocess funnel is `run_bootstrap` (`installation.py:275-334`), imported and aliased `_run_bootstrap` (test file lines 41, 53). Its `timeout=` (default `None`) threads into `subprocess.run(..., timeout=timeout)` (line 330); on expiry it does **not** raise to the caller but converts the hang into a hard failure (lines 333-334):
+
+```python
+except subprocess.TimeoutExpired:
+    pytest.fail(f"the bootstrap did not terminate: {entry}")
+```
+
+So an unbounded regression reds the suite rather than hanging it — the tripwire AC2 relies on. Output is `capture_output=True, text=True`; every test concatenates `result.stdout + result.stderr` itself and asserts on `.returncode` plus a substring. Env is injected via the `extra_env` dict, merged over a fresh (non-`os.environ`) base at `installation.py:313-314` — the same mechanism a new low-ceiling env var would use: `extra_env={"<CEILING_VAR>": "…"}`.
+
+The three tests the work item names:
+
+- **`test_stale_lock_is_reclaimed`** (test lines 311-323) — manufactures a pre-existing `bin/.accelerator-lock-<platform>` with `pid` = `999999\n` (a dead PID), asserts exit 0. Guards the reclaim arm still reclaims. The default cache dir is `bin/` (no `ACCELERATOR_CACHE_DIR`), so the lock path matches `bin/accelerator:307`.
+- **`test_concurrent_cold_cache_slow_downloader_all_succeed`** (test lines 682-700) — 6 concurrent cold-cache bootstraps with `DL_SLEEP=1`; the winner holds the lock a full second while five wait. Asserts all 6 exit 0 and exactly 2 download-log lines (bin + `.minisig`), proving the live-owner arm keeps resetting waiters' budgets rather than a waiter aborting and re-fetching.
+- **`test_unverifiable_launcher_in_readonly_cache_fails_fast`** (test lines 1290-1318) — the 0186 gate guard: warm the cache, poison the launcher (`b"poisoned"`), `_restricted(cache, 0o555)`, `timeout=15`, assert non-zero exit and `"no writable, exec-capable cache directory"`.
+
+**Permission-rule helpers to reuse** (0186's discipline, which the 0190 criteria now adopt):
+
+- `_require_unprivileged()` (test lines 58-68) — a bare `assert os.getuid() != 0`, hard-fail-not-skip under root. Called at the top of every chmod-dependent test (lines 273, 297, 1085, 1178, 1251, 1272, 1300, 1325).
+- `_restricted(path, mode)` (test lines 1115-1137) — chmods, then probes with `os.access(..., W_OK/X_OK)` and asserts the cleared bits are genuinely unavailable (catching advisory-permission filesystems), restoring `0o755` in `finally`.
+
+There is **no** custom pytest marker or skip for these — the convention is the hard `assert`. Faking a live owner is done with a real concurrent process, never a hand-written pid; a dead owner is the literal `999999`.
+
+### Conventions to mirror
+
+**bash 3.2 floor.** `scripts/lint-bashisms.sh` is an awk denylist (lines 42-62) banning associative arrays (`-A`), namerefs (`-n`), escaped braces in expansion defaults, `mapfile`/`readarray`, case-modification (`${var^^}`/`${var,,}`), `&>>`, `|&`, and negative subscripts. `bin/accelerator` is extensionless so the `*.sh` glob misses it — it is appended explicitly at line 33, so it *is* scanned. None of the fix's constructs are banned. The linter is documented KNOWN-INCOMPLETE; the manual bash-3.2 replay is the behavioural backstop.
+
+**Env-injectable ceiling.** The template is the Jira lock (`jira-common.sh:146-151`):
+
+```bash
+local timeout_secs=60
+local sleep_secs=0.1
+if [[ "${ACCELERATOR_TEST_MODE:-}" == "1" ]]; then
+  timeout_secs="${JIRA_LOCK_TIMEOUT_SECS:-$timeout_secs}"
+  sleep_secs="${JIRA_LOCK_SLEEP_SECS:-$sleep_secs}"
+fi
+```
+
+`bin/accelerator` uses `ACCELERATOR_`-prefixed env overrides exclusively (`ACCELERATOR_CACHE_DIR`, `ACCELERATOR_UNAME_M/S`, `ACCELERATOR_RELEASE_BASE_URL`), always `"${VAR:-default}"`. The existing in-file iteration ceiling `max_hops=16` (line 45) is a hard literal for comparison. Mirror the prefix for a new ceiling (e.g. `ACCELERATOR_LOCK_MAX_WAIT`); the work item does not require gating behind `ACCELERATOR_TEST_MODE`, so a plain always-overridable `local` default is the simpler match unless production immutability is wanted.
+
+**Fail-fast message.** Use the in-file `fail` (idiom A), not the library `log_die` — `bin/accelerator` sources nothing (root-of-trust entry point). Match the sibling lock-timeout message shape at line 340, `"<cause>: ${lock_dir}"`, and the writability wording of `fail_no_cache_dir` (lines 208-211). Idiomatic form: `fail "cannot acquire the launcher cache lock (parent not writable): ${lock_dir}"`.
+
+### The structural precedent already in the repo
+
+`atomic-common.sh:104-109` is the fail-fast parent-writability pre-check `acquire_lock` lacks, guarding the identical bug class, with a comment (lines 100-103) that reads as a description of Defect 1: *"Without this check the spin-loop would burn the full timeout on an error mkdir can never recover from (e.g., chmod 555 on the parent)."* Its staleness classification (lines 181-215) gates reclaim on `kill -0` and linearises the reclaim via an atomic `mv` of a sentinel before `rm -rf`, avoiding the race a bare `rm -rf` on a live holder would cause. The Jira lock (`jira-common.sh:186-212`) additionally records `holder.start` (process start time) to detect PID reuse — relevant to the live-owner arm, which today resets the budget forever if a foreign process happens to sit at the reused pid, though 0190 scopes that out.
+
+## Code References
+
+- `bin/accelerator:317-345` — `acquire_lock`; both defects live here.
+- `bin/accelerator:320` — the `mkdir` whose failure is misclassified.
+- `bin/accelerator:333-336` — the dead-owner reclaim arm; `continue` skips budget + sleep (Defect 2).
+- `bin/accelerator:337-342` — the `else` arm; the only budget-advancing arm; literal `300` at 339.
+- `bin/accelerator:343` — the shared `sleep 0.1` tail (skipped only by the reclaim arm).
+- `bin/accelerator:48-51` — `fail`; the fail-fast idiom to mirror.
+- `bin/accelerator:310-315`, `:323` — `release_lock` and the EXIT/INT/TERM trap.
+- `bin/accelerator:380-396` — the cold `else` branch; the sole `acquire_lock` call site (387) behind the 0186 gate (386).
+- `bin/accelerator:180-191`, `:258-267` — `probe_exec_capable` / `require_exec_capable_cache`; probes `cache_dir`, not `lock_dir`.
+- `tests/integration/support/installation.py:275-334` — `run_bootstrap`; `timeout=` → `pytest.fail` on hang (333-334); `extra_env` merge (313-314).
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:311-323` — `test_stale_lock_is_reclaimed`.
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:682-700` — `test_concurrent_cold_cache_slow_downloader_all_succeed`.
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:1290-1318` — `test_unverifiable_launcher_in_readonly_cache_fails_fast`.
+- `tests/integration/entrypoint/test_accelerator_entrypoint.py:58-68`, `:1115-1137` — `_require_unprivileged`, `_restricted`.
+- `scripts/atomic-common.sh:104-109`, `:181-215` — the fail-fast writability pre-check and PID-liveness reclaim precedent.
+- `skills/integrations/jira/scripts/jira-common.sh:146-151`, `:186-212` — env-injectable lock-ceiling template and PID-reuse-aware classifier.
+- `scripts/lint-bashisms.sh:33`, `:48-55` — `bin/accelerator` explicitly scanned; the bash-4 denylist.
+
+## Architecture Insights
+
+- **One choke point, three inline classifications.** `acquire_lock` inlines live/dead/absent-owner handling rather than delegating to helpers like `atomic-common.sh`. The fix keeps that shape; it adds one branch and removes one `continue`, not a redesign.
+- **`continue` as the bug.** Defect 2 is not a missing bound so much as a `continue` that bypasses the loop's single shared budget-and-sleep tail. Framing the fix as "don't `continue` when `rmdir` fails" is both minimal and self-documenting.
+- **The gate probes the wrong granularity.** The 0186 gate probes `cache_dir` writability but the lock is a *subdirectory*; a foreign lock subdir passes the probe. Any durable fix has to live inside `acquire_lock`, not in a pre-check on the parent — which is why 0190 exists despite 0186.
+- **Collapsed pid-read states.** Absent, empty, and unreadable pid files are indistinguishable after `cat ... 2>/dev/null`. The `else` arm deliberately covers all three as "advance the budget", which is correct for the genuine-race window and must survive the fix (the work item's preserved-`else`-arm criterion).
+- **Root-of-trust means no shared library.** `bin/accelerator` sources nothing, so the fix reuses no `log-common`/`atomic-common` helper — it inlines `fail`. The precedents inform the shape but cannot be called.
+
+## Historical Context
+
+- `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` — removed the warm-path exec probe (warm median 125.35 → 29.92 ms, 0186 Validation Results). Added the cold-branch gate that masks the *reachable-today* instance of Defect 1 and recorded Defect 2 as an explicit follow-up it did not fix. Its Acceptance Criteria preamble (0186:135-146) is the permission-test rule the 0190 criteria now inherit: assert `id -u ≠ 0`, hard-fail under root, record a privilege check for any excluded lane. The `TIMEOUT after 31 iters, 3s` figure is 0190's own reduced-ceiling restatement, not a string in 0186; 0186 supplies the "~30 s spin" framing and PR #41 records the 27 ms fail-fast.
+- `meta/prs/41-description.md:84` — "a tampered cached launcher in an unwritable cache dir fails in 27 ms with the cache-dir diagnostic, not after the ~30 s lock budget."
+- `meta/work/0164-launcher-and-git-style-dispatch.md` (+ its 2026-07-03 plan/research) — introduced the `bin/accelerator` bootstrap and the mkdir lock.
+- `meta/work/0136-migrate-shell-scripts-to-rust-cli.md` — the parent epic.
+- `meta/work/0189-once-per-dispatch-cache-root-probe-guarantee.md` and `0205-close-the-warm-dispatch-measurement-method.md` — adjacent warm-path follow-ups; 0189's research is the nearest existing analysis of the bootstrap cache-root probe path (no dedicated `acquire_lock` research existed before this document).
+- `meta/work/0191-batch-the-two-shim-hashes-into-one-invocation.md` — edits a different region of `bin/accelerator` (the shim-staging block); no merge coupling with 0190, now cross-referenced in the work item.
+- No locking-specific ADR exists; the launcher/dispatch ADRs are 0046, 0053, 0054, 0059, 0060.
+
+## Related Research
+
+- `meta/reviews/work/0190-acquire-lock-cannot-classify-mkdir-failures-review-1.md` — two-pass work-item review. Pass 1 REVISE raised three testability majors (AC1 diagnostic not pinned to a substring; AC1/AC2 omitting 0186's root-guard; AC2's ~30 s budget guard slow and flake-prone with the fast seam left optional). Pass 2 COMMENT records all resolved — the env-injectable ceiling became a mandatory Requirement, AC1 pins a verbatim cause substring, the criteria adopt the root-guard, and AC2 asserts the terminating outcome (non-zero + lock-timeout message), not just termination. The item is marked ready for implementation.
+- `meta/research/codebase/2026-08-02-0186-remove-exec-probe-from-bootstrap-warm-path.md`, `meta/research/codebase/2026-08-11-0189-once-per-dispatch-cache-root-probe-guarantee.md` — adjacent bootstrap research.
+
+## Open Questions
+
+- ❓ **Reclaim-arm restructure (implementation).** Where does the `rmdir`-failure path land so it increments `waited`, runs the ceiling check, and reaches the shared `sleep` while leaving the `else` (genuine-race) arm intact? A pure insertion won't do it given the `if/elif/else` + shared-tail shape; the plan should pin the exact restructure.
+- ❓ **Ceiling env var: gated or always-on?** The Jira template gates the override behind `ACCELERATOR_TEST_MODE=1` for production immutability; the work item only requires injectability. Decide whether a plain always-overridable `"${ACCELERATOR_LOCK_MAX_WAIT:-300}"` is acceptable or the fix should gate it. (Naming also unresolved — no existing lock env var in this file to match.)
+- ❓ **Live-owner-resets-forever (scoped out, worth recording).** A foreign process at a reused pid keeps the live-owner arm resetting the budget indefinitely. `jira-common.sh` solves the analogue with a `holder.start` process-start-time check. 0190 scopes this out; confirm it stays a separate concern rather than creeping in.
+- ❓ **AC2 harness `timeout=` value.** It must sit above the injected low ceiling's wall time but far below the default ~30 s, so a correctly-bounded loop exits cleanly while an unbounded regression trips `pytest.fail`. The exact injected ceiling and `timeout=` pair is a plan detail, not yet chosen.

--- a/meta/reviews/plans/2026-08-21-0190-classify-lock-mkdir-failures-review-1.md
+++ b/meta/reviews/plans/2026-08-21-0190-classify-lock-mkdir-failures-review-1.md
@@ -1,0 +1,303 @@
+---
+type: plan-review
+id: "2026-08-21-0190-classify-lock-mkdir-failures-review-1"
+title: "Plan Review: acquire_lock mkdir classification and bounded reclaim"
+date: "2026-08-21T15:44:37+00:00"
+author: Toby Clemson
+producer: review-plan
+status: complete
+parent: "plan:2026-08-21-0190-classify-lock-mkdir-failures"
+target: "plan:2026-08-21-0190-classify-lock-mkdir-failures"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [correctness, test-coverage, code-quality, portability, safety, security]
+review_number: 1
+review_pass: 3
+tags: [bug, shell, bootstrap, bash-3.2, locking]
+last_updated: "2026-08-21T19:51:37+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Plan Review: acquire_lock mkdir classification and bounded reclaim
+
+**Verdict:** REVISE
+
+The plan is a proportionate, well-researched fix that all six lenses agree improves on the status quo — it removes the unbounded busy-spin, fails fast on an uncreatable lock path, and carries a genuine tripwire test for the more severe defect. But the two core code edits each introduce a new defect the change is responsible for: the `[[ ! -d ]]` classifier misreads a competitor releasing its lock as a fatal error (a concurrency regression against the plan's own concurrent-cold-cache criterion), and the new `ACCELERATOR_LOCK_MAX_WAIT` reaches `[[ -gt ]]` arithmetic unvalidated, opening a bash arithmetic-injection surface in a root-of-trust bootstrap. Four major findings gate the plan to REVISE; both high-confidence majors are narrow, localised edits away from resolution.
+
+### Cross-Cutting Themes
+
+- **The `[[ ! -d "${lock_dir}" ]]` classifier is under-specified** (flagged by: correctness, security, portability, test-coverage, code-quality) — the single edit at the heart of the fix draws five findings. It misclassifies a *released competitor* as unrecoverable (correctness, major), *follows symlinks* so an attacker-planted link drives the reclaim `rm`/`rmdir` through the target (security, minor), has no direct test for its unwritable-parent trigger (test-coverage, minor), collapses distinct causes into one message (portability, suggestion), and widens the `else` arm's contract (code-quality, minor). The `[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]` predicate — proposed **independently by correctness and portability** — resolves the race and the cause-collapse at once; adding a `-L` symlink check closes the security vector.
+- **`ACCELERATOR_LOCK_MAX_WAIT` flows in unvalidated** (flagged by: security, correctness, safety, code-quality) — the new env seam reaches arithmetic evaluation with no guard. A value like `a[$(cmd)]` executes `cmd` (security, major); a non-integer makes `[[ -gt ]]` a syntax error that, under `set -u` without `-e`, silently *removes the loop's bound* and re-introduces Defect 2 (correctness, minor); an accidental production value shrinks the budget (safety, suggestion); and the name reads as seconds not iterations (code-quality, minor). One validate-at-read-time change (`case`/regex to non-negative integer, else fall back to 300) closes the security and correctness halves together.
+- **Three prose claims overstate completeness** (flagged by: correctness, safety, test-coverage) — "every arm terminates within a bounded budget" is false for the live-owner reset and the reclaim-*success* `continue` (both budget-free); "new tests fail against the current code" is false for the empty-pid guard (green pre-fix) and imprecise for the fail-fast test (reds only after ~30 s pre-fix). Precision fixes, not code changes.
+
+### Tradeoff Analysis
+
+- **Minimal fix vs. closing the residuals now**: The plan's minimalism is a genuine virtue and the two high-confidence majors (M1, M2) are *not* gold-plating — they are a regression and an injection surface this change introduces, so they should be fixed in scope, not deferred. The reclaim mutual-exclusion residual (M3) is the real defer-vs-fix call: the plan deliberately scopes out the locking-scheme redesign, and safety agrees deferral is acceptable **provided** the plan records both the non-atomic-reclaim gap and the idempotency assumption (per-PID temps + atomic rename) that currently makes it safe. Recommendation: fix M1/M2 now, record M3 as a known residual with its safety precondition stated.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Correctness**: TOCTOU — classifier misreads a released competitor as a fatal "cannot create" error
+  **Location**: Phase 1 §1 — the `[[ ! -d "${lock_dir}" ]]` branch
+  The directory's absence has three causes, not two: the third is a competitor that legitimately held the lock and removed its directory via `release_lock` in the window between this waiter's `mkdir` returning EEXIST and the `-d` stat. The waiter then spuriously aborts instead of retrying; the original code fell through to the genuine-race `else` arm and acquired on the next iteration. Directly threatens `test_concurrent_cold_cache_slow_downloader_all_succeed`. Fix: `[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]`.
+
+- 🟡 **Security + Correctness**: Unvalidated `ACCELERATOR_LOCK_MAX_WAIT` reaches arithmetic evaluation — injection surface and bound-removal
+  **Location**: Phase 1 §1 — `max_wait="${…:-300}"` and `[[ "${waited}" -gt "${max_wait}" ]]`; reinforced by the "always-on, ungated" decision in What We're NOT Doing
+  `-gt` evaluates operands as arithmetic, and bash arithmetic re-expands array-subscript syntax, so `a[$(command)]` executes `command` — present on the bash 3.2 floor too. This is the first externally-influenced value to reach an arithmetic context in this root-of-trust entry point. Separately (correctness), a non-integer value makes `[[ … ]]` return non-zero every iteration under `set -uo pipefail` (no `-e`), so the timeout `fail` never fires and the reclaim arm loses its bound — re-introducing Defect 2. Fix: validate as a non-negative integer at read time, else fall back to 300; or gate behind `ACCELERATOR_TEST_MODE`.
+
+- 🟡 **Safety**: Reclaim's non-atomic `rm -f pid; rmdir` is not single-winner; mutual-exclusion residual unrecorded
+  **Location**: What We're NOT Doing / Phase 1 §1 — the dead-owner reclaim arm
+  Two waiters reading the same dead owner can each reclaim, and a reclaim can destroy a *live* holder's freshly-created directory (a plain TOCTOU, distinct from the scoped-out reused-pid framing), letting two sessions enter the critical section at once. Tolerable here **only** because the protected op is idempotent (per-PID temps + atomic rename of identical verified content) — but that assumption is unstated. The sibling `atomic-common.sh` linearises this with an atomic `mv` of a nonce'd sentinel; this scheme lacks that step. Deferral is acceptable if recorded with the idempotency precondition.
+
+- 🟡 **Test Coverage**: `timeout=5` is tighter than the 15 s precedent and risks a false `pytest.fail` under load
+  **Location**: Phase 1 §3 — `test_unremovable_dead_owner_lock_terminates_within_budget`
+  The correct-path loop exits in ~0.4 s, but the whole bootstrap subprocess must finish inside 5 s, and the closest analogue (`test_unverifiable_launcher_in_readonly_cache_fails_fast`) uses `timeout=15` for the same shape. Given documented flakiness of these shell suites under parallel CI load, a loaded runner could exceed 5 s on a *correctly bounded* run and red the fix intermittently. Raise toward 15 s, keeping it well below the default ~30 s.
+
+#### Minor
+
+- 🔵 **Security**: `[[ -d ]]` follows symlinks — a symlink at the lock path bypasses fail-fast and drives reclaim through the target
+  **Location**: Phase 1 §1 — the classification branch
+  A symlink at `${cache_dir}/.accelerator-lock-<platform>` reads as a genuine competitor; `rm -f "${lock_dir}/pid"` then deletes a `pid`-named file in the attacker-chosen target while `rmdir` fails ENOTDIR. A narrow file-deletion-plus-DoS primitive, realistic only on a shared/multi-user-writable `ACCELERATOR_CACHE_DIR`. Reject a symlink (`[[ -L … ]]`) in the same branch, or record the residual.
+
+- 🔵 **Correctness + Safety**: "Every arm terminates within a bounded budget" overstates completeness
+  **Location**: Desired End State
+  The live-owner reset (`waited=0`, scoped out) and the reclaim-*success* `continue` (unchanged) advance no budget; the latter can loop while an external process recreates the dead-owner directory. Neither is a pure busy-spin (both need external progress), but the blanket claim is inaccurate. Restate to name the exceptions.
+
+- 🔵 **Code Quality**: Compound `elif` folds the side-effecting reclaim into a boolean and silently widens the `else` arm
+  **Location**: Phase 1 §1 — `elif [[ -n "${owner}" ]] && rm -f … && rmdir …; then continue`
+  Two of the three conjuncts are mutations whose exit codes double as the predicate, so a partial reclaim (pid gone, dir remains) re-enters via an `else` that now silently means three things. Defensible as the deliberate DRY choice, but at minimum state that the `else` contract has broadened beyond "empty/unreadable pid".
+
+- 🔵 **Code Quality**: `max_wait` / `ACCELERATOR_LOCK_MAX_WAIT` name implies seconds but denotes an iteration count
+  **Location**: Phase 1 §1 & §2
+  The value is consecutive no-progress iterations (~300 × 0.1 s ≈ 30 s) — a distinction the research had to correct once already. Prefer a unit-bearing name, or keep the header note's "iteration ceiling" wording as the one place the unit is clear.
+
+- 🔵 **Test Coverage**: "New tests fail against the current code" overstates the pre-fix outcome
+  **Location**: Success Criteria — the `-k "lock"` checkbox
+  `test_empty_pid_lock_advances_budget` already passes pre-fix (a characterisation guard), and `test_uncreatable_lock_dir_fails_fast` only reds after ~30 s pre-fix (current code ignores the env knob). State the expected pre-fix outcome per test so the TDD red step is not misread as a broken test.
+
+- 🔵 **Test Coverage**: The classifier's unwritable-parent trigger has no direct regression test
+  **Location**: Key Discoveries / What We're NOT Doing
+  Only the non-directory trigger is exercised (test 1); the unwritable-parent trigger is masked by the 0186 gate and guarded only indirectly. If that gate is ever refactored, the branch silently loses coverage. Note the coupling so a future gate change carries a test obligation.
+
+- 🔵 **Portability**: The bash-3.2 floor is already enforced by the macOS CI integration leg, not just a manual replay
+  **Location**: Success Criteria — Manual Verification
+  The harness pins `/bin/bash` (bash 3.2 on `macos-latest`) and the `test-integration` job runs that leg, so the three tests already exercise the fix under 3.2 in CI. Framing it as manual-only risks under-valuing the leg that actually enforces the floor. Demote the replay to a spot-check and name the macOS leg as the automated gate.
+
+#### Suggestions
+
+- 🔵 **Test Coverage**: Tests 1 and 3 have no harness `timeout=` net against a ceiling-check regression
+  **Location**: Phase 1 §3
+  Both rely solely on the injected ceiling to terminate; a mutation of the `-gt` comparison itself would hang the suite from these two rather than red cleanly (only test 2 carries the tripwire). Add a modest `timeout=` to tests 1 and 3 as cheap hang insurance.
+
+- 🔵 **Safety**: Always-on `ACCELERATOR_LOCK_MAX_WAIT` is a small production footgun vs the gated precedent
+  **Location**: What We're NOT Doing / Migration Notes
+  The `jira-common.sh` precedent gates its override behind `ACCELERATOR_TEST_MODE`; an accidental value here silently shrinks the lock budget. Either gate to match, or record in Migration Notes why always-overridable is acceptable for this file. (Related to the M2 validation fix.)
+
+- 🔵 **Code Quality**: The retained live-owner comment's tail narrates control flow
+  **Location**: Phase 1 §1 — the `# A live owner is fetching…` comment
+  Pre-existing (already at `bin/accelerator:328-331`), not introduced by this plan. Its first half is a legitimate *why*; its tail ("a dead owner is reclaimed immediately below") narrates flow and carries a positional reference that can go stale. Since the plan already rewrites this region, optionally trim to the rationale sentence.
+
+- 🔵 **Portability**: The cause-neutral fail-fast diagnostic collapses distinct cross-platform causes
+  **Location**: Phase 1 §1
+  A file at the path, an unwritable parent, a read-only mount, and ENOSPC all surface identically. Reasonable given `mkdir` has no portable errno, but a cheap `[[ -e ]]` follow-up could append a cause class without relying on errno. (Converges with the M1 predicate change.)
+
+- 🔵 **Security**: The residual shared-cache DoS is bounded, not eliminated
+  **Location**: Desired End State / What We're NOT Doing
+  A co-writer of a shared cache can still repeatedly plant a dead-owner `0o555` directory to bounce the victim to a bounded failure. Inherent to a predictably-named shared lock path; state explicitly that this is knowingly bounded rather than closed, so it reads as a decision, not an oversight.
+
+### Strengths
+
+- ✅ Proportionate and minimal: three coupled edits to one ~30-line function, preserving the inline classification structure rather than redesigning the lock scheme — complexity matches the requirement (code-quality, safety).
+- ✅ The compound `elif`'s leading `[[ -n "${owner}" ]]` plus its ordering after the live-owner `if` correctly guarantees `rm`/`rmdir` only ever touch a *confirmed-dead* owner, and the empty-pid genuine-race `else` arm is preserved exactly by short-circuit (correctness).
+- ✅ The Defect 2 fix is correct and minimal — dropping the unconditional `continue` routes any `rm`/`rmdir` failure to the budget-advancing tail, eliminating the unbounded busy-spin; the fail-fast/timeout exits leave no partial lock state (trap installed only after a successful `mkdir`) (correctness, safety).
+- ✅ Complete arm-by-arm test mapping with a genuine red-green tripwire: the harness converts a hang into `pytest.fail`, and the plan adds a manual step (revert the bound, confirm it flips to a hang) to prove the test is not a tautology (test-coverage).
+- ✅ Cross-platform-aware: every construct is bash-3.2-safe, `[[ -d ]]` is the deliberate portable choice given `mkdir` exposes no shell-portable errno, and the dead-owner test rests on portable POSIX unlink semantics with `_restricted`/`_require_unprivileged` hard-failing where the precondition would not bite (portability).
+- ✅ Retains the 0186 probe gate as defence-in-depth with its own regression guard, and leaves the minisign verification chain and on-disk lock contract untouched (security, safety).
+
+### Recommended Changes
+
+1. **Narrow the classifier to a genuinely-permanent condition** (addresses: correctness TOCTOU major; security symlink minor; portability cause-collapse suggestion; test-coverage untested-trigger minor). Change `[[ ! -d "${lock_dir}" ]]` to `[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]` so a merely-absent directory (released competitor) falls through to the retry loop, and add symlink rejection (`[[ -L … ]]`) so an attacker-planted link is not followed by the reclaim `rm`/`rmdir`. Update the concurrent-test success criterion to note it now guards this race.
+
+2. **Validate `ACCELERATOR_LOCK_MAX_WAIT` at read time** (addresses: security arithmetic-injection major; correctness bound-removal minor; safety production-footgun suggestion). Read via a `case`/regex guard to a non-negative integer, else fall back to 300, e.g. `case "${ACCELERATOR_LOCK_MAX_WAIT:-300}" in ''|*[!0-9]*) max_wait=300 ;; *) max_wait="${ACCELERATOR_LOCK_MAX_WAIT}" ;; esac`. Decide explicitly whether to also gate behind `ACCELERATOR_TEST_MODE`; either way state the decision in Migration Notes.
+
+3. **Record the reclaim mutual-exclusion residual and its safety precondition** (addresses: safety major; security shared-cache-DoS suggestion). In What We're NOT Doing, state both the non-atomic `rm+rmdir` gap (two waiters can co-reclaim; a reclaim can destroy a live holder's dir under a plain TOCTOU) and the idempotency assumption (per-PID temps + atomic rename) that makes it safe today, flagging that it must be revisited before the lock ever guards a non-idempotent op.
+
+4. **Raise the dead-owner test's harness `timeout` and add nets to tests 1 and 3** (addresses: test-coverage flake major; test-coverage no-net suggestion). Move `timeout=5` toward the 15 s precedent, and pass a modest `timeout=` to `test_uncreatable_lock_dir_fails_fast` and `test_empty_pid_lock_advances_budget` so a ceiling-check regression reds cleanly instead of hanging.
+
+5. **Correct the three overstated prose claims** (addresses: correctness/safety bounded-budget minor; test-coverage red-first minor; portability manual-gate minor). Qualify "every arm terminates within a bounded budget" to name the live-owner and reclaim-success exceptions; state the expected pre-fix outcome per new test; name the macOS integration leg as the automated bash-3.2 gate and demote the manual replay to a spot-check.
+
+6. **Optional clarity nits** (addresses: code-quality widened-else minor; code-quality naming minor; code-quality comment suggestion). Note the widened `else` contract, prefer a unit-bearing ceiling name, and trim the retained live-owner comment's flow-narrating tail if the region is being rewritten anyway.
+
+---
+
+## Per-Lens Results
+
+### Correctness
+
+**Summary**: The three-part fix is logically sound in its core intent — the compound `elif` guarantees `rm`/`rmdir` only touch a dead owner, the empty-pid genuine-race `else` arm is preserved exactly by short-circuit, and dropping the unconditional `continue` genuinely bounds Defect 2's spin. However, the new `[[ ! -d "${lock_dir}" ]]` predicate is too broad: it converts a transient contention race (a competitor releasing its directory between a waiter's failed `mkdir` and the `-d` check) into a spurious fatal error, a concurrency regression against behaviour the original code handled gracefully. A secondary gap is incomplete reasoning about malformed `ACCELERATOR_LOCK_MAX_WAIT` values in the `-gt` comparison.
+
+**Strengths**:
+- The compound `elif [[ -n "${owner}" ]] && rm -f … && rmdir …` preserves the invariant that a *live* owner's pid/directory is never removed (leading `[[ -n owner ]]` + ordering after the live-owner `if`).
+- The empty-owner `else` entry is preserved exactly — with `owner=""`, both the live-owner `if` and reclaim `elif` short-circuit before any mutation.
+- The Defect 2 fix is correct and minimal; the boundary `[[ "${waited}" -gt "${max_wait}" ]]` with `waited` starting at 0 and incremented before the check yields a correct bounded count.
+- `max_wait="${ACCELERATOR_LOCK_MAX_WAIT:-300}"` correctly covers unset and set-but-empty under `set -u`; the AC2 `0o555` precondition correctly makes `rm -f` fail while `cat pid` still succeeds.
+
+**Findings**:
+- **Major (high)** — Phase 1 §1, the `[[ ! -d ]]` branch. TOCTOU: the directory's absence has three causes, the third being a competitor that released its lock via `release_lock` (`bin/accelerator:310-315`) between this waiter's EEXIST and the `-d` stat; the waiter spuriously aborts with `cannot create the launcher cache lock` instead of retrying. The original code fell to the `else`/race arm and acquired next iteration. Impact: under concurrent cold-cache bootstraps (the 6-process, ~1 s-hold `test_concurrent_cold_cache_slow_downloader_all_succeed`), a waiter can intermittently fail-closed — a latent CI flake contradicting the plan's own criterion. Suggestion: `[[ -e "${lock_dir}" && ! -d "${lock_dir}" ]]`, letting a merely-absent directory retry; the unwritable-parent case stays covered by the 0186 gate.
+- **Minor (medium)** — Current State / Key Discoveries, `set -uo pipefail` with a malformed ceiling. The `:-300` default covers unset/empty, but a *set, non-integer* value makes the `-gt` operand an arithmetic syntax error; with no `-e`, the `if` evaluates false every iteration, the timeout `fail` never fires, and the reclaim arm loses its bound (re-introducing Defect 2); a value resolving to 0 fails after one iteration. The interaction is undefined and value-dependent, not "harmless". Suggestion: narrow the claim to valid integers, or validate at read time (`^[0-9]+$` → else 300).
+- **Minor (medium)** — Desired End State, "every arm terminates within a bounded budget". The post-fix loop retains two budget-free arms: the live-owner reset (scoped out) and the reclaim-*success* `continue`, which loops back to `mkdir` without advancing `waited`; if an external process recreates the dead-owner directory between `rmdir` and the next `mkdir`, it can loop without advancing the budget. Not a pure busy-spin (needs external progress) but not "bounded by budget" as stated. Suggestion: name the exceptions.
+
+### Test Coverage
+
+**Summary**: The test strategy is strong — a dedicated or retained test maps onto all six post-fix arms, the harness's timeout→`pytest.fail` conversion is a genuine red tripwire for the unbounded-spin defect, and assertions are discriminating (verbatim cause substring plus negatives). All referenced fixtures and helpers exist and are used correctly, and the root-guard reasoning is sound. The main gaps are calibration and precision: `timeout=5` is tighter than the 15 s precedent (a flake risk), the "new tests fail against current code" step overstates the empty-pid guard, and two of three tests lack a harness timeout net.
+
+**Strengths**:
+- Complete arm-by-arm coverage: fail-fast, live-owner reset, dead-owner reclaim success, dead-owner unremovable/bounded, and empty-pid `else` each have a dedicated or retained test.
+- Genuine red-green tripwire for the severe defect, plus an explicit manual step to prove the test is a tripwire not a tautology.
+- Discriminating, mutation-resistant assertions (verbatim substring + negative assertions on both tests 1 and 3).
+- Correct, verified root-guard reasoning: fail-fast needs none (mkdir over a planted file fails for root too); the dead-owner test carries `_require_unprivileged`; `_restricted` probes `os.access`.
+- Faithful reuse of existing harness idioms and retention of the three existing guards.
+
+**Findings**:
+- **Major (medium)** — Phase 1 §3, `test_unremovable_dead_owner_lock_terminates_within_budget`. `timeout=5` vs the `timeout=15` of the closest analogue; the whole subprocess must finish in 5 s. Given documented shell-suite flakiness under parallel CI load, a loaded runner could exceed 5 s on a correctly-bounded run and produce a false `pytest.fail`. Suggestion: raise toward 15 s, well below the default ~30 s.
+- **Minor (medium)** — Success Criteria, the `-k "lock"` checkbox. `test_empty_pid_lock_advances_budget` already passes pre-fix (a guard), and `test_uncreatable_lock_dir_fails_fast` only reds after ~30 s pre-fix (current code ignores the env knob). Suggestion: state the expected pre-fix outcome per test.
+- **Suggestion (medium)** — Phase 1 §3, tests 1 and 3. No `timeout=` passed; a regression of the ceiling comparison itself would hang the suite from these rather than red cleanly (only test 2 carries the tripwire). Suggestion: add a modest `timeout=`.
+- **Minor (low)** — Key Discoveries / What We're NOT Doing. The classifier's unwritable-parent trigger has no direct test (masked by the 0186 gate, guarded only indirectly); a future gate refactor would silently drop coverage. Suggestion: note the coupling.
+
+### Code Quality
+
+**Summary**: A tight, proportionate fix to a single ~30-line function that keeps the existing inline structure rather than over-engineering, with a clean, well-documented testability seam. The main readability cost is the compound `elif` folding the reclaim's side effects into a boolean guard and silently widening the `else` arm; the `max_wait` naming and a retained flow-narrating comment are smaller nits. Error handling is sound — the fail-fast path is an early guard clause with a distinct, cause-neutral message mirroring the sibling timeout diagnostic.
+
+**Strengths**:
+- Proportionate, minimal change preserving the inline classification structure.
+- The fail-fast path is an early guard clause that short-circuits the wait loop clearly.
+- The `cannot create the launcher cache lock: ${lock_dir}` message is cause-neutral (correct, no portable errno), distinct from the timeout message, and matches the in-file `<cause>: ${lock_dir}` shape.
+- The reclaim fix reuses the shared `else` tail rather than duplicating the increment (DRY); reading `max_wait` once keeps the body clean.
+- The env ceiling is a genuine seam mirroring an existing template and documented in the header note.
+- Not declaring `max_wait`/`waited` as `local` matches the file's convention.
+
+**Findings**:
+- **Minor (high)** — Phase 1 §1, bounded reclaim arm. The compound `elif` makes two state mutations double as the branch predicate, hiding side effects inside what scans as a classification test, and the trailing `else` silently becomes a three-way catch-all. A partial reclaim (pid removed, dir remains) re-enters and is thereafter read as an empty-pid race. Defensible as the deliberate DRY choice; if kept, state that the `else` contract has broadened.
+- **Minor (medium)** — Phase 1 §1 & §2. `max_wait` / `ACCELERATOR_LOCK_MAX_WAIT` reads as a duration in seconds but is an iteration count (~300 × 0.1 s) — a distinction the research already had to correct. Prefer a unit-bearing name; at minimum keep the header note's "iteration ceiling" wording.
+- **Suggestion (medium)** — Phase 1 §1, the live-owner comment. Already present verbatim at `bin/accelerator:328-331` (retained, not introduced). Its first half is a legitimate *why*; its tail narrates control flow and carries a positional reference that can go stale. Optionally trim to the rationale sentence since the region is being rewritten.
+
+### Portability
+
+**Summary**: A tightly-scoped, cross-platform-aware shell fix. Every construct in the rewrite is bash-3.2-safe, so the macOS `/bin/bash` floor is respected; directory-presence is a deliberate portable choice over an errno; and the dead-owner test's precondition rests on portable POSIX unlink semantics that hold on macOS APFS/HFS+ and Linux ext4/tmpfs. No new vendor or hardcoded-path coupling. The one framing gap: the plan treats bash-3.2 verification as manual when the integration suite already forces `/bin/bash` on a `macos-latest` CI leg, so the floor is enforced automatically.
+
+**Strengths**:
+- All rewritten constructs are bash-3.2-safe, and the suite pins `/bin/bash` (`installation.py:43`) — bash 3.2 on `macos-latest` — so the three tests run under the real floor on both matrix legs automatically.
+- `[[ -d ]]` is a deliberate, portability-correct discriminator given `mkdir` exposes no portable errno.
+- Test determinism depends only on portable POSIX semantics; `_restricted`'s `os.access` probe hard-fails on advisory-permission filesystems and `_require_unprivileged` hard-fails under root.
+- No new hardcoded paths or vendor coupling; the ceiling is a documented runtime-injectable seam defaulting to production behaviour.
+
+**Findings**:
+- **Minor (medium)** — Success Criteria, Manual Verification. The bash-3.2 replay is listed only as manual, but the harness pins `/bin/bash` and the `test-integration` job runs the `macos-latest` leg (`main.yml:55-61`), so the tests already execute under 3.2 in CI. Mischaracterising the gate as manual risks under-valuing (or removing) that leg and misleads a Linux-only contributor whose `mise run` uses bash 5.x. Suggestion: name the macOS leg as the automated gate; demote the replay to a spot-check.
+- **Suggestion (low)** — Phase 1 §1, the fail-fast diagnostic. Because `mkdir` has no portable errno, one cause-neutral message covers a file at the path, an unwritable parent, a read-only mount, and ENOSPC alike. Reasonable trade-off, but a cheap `[[ -e ]]` follow-up could append a cause class without relying on errno.
+
+### Safety
+
+**Summary**: A net safety improvement for a low-criticality dev-tool bootstrap lock: it eliminates the more severe defect (an unbounded, no-sleep busy-spin) and converts a misleading full-budget timeout into a fast, correctly-named fail. The fail-fast and timeout exits leave no partial lock state. Two residual footguns in the retained scheme deserve recording: the reclaim arm's non-atomic `rm -f pid; rmdir` is not single-winner (a TOCTOU mutual-exclusion gap the plan scopes out only on its live-owner dual), and the live-owner arm remains an unbounded wait under PID reuse, so "every arm terminates within a bounded budget" is not literally complete.
+
+**Strengths**:
+- Eliminates the unbounded busy-spin (Defect 2), removing a genuine CPU-pegging runaway with no timeout.
+- Fail-fast and timeout exits leave on-disk state clean: the `[[ ! -d ]]` branch fires before any lock dir exists, the trap installs only inside the mkdir-success block, and `release_lock` short-circuits on empty `lock_held`; no foreign artifact is ever removed.
+- The protected critical section is idempotent (per-PID `.tmp-launcher-$$` + atomic rename of identical verified content), structurally bounding the harm of any residual reclaim race.
+- Retains the 0186 probe gate as defence-in-depth.
+- Sub-second determinism via an injectable ceiling plus a real tripwire.
+
+**Findings**:
+- **Major (medium)** — What We're NOT Doing / Phase 1 §1. The plan scopes out only the live-owner-resets-forever concern but leaves unrecorded the dual reclaim-side hazard: `rm -f pid; rmdir` is a non-atomic read-then-act, so two waiters can each reclaim, and a reclaim can destroy a *live* holder's freshly-created dir (a plain TOCTOU, not the reused-pid framing), letting two sessions enter the critical section. Tolerable only because the protected op is idempotent — but that assumption is unstated, so a future read-modify-write critical section would inherit a lost-write hole. Suggestion: record both the gap and the idempotency assumption; flag it must be revisited before the lock guards a non-idempotent op.
+- **Minor (medium)** — Desired End State / What We're NOT Doing. "Every arm terminates within a bounded budget" overstates: the live-owner arm resets `waited=0` and, under PID reuse of the recorded owner, resets forever — a false-positive unbounded hang recorded only as a budget-*reset* concern, not reconciled with the headline claim. Suggestion: qualify the claim and record the live-owner PID-reuse residual (the `holder.start` precedent being the future fix).
+- **Suggestion (low)** — What We're NOT Doing / Migration Notes. Always-on `ACCELERATOR_LOCK_MAX_WAIT` (vs the `ACCELERATOR_TEST_MODE`-gated `jira-common.sh` precedent) is a small production footgun; an accidental value shrinks the budget and could cause spurious timeouts under genuine contention (a non-numeric value degrades safe via `[[ -gt ]]`). Suggestion: gate to match, or record why always-overridable is acceptable.
+
+### Security
+
+**Summary**: A net security improvement for its core purpose — it removes an attacker-triggerable unbounded busy-spin (CPU-exhaustion DoS) by bounding the reclaim arm, and fails fast with a non-leaking message. However, it introduces `ACCELERATOR_LOCK_MAX_WAIT`, which flows unvalidated into a `[[ -gt ]]` arithmetic comparison inside a root-of-trust bootstrap — a classic bash arithmetic-injection surface — and the "always-on" decision keeps that surface live in production. The filesystem-level vectors (symlink following, a foreign/unremovable lock directory in a shared cache) are bounded but not eliminated; those are largely inherent to the mkdir+pid scheme the plan deliberately does not redesign.
+
+**Strengths**:
+- Removing the reclaim `continue` closes a genuine CPU-exhaustion DoS.
+- The fail-fast message discloses only the local lock path (no permissions/uid/errno), consistent with the `fail` idiom.
+- Explicitly retains the 0186 probe gate as defence-in-depth.
+- The on-disk lock/pid contract and minisign verification chain are untouched.
+- The unset-env case degrades to the safe default via `${…:-300}` under `set -u`.
+
+**Findings**:
+- **Major (high)** — Phase 1 §1 (`max_wait="${…:-300}"` and `[[ "${waited}" -gt "${max_wait}" ]]`), reinforced by the always-on decision. `-gt` evaluates operands as arithmetic, and bash arithmetic re-expands array-subscript syntax, so `a[$(command)]` executes `command` (present on the bash 3.2 floor). This is the first externally-influenced value to reach an arithmetic context in `bin/accelerator`; non-injection abuse (`0`/negative → immediate DoS; huge → long wait) also applies, and ShellCheck will not flag it. Impact: an actor able to influence the process environment (direnv/`.envrc`, shared profile, CI config) can achieve command execution as the user before verification, or force a lock-wait DoS. Suggestion: validate as a non-negative integer with a `300` fallback (`case … in ''|*[!0-9]*) …`), or gate behind `ACCELERATOR_TEST_MODE`.
+- **Minor (medium)** — Phase 1 §1, the classification branch. `[[ -d ]]` follows symlinks: a symlink at the lock path reads as a competitor and drives the reclaim through the target — `rm -f "${lock_dir}/pid"` deletes a `pid`-named file in the attacker-chosen dir; `rmdir` fails ENOTDIR. A narrow file-deletion-plus-DoS primitive, pre-existing, realistic only on a shared/multi-user-writable cache. Suggestion: reject a symlink (`[[ -L … ]]`) in the classification branch, or record the residual.
+- **Suggestion (medium)** — Desired End State / What We're NOT Doing. The residual shared-cache DoS is bounded, not eliminated: a co-writer can repeatedly plant a dead-owner `0o555` directory to bounce the victim to a bounded failure; and the `mkdir`/`[[ -d ]]` TOCTOU only steers between two bounded outcomes (no escalation). Suggestion: state explicitly that the shared-cache DoS is knowingly bounded rather than closed.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Re-Review (Pass 2) — 2026-08-21T16:24:32+00:00
+
+**Verdict:** REVISE
+
+The Pass 1 revision resolved every major and nearly every minor, and both high-confidence Pass 1 majors (the classifier TOCTOU and the arithmetic-injection surface) are confirmed closed by the lenses that raised them. But the re-review surfaced a **new high-confidence major that the Pass 1 fix itself introduced** — the `case` ceiling validation accepts all-digit strings without forcing base 10, so a leading-zero value (`08`/`09`) reaches `[[ -gt ]]` as an invalid-octal literal and, under `set -uo pipefail` with no `-e`, silently removes the loop's bound — flagged independently by Correctness and Safety. A second major (Correctness + Test Coverage) found the Pass 1 rewrite of the red-first Success Criteria became inaccurate and self-contradictory once the `timeout=15` nets were added, and the newly-added `-L` symlink branch had no test. All Pass 2 findings were addressed in an immediate follow-up edit (see Assessment); the REVISE verdict reflects the state the six agents reviewed and is pending a third verification pass.
+
+### Previously Identified Issues
+
+- 🟡 **Correctness** — TOCTOU classifier misreads a released competitor — **Resolved.** Narrowed to `[[ -L … ]] || [[ -e … && ! -d … ]]`; an absent directory now falls through and retries. Correctness re-review confirms the ordering and short-circuit are sound.
+- 🟡 **Security + Correctness** — unvalidated `ACCELERATOR_LOCK_MAX_WAIT` (injection + bound-loss) — **Partially resolved.** Injection fully sealed (Security confirms the `case` glob matches lexically, no evaluation). The bound-loss half recurred via the octal sub-case (see New Issues).
+- 🟡 **Safety** — reclaim non-single-winner mutual exclusion — **Resolved.** Recorded in *What We're NOT Doing* with the idempotency precondition; Safety confirms the record accurate and the idempotency claim true of `fetch_and_verify`.
+- 🟡 **Test Coverage** — `timeout=5` flake risk — **Resolved.** Raised to `timeout=15`; Test Coverage confirms it is well-calibrated (above the injected budget, below the default ~30 s).
+- 🔵 **Security** — `[[ -d ]]` follows symlinks — **Resolved.** The `-L` guard rejects symlink-to-dir, symlink-to-file, and dangling symlinks before any reclaim `rm`/`rmdir`.
+- 🔵 **Correctness + Safety** — "every arm terminates within a bounded budget" overstated — **Partially resolved.** Desired End State now qualifies it; Safety noted the reclaim-*success* no-sleep spin was still conflated with the sleeping waits (addressed in Pass 2).
+- 🔵 **Test Coverage** — red-first pre-fix outcomes overstated — **Regressed → new major.** The Pass 1 rewrite plus the added nets made the narrative inaccurate (see New Issues).
+- 🔵 **Portability** — bash-3.2 gate framed as manual-only — **Resolved.** Portability verified the `macos-latest` integration leg runs the tests under `/bin/bash` 3.2 end-to-end.
+- 🔵 **Code Quality** — retained comment tail narrated flow — **Resolved.** Trimmed to rationale; Code Quality confirms it now fits the low-comment rule.
+- 🔵 Other Pass 1 minors/suggestions (widened-`else` note, no-net tests, always-on footgun, shared-cache DoS record, unwritable-parent coupling) — **Resolved** in Pass 1.
+
+### New Issues Introduced
+
+- 🔴 **Correctness + Safety** (high) — Leading-zero ceiling silently disables the bound. `case … *[!0-9]*` accepts `08`/`09`; `[[ -gt "08" ]]` reads octal, errors on the invalid digit, and returns non-zero every iteration under no-`-e`, so the timeout `fail` never fires — the exact loss-of-bound Pass 1 claimed to close. Introduced by the Pass 1 validation.
+- 🟡 **Correctness + Test Coverage** (high) — Success Criteria red-first narrative inaccurate and self-contradictory. With the injected ceiling inert on current `main`, all new tests red as `timeout=15` hangs, contradicting the stated "wrong message after ~30 s" (test 1) and "green both before and after" (test 3).
+- 🟡 **Test Coverage** (high) — The `-L` symlink fail-fast branch had no test; a refactor dropping `-L` would fail no planned case.
+- 🟡 **Safety** (med) — The reclaim-*success* `continue` is a no-sleep spin the qualification lumped with the sleeping live-owner reset.
+- 🔵 **Code Quality** (med) — The `{ …; }` grouping in the guard is over-engineered; `300` appears twice.
+- 🔵 **Security / Safety** (minor) — A check-to-`rm` symlink-swap TOCTOU and the fact that `release_lock` shares the non-owner-gated `rm+rmdir` shape were unrecorded.
+- 🔵 **Portability / Test Coverage** (low/minor) — The `case` matching arm and the absent-path fall-through were unexercised; the latter cannot be pinned deterministically.
+
+### Assessment
+
+The re-review did its job: it caught a real regression the Pass 1 fix introduced (the octal bound-loss) — found independently by two lenses — and a prose fix that had turned self-contradictory. Both, plus every other Pass 2 finding, were addressed in an immediate follow-up edit:
+
+- Ceiling now normalised with `case … *) max_wait=$((10#${max_wait})) ;;` (base 10; `08` → 8, not an octal error).
+- Guard simplified to `[[ -L … ]] || [[ -e … && ! -d … ]]` (no brace group).
+- Success Criteria restated: all five new tests red against current `main` as `timeout=15` hangs and pass sub-second after the fix.
+- Two tests added — `test_symlink_lock_path_fails_fast` (pins the `-L` guard and that reclaim does not follow the link) and `test_leading_zero_ceiling_is_decimal_not_octal` (pins base-10 normalisation).
+- *What We're NOT Doing* extended: reclaim-success no-sleep spin, `release_lock` shares the non-owner-gated shape, the check-to-`rm` symlink TOCTOU, and the per-user-cache trust assumption.
+
+The plan is in materially better shape than at either prior state. The verdict remains REVISE because these Pass 2 fixes have not themselves been reviewed; a third pass (Correctness, Safety, Test Coverage) would confirm the octal fix, the restated red-first narrative, and the two new tests, and is expected to clear to APPROVE.
+
+## Re-Review (Pass 3) — 2026-08-21T19:51:37+00:00
+
+**Verdict:** APPROVE
+
+The three lenses whose findings the Pass 2 edits touched re-reviewed the twice-revised plan. Correctness and Safety returned **zero findings** — both verified, against the live `bin/accelerator`, that the base-10 ceiling normalisation fully closes the octal loss-of-bound (only all-digit strings reach `$((10#…))`, and the `*)` arm references `${max_wait}` not the bare env var, so no `set -u` abort), that the simplified `[[ -L … ]] || [[ -e … && ! -d … ]]` guard is logically identical to its predecessor, and that the reclaim/`release_lock`/TOCTOU residuals are accurately recorded. Test Coverage found no defect in the fix itself but three consistency/coverage issues — a `-k "lock"` verification command that silently dropped the leading-zero test, three stale "three tests" lead-ins, a vacuous no-follow assertion in the symlink test, and the untested non-numeric fallback arm. All were addressed in a follow-up edit; the verdict is APPROVE because the two substantive lenses are clean and the remaining items were documentation/consistency fixes plus one inherent, now-recorded coverage limitation.
+
+### Previously Identified Issues (Pass 2 findings)
+
+- 🔴 **Correctness + Safety** — leading-zero octal loss-of-bound — **Resolved and verified.** `$((10#${max_wait}))` normalises to decimal; both lenses confirmed no residual value can disable the timeout.
+- 🟡 **Correctness + Test Coverage** — red-first narrative inaccurate — **Resolved and verified.** Correctness and Test Coverage both confirm the restated "all five red as `timeout=15` hangs pre-fix, pass sub-second post-fix" is accurate per test.
+- 🟡 **Test Coverage** — `-L` branch untested — **Resolved.** `test_symlink_lock_path_fails_fast` added; its no-follow assertion strengthened in Pass 3 (see below).
+- 🟡 **Safety** — reclaim-success no-sleep spin conflated — **Resolved and verified.** Recorded distinctly; Safety confirms the characterisation accurate.
+- 🔵 Code-quality / Security / Portability minors (brace-group simplified, `release_lock` note, symlink-swap TOCTOU, case-arm coverage) — **Resolved.**
+
+### New Issues Introduced
+
+- 🟡 **Test Coverage** (high) — `-k "lock"` selector silently excluded `test_leading_zero_ceiling_is_decimal_not_octal` (no "lock" substring). **Fixed:** selector broadened to `-k "lock or leading_zero"`.
+- 🟡 **Test Coverage** (high) — three stale "three tests" lead-ins (Overview, Changes #3, Manual step 1) contradicted the five enumerated tests. **Fixed:** all three now say "five".
+- 🟡 **Test Coverage** (med) — the non-numeric / arithmetic-injection fallback arm has no test. **Recorded as an inherent limitation** (not fixed with a test): any rejected value falls back to the 300-iteration ~30 s default and a fail-fast setup never reaches `[[ -gt ]]`, so a payload never executes regardless of the guard — a behavioural test is either vacuous or ~30 s. Covered by the `case`-before-arithmetic ordering (verified by Correctness Pass 3) and ShellCheck.
+- 🔵 **Test Coverage** (minor) — the symlink test's `target.is_dir()` no-follow assertion was vacuous (empty target → reclaim never reached). **Fixed:** the test now plants a dead-owner pid inside the target and asserts it survives, a genuine reclaim-no-follow tripwire.
+
+### Assessment
+
+The three-pass review converged. The substantive correctness and safety of the fix are verified clean by two independent passes; the fix now closes both original defects (misclassification, unbounded reclaim) without the regression Pass 2 introduced (octal loss-of-bound). The Pass 3 items were mechanical consistency fixes (a selector string, count numbers, one strengthened assertion) plus one coverage limitation that is inherent to the design and now explicitly recorded. Those Pass 3 fixes are self-evidently correct and low-risk; the plan is ready for implementation. Remaining scoped-out residuals (reclaim not single-winner, reused-pid live-owner reset, shared-cache DoS) are recorded decisions, safe under the current idempotent critical section.

--- a/meta/reviews/work/0190-acquire-lock-cannot-classify-mkdir-failures-review-1.md
+++ b/meta/reviews/work/0190-acquire-lock-cannot-classify-mkdir-failures-review-1.md
@@ -14,7 +14,7 @@ lenses: [clarity, completeness, dependency, scope, testability]
 review_number: 1
 review_pass: 2
 tags: []
-last_updated: "2026-08-21T00:00:06+00:00"
+last_updated: "2026-08-21T14:47:24+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -265,3 +265,9 @@ implementation.
 ### Assessment
 
 The work item is ready for implementation. The three review-1 majors and the one major introduced during revision are all resolved; what remains is optional, low-severity polish (a slightly more descriptive title, a couple of term glosses, minor dependency-label precision) that does not block planning.
+
+## Author Acceptance — 2026-08-21
+
+**Accepted by:** Toby Clemson (author)
+
+Accepted as-is. Both review passes are closed: the three round-1 testability majors and the one major introduced during revision are resolved, and the residual items are optional low-severity polish. No further revisions requested — the work item is cleared for planning.

--- a/meta/reviews/work/0190-acquire-lock-cannot-classify-mkdir-failures-review-1.md
+++ b/meta/reviews/work/0190-acquire-lock-cannot-classify-mkdir-failures-review-1.md
@@ -1,0 +1,267 @@
+---
+type: work-item-review
+id: "0190-acquire-lock-cannot-classify-mkdir-failures-review-1"
+title: "Work Item Review: acquire_lock cannot classify an unusable lock directory"
+date: "2026-08-20T23:09:33+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+target: "work-item:0190"
+work_item_id: "0190"
+reviewer: Toby Clemson
+verdict: COMMENT
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-21T00:00:06+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: acquire_lock cannot classify an unusable lock directory
+
+**Verdict:** REVISE
+
+0190 is a disciplined, tightly-scoped bug item: every section describes the
+same two-part fix (classify a failed `mkdir`, bound the dead-owner reclaim
+arm), the frontmatter is complete, and an explicit Scope note holds the
+redesign out. The REVISE verdict rests entirely on the Acceptance Criteria,
+where three major testability gaps mean the criteria as written do not reliably
+verify the behaviour they target — AC1's diagnostic is not pinned to an
+assertable substring, AC1/AC2's `chmod`-manufactured preconditions omit the
+root-guard and filesystem caveats the item's own sibling 0186 required, and
+AC2's ~30 s budget guard is slow and flake-prone with its fast seam left
+optional. Clarity, completeness, dependency, and scope raise only minor and
+suggestion-level polish.
+
+### Cross-Cutting Themes
+
+- **AC2's timeout mechanism is both ambiguous and operationally risky** (flagged
+  by: testability, clarity) — the criterion overloads "timeout" for the loop's
+  internal ~30 s budget and the harness subprocess `timeout=`, and a correct
+  implementation runs ~30 s of real sleeps every time, so the guard can flake
+  under CI load. The env-injectable ceiling that would make it fast and
+  deterministic is left "optional" in Technical Notes.
+- **The higher-severity unbounded arm is under-anchored** (flagged by: scope,
+  completeness, testability) — the dead-owner spin is the more severe defect
+  (an unbounded hang, not a wrong diagnostic after a bounded budget), yet its
+  broken behaviour is reasoned rather than observed, its severity is not
+  distinguished from the milder arm, and AC2 proves only termination, not the
+  terminating outcome.
+- **0186's test discipline is leaned on for context but not inherited by these
+  criteria** (flagged by: testability, dependency) — the item reuses 0186's
+  masked-instance framing and cites its precedents, but AC1/AC2 do not adopt
+  0186's root-guard and permission-ignoring-filesystem rules for the very
+  `chmod`-based preconditions they share.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Testability**: AC1 diagnostic "naming the cause" is not pinned to an assertable substring
+  **Location**: Acceptance Criteria
+  AC1 requires the cold run to fail "with a diagnostic naming the cause" but never states the exact substring a test must assert; the concrete properties (lock path plus a "permission or I/O" clause) live only in Technical Notes. Sibling 0186 set the precedent of pinning the analogous diagnostic to an exact substring, so two verifiers could disagree on whether a message "names the cause".
+
+- 🟡 **Testability**: AC1/AC2 permission preconditions omit the root-guard and filesystem caveats 0186 required
+  **Location**: Acceptance Criteria
+  Both preconditions are manufactured by `chmod`, exactly the setup for which 0186 devoted a whole preamble: assert `id -u ≠ 0`, hard-fail rather than skip under root, and handle permission-ignoring filesystems via a recorded privilege check. Under root the `mkdir`/`rmdir` succeed regardless of the fix, so both criteria pass vacuously without the fix present.
+
+- 🟡 **Testability**: AC2's ~30 s budget-timeout guard is slow and flake-prone, with the fast seam left optional
+  **Location**: Acceptance Criteria
+  AC2 pins the bound at the literal 300 × `sleep 0.1` ≈ 30 s ceiling and sets the harness `timeout=` "above ~30 s", so a correct implementation runs ~30 s of real sleeps plus 300 process spawns every time. On a loaded CI host the loop can exceed a just-above-30 s timeout and a correct-but-slow run flakes — a known pattern for this repo's timeout-based shell suites.
+
+#### Minor
+
+- 🔵 **Clarity**: "neither gate" implies two gates but only one is named
+  **Location**: Context
+  The Context names a single probe gate, then says the dead-owner arm is one "which neither gate prevents". "Neither" presupposes exactly two gates, but only the probe gate is ever named — a reader cannot tell whether a second safeguard exists or whether this is a slip.
+
+- 🔵 **Clarity**: "timeout budget" and "explicit timeout=" name two different timeouts
+  **Location**: Acceptance Criteria
+  AC2 uses "timeout" for two distinct mechanisms — the loop's internal ~30 s budget and the pytest harness subprocess `timeout=`. Read on its own the criterion invites setting the harness timeout to the loop budget, which would race a correctly-bounded loop against the harness and flake.
+
+- 🔵 **Testability**: AC2 asserts termination but not the terminating outcome
+  **Location**: Acceptance Criteria
+  AC2 verifies the subprocess terminates before the harness `timeout=` fires but does not require asserting *how* it terminated. A regression that exits for an unrelated reason inside the budget would satisfy the criterion.
+
+- 🔵 **Dependency**: Sibling follow-up 0191 also edits `bin/accelerator` but is not cross-referenced
+  **Location**: Dependencies
+  0191, raised alongside 0190 in 0186, also edits `bin/accelerator` (the staging block). Neither Dependencies nor `relates_to` cross-references it, so the implied coupling between two concurrently-editable changes to the same file is invisible in the record.
+
+#### Suggestions
+
+- 🔵 **Completeness**: Bug reproduction elements are woven into prose rather than consolidated as steps
+  **Location**: Context
+  All four reproduction elements are present but distributed across Context and Acceptance Criteria; the first arm carries a measured actual outcome while the more severe unbounded arm's behaviour is stated analytically. A short Reproduction subsection listing each arm's setup/action/expected/actual would let a verifier confirm the fix addresses both.
+
+- 🔵 **Clarity**: "else arm" is not identified among the listed post-fix arms
+  **Location**: Technical Notes
+  The post-fix arm-order list enumerates six arrow-labelled arms, then refers to "The `else` arm" without indicating which listed arm that is — an inference needed to follow the claim that the reclaim arm shares the else arm's 300-iteration cap.
+
+- 🔵 **Dependency**: No downstream Blocks edge for the 0186 masking gate this fix may make redundant
+  **Location**: Context
+  Once 0190 lands a general `mkdir`-failure classification, 0186's cold-branch probe gate may become redundant defence, yet no downstream item records that a future "remove the gate" cleanup depends on this fix. A one-line note either recording the follow-up or confirming the gate is retained as defence-in-depth closes the question.
+
+- 🔵 **Scope**: Two bundled defects carry different severities and are separately deliverable
+  **Location**: Requirements
+  The item bundles a wrong-diagnostic fix (bounded ~30 s budget) with an infinite-hang fix (unbounded spin). Keeping them together is right — both are small and share the root theme — but the unbounded arm is arguably higher severity than the item's medium priority, worth noting so the liveness fix is not deprioritised alongside the milder one.
+
+- 🔵 **Testability**: No criterion maps to the preserved empty/unreadable-pid and genuine-race arms
+  **Location**: Technical Notes
+  The post-fix control flow enumerates six arms, but the criteria pin only the two new arms and the live-owner/reclaim arms. The "empty/unreadable pid → advance budget" arm and the `else` race arm are asserted preserved with no explicitly named guard — AC3's concurrency test is assumed to cover the race but the mapping is unstated.
+
+### Strengths
+
+- ✅ Summary, Context, Requirements, the explicit Scope note, Acceptance Criteria, and Technical Notes all describe the identical narrow two-arm fix, with no drift between the stated problem and the proposed solution.
+- ✅ Both defects live in the same `acquire_lock` loop in one file, serving one unified purpose, so the item is a single indivisible unit of delivery — correctly sized as a `bug` rather than inflated or over-decomposed.
+- ✅ Requirements close with an explicit in/out-of-scope statement, and Technical Notes actively resist creep by flagging the env-injectable ceiling as "a testability seam, not a redesign of the scheme".
+- ✅ AC2 engineers against a hung suite by pinning the bound with an explicit harness `timeout=`, and AC3 names two existing tests as concrete preservation guards for the live-owner and dead-owner arms.
+- ✅ Upstream provenance is captured with a reason per reference — 0164 (introduced the lock), 0186 (masked the reachable instance, recorded the unbounded arm), parent epic 0136 — and the 0186 relationship is described structurally rather than by volatile line numbers.
+- ✅ Frontmatter is complete and internally consistent; domain terms (EEXIST, `kill -0`, the bash 3.2 floor) are standard for the audience or glossed in context.
+
+### Recommended Changes
+
+1. **Pin AC1's diagnostic to an exact assertable substring** (addresses: AC1 diagnostic "naming the cause" is not pinned)
+   State in AC1 the concrete tokens a test must assert — the lock directory path plus a "permission or I/O" cause clause — mirroring how 0186 pinned its `no writable, exec-capable cache directory` substring, rather than leaving those properties in Technical Notes.
+
+2. **Govern AC1/AC2's permission preconditions with 0186's root-guard rule** (addresses: AC1/AC2 permission preconditions omit the root-guard and filesystem caveats)
+   Require a non-root runner, assert `id -u ≠ 0` with a hard-fail-not-skip under root, and record the privilege/filesystem check — or add one line making 0186's Acceptance Criteria preamble govern these two criteria.
+
+3. **Make the env-injectable ceiling mandatory and disambiguate the two timeouts** (addresses: AC2's ~30 s guard is slow and flake-prone; "timeout budget" and "timeout=" name two different timeouts)
+   Move the env-injectable ceiling from "optional" into the fix so AC2 runs under a small budget (sub-second wall time) with a correspondingly small harness `timeout=`, and reword the criterion to distinguish the loop's internal budget from the harness subprocess timeout.
+
+4. **Extend AC2 to assert the terminating outcome, not just termination** (addresses: AC2 asserts termination but not the terminating outcome)
+   Require the terminating exit to be non-zero and its output to contain the existing lock-timeout message substring (which Scope keeps unchanged), so the criterion pins the intended bounded-failure path rather than merely "did not hang".
+
+5. **Fix the "neither gate" referent** (addresses: "neither gate" implies two gates but only one is named)
+   Either name both gates explicitly (the staging gate and the cold-branch gate) so the count of existing safeguards is unambiguous, or reword to "the probe gate does not prevent".
+
+6. **Cross-reference sibling 0191 in `relates_to`/Dependencies** (addresses: 0191 also edits `bin/accelerator` but is not cross-referenced)
+   Add 0191 (and, if relevant, 0189) with a one-line note that they touch different regions of `bin/accelerator`, so the merge order is stated as a non-issue rather than discovered at rebase time.
+
+7. **Apply the remaining polish** (addresses: reproduction consolidation; "else arm" label; downstream 0186-gate edge; bundled-defect severity; empty-pid/race arm mapping)
+   Consolidate the two arms' reproduction steps, label which listed arm is the `else` arm, record whether the 0186 gate becomes a follow-up cleanup or stays as defence-in-depth, note the unbounded arm's higher severity, and state which criterion or existing test guards the empty-pid and genuine-race arms.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: 0190 is internally consistent and unusually disciplined: the Summary, Context, Requirements, Scope note, Acceptance Criteria and Technical Notes all describe the same narrow two-part fix, and its outcomes are concrete and observable. The clarity weaknesses are localised: one genuine referent mismatch ("neither gate" presupposes two gates while only one is named), a subtle overloading of the word "timeout" across two different mechanisms, and an unlabelled "else arm" in the post-fix arm-order list.
+
+**Strengths**:
+- Strong cross-section consistency across Summary, Context, Requirements, the explicit Scope note, Acceptance Criteria and Technical Notes, with no contradiction between the stated problem and the proposed solution.
+- Outcomes are stated as observable system states rather than vague properties ("fails within a second with a diagnostic naming the cause", named tests stay green, "mise run exits 0 end-to-end").
+- Pronouns and subjects generally resolve cleanly despite the passive framing typical of a bug write-up.
+- Domain terms (EEXIST, `mkdir`/`rmdir`, `kill -0`, the bash 3.2 floor) are either standard for the audience or explained in context.
+
+**Findings**:
+- 🔵 Minor (high confidence) — Context: "neither gate" implies two gates but only one is named. "Neither" presupposes exactly two gates, but only the probe gate is ever named; a reader cannot tell whether a second safeguard exists or whether this is a slip, which undercuts the paragraph's central claim. Suggestion: name both gates explicitly, or reword to "the probe gate does not prevent".
+- 🔵 Minor (medium confidence) — Acceptance Criteria: "timeout budget" and "explicit timeout=" name two different timeouts. AC2 uses "timeout" for both the loop's internal ~30 s budget and the harness subprocess `timeout=`; without cross-referencing Technical Notes a reader could set the harness timeout to the loop budget, making the pinning test flake. Suggestion: "a harness `timeout=` set above the loop's ~30 s budget".
+- 🔵 Suggestion (low confidence) — Technical Notes: "else arm" not identified among the listed post-fix arms. The list enumerates six arrow-labelled arms then refers to "The `else` arm" without indicating which one it is — an inference needed to follow the shared-cap claim. Suggestion: label the relevant list item as the else arm.
+
+### Completeness
+
+**Summary**: A thorough, well-populated bug work item: the Summary names the defect precisely, the Context explains both failure arms and their forces, Requirements are specific and explicitly scoped, and five concrete Acceptance Criteria define done. Frontmatter is complete and valid (kind: bug, status: draft). The only completeness observation is that the bug's reproduction elements, while all present, are woven into Context prose rather than presented as explicit reproduce-and-observe steps.
+
+**Strengths**:
+- The Summary is a single, unambiguous statement of the defect.
+- The Context explains why the work is needed and captures both failure arms in depth, including a measured actual outcome for the first arm and the conditions that trigger each.
+- Requirements are specific enough to start work and carry an explicit Scope/"Not" boundary that prevents scope drift.
+- Acceptance Criteria give five concrete, self-standing conditions including named regression-guard tests, well above the two-criterion bar.
+- Frontmatter is complete and internally consistent — kind: bug and status: draft both present, recognised, and appropriate.
+
+**Findings**:
+- 🔵 Suggestion (medium confidence) — Context: the four reproduction elements are all present but distributed across Context prose and Acceptance Criteria rather than consolidated as explicit reproduce-and-observe steps; the first arm carries a measured actual outcome ("TIMEOUT after 31 iters, 3s") while the more severe unbounded-spin arm's behaviour is stated analytically rather than as an observed reproduction. Impact: an implementer or reviewer must reconstruct the two scenarios from narrative. Suggestion: a short Reproduction subsection listing each arm's setup/action/expected/actual, noting where the second arm's failure is reasoned rather than observed.
+
+### Dependency
+
+**Summary**: 0190 is a self-contained shell bug fix with no external systems, vendors, or cross-team actions, and its upstream couplings are well captured: Dependencies names 0164, 0186, and parent epic 0136, each with a one-line rationale. Both upstream items are complete, so the "Relates to" framing correctly signals no live blocker. The only gaps are interpretive and minor: sibling follow-up 0191 (which also edits `bin/accelerator`) is not cross-referenced, and no downstream "Blocks" edge records whether landing this fix enables removal of 0186's now-potentially-redundant masking gate.
+
+**Strengths**:
+- Upstream provenance is explicitly captured — 0164 as the origin of the lock, 0186 as the item that masked the reachable instance and recorded the unbounded arm, 0136 as the parent epic — each with a reason.
+- The relationship to 0186 is described structurally (the probe gate, the cold branch, the masked instance) rather than by volatile line numbers, so the coupling survives the concurrent rework of `bin/accelerator`.
+- No external, third-party, or cross-team coupling is claimed where none exists — the absence is correct rather than a gap.
+
+**Findings**:
+- 🔵 Minor (low confidence) — Dependencies: sibling follow-up 0191 also edits `bin/accelerator` (the staging block) but is not cross-referenced in Dependencies or `relates_to`. Impact: whoever picks up the second follow-up discovers the shared-file coupling at rebase time rather than at planning time. Suggestion: add 0191 (and, if relevant, 0189) with a one-line note that they touch different regions of the file.
+- 🔵 Suggestion (low confidence) — Context: no downstream Blocks edge for the 0186 masking gate this fix may make redundant. Once 0190 lands a general classification, that gate may become redundant defence, yet no downstream item records the "this enables Y" edge. Suggestion: record a follow-up if a cleanup is intended, or a single line stating the gate is retained as defence-in-depth.
+
+### Scope
+
+**Summary**: Work item 0190 is a well-scoped, coherent bug fix: both defects it addresses live in the same `acquire_lock` loop in a single file and serve one unified purpose — making `acquire_lock` handle an unusable lock directory correctly. It carries an explicit in/out-of-scope statement, its Summary, Requirements, and Acceptance Criteria describe the same work, and the `bug` kind fits the small, indivisible scope. The only scope-adjacent observation is that the two arms carry materially different severities and are technically separable, a low-confidence note rather than a delivery risk.
+
+**Strengths**:
+- The Requirements section closes with an explicit Scope statement giving clear in-scope and out-of-scope boundaries.
+- Summary, Context, Requirements, and Acceptance Criteria all describe the same two-arm fix; each acceptance criterion maps to a stated requirement.
+- Both fixes target a single function in one file with no cross-service or multi-team span.
+- The `bug` kind and medium priority fit the scope — neither inflated to a story nor over-decomposed into separate tickets.
+- Scope creep is actively resisted — the env-injectable ceiling is explicitly flagged as an optional testability seam.
+
+**Findings**:
+- 🔵 Suggestion (low confidence) — Requirements: the item bundles the mkdir-misclassification (burns the bounded ~30 s budget then fails with the wrong diagnostic) with the dead-owner reclaim arm (spins unbounded with no timeout at all). The fixes touch different arms and are independently completable, and the unbounded-hang defect is arguably higher severity than the item's medium priority. Impact: the more urgent liveness fix cannot ship on its own timeline if that becomes desirable. Suggestion: keep them bundled — splitting would be over-decomposition — but note the unbounded-spin arm's higher severity so it is not deprioritised alongside the milder fix.
+
+### Testability
+
+**Summary**: As a bug, both failure modes are well characterised — each has a specified trigger, a measured broken outcome, and a clear expected outcome — and the criteria sensibly reuse two named existing tests as preservation guards while engineering AC2 against a hung suite. However, AC1's "diagnostic naming the cause" is not pinned to a concrete assertable substring (unlike 0186's exact-substring precedent), and AC1/AC2 both manufacture their preconditions by directory-permission manipulation whose reliability caveats — root bypass, permission-ignoring filesystems — were documented at length in the referenced 0186 but are entirely absent here. AC2's ~30 s budget-timeout mechanism is also verifiable but slow and flake-prone, with its fast-path seam left optional.
+
+**Strengths**:
+- AC2 explicitly engineers against a hung suite by pinning the bound with an explicit harness `timeout=`, so an unbounded regression surfaces as a pytest failure rather than a hang.
+- AC3 names two specific existing tests as concrete preservation guards for the live-owner-extends-budget and dead-owner-reclaim arms.
+- The Context supplies a measured broken outcome and AC1 pins a one-second wall-clock threshold that cleanly separates the new fail-fast path from the old ~30 s timeout.
+- The Technical Notes surface an env-injectable ceiling as an explicit testability seam and correctly identify directory-presence as the only portable EEXIST discriminator.
+
+**Findings**:
+- 🟡 Major (medium confidence) — Acceptance Criteria: AC1 requires the run to fail "with a diagnostic naming the cause" but never states the exact substring a test must assert; the concrete properties live only in Technical Notes, and 0186 set the precedent of pinning the analogous diagnostic to an exact substring. Impact: two verifiers could disagree on whether an arbitrary message "names the cause", so the criterion does not yield a single deterministic assertion. Suggestion: state the exact assertable substring in AC1 (lock path plus a "permission or I/O" cause token).
+- 🟡 Major (medium confidence) — Acceptance Criteria: AC1's and AC2's preconditions are both manufactured by `chmod`, exactly the setup for which 0186 required asserting `id -u ≠ 0`, hard-failing rather than skipping under root, and handling permission-ignoring filesystems via a recorded privilege check. Under root the `mkdir`/`rmdir` succeed regardless of the fix, so both criteria pass vacuously. Impact: on a privileged lane, a local root run, or a permission-ignoring filesystem, AC1/AC2 report pass without the fix present. Suggestion: reuse 0186's rule, or reference its preamble as governing these two criteria.
+- 🟡 Major (medium confidence) — Acceptance Criteria: AC2 pins the bound at the literal 300 × `sleep 0.1` ≈ 30 s ceiling and requires the harness `timeout=` "above ~30 s", so a correct implementation runs ~30 s of real sleeps plus 300 process spawns every time, and the env-injectable ceiling that would shrink this is left optional. Impact: on a loaded CI host the loop can exceed a just-above-30 s timeout and a correct-but-slow run flakes — a known pattern for this repo's timeout-based shell suites. Suggestion: make the ceiling env-injectable a mandatory part of the fix so AC2 runs under a small budget with a small harness `timeout=`.
+- 🔵 Minor (medium confidence) — Acceptance Criteria: AC2 verifies the subprocess terminates before the harness `timeout=` fires but does not require asserting how it terminated. A regression that exits for an unrelated reason inside the budget would satisfy the criterion. Suggestion: also assert the terminating exit is non-zero and its output contains the existing lock-timeout message substring.
+- 🔵 Suggestion (low confidence) — Technical Notes: the post-fix control flow enumerates six arms, but the criteria pin only the two new arms and the live-owner/reclaim arms; the "empty/unreadable pid → advance budget" arm and the `else` race arm are asserted preserved with no explicitly named guard. Impact: a verifier cannot confirm the classification branch left these arms intact. Suggestion: state which criterion or existing test exercises the empty-pid and genuine-race arms, or note that AC3's concurrency case is the intended guard.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-08-21
+
+**Verdict:** COMMENT
+
+All three major findings from review 1 are resolved, and every round-1 minor
+and suggestion is addressed. The revised criteria pin an assertable diagnostic,
+adopt 0186's root-guard rule, and run the bounded arm sub-second under an
+env-injected ceiling. The re-review surfaced one new major — a crossed
+test/behaviour pairing in the reworked AC3, introduced by the review-1 edit —
+now fixed in this same pass, leaving no findings above minor. The residual
+minors and suggestions are optional polish; the work item is ready for
+implementation.
+
+### Previously Identified Issues
+
+- 🟡 **Testability**: AC1 diagnostic not pinned to an assertable substring — Resolved (AC1 now asserts a fixed cause substring verbatim, run under the injected ceiling).
+- 🟡 **Testability**: AC1/AC2 permission preconditions omit 0186's root-guard/filesystem caveats — Resolved (Acceptance Criteria preamble adopts 0186's `id -u ≠ 0` hard-fail rule and privilege check).
+- 🟡 **Testability**: AC2's ~30 s budget guard is slow and flake-prone — Resolved (env-injectable ceiling is now a Requirement; AC2 runs sub-second with a small harness timeout).
+- 🔵 **Testability**: AC2 asserts termination but not the terminating outcome — Resolved (AC2 asserts non-zero exit + the existing lock-timeout message).
+- 🔵 **Clarity**: "neither gate" implies two gates — Resolved (reworded to "the probe gate does not prevent").
+- 🔵 **Clarity**: "timeout budget"/"timeout=" name two different timeouts — Resolved (AC2 + Technical Notes mark the loop budget and harness `timeout=` as distinct).
+- 🔵 **Clarity**: "else arm" not labelled — Resolved (the empty/unreadable-pid arm is now labelled the `else` arm).
+- 🔵 **Dependency**: sibling 0191 not cross-referenced — Resolved (added to `relates_to` + Dependencies with a merge-order note).
+- 🔵 **Dependency**: no downstream Blocks edge for the 0186 gate — Resolved (recorded as retained defence-in-depth; nothing downstream waits).
+- 🔵 **Scope**: two bundled defects carry different severities — Resolved (reclaim Requirement flags it as the more severe, unbounded-hang defect).
+- 🔵 **Completeness**: reproduction elements woven into prose — Resolved (completeness re-review is clean; actual-vs-expected is now contrasted in Requirements and the criteria).
+- 🔵 **Testability**: empty-pid/genuine-race arms not mapped to a guard — Resolved (a deterministic empty/unreadable-pid criterion now pins the `else` arm directly).
+
+### New Issues Introduced
+
+- 🟡 **Clarity** (Acceptance Criteria): crossed test/behaviour pairing and an ambiguous "The latter" in the reworked AC3 — introduced by the review-1 edit; **fixed in this pass**: the tests are now paired inline with their behaviours and the `else`-arm guard is a separate deterministic criterion, so "The latter" is gone.
+- 🔵 **Testability** (Acceptance Criteria): the fail-fast criterion ran against the default budget, so a regression yielded a ~30 s test — **fixed in this pass**: AC1 now runs under the injected ceiling and discriminates on the diagnostic.
+- 🔵 **Dependency**: the 0191 coupling note covers only `bin/accelerator`, not the shared entrypoint test file (minor); 0164/0186 sit under "Relates to" rather than a "completed dependencies" category (suggestion). Not applied — the record is already thorough and both are label-precision nits.
+- 🔵 **Scope**: the title/summary lead with the less-severe defect (suggestion). Partly addressed — the Summary now names the unbounded-hang branch self-containedly; the title is left unchanged, deferred to the author.
+- 🔵 **Clarity**: `EEXIST` used before a gloss; "arm" used in the Summary ahead of its definition (both low). "arm" addressed in the Summary ("one branch of the retry loop"); the `EEXIST` gloss is left — it already carries an inline parenthetical gloss on first use.
+- 🔵 **Testability**: the "default stays 300" Requirement has no verifying criterion (low). Not applied — verifying a constant has limited behavioural value; left intentionally ungated.
+
+### Assessment
+
+The work item is ready for implementation. The three review-1 majors and the one major introduced during revision are all resolved; what remains is optional, low-severity polish (a slightly more descriptive title, a couple of term glosses, minor dependency-label precision) that does not block planning.

--- a/meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md
+++ b/meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md
@@ -1,0 +1,111 @@
+---
+type: plan-validation
+id: "2026-08-21-0190-classify-lock-mkdir-failures-validation"
+title: "Validation Report: acquire_lock mkdir classification and bounded reclaim"
+date: "2026-08-22T19:11:26+00:00"
+author: Toby Clemson
+producer: validate-plan
+status: complete
+result: pass
+parent: "work-item:0190"
+target: "plan:2026-08-21-0190-classify-lock-mkdir-failures"
+tags: [bug, shell, bootstrap, bash-3.2, locking]
+last_updated: "2026-08-22T19:11:26+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Validation Report: acquire_lock mkdir classification and bounded reclaim
+
+Implementation matches the plan verbatim. The single phase landed in one commit
+(`mumkrlwxwxvz`, "Classify acquire_lock mkdir failures and bound the reclaim
+arm") touching exactly the three planned surfaces; all runnable automated checks
+pass.
+
+### Implementation Status
+
+✓ Phase 1: Classify the mkdir failure and bound the reclaim arm — fully
+implemented
+
+All three coupled edits landed in the planned 10-line region of
+`bin/accelerator`:
+
+- **Classification branch** — `[[ -L ]] || [[ -e && ! -d ]]` fail-fast on a
+  symlink or non-directory at the lock path, sitting between the `mkdir`-success
+  block and the pid read (`bin/accelerator:337-341`).
+- **Bounded reclaim** — the reclaim arm is now a compound `elif` whose
+  `continue` fires only when both `rm -f` and `rmdir` succeed; any failure falls
+  through to the budget-advancing `else` (`bin/accelerator:346-349`).
+- **Injectable ceiling** — `max_wait` read once, validated all-digit, base-10
+  normalised via `$((10#…))` (`bin/accelerator:318-323`), compared as a decimal
+  integer at `:351`.
+
+Header "Test seams" note extended with `ACCELERATOR_LOCK_MAX_WAIT` (`:18`). Five
+integration tests added to `test_accelerator_entrypoint.py:325-445`.
+
+### Automated Verification Results
+
+✅ New lock tests pass (`pytest … -k "lock or leading_zero"`): 6 passed, 3.52 s —
+the five new tests plus `test_stale_lock_is_reclaimed`.
+✅ Retained guards pass (`-k "stale_lock or slow_downloader or
+readonly_cache_fails_fast"`): 3 passed.
+✅ Shell lint clean (`mise run scripts:check`): bashisms, exec-bits, shfmt,
+ShellCheck all green.
+✅ Read-only CI mirror (`mise run check`): exit 0.
+
+⚠️ Full default gate (`mise run`, AC6) not re-run this session — it was marked
+`[x]` at implementation time. The read-only mirror plus the affected test suite
+are green; the outstanding delta is the docs CI lane and the full test sweep,
+neither touched by this change. The dead-owner test terminated sub-second inside
+the 6-test run (3.52 s total), confirming the bound rather than the `timeout=15`
+tripwire ends it (Manual Verification item 2).
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- Loop body rewrite is byte-identical to the plan's proposed `acquire_lock`,
+  including the widened `else` contract and the arm ordering documented in the
+  plan.
+- The `sleep 0.1` shared tail sits outside the `if/elif/else`, so the reclaim
+  arm's `continue` is the only branch that skips it — exactly the plan's
+  intended budget mechanism.
+- All five tests carry the planned preconditions, discriminators, and root
+  guards (`_require_unprivileged` on the dead-owner test only).
+- The live-owner-reset comment was extended one clause beyond the plan snippet
+  ("The budget elapses only while no live owner is seen…") — a clarifying
+  addition, not a deviation.
+
+#### Deviations from Plan:
+
+- None material. The plan file itself shows an 18-line diff in the commit
+  (success-criteria boxes flipped to `[x]`), expected as part of closing the
+  plan.
+
+#### Potential Issues:
+
+- None introduced. The residual availability classes (reused-pid live-owner
+  reset, shared-cache DoS, reclaim-success hot-spin) are explicitly scoped out
+  in the plan's "What We're NOT Doing" and remain unchanged.
+- Two branches stay behavioural-test-blind by design — absent-path fall-through
+  and non-numeric ceiling fallback — covered by inspection plus ShellCheck, as
+  the plan states.
+
+### Manual Testing Required:
+
+1. bash 3.2 floor:
+  - [ ] The `macos-latest` integration leg is the automated 3.2 gate; a local
+    `/bin/bash` spot-check on macOS is an optional supplementary backstop. The
+    fix uses only 3.2-safe constructs.
+
+2. Tripwire confirmation (optional):
+  - [ ] Temporarily restore the bare `continue` and confirm
+    `test_unremovable_dead_owner_lock_terminates_within_budget` flips to a
+    `pytest.fail` hang, proving the test is a genuine tripwire.
+
+### Recommendations:
+
+- Run the full `mise run` default gate once before merge to cover the docs CI
+  lane, per AC6 — the only automated criterion not re-exercised this session.
+- No code changes recommended. The implementation is faithful and the fix
+  strictly improves worst-case behaviour (removes an unbounded busy spin).

--- a/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
+++ b/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
@@ -11,7 +11,7 @@ priority: medium
 parent: "work-item:0136"
 relates_to: ["work-item:0186", "work-item:0164", "work-item:0191"]
 tags: [bug, shell, bootstrap, bash-3.2]
-last_updated: "2026-08-21T00:00:06+00:00"
+last_updated: "2026-08-21T15:21:54+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -53,9 +53,10 @@ happens to be foreign.
 ## Requirements
 
 - Classify the `mkdir` failure instead of assuming contention: after a failed
-  `mkdir`, `[[ -d "${lock_dir}" ]]` distinguishes `EEXIST` (a genuine
-  competitor) from a permission or I/O failure (unrecoverable — fail
-  immediately, naming the lock path and a permission-or-I/O cause).
+  `mkdir`, `[[ -d "${lock_dir}" ]]` distinguishes `EEXIST` on a real directory
+  (a genuine competitor) from a path that is not a usable directory — a
+  non-directory occupying it, or an unwritable parent — which `mkdir` can never
+  resolve. Fail immediately, naming the lock path with a cause-neutral message.
 - Give the dead-owner reclaim arm a bound: a failed `rmdir` must not loop
   without advancing the budget. This arm is the more severe of the two defects
   — an unbounded hang, not a wrong diagnostic after a bounded budget — even
@@ -72,32 +73,44 @@ message, and not redesigning the locking scheme.
 
 ## Acceptance Criteria
 
-The first two criteria manufacture their preconditions by `chmod`, so 0186's
-permission-test rule governs them: each asserts `id -u` ≠ 0 and **hard-fails
-rather than skips** when run as root, since root bypasses the write and removal
-restrictions these cases rely on and would satisfy the assertions regardless of
-the fix. A lane structurally unable to comply is **excluded explicitly** by the
-implementer, justified by a recorded privilege check (`id -u` returning 0, or a
-temp-dir check that file creation inside a `chmod`-restricted directory fails),
-never skipped silently. See the Acceptance Criteria preamble of
+The second criterion (the unremovable dead-owner arm) manufactures its
+precondition by `chmod` — a lock directory at `0o555`, so `rm -f` of its pid
+file fails and the pid persists across iterations — so 0186's permission-test
+rule governs it: it asserts `id -u` ≠ 0 and **hard-fails rather than skips**
+when run as root, since root bypasses the removal restriction the case relies on
+and would satisfy the assertion regardless of the fix. A lane structurally
+unable to comply is **excluded explicitly** by the implementer, justified by a
+recorded privilege check (`id -u` returning 0, or a temp-dir check that file
+removal inside a `chmod`-restricted directory fails), never skipped silently.
+See the Acceptance Criteria preamble of
 `meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` for the full
 rule.
 
-- [ ] A cold run against a cache directory whose lock directory cannot be
-      created fails fast, its combined output containing the lock directory path
-      and a fixed cause substring the fail-fast branch emits (asserted verbatim)
-      — not after the budget with a lock-timeout message. Run under the injected
-      low ceiling so a regression that falls through to the `else` arm still
-      completes in well under a second, making the diagnostic the discriminator
-      rather than wall-clock.
+The first criterion (the fail-fast arm) does **not** use `chmod` and needs no
+root guard. The 0186 probe gate checks `cache_dir` writability, not the lock
+*subdirectory*, so a `chmod`-unwritable cache directory is caught before
+`acquire_lock` is ever reached — the fail-fast branch is deterministically
+reachable only by planting a **non-directory file at the lock path**, which
+makes `mkdir` fail while `[[ -d ]]` is false without any permission
+manipulation.
+
+- [ ] A cold run whose lock path is occupied by a non-directory file (so
+      `mkdir` fails and `[[ -d "${lock_dir}" ]]` is false) fails fast, its
+      combined output containing the lock directory path and the fixed cause
+      substring `cannot create the launcher cache lock` (asserted verbatim) —
+      not after the budget with a lock-timeout message. Needs no `chmod` and no
+      root guard. Run under the injected low ceiling so a regression that falls
+      through to the `else` arm still completes in well under a second, making
+      the diagnostic the discriminator rather than wall-clock.
 - [ ] A lock directory holding a dead owner's pid file that cannot be removed
-      terminates within the loop's budget rather than spinning unbounded, and
-      its terminating exit is non-zero carrying the existing lock-timeout
-      message. Run under a small env-injected ceiling so the case completes in
-      well under a second, pinned by a harness subprocess `timeout=` set above
-      that injected budget (distinct from, and far below, the default
-      `300`-iteration budget) — so an unbounded regression trips the harness
-      timeout and shows as a failure rather than a hung suite.
+      — its directory `chmod`ed to `0o555`, so `rm -f` of the pid fails and the
+      pid persists — terminates within the loop's budget rather than spinning
+      unbounded, and its terminating exit is non-zero carrying the existing
+      lock-timeout message. Run under a small env-injected ceiling so the case
+      completes in well under a second, pinned by a harness subprocess
+      `timeout=` set above that injected budget (distinct from, and far below,
+      the default `300`-iteration budget) — so an unbounded regression trips the
+      harness timeout and shows as a failure rather than a hung suite.
 - [ ] `test_stale_lock_is_reclaimed` (a dead owner is still reclaimed) and
       `test_concurrent_cold_cache_slow_downloader_all_succeed` (a live owner
       still extends the budget) stay green.
@@ -129,12 +142,15 @@ unchanged.
 
 **Classification branch (mkdir arm).** After a failed `mkdir "${lock_dir}"`,
 test `[[ -d "${lock_dir}" ]]` before reading the pid file. A failed `mkdir`
-whose directory is *absent* is not `EEXIST` — the parent cache directory is
-unwritable and the `mkdir` can never succeed. Fail immediately, naming the lock
-path and the likely cause (permission or I/O), instead of entering the wait
-loop. `mkdir` exposes no shell-portable errno, so directory-presence is the only
-portable `EEXIST` discriminator — which is why the Requirements pick that
-predicate.
+whose path is *not a directory* is not a live-competitor `EEXIST` — either a
+non-directory file occupies the path or the parent is unwritable, and the
+`mkdir` can never succeed. Fail immediately, naming the lock path with a
+cause-neutral message, instead of entering the wait loop. `mkdir` exposes no
+shell-portable errno, so directory-presence is the only portable discriminator —
+which is why the Requirements pick that predicate. The 0186 probe gate guards
+`cache_dir`, not the lock subdirectory, so the reachable-in-test trigger for
+this branch is a non-directory at the lock path, not an unwritable parent (which
+the gate catches first).
 
 **Bounding the dead-owner arm.** The reclaim arm (`rm -f pid` → `rmdir` →
 `continue`) advances neither `waited` nor `sleep`, so a `rmdir` that fails on a
@@ -145,8 +161,8 @@ acceptance criterion specifies "terminates within the timeout budget" for this
 arm rather than fail-fast, so a foreign lock directory is caught by the existing
 bound, not a new immediate-fail path.
 
-**Post-fix arm order.** mkdir succeeds → hold; mkdir fails + directory absent →
-fail fast (new); directory + live owner → reset budget; directory + dead owner +
+**Post-fix arm order.** mkdir succeeds → hold; mkdir fails + path is not a
+directory → fail fast (new); directory + live owner → reset budget; directory + dead owner +
 `rmdir` ok → reclaim and retry; directory + dead owner + `rmdir` fails → advance
 budget; directory + empty/unreadable pid (the `else` arm) → advance budget. That
 `else` arm still covers the genuine race window — a competitor that created the

--- a/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
+++ b/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
@@ -1,7 +1,7 @@
 ---
 type: work-item
 id: "0190"
-title: "acquire_lock cannot classify an unusable lock directory"
+title: "acquire_lock misclassifies an unusable lock directory and can spin unbounded on reclaim"
 date: "2026-08-03T00:00:00+00:00"
 author: Toby Clemson
 producer: implement-plan
@@ -9,14 +9,14 @@ status: draft
 kind: bug
 priority: medium
 parent: "work-item:0136"
-relates_to: ["work-item:0186", "work-item:0164"]
+relates_to: ["work-item:0186", "work-item:0164", "work-item:0191"]
 tags: [bug, shell, bootstrap, bash-3.2]
-last_updated: "2026-08-03T00:00:00+00:00"
+last_updated: "2026-08-21T00:00:06+00:00"
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
 
-# 0190: acquire_lock cannot classify an unusable lock directory
+# 0190: acquire_lock misclassifies an unusable lock directory and can spin unbounded on reclaim
 
 **Kind**: Bug
 **Status**: Draft
@@ -28,8 +28,8 @@ schema_version: 1
 `acquire_lock` in [`bin/accelerator`](../../bin/accelerator) treats every failed
 `mkdir "${lock_dir}"` as "someone else holds the lock". It has no notion of an
 `mkdir` that can never succeed, so an unusable lock directory is reported as a
-lock timeout after the full 300 × 0.1 s budget — and one arm has no bound at
-all.
+lock timeout after the full 300 × 0.1 s budget — and one branch of the retry
+loop has no bound at all.
 
 ## Context
 
@@ -42,7 +42,7 @@ failing with the wrong diagnostic (measured at a reduced ceiling as
 `TIMEOUT after 31 iters, 3s`). The gate masks that instance; it does not fix the
 classification.
 
-There is a worse arm, which neither gate prevents. When the pid file names a
+There is a worse arm, which the probe gate does not prevent. When the pid file names a
 dead process, the loop does `rm -f`/`rmdir` then `continue` — **with no `sleep`
 and no `waited` increment**. If the lock directory cannot be removed (created by
 another user, or the cache directory is writable but the lock directory is not),
@@ -55,34 +55,118 @@ happens to be foreign.
 - Classify the `mkdir` failure instead of assuming contention: after a failed
   `mkdir`, `[[ -d "${lock_dir}" ]]` distinguishes `EEXIST` (a genuine
   competitor) from a permission or I/O failure (unrecoverable — fail
-  immediately, naming the cause).
+  immediately, naming the lock path and a permission-or-I/O cause).
 - Give the dead-owner reclaim arm a bound: a failed `rmdir` must not loop
-  without advancing the budget.
+  without advancing the budget. This arm is the more severe of the two defects
+  — an unbounded hang, not a wrong diagnostic after a bounded budget — even
+  though the item as a whole is medium priority.
+- Make the loop's iteration ceiling env-injectable so the bounded arm can be
+  exercised under a small budget: the default stays `300` (× `sleep 0.1`), and
+  a test overrides it to a low value for a sub-second, deterministic
+  bounded-vs-unbounded check.
 - Stay within the bash 3.2 floor.
 
-**Scope**: classifying `mkdir` and `rmdir` failures. **Not** re-wording the
-timeout message, and not redesigning the locking scheme.
+**Scope**: classifying `mkdir` and `rmdir` failures, and the env-injectable
+ceiling that makes the bounded arm testable. **Not** re-wording the timeout
+message, and not redesigning the locking scheme.
 
 ## Acceptance Criteria
 
+The first two criteria manufacture their preconditions by `chmod`, so 0186's
+permission-test rule governs them: each asserts `id -u` ≠ 0 and **hard-fails
+rather than skips** when run as root, since root bypasses the write and removal
+restrictions these cases rely on and would satisfy the assertions regardless of
+the fix. A lane structurally unable to comply is **excluded explicitly** by the
+implementer, justified by a recorded privilege check (`id -u` returning 0, or a
+temp-dir check that file creation inside a `chmod`-restricted directory fails),
+never skipped silently. See the Acceptance Criteria preamble of
+`meta/work/0186-remove-exec-probe-from-bootstrap-warm-path.md` for the full
+rule.
+
 - [ ] A cold run against a cache directory whose lock directory cannot be
-      created fails within a second with a diagnostic naming the cause, not
-      after the timeout budget with a lock-timeout message.
+      created fails fast, its combined output containing the lock directory path
+      and a fixed cause substring the fail-fast branch emits (asserted verbatim)
+      — not after the budget with a lock-timeout message. Run under the injected
+      low ceiling so a regression that falls through to the `else` arm still
+      completes in well under a second, making the diagnostic the discriminator
+      rather than wall-clock.
 - [ ] A lock directory holding a dead owner's pid file that cannot be removed
-      terminates within the timeout budget rather than spinning unbounded —
-      pinned by a case with an explicit `timeout=`, so a regression shows as a
-      failure rather than a hung suite.
-- [ ] `test_stale_lock_is_reclaimed` and
-      `test_concurrent_cold_cache_slow_downloader_all_succeed` stay green: a
-      live owner still extends the budget and a dead owner is still reclaimed.
+      terminates within the loop's budget rather than spinning unbounded, and
+      its terminating exit is non-zero carrying the existing lock-timeout
+      message. Run under a small env-injected ceiling so the case completes in
+      well under a second, pinned by a harness subprocess `timeout=` set above
+      that injected budget (distinct from, and far below, the default
+      `300`-iteration budget) — so an unbounded regression trips the harness
+      timeout and shows as a failure rather than a hung suite.
+- [ ] `test_stale_lock_is_reclaimed` (a dead owner is still reclaimed) and
+      `test_concurrent_cold_cache_slow_downloader_all_succeed` (a live owner
+      still extends the budget) stay green.
+- [ ] A lock directory holding an empty or unreadable pid file advances the
+      budget rather than failing fast or reclaiming — a deterministic case that
+      pins the `else` arm the classification branch must leave intact, run under
+      the injected low ceiling so it terminates in well under a second.
 - [ ] `scripts/lint-bashisms.sh`, shfmt and ShellCheck report no findings.
 - [ ] `mise run` (bare default task) exits 0 end-to-end.
 
 ## Dependencies
 
 - **Relates to**: 0186, which masked the one reachable instance and recorded the
-  unbounded arm; 0164, which introduced the lock.
+  unbounded arm; 0164, which introduced the lock; 0191, which edits a different
+  region of `bin/accelerator` (the shim-staging block), so the two can land in
+  either order — the shared file is not a merge coupling.
+- **On 0186's masking gate**: the cold-branch probe gate 0186 added is retained
+  as defence-in-depth, not removed by this fix — the item does not redesign the
+  locking scheme, and the gate keeps its own regression guard
+  (`test_unverifiable_launcher_in_readonly_cache_fails_fast`). Nothing
+  downstream waits on this fix.
 - **Parent**: epic 0136.
+
+## Technical Notes
+
+The loop in `acquire_lock` has three post-`mkdir`-failure arms. The fix adds one
+classification branch and bounds a second arm; the mkdir+pid scheme is otherwise
+unchanged.
+
+**Classification branch (mkdir arm).** After a failed `mkdir "${lock_dir}"`,
+test `[[ -d "${lock_dir}" ]]` before reading the pid file. A failed `mkdir`
+whose directory is *absent* is not `EEXIST` — the parent cache directory is
+unwritable and the `mkdir` can never succeed. Fail immediately, naming the lock
+path and the likely cause (permission or I/O), instead of entering the wait
+loop. `mkdir` exposes no shell-portable errno, so directory-presence is the only
+portable `EEXIST` discriminator — which is why the Requirements pick that
+predicate.
+
+**Bounding the dead-owner arm.** The reclaim arm (`rm -f pid` → `rmdir` →
+`continue`) advances neither `waited` nor `sleep`, so a `rmdir` that fails on a
+foreign lock directory spins unbounded. Gate the `continue` on `rmdir`
+succeeding; on `rmdir` failure fall through to `waited=$((waited + 1))` and
+`sleep 0.1`, so the arm shares the `else` arm's 300-iteration cap. The
+acceptance criterion specifies "terminates within the timeout budget" for this
+arm rather than fail-fast, so a foreign lock directory is caught by the existing
+bound, not a new immediate-fail path.
+
+**Post-fix arm order.** mkdir succeeds → hold; mkdir fails + directory absent →
+fail fast (new); directory + live owner → reset budget; directory + dead owner +
+`rmdir` ok → reclaim and retry; directory + dead owner + `rmdir` fails → advance
+budget; directory + empty/unreadable pid (the `else` arm) → advance budget. That
+`else` arm still covers the genuine race window — a competitor that created the
+directory but has not yet written its pid.
+
+**bash 3.2 floor.** `[[ -d ]]`, `[[ -n ]]`, `kill -0`, and `$(( ))` are all
+3.2-safe; the fix needs no bash-4 construct (no associative arrays, `${var,,}`,
+or `mapfile`).
+
+**Testability of the timeout case.** The ceiling defaults to `300`
+(× `sleep 0.1` ≈ 30 s wall) but is env-injectable (a Requirement), so the
+bounded-arm case overrides it to a low value and completes in well under a
+second. The acceptance criterion's harness subprocess `timeout=`
+(`_run_bootstrap(..., timeout=N)` in
+`tests/integration/entrypoint/test_accelerator_entrypoint.py`) is a **distinct**
+timeout from the loop's own budget: set it above the injected ceiling but far
+below the default 30 s, so a correctly-bounded loop exits cleanly before it
+fires while an unbounded regression trips it — either way a failure, never a
+hung suite and never a permanently ~30 s test. The env-injectable ceiling is a
+testability seam, not a redesign of the scheme.
 
 ## References
 

--- a/tests/integration/entrypoint/test_accelerator_entrypoint.py
+++ b/tests/integration/entrypoint/test_accelerator_entrypoint.py
@@ -322,6 +322,129 @@ def test_stale_lock_is_reclaimed(
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_uncreatable_lock_dir_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    # A file at the lock path: mkdir fails and the path is a non-directory.
+    (root / f"bin/.accelerator-lock-{host_platform}").write_text("")
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "cannot create the launcher cache lock" in output, output
+    assert "timed out" not in output, output
+
+
+def test_unremovable_dead_owner_lock_terminates_within_budget(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    _require_unprivileged()
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text("999999\n")  # dead PID, unreadable-to-rm below
+    with _restricted(lock, 0o555):  # rm of pid fails; the pid persists
+        result = _run_bootstrap(
+            root,
+            server,
+            downloader,
+            extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+            timeout=15,
+        )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+
+
+def test_empty_pid_lock_advances_budget(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text("")  # competitor made the dir, no pid written yet
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+    assert "cannot create the launcher cache lock" not in output, output
+
+
+def test_symlink_lock_path_fails_fast(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    target = root / "foreign-lock-target"
+    target.mkdir()
+    (target / "pid").write_text(
+        "999999\n"
+    )  # a dead owner: reclaim would rm this
+    (root / f"bin/.accelerator-lock-{host_platform}").symlink_to(target)
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "3"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "cannot create the launcher cache lock" in output, output
+    assert "timed out" not in output, output
+    assert (target / "pid").read_text() == "999999\n", (
+        "reclaim followed symlink"
+    )
+
+
+def test_leading_zero_ceiling_is_decimal_not_octal(
+    make_harness: Callable[..., Harness],
+    downloader: Path,
+    host_platform: str,
+) -> None:
+    harness = make_harness()
+    root, server = harness.root, harness.server
+    lock = root / f"bin/.accelerator-lock-{host_platform}"
+    lock.mkdir()
+    (lock / "pid").write_text(
+        ""
+    )  # empty pid → else arm, bounded by the ceiling
+    result = _run_bootstrap(
+        root,
+        server,
+        downloader,
+        # 08: invalid octal; base-10 makes it a ceiling of 8, not an error
+        extra_env={"ACCELERATOR_LOCK_MAX_WAIT": "08"},
+        timeout=15,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, output
+    assert "timed out acquiring the launcher cache lock" in output, output
+
+
 def test_path_planted_decoy_shim_is_not_used(
     make_harness: Callable[..., Harness],
     downloader: Path,


### PR DESCRIPTION

# [0190] Classify acquire_lock mkdir failures and bound the reclaim arm

## Summary

Fixes two defects in `acquire_lock` (`bin/accelerator`): a failed `mkdir` on an unusable lock path was misclassified as contention and reported as a ~30 s lock timeout, and the dead-owner reclaim arm could spin unbounded when the lock directory could not be removed. The production change is 19 lines in one function, guarded by five deterministic integration tests; the remaining files are the 0190 lifecycle artefacts (work item, research, reviews, plan, validation).

## Changes

- **Classify the mkdir failure before assuming contention.** A symlink or non-directory occupying the lock path now fails fast with `cannot create the launcher cache lock: <path>` instead of burning the wait budget and reporting a lock timeout. A merely-absent directory (a competitor that just released) falls through and retries, so a released competitor is never misclassified. The `-L` guard also stops the reclaim `rm`/`rmdir` from following an attacker-planted symlink.
- **Bound the dead-owner reclaim arm.** The reclaim `continue` now fires only when both `rm -f` and `rmdir` succeed; any failure falls through to the budget-advancing `else`, so an unremovable foreign lock terminates within the ceiling rather than busy-spinning with no timeout — the more severe of the two defects.
- **Make the iteration ceiling env-injectable and injection-safe.** `max_wait` is read once from `ACCELERATOR_LOCK_MAX_WAIT` (default 300), validated to an all-digit string, and normalised to base 10 via `$((10#…))`. A non-numeric value falls back to 300 and a leading-zero value (`08`) is read decimally, not as an invalid octal literal — closing the arithmetic-injection surface and the silent loss-of-bound under `set -uo pipefail` (no `-e`). The knob also lets the bounded arm test sub-second.
- **Five integration tests** in `test_accelerator_entrypoint.py`, one per post-fix arm: fail-fast on a file and on a symlink at the lock path, bounded termination on an unremovable dead owner, the empty-pid `else` arm, and the base-10 ceiling.

## Context

- Work item: `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`
- Research: `meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md`
- Plan: `meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md`
- Validation: `meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md`

## Testing

- [x] New lock tests pass: `uv run pytest tests/integration/entrypoint/test_accelerator_entrypoint.py -k "lock or leading_zero"` (6 passed).
- [x] Retained lock guards stay green: `-k "stale_lock or slow_downloader or readonly_cache_fails_fast"` (3 passed).
- [x] Shell lint clean: `mise run scripts:check` (bashisms, exec-bits, shfmt, ShellCheck).
- [x] Read-only CI mirror passes: `mise run check` (exit 0).
- [ ] Full default gate `mise run` not re-run locally this session — the outstanding delta is the docs CI lane, untouched by this change; CI covers it.
- [x] bash 3.2 floor: the `macos-latest` integration leg exercises the tests under system bash 3.2; the fix uses only 3.2-safe constructs.

## Notes for Reviewers

- The reclaim remains intentionally non-single-winner and the reclaim-*success* `continue` stays a no-sleep fast-retry — both scoped out in the plan's "What We're NOT Doing", safe because the guarded critical section is idempotent. Residual availability classes (reused-pid live-owner reset, shared-cache DoS) are documented there and unchanged.
- ⚠️ The AC1 fail-fast branch is reachable in tests only via a non-directory/symlink at the lock path, because the 0186 gate `require_exec_capable_cache` probes `cache_dir` (not the lock subdirectory). If that gate is ever removed, add a direct test for the unwritable-parent trigger.
- Follow-up 0191 edits a different region of the same file, so there is no merge coupling.
