### PR TITLE
[0190] Mark the acquire_lock mkdir classification work item done

### DIFF
--- a/meta/prs/75-description.md
+++ b/meta/prs/75-description.md
@@ -1,0 +1,45 @@
+---
+type: pr-description
+id: "75"
+title: "Mark the acquire_lock mkdir classification work item done"
+date: "2026-08-22T19:56:17+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "work-item:0190"
+parent: "work-item:0190"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/75"
+pr_number: 75
+tags: [work-item, status, housekeeping]
+revision: "8135fffef8070e43c4002a7e8b275947a4bdf0f7"
+repository: "accelerator"
+last_updated: "2026-08-22T19:56:17+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0190] Mark the acquire_lock mkdir classification work item done
+
+## Summary
+
+Closes the lifecycle of work item 0190 by transitioning its status to `done`, now that the acquire_lock mkdir-classification fix has landed on `main`. Metadata only — a single-file change with no code or test impact.
+
+## Changes
+
+- Set `status: draft → done` in the frontmatter of `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`.
+- Sync the `**Status**:` body label from `Draft` to `Done` to match.
+
+## Context
+
+- Work item: `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`
+- Implementation and validation merged separately; `main` already carries the fix through commit `e3ee966e` (the 0190 bookmark's tip).
+- Validation: `meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md` (result: pass).
+
+## Testing
+
+- [x] No code paths touched — the change is confined to a work-item markdown file's frontmatter and body label.
+- [x] Frontmatter written via `accelerator work update` (exit 0); body label edited to match.
+
+## Notes for Reviewers
+
+- Pure status bookkeeping. The substantive acquire_lock fix — mkdir-failure classification, bounded reclaim arm, and the `ACCELERATOR_LOCK_MAX_WAIT` ceiling — is already on `main` and out of scope here.

--- a/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
+++ b/meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md
@@ -1,17 +1,19 @@
 ---
 type: work-item
 id: "0190"
-title: "acquire_lock misclassifies an unusable lock directory and can spin unbounded on reclaim"
-date: "2026-08-03T00:00:00+00:00"
+title: >-
+  acquire_lock misclassifies an unusable lock directory and can spin unbounded on
+  reclaim
+date: 2026-08-03T00:00:00+00:00
 author: Toby Clemson
 producer: implement-plan
-status: draft
+status: done
 kind: bug
 priority: medium
 parent: "work-item:0136"
 relates_to: ["work-item:0186", "work-item:0164", "work-item:0191"]
 tags: [bug, shell, bootstrap, bash-3.2]
-last_updated: "2026-08-21T15:21:54+00:00"
+last_updated: 2026-08-21T15:21:54+00:00
 last_updated_by: Toby Clemson
 schema_version: 1
 ---
@@ -19,7 +21,7 @@ schema_version: 1
 # 0190: acquire_lock misclassifies an unusable lock directory and can spin unbounded on reclaim
 
 **Kind**: Bug
-**Status**: Draft
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 


### PR DESCRIPTION

# [0190] Mark the acquire_lock mkdir classification work item done

## Summary

Closes the lifecycle of work item 0190 by transitioning its status to `done`, now that the acquire_lock mkdir-classification fix has landed on `main`. Metadata only — a single-file change with no code or test impact.

## Changes

- Set `status: draft → done` in the frontmatter of `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`.
- Sync the `**Status**:` body label from `Draft` to `Done` to match.

## Context

- Work item: `meta/work/0190-acquire-lock-cannot-classify-mkdir-failures.md`
- Implementation and validation merged separately; `main` already carries the fix through commit `e3ee966e` (the 0190 bookmark's tip).
- Validation: `meta/validations/2026-08-21-0190-classify-lock-mkdir-failures-validation.md` (result: pass).

## Testing

- [x] No code paths touched — the change is confined to a work-item markdown file's frontmatter and body label.
- [x] Frontmatter written via `accelerator work update` (exit 0); body label edited to match.

## Notes for Reviewers

- Pure status bookkeeping. The substantive acquire_lock fix — mkdir-failure classification, bounded reclaim arm, and the `ACCELERATOR_LOCK_MAX_WAIT` ceiling — is already on `main` and out of scope here.
