### PR TITLE
[0220] Bound Linear untracked discovery to the configured team

### DIFF
--- a/cli/jira-client/src/client.rs
+++ b/cli/jira-client/src/client.rs
@@ -16,6 +16,7 @@ use tracker::FieldResolution;
 use tracker::RemoteIssue;
 use tracker::RemoteTimestamp;
 use tracker::RemoteTracker;
+use tracker::ScopeError;
 use tracker::SearchScope;
 use tracker::TrackerError;
 use tracker::ValidationOutcome;
@@ -586,6 +587,20 @@ impl RemoteTracker for JiraClient {
             }
         }
         Ok(outcome)
+    }
+
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, ScopeError> {
+        if scope.project.is_none() && !scope.all_projects {
+            return Err(ScopeError {
+                detail: "E_JQL_NO_PROJECT: specify a project or all_projects, \
+                         or run --push-only to push without discovery"
+                    .to_owned(),
+            });
+        }
+        Ok(scope.clone())
     }
 
     fn search(&self, scope: &SearchScope) -> Result<Discovery, TrackerError> {

--- a/cli/jira-client/tests/resolve_scope.rs
+++ b/cli/jira-client/tests/resolve_scope.rs
@@ -1,0 +1,68 @@
+//! `resolve_scope`: Jira's discovery-path refusal, moved ahead of `search`.
+//! An unscoped scope is refused with `E_JQL_NO_PROJECT`; a scoped one passes
+//! through unchanged (Jira's JQL uses the project key directly).
+
+#![allow(clippy::expect_used)]
+
+mod support;
+
+use http_test_support::MockServer;
+use support::client::client_for;
+use tracker::RemoteTracker;
+use tracker::SearchScope;
+use tracker_support::TransportConfig;
+
+fn scope(project: Option<&str>, all_projects: bool) -> SearchScope {
+    SearchScope {
+        project: project.map(str::to_owned),
+        all_projects,
+        filters: Vec::new(),
+    }
+}
+
+#[test]
+fn a_scoped_project_passes_through_unchanged() {
+    let server = MockServer::start();
+    let client = client_for(&server, TransportConfig::default());
+
+    let resolved = client
+        .resolve_scope(&scope(Some("OPS"), false))
+        .expect("a project-scoped run resolves");
+
+    assert_eq!(resolved.project.as_deref(), Some("OPS"));
+    assert_eq!(
+        server.hits(&http_test_support::RequestKey::post(
+            "/rest/api/3/search/jql"
+        )),
+        0,
+        "resolve_scope makes no network call"
+    );
+}
+
+#[test]
+fn all_projects_passes_through_unchanged() {
+    let server = MockServer::start();
+    let client = client_for(&server, TransportConfig::default());
+
+    let resolved = client
+        .resolve_scope(&scope(None, true))
+        .expect("an all-projects run resolves");
+
+    assert!(resolved.all_projects);
+}
+
+#[test]
+fn an_unscoped_run_is_refused_with_e_jql_no_project() {
+    let server = MockServer::start();
+    let client = client_for(&server, TransportConfig::default());
+
+    let error = client
+        .resolve_scope(&scope(None, false))
+        .expect_err("an unscoped run is refused");
+
+    assert!(
+        error.detail.contains("E_JQL_NO_PROJECT"),
+        "{}",
+        error.detail
+    );
+}

--- a/cli/jira-client/tests/resolve_scope.rs
+++ b/cli/jira-client/tests/resolve_scope.rs
@@ -1,4 +1,4 @@
-//! `resolve_scope`: Jira's discovery-path refusal, moved ahead of `search`.
+//! `resolve_scope`: Jira's discovery-path refusal, run before `search`.
 //! An unscoped scope is refused with `E_JQL_NO_PROJECT`; a scoped one passes
 //! through unchanged (Jira's JQL uses the project key directly).
 

--- a/cli/linear-cli/src/context.rs
+++ b/cli/linear-cli/src/context.rs
@@ -19,6 +19,7 @@ use config_adapters::LegacyPolicy;
 use linear_client::auth::catalogue_team_key;
 use linear_client::auth::resolve_credentials;
 use linear_client::catalogue::CatalogueStates;
+use linear_client::catalogue::CatalogueTeam;
 use linear_client::transport::Transport;
 use linear_client::transport::Url;
 use linear_client::upload::url_is_allowed;
@@ -178,11 +179,13 @@ fn build_with_override(
     let allow_loopback = cfg!(feature = "test-loopback");
     let upload = UploadTransport::new(allow_loopback, Duration::from_secs(1))?;
     let team_key = catalogue_team_key(integrations_root);
+    let teams = CatalogueTeam::load(integrations_root);
     let states = CatalogueStates::load(integrations_root);
     Ok(LinearClient::new(
         transport,
         upload,
         team_key,
+        Box::new(teams),
         Box::new(states),
     ))
 }

--- a/cli/linear-client/src/catalogue.rs
+++ b/cli/linear-client/src/catalogue.rs
@@ -10,6 +10,20 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::filter::StateResolver;
+use crate::filter::TeamResolver;
+
+/// A non-empty string at `pointer` in `catalogue`, or `None`.
+///
+/// Mirrors `auth.rs`'s `catalogue_field`: an empty string reads as `None`, so a
+/// blank `/team/key` never resolves and a blank `/team/id` never masquerades as
+/// a UUID.
+fn pointer_string(catalogue: &Value, pointer: &str) -> Option<String> {
+    catalogue
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
 
 /// Workflow states loaded from a catalogue, each a display name paired with its
 /// UUID.
@@ -73,5 +87,51 @@ impl StateResolver for CatalogueStates {
             .filter(|(state_name, _)| normalise(state_name) == wanted)
             .map(|(_, id)| id.clone())
             .collect()
+    }
+}
+
+/// The single team a catalogue names, its key paired with its UUID — the
+/// cache-backed [`TeamResolver`], resolving a configured team key to the UUID a
+/// search filter needs.
+#[derive(Debug, Clone, Default)]
+pub struct CatalogueTeam {
+    key: Option<String>,
+    id: Option<String>,
+}
+
+impl CatalogueTeam {
+    /// Loads the team from `<integrations_root>/linear/catalogue.json`, yielding
+    /// an empty resolver when the catalogue is absent or unreadable — so a
+    /// missing catalogue resolves nothing rather than erroring.
+    #[must_use]
+    pub fn load(integrations_root: &Path) -> Self {
+        let path = integrations_root.join("linear/catalogue.json");
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .map(|catalogue| Self::from_catalogue(&catalogue))
+            .unwrap_or_default()
+    }
+
+    /// Builds a resolver directly from a parsed catalogue.
+    #[must_use]
+    pub fn from_catalogue(catalogue: &Value) -> Self {
+        Self {
+            key: pointer_string(catalogue, "/team/key"),
+            id: pointer_string(catalogue, "/team/id"),
+        }
+    }
+}
+
+impl TeamResolver for CatalogueTeam {
+    fn resolve(&self, key: &str) -> Option<String> {
+        match (&self.key, &self.id) {
+            (Some(team_key), Some(team_id))
+                if team_key.trim() == key.trim() =>
+            {
+                Some(team_id.clone())
+            }
+            _ => None,
+        }
     }
 }

--- a/cli/linear-client/src/client.rs
+++ b/cli/linear-client/src/client.rs
@@ -18,6 +18,7 @@ use tracker::FieldResolution;
 use tracker::RemoteIssue;
 use tracker::RemoteTimestamp;
 use tracker::RemoteTracker;
+use tracker::ScopeError;
 use tracker::SearchScope;
 use tracker::TrackerError;
 use tracker::ValidationOutcome;
@@ -31,6 +32,7 @@ use crate::auth::check_identifier;
 use crate::auth::resolve_credentials;
 use crate::auth::Credentials;
 use crate::catalogue::CatalogueStates;
+use crate::catalogue::CatalogueTeam;
 use crate::classify::carries_errors;
 use crate::classify::classify;
 use crate::classify::classify_errors;
@@ -41,6 +43,7 @@ use crate::failure::LinearFailure;
 use crate::filter::compose;
 use crate::filter::Search;
 use crate::filter::StateResolver;
+use crate::filter::TeamResolver;
 use crate::filter::FETCH_PAGE_SIZE;
 use crate::surface::interpret as interpret_surface;
 use crate::surface::SurfaceError;
@@ -122,6 +125,7 @@ pub struct LinearClient {
     transport: Transport,
     upload: UploadTransport,
     team_key: Option<String>,
+    teams: Box<dyn TeamResolver>,
     states: Box<dyn StateResolver>,
 }
 
@@ -131,12 +135,14 @@ impl LinearClient {
         transport: Transport,
         upload: UploadTransport,
         team_key: Option<String>,
+        teams: Box<dyn TeamResolver>,
         states: Box<dyn StateResolver>,
     ) -> Self {
         Self {
             transport,
             upload,
             team_key,
+            teams,
             states,
         }
     }
@@ -161,8 +167,15 @@ impl LinearClient {
             Box::new(ClockJitter),
         )?;
         let upload = UploadTransport::production()?;
+        let teams = CatalogueTeam::load(integrations_root);
         let states = CatalogueStates::load(integrations_root);
-        Ok(Self::new(transport, upload, team_key, Box::new(states)))
+        Ok(Self::new(
+            transport,
+            upload,
+            team_key,
+            Box::new(teams),
+            Box::new(states),
+        ))
     }
 
     #[must_use]
@@ -658,12 +671,44 @@ impl RemoteTracker for LinearClient {
         Ok(outcome)
     }
 
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, ScopeError> {
+        let Some(key) = scope.project.as_deref() else {
+            return Err(ScopeError {
+                detail: "E_SEARCH_NO_TEAM: discovery needs a team key; set \
+                         work.default_project_code, or run --push-only to push \
+                         without discovery"
+                    .to_owned(),
+            });
+        };
+        let Some(team_id) = self.teams.resolve(key) else {
+            return Err(ScopeError {
+                detail: format!(
+                    "E_SEARCH_UNKNOWN_TEAM: team key {key:?} resolves to no \
+                     team in the catalogue; check work.default_project_code \
+                     matches the catalogue team key, or refresh \
+                     linear/catalogue.json"
+                ),
+            });
+        };
+        Ok(SearchScope {
+            project: Some(team_id),
+            ..scope.clone()
+        })
+    }
+
     fn search(&self, scope: &SearchScope) -> Result<Discovery, TrackerError> {
+        let Some(team_id) = scope.project.clone() else {
+            return Err(TrackerError::Retryable {
+                detail: "E_SEARCH_UNRESOLVED_SCOPE: search needs a resolved \
+                         team id; call resolve_scope first"
+                    .to_owned(),
+            });
+        };
         let mut search = Search {
-            team_id: scope
-                .project
-                .clone()
-                .or_else(|| Some(self.credentials().team_id.clone())),
+            team_id: Some(team_id),
             ..Search::default()
         };
         for (field, value) in &scope.filters {

--- a/cli/linear-client/src/filter.rs
+++ b/cli/linear-client/src/filter.rs
@@ -12,9 +12,6 @@ use serde_json::Value;
 use crate::error::ClientError;
 
 /// Resolves a workflow-state name to its UUID.
-///
-/// A port from the outset so the cache-backed implementation can land later
-/// without a constructor change.
 pub trait StateResolver {
     /// The single UUID a name resolves to, or `None` when it names no state or
     /// more than one.
@@ -44,8 +41,7 @@ impl StateResolver for FixedStates {
 ///
 /// A separate job from [`StateResolver`]: a config names the team by its key,
 /// but the `{team:{id:{eq:…}}}` filter is evaluated against the UUID, so an
-/// unresolved key silently matches no team. A port from the outset so the
-/// catalogue-backed implementation can land beside the fixed one.
+/// unresolved key silently matches no team.
 pub trait TeamResolver {
     /// The team UUID `key` resolves to, or `None` when it matches no team.
     fn resolve(&self, key: &str) -> Option<String>;

--- a/cli/linear-client/src/filter.rs
+++ b/cli/linear-client/src/filter.rs
@@ -39,6 +39,28 @@ impl StateResolver for FixedStates {
     }
 }
 
+/// Resolves a team **key** — the `ENG` in `ENG-42` — to the team UUID a search
+/// filter needs.
+///
+/// A separate job from [`StateResolver`]: a config names the team by its key,
+/// but the `{team:{id:{eq:…}}}` filter is evaluated against the UUID, so an
+/// unresolved key silently matches no team. A port from the outset so the
+/// catalogue-backed implementation can land beside the fixed one.
+pub trait TeamResolver {
+    /// The team UUID `key` resolves to, or `None` when it matches no team.
+    fn resolve(&self, key: &str) -> Option<String>;
+}
+
+/// A fixed map, used by the search suites and by any caller with no catalogue.
+#[derive(Debug, Clone, Default)]
+pub struct FixedTeam(pub std::collections::BTreeMap<String, String>);
+
+impl TeamResolver for FixedTeam {
+    fn resolve(&self, key: &str) -> Option<String> {
+        self.0.get(key.trim()).cloned()
+    }
+}
+
 /// Everything the search surface accepts, in the bash's own shape.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Search {

--- a/cli/linear-client/src/lib.rs
+++ b/cli/linear-client/src/lib.rs
@@ -24,6 +24,7 @@ pub mod upload;
 pub use crate::auth::resolve_credentials;
 pub use crate::auth::Credentials;
 pub use crate::catalogue::CatalogueStates;
+pub use crate::catalogue::CatalogueTeam;
 pub use crate::classify::classify;
 pub use crate::classify::GraphQlError;
 pub use crate::classify::Operation;

--- a/cli/linear-client/tests/catalogue.rs
+++ b/cli/linear-client/tests/catalogue.rs
@@ -4,7 +4,9 @@
 #![allow(clippy::expect_used)]
 
 use linear_client::filter::StateResolver as _;
+use linear_client::filter::TeamResolver as _;
 use linear_client::CatalogueStates;
+use linear_client::CatalogueTeam;
 use serde_json::json;
 
 fn catalogue() -> serde_json::Value {
@@ -51,4 +53,32 @@ fn a_shared_display_name_resolves_to_every_matching_id() {
 fn an_absent_catalogue_loads_an_empty_resolver() {
     let states = CatalogueStates::load(std::path::Path::new("/nonexistent"));
     assert!(states.resolve_all("anything").is_empty());
+}
+
+#[test]
+fn catalogue_team_resolves_the_matching_key_to_its_uuid() {
+    let team = CatalogueTeam::from_catalogue(&catalogue());
+    assert_eq!(team.resolve("ENG"), Some("team-1".to_owned()));
+    assert_eq!(team.resolve("  ENG  "), Some("team-1".to_owned()));
+}
+
+#[test]
+fn catalogue_team_resolves_a_non_matching_key_to_nothing() {
+    let team = CatalogueTeam::from_catalogue(&catalogue());
+    assert_eq!(team.resolve("OTHER"), None);
+}
+
+#[test]
+fn catalogue_team_from_an_absent_catalogue_resolves_nothing() {
+    let team = CatalogueTeam::load(std::path::Path::new("/nonexistent"));
+    assert_eq!(team.resolve("ENG"), None);
+}
+
+#[test]
+fn catalogue_team_with_a_blank_key_resolves_nothing() {
+    let team = CatalogueTeam::from_catalogue(&json!({
+        "team": { "id": "team-1", "key": "" }
+    }));
+    assert_eq!(team.resolve(""), None, "a blank key must not resolve");
+    assert_eq!(team.resolve("ENG"), None);
 }

--- a/cli/linear-client/tests/contract.rs
+++ b/cli/linear-client/tests/contract.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use linear_client::filter::FixedStates;
+use linear_client::filter::FixedTeam;
 use linear_client::transport::Transport;
 use linear_client::{LinearClient, UploadTransport};
 use tracker::ExternalId;
@@ -147,6 +148,7 @@ fn live_client() -> LiveClient {
             transport,
             UploadTransport::production().expect("the upload transport builds"),
             Some(team_key),
+            Box::new(FixedTeam::default()),
             Box::new(FixedStates::default()),
         ),
         unaccountable: ExternalId::new(

--- a/cli/linear-client/tests/contract_offline.rs
+++ b/cli/linear-client/tests/contract_offline.rs
@@ -11,11 +11,12 @@ mod support;
 
 use http_test_support::{MockServer, RequestKey, Route};
 use linear_client::LinearClient;
-use support::client::{brief, client_with, TEAM_KEY};
+use support::client::{brief, client_with, TEAM_ID, TEAM_KEY};
 use tracker::CreatePreview;
 use tracker::ExternalId;
 use tracker::FieldResolution;
 use tracker::RemoteTracker;
+use tracker::SearchScope;
 use tracker::ValidationOutcome;
 use tracker_test_support::contract::{
     a_failing_read_is_retryable_property,
@@ -50,6 +51,16 @@ impl ContractSubject for MockBackedClient {
 
     fn unreadable_id(&self) -> ExternalId {
         ExternalId::new(UNREADABLE.to_owned())
+    }
+
+    /// The truncation property calls `search` directly, so its scope must
+    /// already carry the resolved team UUID `resolve_scope` would have produced.
+    fn truncating_scope(&self) -> SearchScope {
+        SearchScope {
+            project: Some(TEAM_ID.to_owned()),
+            all_projects: false,
+            filters: Vec::new(),
+        }
     }
 }
 

--- a/cli/linear-client/tests/resolve_scope.rs
+++ b/cli/linear-client/tests/resolve_scope.rs
@@ -1,0 +1,68 @@
+//! `resolve_scope`: the pre-flight step that substitutes a team key for its
+//! UUID and refuses a scope that names no team.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+mod support;
+
+use http_test_support::MockServer;
+use support::client::{brief, client_for, TEAM_ID, TEAM_KEY};
+use tracker::RemoteTracker;
+use tracker::SearchScope;
+
+fn keyed(project: Option<&str>) -> SearchScope {
+    SearchScope {
+        project: project.map(str::to_owned),
+        all_projects: false,
+        filters: Vec::new(),
+    }
+}
+
+#[test]
+fn a_matching_team_key_resolves_to_the_uuid() {
+    let server = MockServer::start();
+    let client = client_for(&server, brief());
+
+    let resolved = client
+        .resolve_scope(&keyed(Some(TEAM_KEY)))
+        .expect("a known team key resolves");
+
+    assert_eq!(
+        resolved.project.as_deref(),
+        Some(TEAM_ID),
+        "the resolved scope carries the UUID, not the raw key"
+    );
+}
+
+#[test]
+fn an_unknown_team_key_is_refused_naming_it() {
+    let server = MockServer::start();
+    let client = client_for(&server, brief());
+
+    let error = client
+        .resolve_scope(&keyed(Some("ZZ")))
+        .expect_err("a key matching no team is refused");
+
+    assert!(
+        error.detail.contains("E_SEARCH_UNKNOWN_TEAM"),
+        "{}",
+        error.detail
+    );
+    assert!(error.detail.contains("ZZ"), "{}", error.detail);
+}
+
+#[test]
+fn a_missing_team_key_is_refused() {
+    let server = MockServer::start();
+    let client = client_for(&server, brief());
+
+    let error = client
+        .resolve_scope(&keyed(None))
+        .expect_err("an unkeyed scope is refused");
+
+    assert!(
+        error.detail.contains("E_SEARCH_NO_TEAM"),
+        "{}",
+        error.detail
+    );
+}

--- a/cli/linear-client/tests/search_projection.rs
+++ b/cli/linear-client/tests/search_projection.rs
@@ -13,6 +13,8 @@ use http_test_support::{MockServer, RequestKey, Route};
 use linear_client::Search;
 use serde_json::Value;
 use support::client::{brief, client_for, TEAM_ID};
+use tracker::RemoteTracker;
+use tracker::SearchScope;
 
 const GRAPHQL: &str = "/graphql";
 
@@ -98,6 +100,46 @@ fn the_projection_selects_state_and_assignee_and_follows_the_cursor() {
         Some("c1"),
         "the second page carries the first page's endCursor"
     );
+}
+
+#[test]
+fn the_port_search_projects_the_resolved_team_uuid_into_every_body() {
+    let server = MockServer::start();
+    server.route(
+        RequestKey::post(GRAPHQL),
+        Route::Sequence(vec![
+            Route::Json {
+                status: 200,
+                body: page(&node("ENG-1", "Todo", "Ada"), true, "c1"),
+            },
+            Route::Json {
+                status: 200,
+                body: page(&node("ENG-2", "Done", "Grace"), false, ""),
+            },
+        ]),
+    );
+    let client = client_for(&server, brief());
+
+    // A pre-resolved scope: `project` is the UUID `resolve_scope` produces.
+    let scope = SearchScope {
+        project: Some(TEAM_ID.to_owned()),
+        all_projects: false,
+        filters: Vec::new(),
+    };
+
+    let discovery = client.search(&scope).expect("the search runs");
+    assert_eq!(discovery.found.len(), 2, "both pages accumulate");
+
+    let bodies = server.bodies(&RequestKey::post(GRAPHQL));
+    assert_eq!(bodies.len(), 2, "two pages were fetched");
+    let expected = format!("\"team\":{{\"id\":{{\"eq\":\"{TEAM_ID}\"}}}}");
+    for body in &bodies {
+        let text = String::from_utf8(body.clone()).expect("utf8");
+        assert!(
+            text.contains(&expected),
+            "every search body carries the resolved team UUID: {text}"
+        );
+    }
 }
 
 #[test]

--- a/cli/linear-client/tests/support/client.rs
+++ b/cli/linear-client/tests/support/client.rs
@@ -5,7 +5,9 @@
 use std::time::Duration;
 
 use http_test_support::MockServer;
-use linear_client::filter::{FixedStates, StateResolver};
+use linear_client::filter::{
+    FixedStates, FixedTeam, StateResolver, TeamResolver,
+};
 use linear_client::transport::Transport;
 use linear_client::{Credentials, LinearClient, UploadTransport};
 use reqwest::Url;
@@ -15,6 +17,15 @@ use super::{NoJitter, RecordingSleeper};
 
 pub const TEAM_ID: &str = "5c9f2a1b-0000-4000-8000-000000000001";
 pub const TEAM_KEY: &str = "ENG";
+
+/// The catalogue's single key → UUID pairing, so a scope keyed by `TEAM_KEY`
+/// resolves to `TEAM_ID` the way `CatalogueTeam` would in production.
+#[must_use]
+pub fn fixed_team() -> Box<dyn TeamResolver> {
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(TEAM_KEY.to_owned(), TEAM_ID.to_owned());
+    Box::new(FixedTeam(map))
+}
 
 #[must_use]
 pub fn credentials() -> Credentials {
@@ -69,6 +80,7 @@ pub fn client_with_states(
         transport,
         loopback_upload(),
         Some(TEAM_KEY.to_owned()),
+        fixed_team(),
         states,
     )
 }
@@ -93,6 +105,7 @@ pub fn client_with(
         transport,
         loopback_upload(),
         team_key,
+        fixed_team(),
         Box::new(FixedStates::default()),
     )
 }

--- a/cli/tracker-test-support/src/lib.rs
+++ b/cli/tracker-test-support/src/lib.rs
@@ -68,6 +68,7 @@ pub struct RecordingTracker {
     create_failure: Option<(TrackerError, bool)>,
     preview_failure: Option<TrackerError>,
     scope_refusal: Option<ScopeError>,
+    search_failure: Option<TrackerError>,
     search_result: RefCell<Option<Discovery>>,
     preview: RefCell<Option<CreatePreview>>,
     next_id: RefCell<u32>,
@@ -85,6 +86,7 @@ impl RecordingTracker {
             create_failure: None,
             preview_failure: None,
             scope_refusal: None,
+            search_failure: None,
             search_result: RefCell::new(None),
             preview: RefCell::new(None),
             next_id: RefCell::new(1),
@@ -169,6 +171,16 @@ impl RecordingTracker {
     #[must_use]
     pub fn refusing_scope(mut self, error: ScopeError) -> Self {
         self.scope_refusal = Some(error);
+        self
+    }
+
+    /// A tracker whose `search` fails transiently with `error`, so the
+    /// discovery-failure report path can be driven without a real client. The
+    /// error must be `Retryable` or `Terminal` — the port contract forbids any
+    /// other class on a read.
+    #[must_use]
+    pub fn failing_search(mut self, error: TrackerError) -> Self {
+        self.search_failure = Some(error);
         self
     }
 
@@ -327,6 +339,9 @@ impl RemoteTracker for RecordingTracker {
         self.calls.borrow_mut().push(Call::Search {
             scope: scope.clone(),
         });
+        if let Some(error) = &self.search_failure {
+            return Err(error.clone());
+        }
         Ok(self.search_result.borrow().clone().unwrap_or(Discovery {
             found: Vec::new(),
             complete: true,

--- a/cli/tracker-test-support/src/lib.rs
+++ b/cli/tracker-test-support/src/lib.rs
@@ -20,6 +20,7 @@ use tracker::FetchOutcome;
 use tracker::RemoteIssue;
 use tracker::RemoteTimestamp;
 use tracker::RemoteTracker;
+use tracker::ScopeError;
 use tracker::SearchScope;
 use tracker::TrackerError;
 use tracker::ValidationOutcome;
@@ -66,6 +67,7 @@ pub struct RecordingTracker {
     update_failures: Vec<(ExternalId, TrackerError)>,
     create_failure: Option<(TrackerError, bool)>,
     preview_failure: Option<TrackerError>,
+    scope_refusal: Option<ScopeError>,
     search_result: RefCell<Option<Discovery>>,
     preview: RefCell<Option<CreatePreview>>,
     next_id: RefCell<u32>,
@@ -82,6 +84,7 @@ impl RecordingTracker {
             update_failures: Vec::new(),
             create_failure: None,
             preview_failure: None,
+            scope_refusal: None,
             search_result: RefCell::new(None),
             preview: RefCell::new(None),
             next_id: RefCell::new(1),
@@ -158,6 +161,14 @@ impl RecordingTracker {
     #[must_use]
     pub fn failing_show(mut self, id: ExternalId, error: TrackerError) -> Self {
         self.show_failures.push((id, error));
+        self
+    }
+
+    /// A tracker whose `resolve_scope` refuses with `error`, so a run can be
+    /// driven into the pre-flight discovery refusal without a real client.
+    #[must_use]
+    pub fn refusing_scope(mut self, error: ScopeError) -> Self {
+        self.scope_refusal = Some(error);
         self
     }
 
@@ -320,6 +331,15 @@ impl RemoteTracker for RecordingTracker {
             found: Vec::new(),
             complete: true,
         }))
+    }
+
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, ScopeError> {
+        self.scope_refusal
+            .clone()
+            .map_or_else(|| Ok(scope.clone()), Err)
     }
 
     fn preview_create(

--- a/cli/tracker/src/lib.rs
+++ b/cli/tracker/src/lib.rs
@@ -178,6 +178,20 @@ pub enum TrackerError {
     },
 }
 
+impl TrackerError {
+    /// The inner `detail`, unwrapped from either class.
+    ///
+    /// The two variants carry the same field, so a caller wanting the message
+    /// alone — a report line, not the `Display` wrapper's class prose — takes it
+    /// through one exhaustive match here rather than destructuring both arms.
+    #[must_use]
+    pub fn into_detail(self) -> String {
+        match self {
+            Self::Retryable { detail } | Self::Terminal { detail } => detail,
+        }
+    }
+}
+
 impl Display for TrackerError {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/cli/tracker/src/lib.rs
+++ b/cli/tracker/src/lib.rs
@@ -269,6 +269,33 @@ pub struct Discovery {
     pub complete: bool,
 }
 
+/// A discovery scope that names no valid search target for this tracker — a
+/// missing or unresolvable key.
+///
+/// A configuration fault, distinct from a transient read failure. It carries
+/// its own type rather than overloading [`TrackerError::Retryable`] so it can
+/// never be routed through a caller's tracker-error path and mis-exit as a
+/// transient failure: `resolve_scope` mutates nothing, so a scope fault is
+/// always something the operator must fix before any request goes out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeError {
+    /// What is wrong with the scope, for a human. Names the missing or
+    /// unresolvable key and how to supply it.
+    pub detail: String,
+}
+
+impl Display for ScopeError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "the discovery scope names no valid target: {}",
+            self.detail
+        )
+    }
+}
+
+impl std::error::Error for ScopeError {}
+
 /// One create-preview field, resolved to one of three states.
 ///
 /// The three stay distinct because the create skill renders each field's
@@ -425,6 +452,26 @@ pub trait RemoteTracker {
     /// a read mutates nothing. A retrieval cut short reports
     /// `complete == false` rather than erroring.
     fn search(&self, scope: &SearchScope) -> Result<Discovery, TrackerError>;
+
+    /// Resolves and validates a discovery `scope` for this tracker, without any
+    /// network call, returning the scope ready for [`RemoteTracker::search`].
+    ///
+    /// The one deterministic, local step in the discovery path: it substitutes
+    /// provider identity a search needs but a config only names — a Linear team
+    /// *key* for its UUID — and validates that the scope names a target at all.
+    /// A caller runs it before any mutation, so a scope fault refuses the run
+    /// before a single request goes out.
+    ///
+    /// # Errors
+    ///
+    /// [`ScopeError`] when the scope names no valid target — a missing or
+    /// unresolvable key. It resolves locally and mutates nothing, so it never
+    /// reports a transient or terminal failure; that separation is why the error
+    /// is a [`ScopeError`] and not a [`TrackerError`].
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, ScopeError>;
 
     /// Previews the fields a `create` of the given `kind` would resolve,
     /// without creating anything.

--- a/cli/tracker/src/lib.rs
+++ b/cli/tracker/src/lib.rs
@@ -479,9 +479,7 @@ pub trait RemoteTracker {
     /// # Errors
     ///
     /// [`ScopeError`] when the scope names no valid target — a missing or
-    /// unresolvable key. It resolves locally and mutates nothing, so it never
-    /// reports a transient or terminal failure; that separation is why the error
-    /// is a [`ScopeError`] and not a [`TrackerError`].
+    /// unresolvable key.
     fn resolve_scope(
         &self,
         scope: &SearchScope,

--- a/cli/tracker/tests/fixtures/public-api.txt
+++ b/cli/tracker/tests/fixtures/public-api.txt
@@ -31,6 +31,8 @@ pub tracker::TrackerError::Retryable
 pub tracker::TrackerError::Retryable::detail: alloc::string::String
 pub tracker::TrackerError::Terminal
 pub tracker::TrackerError::Terminal::detail: alloc::string::String
+impl tracker::TrackerError
+pub fn tracker::TrackerError::into_detail(self) -> alloc::string::String
 impl core::clone::Clone for tracker::TrackerError
 pub fn tracker::TrackerError::clone(&self) -> tracker::TrackerError
 impl core::cmp::Eq for tracker::TrackerError

--- a/cli/tracker/tests/fixtures/public-api.txt
+++ b/cli/tracker/tests/fixtures/public-api.txt
@@ -115,6 +115,19 @@ pub fn tracker::RemoteIssue::eq(&self, other: &tracker::RemoteIssue) -> bool
 impl core::fmt::Debug for tracker::RemoteIssue
 pub fn tracker::RemoteIssue::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::marker::StructuralPartialEq for tracker::RemoteIssue
+pub struct tracker::ScopeError
+pub tracker::ScopeError::detail: alloc::string::String
+impl core::clone::Clone for tracker::ScopeError
+pub fn tracker::ScopeError::clone(&self) -> tracker::ScopeError
+impl core::cmp::Eq for tracker::ScopeError
+impl core::cmp::PartialEq for tracker::ScopeError
+pub fn tracker::ScopeError::eq(&self, other: &tracker::ScopeError) -> bool
+impl core::error::Error for tracker::ScopeError
+impl core::fmt::Debug for tracker::ScopeError
+pub fn tracker::ScopeError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for tracker::ScopeError
+pub fn tracker::ScopeError::fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::StructuralPartialEq for tracker::ScopeError
 pub struct tracker::SearchScope
 pub tracker::SearchScope::all_projects: bool
 pub tracker::SearchScope::filters: alloc::vec::Vec<(alloc::string::String, alloc::string::String)>
@@ -133,6 +146,7 @@ pub trait tracker::RemoteTracker
 pub fn tracker::RemoteTracker::create(&self, title: &str, body: &str, kind: &str) -> core::result::Result<tracker::ExternalId, tracker::TrackerError>
 pub fn tracker::RemoteTracker::fetch_all(&self, ids: &[tracker::ExternalId]) -> core::result::Result<tracker::FetchOutcome, tracker::TrackerError>
 pub fn tracker::RemoteTracker::preview_create(&self, kind: &str) -> core::result::Result<tracker::CreatePreview, tracker::TrackerError>
+pub fn tracker::RemoteTracker::resolve_scope(&self, scope: &tracker::SearchScope) -> core::result::Result<tracker::SearchScope, tracker::ScopeError>
 pub fn tracker::RemoteTracker::search(&self, scope: &tracker::SearchScope) -> core::result::Result<tracker::Discovery, tracker::TrackerError>
 pub fn tracker::RemoteTracker::show(&self, id: &tracker::ExternalId) -> core::result::Result<tracker::RemoteIssue, tracker::TrackerError>
 pub fn tracker::RemoteTracker::update(&self, id: &tracker::ExternalId, title: &str, body: &str) -> core::result::Result<(), tracker::TrackerError>

--- a/cli/tracker/tests/port.rs
+++ b/cli/tracker/tests/port.rs
@@ -140,6 +140,13 @@ impl RemoteTracker for FixedTracker {
         })
     }
 
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, tracker::ScopeError> {
+        Ok(scope.clone())
+    }
+
     fn preview_create(
         &self,
         _kind: &str,

--- a/cli/work-adapters/src/sync/run.rs
+++ b/cli/work-adapters/src/sync/run.rs
@@ -125,12 +125,31 @@ pub struct ReportedItem {
     pub validation: Option<tracker::ValidationOutcome>,
 }
 
+/// What untracked-remote discovery did on a run that got past the pre-flight
+/// scope check, so a skip is never mistaken for a search that found nothing.
+///
+/// A config fault never reaches here — it is refused pre-flight as
+/// [`RunError::DiscoveryUnconfigured`] before a report exists — so there is no
+/// unconfigured variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryStatus {
+    /// The search ran and completed, seeing `found` untracked issues. `found ==
+    /// 0` is a real, distinguishable "searched and found nothing".
+    Ran { found: usize },
+    /// The run was push-only, so discovery was deliberately not run.
+    SkippedPushOnly,
+    /// The search failed transiently (network). Maps to `RETRYABLE` (70), the
+    /// fate a failed read carries.
+    Failed { detail: String },
+}
+
 pub struct RunReport {
     pub reported: Vec<ReportedItem>,
     pub read_failure: Option<TrackerError>,
     pub baseline_degradation: Degradation,
     pub finalised: bool,
     pub dossiers: Vec<ConflictDossier>,
+    pub discovery: DiscoveryStatus,
 }
 
 impl RunReport {
@@ -619,6 +638,7 @@ struct PreparedRun<'a> {
     facts: GatheredFacts,
     plan: SyncPlan,
     untracked: Vec<ExternalId>,
+    discovery: DiscoveryStatus,
     creates_from_local: Vec<&'a LocalItem>,
     index: ItemIndex<'a>,
     dossiers: Vec<ConflictDossier>,
@@ -676,7 +696,7 @@ fn prepare_run<'a>(
         compute_plan(&plan_inputs, request.direction, request.resolutions)
             .map_err(RunError::Internal)?;
 
-    let mut read_failure = facts.read_failure.clone();
+    let read_failure = facts.read_failure.clone();
 
     // Untracked-remote discovery and unsynced-local creates are computed from
     // reads only, so the combined gate below can bound every write — planned
@@ -684,29 +704,34 @@ fn prepare_run<'a>(
     // A non-push-only run resolves its scope first: a missing or unresolvable
     // key refuses the whole run here, before the apply/push phase, so nothing
     // is sent.
-    let untracked = if matches!(request.direction, SyncDirection::PushOnly) {
-        Vec::new()
-    } else {
-        let resolved =
-            ports
+    let (untracked, discovery) =
+        if matches!(request.direction, SyncDirection::PushOnly) {
+            (Vec::new(), DiscoveryStatus::SkippedPushOnly)
+        } else {
+            let resolved = ports
                 .tracker
                 .resolve_scope(&request.scope)
                 .map_err(|error| RunError::DiscoveryUnconfigured {
                     detail: error.detail,
                 })?;
-        match discover_untracked(ports.tracker, &resolved, request.items) {
-            Ok(discovered) if !discovered.complete => {
-                return Err(RunError::DiscoveryIncomplete {
-                    found: discovered.ids.len(),
-                });
+            match discover_untracked(ports.tracker, &resolved, request.items) {
+                Ok(discovered) if !discovered.complete => {
+                    return Err(RunError::DiscoveryIncomplete {
+                        found: discovered.ids.len(),
+                    });
+                }
+                Ok(discovered) => {
+                    let found = discovered.ids.len();
+                    (discovered.ids, DiscoveryStatus::Ran { found })
+                }
+                Err(error) => (
+                    Vec::new(),
+                    DiscoveryStatus::Failed {
+                        detail: error.into_detail(),
+                    },
+                ),
             }
-            Ok(discovered) => discovered.ids,
-            Err(error) => {
-                read_failure = read_failure.or(Some(error));
-                Vec::new()
-            }
-        }
-    };
+        };
     let creates_from_local =
         unsynced_creates(&plan, request.items, request.direction);
 
@@ -736,6 +761,7 @@ fn prepare_run<'a>(
         facts,
         plan,
         untracked,
+        discovery,
         creates_from_local,
         index,
         dossiers,
@@ -766,6 +792,7 @@ pub fn run<'a>(
         facts,
         plan,
         untracked,
+        discovery,
         creates_from_local,
         index,
         dossiers,
@@ -793,6 +820,7 @@ pub fn run<'a>(
             baseline_degradation: degradation,
             finalised: false,
             dossiers,
+            discovery,
         });
     }
 
@@ -856,6 +884,7 @@ pub fn run<'a>(
         baseline_degradation: degradation,
         finalised,
         dossiers,
+        discovery,
     })
 }
 

--- a/cli/work-adapters/src/sync/run.rs
+++ b/cli/work-adapters/src/sync/run.rs
@@ -60,6 +60,12 @@ pub enum RunError {
     DiscoveryIncomplete {
         found: usize,
     },
+    /// The discovery scope names no valid search target — a missing or
+    /// unresolvable key. Caught pre-flight, before the apply/push phase, so
+    /// nothing was sent; the operator fixes the config and re-runs.
+    DiscoveryUnconfigured {
+        detail: String,
+    },
     Read(TrackerError),
     Internal(kernel::Error),
 }
@@ -624,8 +630,9 @@ struct PreparedRun<'a> {
 /// # Errors
 ///
 /// [`RunError::Internal`] for a clock, baseline-store or planning failure;
-/// [`RunError::DiscoveryIncomplete`] when the untracked search is cut short;
-/// [`RunError::Refused`] when the plan would exceed the write bounds.
+/// [`RunError::DiscoveryUnconfigured`] when the discovery scope names no valid
+/// target; [`RunError::DiscoveryIncomplete`] when the untracked search is cut
+/// short; [`RunError::Refused`] when the plan would exceed the write bounds.
 fn prepare_run<'a>(
     ports: &SyncPorts<'_>,
     baseline: &BaselineStore<'_>,
@@ -674,11 +681,20 @@ fn prepare_run<'a>(
     // Untracked-remote discovery and unsynced-local creates are computed from
     // reads only, so the combined gate below can bound every write — planned
     // pulls, planned pushes, and both create paths — before a single one runs.
-    let discovery_enabled =
-        !matches!(request.direction, SyncDirection::PushOnly)
-            && (request.scope.project.is_some() || request.scope.all_projects);
-    let untracked = if discovery_enabled {
-        match discover_untracked(ports.tracker, &request.scope, request.items) {
+    // A non-push-only run resolves its scope first: a missing or unresolvable
+    // key refuses the whole run here, before the apply/push phase, so nothing
+    // is sent.
+    let untracked = if matches!(request.direction, SyncDirection::PushOnly) {
+        Vec::new()
+    } else {
+        let resolved =
+            ports
+                .tracker
+                .resolve_scope(&request.scope)
+                .map_err(|error| RunError::DiscoveryUnconfigured {
+                    detail: error.detail,
+                })?;
+        match discover_untracked(ports.tracker, &resolved, request.items) {
             Ok(discovered) if !discovered.complete => {
                 return Err(RunError::DiscoveryIncomplete {
                     found: discovered.ids.len(),
@@ -690,8 +706,6 @@ fn prepare_run<'a>(
                 Vec::new()
             }
         }
-    } else {
-        Vec::new()
     };
     let creates_from_local =
         unsynced_creates(&plan, request.items, request.direction);

--- a/cli/work-adapters/tests/sync_apply.rs
+++ b/cli/work-adapters/tests/sync_apply.rs
@@ -147,6 +147,13 @@ impl RemoteTracker for Fake {
         unimplemented!("not exercised by the apply suite")
     }
 
+    fn resolve_scope(
+        &self,
+        scope: &tracker::SearchScope,
+    ) -> Result<tracker::SearchScope, tracker::ScopeError> {
+        Ok(scope.clone())
+    }
+
     fn preview_create(
         &self,
         _kind: &str,

--- a/cli/work-adapters/tests/sync_create.rs
+++ b/cli/work-adapters/tests/sync_create.rs
@@ -31,6 +31,7 @@ use work_adapters::sync::fetch::LocalItem;
 use work_adapters::sync::fetch::RetrievalStrategy;
 use work_adapters::sync::fetch::WorkingCopyStatus;
 use work_adapters::sync::run::run;
+use work_adapters::sync::run::DiscoveryStatus;
 use work_adapters::sync::run::ItemOutcome;
 use work_adapters::sync::run::RunError;
 use work_adapters::sync::run::RunMode;
@@ -487,6 +488,114 @@ fn a_push_only_run_authors_no_untracked_local_files() -> Result<(), TestError> {
             .iter()
             .any(|call| matches!(call, Call::Search { .. })),
         "push-only must not even search"
+    );
+    Ok(())
+}
+
+#[test]
+fn discovery_status_is_skipped_push_only() -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(Vec::new());
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync(
+        &ports,
+        &[],
+        fixture.dir.path(),
+        SyncDirection::PushOnly,
+        scoped(),
+        25,
+        25,
+        RunMode::Preview,
+    )
+    .map_err(|_| "push-only must not refuse")?;
+
+    assert_eq!(report.discovery, DiscoveryStatus::SkippedPushOnly);
+    Ok(())
+}
+
+#[test]
+fn discovery_status_is_ran_with_the_untracked_count() -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(Vec::new()).discovering(
+        vec![
+            (
+                ExternalId::new("ENG-1".to_owned()),
+                RemoteTimestamp::NotReported,
+            ),
+            (
+                ExternalId::new("ENG-2".to_owned()),
+                RemoteTimestamp::NotReported,
+            ),
+        ],
+        true,
+    );
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync(
+        &ports,
+        &[],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        scoped(),
+        25,
+        25,
+        RunMode::Preview,
+    )
+    .map_err(|_| "the run must not refuse")?;
+
+    assert_eq!(report.discovery, DiscoveryStatus::Ran { found: 2 });
+    Ok(())
+}
+
+#[test]
+fn discovery_status_is_failed_on_a_transient_search_error(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(Vec::new()).failing_search(
+        TrackerError::Retryable {
+            detail: "connection refused".to_owned(),
+        },
+    );
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync(
+        &ports,
+        &[],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        scoped(),
+        25,
+        25,
+        RunMode::Preview,
+    )
+    .map_err(|_| "a failed search degrades, it does not refuse")?;
+
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::Failed {
+            detail: "connection refused".to_owned(),
+        },
+        "the detail is the raw inner string, without the Display prefix"
+    );
+    assert!(
+        report.read_failure.is_none(),
+        "a discovery search failure no longer folds into read_failure"
     );
     Ok(())
 }

--- a/cli/work-adapters/tests/sync_create.rs
+++ b/cli/work-adapters/tests/sync_create.rs
@@ -14,6 +14,7 @@ use corpus::store::StoreError;
 use tracker::ExternalId;
 use tracker::RemoteIssue;
 use tracker::RemoteTimestamp;
+use tracker::ScopeError;
 use tracker::SearchScope;
 use tracker::TrackerError;
 use tracker_test_support::Call;
@@ -384,6 +385,62 @@ fn an_over_threshold_untracked_set_aborts_with_no_creations_or_shows(
         "no per-issue show fan-out before the gate"
     );
     assert_eq!(fixture.spy.write_count(), 0);
+    Ok(())
+}
+
+#[test]
+fn an_unresolvable_scope_refuses_pre_flight_and_sends_nothing(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    // An unsynced draft that would create-from-local were the run to proceed.
+    let item = fixture.unsynced_item("0001", "Draft")?;
+    let tracker =
+        RecordingTracker::holding(Vec::new()).refusing_scope(ScopeError {
+            detail: "E_SEARCH_NO_TEAM: discovery needs a team key".to_owned(),
+        });
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let error = run_sync(
+        &ports,
+        &[item],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        scoped(),
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .err()
+    .expect("an unresolvable scope must refuse the run");
+
+    assert!(
+        matches!(error, RunError::DiscoveryUnconfigured { .. }),
+        "an unresolvable scope refuses as DiscoveryUnconfigured, got: {error:?}"
+    );
+    assert!(
+        !tracker
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::Search { .. })),
+        "a refused scope must not reach the search"
+    );
+    assert!(
+        !tracker.calls().iter().any(|call| matches!(
+            call,
+            Call::Create { .. } | Call::Update { .. }
+        )),
+        "a pre-flight refusal must send no push"
+    );
+    assert_eq!(
+        fixture.spy.write_count(),
+        0,
+        "a pre-flight refusal must not write"
+    );
     Ok(())
 }
 
@@ -1024,6 +1081,13 @@ impl tracker::RemoteTracker for MarkerObservingTracker {
             found: Vec::new(),
             complete: true,
         })
+    }
+
+    fn resolve_scope(
+        &self,
+        scope: &SearchScope,
+    ) -> Result<SearchScope, tracker::ScopeError> {
+        Ok(scope.clone())
     }
 
     fn preview_create(

--- a/cli/work-adapters/tests/sync_run.rs
+++ b/cli/work-adapters/tests/sync_run.rs
@@ -385,7 +385,8 @@ fn a_plan_one_over_the_pull_bound_is_refused() -> Result<(), TestError> {
         }
         RunError::Read(_)
         | RunError::Internal(_)
-        | RunError::DiscoveryIncomplete { .. } => {
+        | RunError::DiscoveryIncomplete { .. }
+        | RunError::DiscoveryUnconfigured { .. } => {
             panic!("expected Refused, got a read or internal failure")
         }
     }
@@ -437,7 +438,8 @@ fn an_over_bound_push_count_is_refused() -> Result<(), TestError> {
         } => assert_eq!((pushes, max_pushes), (2, 1)),
         RunError::Read(_)
         | RunError::Internal(_)
-        | RunError::DiscoveryIncomplete { .. } => {
+        | RunError::DiscoveryIncomplete { .. }
+        | RunError::DiscoveryUnconfigured { .. } => {
             panic!("expected Refused, got a read or internal failure")
         }
     }

--- a/cli/work-adapters/tests/sync_run_real_client.rs
+++ b/cli/work-adapters/tests/sync_run_real_client.rs
@@ -25,6 +25,7 @@ use jira_client::transport::Transport as JiraTransport;
 use jira_client::Credentials as JiraCredentials;
 use jira_client::JiraClient;
 use linear_client::filter::FixedStates;
+use linear_client::filter::FixedTeam;
 use linear_client::transport::Transport as LinearTransport;
 use linear_client::Credentials as LinearCredentials;
 use linear_client::{LinearClient, UploadTransport};
@@ -56,6 +57,12 @@ type TestError = Box<dyn std::error::Error>;
 const STAMP: &str = "2026-06-01T00:00:00.000+0000";
 const LINEAR_STAMP: &str = "2026-06-01T00:00:00.000Z";
 const BASELINE_PATH: &str = "/baseline/last-sync.json";
+
+/// The catalogue key → UUID pairing the Linear client resolves a scope through.
+/// Local to this crate because `linear-client`'s test constants are not visible
+/// here.
+const LINEAR_TEAM_KEY: &str = "ENG";
+const LINEAR_TEAM_ID: &str = "5c9f2a1b-0000-4000-8000-000000000001";
 
 #[derive(Default)]
 struct Spy {
@@ -168,7 +175,7 @@ fn linear_client(base: &str, config: TransportConfig) -> LinearClient {
         Url::parse(&format!("{base}/graphql")).expect("an endpoint"),
         LinearCredentials {
             token: Secret::new("lin_api_secret".to_owned()),
-            team_id: "5c9f2a1b-0000-4000-8000-000000000001".to_owned(),
+            team_id: LINEAR_TEAM_ID.to_owned(),
             source: TokenSource::Env,
         },
         config,
@@ -176,10 +183,14 @@ fn linear_client(base: &str, config: TransportConfig) -> LinearClient {
         Box::new(NoJitter),
     )
     .expect("the linear transport builds");
+    let mut team_map = std::collections::BTreeMap::new();
+    team_map.insert(LINEAR_TEAM_KEY.to_owned(), LINEAR_TEAM_ID.to_owned());
+    let teams = FixedTeam(team_map);
     LinearClient::new(
         transport,
         UploadTransport::production().expect("the upload transport builds"),
-        Some("ENG".to_owned()),
+        Some(LINEAR_TEAM_KEY.to_owned()),
+        Box::new(teams),
         Box::new(FixedStates::default()),
     )
 }
@@ -212,8 +223,10 @@ fn execute(
     tracker: &dyn RemoteTracker,
     spy: &Spy,
     items: &[LocalItem],
+    direction: SyncDirection,
+    scope: tracker::SearchScope,
     mode: RunMode,
-) -> RunReport {
+) -> Result<RunReport, work_adapters::sync::run::RunError> {
     let clock = FixedClock(1_700_000_000);
     let status = AlwaysClean;
     let author = UnusedAuthor;
@@ -229,21 +242,36 @@ fn execute(
     let integrations_root = std::env::temp_dir();
     let request = SyncRequest {
         items,
-        direction: SyncDirection::Bidirectional,
+        direction,
         strategy: RetrievalStrategy::Bulk,
         resolutions: &resolutions,
         max_pulls: 25,
         max_pushes: 25,
         mode,
-        // The default scope disables untracked discovery, so these
-        // real-client scenarios exercise only the keyed pull/push flow and
-        // never issue a search against the mock.
         integrations_root: &integrations_root,
         integration: "jira",
-        scope: tracker::SearchScope::default(),
+        scope,
     };
     run(&ports, &mut store, &request)
-        .unwrap_or_else(|_| panic!("the run must not refuse"))
+}
+
+/// A push-only run: discovery is skipped, so the pull/push classification is
+/// exercised without a search against the mock.
+fn push_only_report(
+    tracker: &dyn RemoteTracker,
+    spy: &Spy,
+    items: &[LocalItem],
+    mode: RunMode,
+) -> RunReport {
+    execute(
+        tracker,
+        spy,
+        items,
+        SyncDirection::PushOnly,
+        tracker::SearchScope::default(),
+        mode,
+    )
+    .unwrap_or_else(|_| panic!("the run must not refuse"))
 }
 
 #[test]
@@ -294,7 +322,7 @@ fn jira_classifies_a_locally_modified_item_through_the_real_client(
         &baseline_document(&entry("0001", STAMP, &remote_hash, "stale")),
     );
 
-    let report = execute(&client, &spy, &[item], RunMode::Preview);
+    let report = push_only_report(&client, &spy, &[item], RunMode::Preview);
     assert_eq!(report.reported.len(), 1);
     assert_eq!(
         report.reported[0].planned.state,
@@ -342,7 +370,7 @@ fn jira_marks_a_truncated_read_indeterminate_and_deletes_nothing(
         &baseline_document(&entry("0002", STAMP, "stale", "stale")),
     );
 
-    let report = execute(&client, &spy, &[item], RunMode::Apply);
+    let report = push_only_report(&client, &spy, &[item], RunMode::Apply);
     assert_eq!(report.reported.len(), 1);
     assert_eq!(
         report.reported[0].planned.state,
@@ -418,7 +446,7 @@ fn linear_classifies_a_locally_modified_item_through_the_real_client(
         &baseline_document(&entry("0001", LINEAR_STAMP, &remote_hash, "stale")),
     );
 
-    let report = execute(&client, &spy, &[item], RunMode::Preview);
+    let report = push_only_report(&client, &spy, &[item], RunMode::Preview);
     assert_eq!(report.reported.len(), 1);
     assert_eq!(report.reported[0].planned.state, SyncState::LocallyModified);
     assert_eq!(report.reported[0].planned.action, work::sync::Action::Push);
@@ -461,7 +489,7 @@ fn linear_marks_a_truncated_read_indeterminate_and_deletes_nothing(
         &baseline_document(&entry("0002", LINEAR_STAMP, "stale", "stale")),
     );
 
-    let report = execute(&client, &spy, &[item], RunMode::Apply);
+    let report = push_only_report(&client, &spy, &[item], RunMode::Apply);
     assert_eq!(report.reported.len(), 1);
     assert_eq!(report.reported[0].planned.state, SyncState::Indeterminate);
     assert_eq!(
@@ -556,7 +584,19 @@ fn jira_builds_a_dossier_per_conflict_with_values_bound_to_each_side(
         ),
     );
 
-    let report = execute(&client, &spy, &items, RunMode::Preview);
+    let report = execute(
+        &client,
+        &spy,
+        &items,
+        SyncDirection::Bidirectional,
+        tracker::SearchScope {
+            project: Some("ENG".to_owned()),
+            all_projects: false,
+            filters: Vec::new(),
+        },
+        RunMode::Preview,
+    )
+    .expect("the run must not refuse");
 
     assert_eq!(report.dossiers.len(), 2, "one dossier per conflict");
     let ids: std::collections::BTreeSet<&str> =
@@ -587,4 +627,123 @@ fn jira_builds_a_dossier_per_conflict_with_values_bound_to_each_side(
         "an operand swap would leak the local body into the remote side"
     );
     Ok(())
+}
+
+/// AC-1/AC-4/AC-8: a keyed Linear discovery resolves the team key to the UUID,
+/// bounds the search to it, and reports the untracked issue as a planned pull.
+/// The load-bearing assertion is the captured body carrying `LINEAR_TEAM_ID` —
+/// a `MockServer` routes by method+path and does not evaluate the team filter,
+/// so the seeded issue surfaces even with the raw key; the raw key in the body
+/// is what fails against the old, unresolved gate.
+#[test]
+fn linear_discovery_bounds_the_search_to_the_resolved_team_uuid() {
+    let search_body = format!(
+        "{{\"data\":{{\"issues\":{{\"nodes\":[{{\"id\":\"i2\",\
+         \"identifier\":\"ENG-2\",\"title\":\"Untracked\",\
+         \"updatedAt\":\"{LINEAR_STAMP}\"}}],\"pageInfo\":\
+         {{\"hasNextPage\":false,\"endCursor\":null}}}}}}}}"
+    );
+
+    let server = MockServer::start();
+    server.route(
+        RequestKey::post("/graphql"),
+        Route::Json {
+            status: 200,
+            body: search_body,
+        },
+    );
+    let client = linear_client(&server.base_url(), TransportConfig::default());
+
+    let spy = Spy::default();
+    spy.seed(BASELINE_PATH, &baseline_document(""));
+
+    let report = execute(
+        &client,
+        &spy,
+        &[],
+        SyncDirection::Bidirectional,
+        tracker::SearchScope {
+            project: Some(LINEAR_TEAM_KEY.to_owned()),
+            all_projects: false,
+            filters: Vec::new(),
+        },
+        RunMode::Preview,
+    )
+    .expect("the keyed discovery run must not refuse");
+
+    let created: Vec<&str> = report
+        .reported
+        .iter()
+        .filter(|item| {
+            item.planned.action == work::sync::Action::CreateFromRemote
+        })
+        .map(|item| item.planned.id.as_str())
+        .collect();
+    assert_eq!(
+        created,
+        vec!["ENG-2"],
+        "the untracked issue is reported as a create-from-remote pull"
+    );
+
+    let bodies = server.bodies(&RequestKey::post("/graphql"));
+    assert!(
+        !bodies.is_empty(),
+        "the discovery search must reach the mock"
+    );
+    for body in &bodies {
+        let text = String::from_utf8_lossy(body);
+        assert!(
+            text.contains(LINEAR_TEAM_ID),
+            "every search body must carry the resolved team UUID, got: {text}"
+        );
+        assert!(
+            !text.contains("\"eq\":\"ENG\""),
+            "no search body may carry the raw team key, got: {text}"
+        );
+    }
+}
+
+/// AC-3: a bidirectional Linear run with no key refuses pre-flight and sends
+/// nothing. Linear posts search and every mutation to the one `/graphql` route,
+/// so "nothing was sent" is checkable only as zero requests.
+#[test]
+fn linear_discovery_with_no_key_refuses_before_any_request() {
+    let server = MockServer::start();
+    server.route(
+        RequestKey::post("/graphql"),
+        Route::Json {
+            status: 200,
+            body: "{\"data\":{\"issues\":{\"nodes\":[],\"pageInfo\":\
+                   {\"hasNextPage\":false,\"endCursor\":null}}}}"
+                .to_owned(),
+        },
+    );
+    let client = linear_client(&server.base_url(), TransportConfig::default());
+
+    let spy = Spy::default();
+    spy.seed(BASELINE_PATH, &baseline_document(""));
+
+    let error = execute(
+        &client,
+        &spy,
+        &[],
+        SyncDirection::Bidirectional,
+        tracker::SearchScope::default(),
+        RunMode::Preview,
+    )
+    .err()
+    .expect("an unkeyed discovery run must refuse");
+
+    assert!(
+        matches!(
+            error,
+            work_adapters::sync::run::RunError::DiscoveryUnconfigured { .. }
+        ),
+        "an unkeyed run refuses as DiscoveryUnconfigured, got: {error:?}"
+    );
+    assert_eq!(
+        server.hits(&RequestKey::post("/graphql")),
+        0,
+        "a pre-flight config refusal must send nothing"
+    );
 }

--- a/cli/work-adapters/tests/sync_run_real_client.rs
+++ b/cli/work-adapters/tests/sync_run_real_client.rs
@@ -629,8 +629,8 @@ fn jira_builds_a_dossier_per_conflict_with_values_bound_to_each_side(
     Ok(())
 }
 
-/// AC-1/AC-4/AC-8: a keyed Linear discovery resolves the team key to the UUID,
-/// bounds the search to it, and reports the untracked issue as a planned pull.
+/// A keyed Linear discovery resolves the team key to the UUID, bounds the
+/// search to it, and reports the untracked issue as a planned pull.
 /// The load-bearing assertion is the captured body carrying `LINEAR_TEAM_ID` —
 /// a `MockServer` routes by method+path and does not evaluate the team filter,
 /// so the seeded issue surfaces even with the raw key; the raw key in the body
@@ -703,7 +703,7 @@ fn linear_discovery_bounds_the_search_to_the_resolved_team_uuid() {
     }
 }
 
-/// AC-3: a bidirectional Linear run with no key refuses pre-flight and sends
+/// A bidirectional Linear run with no key refuses pre-flight and sends
 /// nothing. Linear posts search and every mutation to the one `/graphql` route,
 /// so "nothing was sent" is checkable only as zero requests.
 #[test]

--- a/cli/work-cli/src/exit_codes.rs
+++ b/cli/work-cli/src/exit_codes.rs
@@ -21,9 +21,9 @@
 //! skills branch on it:
 //!
 //! - `70` `RETRYABLE` — the failure is provably *before* any remote mutation
-//!   (argument/validation/auth/connect, or a read that failed). **Safe to
-//!   retry.** A read that fails degrades to presence-only and reports `70`; a
-//!   read never emits `71`.
+//!   (argument/validation/auth/connect, a read that failed, or a discovery
+//!   search that failed transiently). **Safe to retry.** A read that fails
+//!   degrades to presence-only and reports `70`; a read never emits `71`.
 //! - `71` `TERMINAL` — the failure is *at or after* a mutation, so its outcome
 //!   is unknown. **Never auto-retried.** The hazard differs by path: a remote
 //!   `create` is non-idempotent, so a repeat would *double-apply* (a second
@@ -31,17 +31,22 @@
 //!   idempotent, so there the hazard is response *uncertainty*, not
 //!   double-apply. Either way the operator reconciles by hand.
 //!
-//! Tracker selection/configuration codes (`72`–`74`), emitted from
-//! `SelectionError` — a failure to *select or configure* a tracker, not a
-//! tracker-error class:
+//! Tracker selection/configuration codes (`72`–`74`), a failure to *select or
+//! configure* a tracker rather than a tracker-error class. `72`/`73` and the
+//! credential branch of `74` come from `SelectionError`; `74` is also emitted
+//! pre-flight when a run's discovery scope names no valid target
+//! (`RunError::DiscoveryUnconfigured`):
 //!
 //! - `72` `NOT_AVAILABLE` — the configured tracker is recognised but has no
 //!   client wired yet (`trello`/`github-issues`).
 //! - `73` `UNRECOGNISED` — `work.integration` is unset or names a tracker
 //!   outside `{linear, jira, trello, github-issues}`. Fail closed.
-//! - `74` `UNCONFIGURED` — the tracker is wired but its configuration or
-//!   credentials are missing or refused. **Nothing was sent** — save locally
-//!   and fix the config; never reconcile against a create that never happened.
+//! - `74` `UNCONFIGURED` — the tracker is wired but a run cannot proceed on its
+//!   configuration: its credentials are missing or refused, or a non-push-only
+//!   run's discovery scope names no valid target (an unset or unresolvable
+//!   key). **Nothing was sent** — the discovery refusal is pre-flight, before
+//!   the apply/push phase — so save locally and fix the config; never reconcile
+//!   against a create that never happened.
 
 use tracker::TrackerError;
 

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -514,6 +514,10 @@ pub fn run_sync(
             );
             ExitCode::from(exit_codes::REFUSED_BULK_OVERWRITE)
         }
+        Err(RunError::DiscoveryUnconfigured { detail }) => {
+            eprintln!("refused: discovery is unconfigured — {detail}");
+            ExitCode::from(exit_codes::UNCONFIGURED)
+        }
         Err(RunError::Read(error)) => {
             eprintln!("{error}");
             ExitCode::from(exit_codes::RETRYABLE)

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -21,6 +21,7 @@ use work_adapters::sync::fetch::LocalItem;
 use work_adapters::sync::fetch::RetrievalStrategy;
 use work_adapters::sync::run::render_dossier;
 use work_adapters::sync::run::ConflictDossier;
+use work_adapters::sync::run::DiscoveryStatus;
 use work_adapters::sync::run::DossierRender;
 use work_adapters::sync::run::ItemOutcome;
 use work_adapters::sync::run::RunError;
@@ -168,6 +169,26 @@ const fn action_keyword(action: work::sync::Action) -> &'static str {
     }
 }
 
+/// Collapses tab, newline and carriage return to a space, so a transport
+/// `detail` cannot break the single-record TSV format.
+fn single_line(text: &str) -> String {
+    text.replace(['\t', '\n', '\r'], " ")
+}
+
+fn discovery_line(discovery: &DiscoveryStatus) -> String {
+    match discovery {
+        DiscoveryStatus::Ran { found } => {
+            format!("#\tdiscovery\tran\tfound={found}")
+        }
+        DiscoveryStatus::SkippedPushOnly => {
+            "#\tdiscovery\tskipped\tpush-only".to_owned()
+        }
+        DiscoveryStatus::Failed { detail } => {
+            format!("#\tdiscovery\tfailed\t{}", single_line(detail))
+        }
+    }
+}
+
 fn render_report(report: &RunReport) -> String {
     let mut lines = Vec::new();
     let mut synced_count = 0usize;
@@ -196,8 +217,12 @@ fn render_report(report: &RunReport) -> String {
             item.planned.id, action_field, item.planned.state, detail
         ));
     }
+    // Capture before appending the always-present discovery line, which would
+    // otherwise make `is_empty()` false and drop the empty-run summary.
+    let summary_needed = synced_count > 0 || lines.is_empty();
     lines.sort();
-    if synced_count > 0 || lines.is_empty() {
+    lines.push(discovery_line(&report.discovery));
+    if summary_needed {
         lines.push(format!("#\tsummary\tsynced\t{synced_count}"));
     }
     lines.join("\n")
@@ -224,7 +249,10 @@ fn exit_code_for_report(report: &RunReport) -> u8 {
         exit_codes::TERMINAL
     } else if awaiting_human {
         exit_codes::UNRESOLVED
-    } else if any_retryable || report.read_failure.is_some() {
+    } else if any_retryable
+        || report.read_failure.is_some()
+        || matches!(report.discovery, DiscoveryStatus::Failed { .. })
+    {
         exit_codes::RETRYABLE
     } else {
         exit_codes::CLEAN
@@ -542,6 +570,7 @@ mod tests {
     use work_adapters::sync::apply::ApplyError;
     use work_adapters::sync::baseline::Degradation;
     use work_adapters::sync::run::ConflictDossier;
+    use work_adapters::sync::run::DiscoveryStatus;
     use work_adapters::sync::run::ItemOutcome;
     use work_adapters::sync::run::ReportedItem;
     use work_adapters::sync::run::RunReport;
@@ -636,6 +665,7 @@ mod tests {
             baseline_degradation: Degradation::None,
             finalised: true,
             dossiers: Vec::new(),
+            discovery: DiscoveryStatus::Ran { found: 0 },
         };
 
         let golden = std::fs::read_to_string(concat!(
@@ -655,9 +685,87 @@ mod tests {
             baseline_degradation: Degradation::None,
             finalised: true,
             dossiers: Vec::new(),
+            discovery: DiscoveryStatus::SkippedPushOnly,
         };
 
-        assert_eq!(render_report(&report), "#\tsummary\tsynced\t0");
+        assert_eq!(
+            render_report(&report),
+            "#\tdiscovery\tskipped\tpush-only\n#\tsummary\tsynced\t0"
+        );
+    }
+
+    fn report_with(discovery: DiscoveryStatus) -> RunReport {
+        RunReport {
+            reported: Vec::new(),
+            read_failure: None,
+            baseline_degradation: Degradation::None,
+            finalised: true,
+            dossiers: Vec::new(),
+            discovery,
+        }
+    }
+
+    #[test]
+    fn render_report_emits_each_discovery_status_line() {
+        assert!(
+            render_report(&report_with(DiscoveryStatus::Ran { found: 3 }))
+                .contains("#\tdiscovery\tran\tfound=3")
+        );
+        assert!(
+            render_report(&report_with(DiscoveryStatus::SkippedPushOnly))
+                .contains("#\tdiscovery\tskipped\tpush-only")
+        );
+        let failed = render_report(&report_with(DiscoveryStatus::Failed {
+            detail: "connection refused".to_owned(),
+        }));
+        assert!(
+            failed.contains("#\tdiscovery\tfailed\tconnection refused"),
+            "{failed}"
+        );
+    }
+
+    #[test]
+    fn a_failed_discovery_detail_is_flattened_to_one_record() {
+        let rendered = render_report(&report_with(DiscoveryStatus::Failed {
+            detail: "line one\tsplit\nline two\r".to_owned(),
+        }));
+        let discovery = rendered
+            .lines()
+            .find(|line| line.starts_with("#\tdiscovery\tfailed"))
+            .expect("a failed discovery line");
+        assert_eq!(
+            discovery, "#\tdiscovery\tfailed\tline one split line two ",
+            "tabs, newlines and carriage returns are collapsed to spaces"
+        );
+    }
+
+    #[test]
+    fn single_line_strips_record_breaking_whitespace() {
+        assert_eq!(super::single_line("a\tb\nc\rd"), "a b c d");
+    }
+
+    #[test]
+    fn a_failed_discovery_exits_retryable_and_the_others_are_clean() {
+        assert_eq!(
+            super::exit_code_for_report(&report_with(
+                DiscoveryStatus::Failed {
+                    detail: "boom".to_owned(),
+                }
+            )),
+            super::exit_codes::RETRYABLE
+        );
+        assert_eq!(
+            super::exit_code_for_report(&report_with(DiscoveryStatus::Ran {
+                found: 0
+            })),
+            super::exit_codes::CLEAN
+        );
+        assert_eq!(
+            super::exit_code_for_report(&report_with(
+                DiscoveryStatus::SkippedPushOnly
+            )),
+            super::exit_codes::CLEAN
+        );
     }
 
     #[test]

--- a/cli/work-cli/tests/fixtures/sync-report.golden
+++ b/cli/work-cli/tests/fixtures/sync-report.golden
@@ -7,4 +7,5 @@
 0007	failed	locally-modified	terminal
 0009	noop	remote-absent	-
 0010	noop	indeterminate	-
+#	discovery	ran	found=0
 #	summary	synced	1

--- a/cli/work-cli/tests/sync_resolves_real_client.rs
+++ b/cli/work-cli/tests/sync_resolves_real_client.rs
@@ -103,15 +103,47 @@ fn jira_without_a_token_reports_unconfigured() -> Result<(), TestError> {
 }
 
 #[test]
-fn linear_resolves_with_credentials_and_an_empty_corpus_exits_0(
+fn linear_push_only_resolves_with_credentials_and_an_empty_corpus_exits_0(
 ) -> Result<(), TestError> {
+    // `--push-only` skips discovery, so an unkeyed Linear config still exits 0:
+    // resolution succeeds and the empty push makes no network call.
+    let repo = scratch_repo(LINEAR_CONFIG)?;
+    let output = run_with_args(
+        repo.path(),
+        &["--push-only"],
+        &[("ACCELERATOR_LINEAR_TOKEN", "dummy")],
+    )?;
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "resolution succeeded and the empty push made no network call: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+#[test]
+fn linear_bidirectional_without_a_key_refuses_discovery_and_exits_74(
+) -> Result<(), TestError> {
+    // A bidirectional run needs a discovery scope. An unkeyed Linear config
+    // names no team, so the run is refused pre-flight — nothing sent, exit 74 —
+    // rather than searching whatever team the credential happens to reach.
     let repo = scratch_repo(LINEAR_CONFIG)?;
     let output = run(repo.path(), &[("ACCELERATOR_LINEAR_TOKEN", "dummy")])?;
     assert_eq!(
         output.status.code(),
-        Some(0),
-        "resolution succeeded and the empty fetch made no network call: {}",
+        Some(74),
+        "an unkeyed bidirectional run refuses: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("discovery is unconfigured"),
+        "the refusal names the discovery fault: {stderr}"
+    );
+    assert!(
+        stderr.contains("work.default_project_code"),
+        "the refusal names the missing key: {stderr}"
     );
     Ok(())
 }

--- a/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
+++ b/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
@@ -789,12 +789,12 @@ a discovery search failed transiently".
 
 #### Automated Verification:
 
-- [ ] `work-adapters` and `work-cli` build and lint: `mise run cli:check`
-- [ ] Discovery-status run tests pass: `cd cli && cargo nextest run -p work-adapters discovery`
-- [ ] Render/exit-code tests pass: `cd cli && cargo nextest run -p work-cli render_report`
-- [ ] Full CLI unit suite passes: `mise run test:unit:cli`
-- [ ] Read-only aggregate is green: `mise run check`
-- [ ] The updated `skills/work/sync-work-items/SKILL.md` exit-code list matches
+- [x] `work-adapters` and `work-cli` build and lint: `mise run cli:check`
+- [x] Discovery-status run tests pass: `cd cli && cargo nextest run -p work-adapters discovery`
+- [x] Render/exit-code tests pass: `cd cli && cargo nextest run -p work-cli render_report`
+- [x] Full CLI unit suite passes: `mise run test:unit:cli`
+- [x] Read-only aggregate is green: `mise run check`
+- [x] The updated `skills/work/sync-work-items/SKILL.md` exit-code list matches
       `exit_codes.rs` (checked by eye — there is no automated drift check).
 
 #### Manual Verification:

--- a/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
+++ b/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
@@ -5,7 +5,7 @@ title: "Untracked-Remote Discovery on Linear Implementation Plan"
 date: "2026-08-30T17:33:07+00:00"
 author: "Toby Clemson"
 producer: create-plan
-status: ready
+status: done
 work_item_id: "work-item:0220"
 parent: "work-item:0220"
 derived_from: ["codebase-research:2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear"]

--- a/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
+++ b/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
@@ -567,15 +567,15 @@ test double, or the override discovery path would refuse every key.
 
 #### Automated Verification:
 
-- [ ] `linear-client`/`jira-client` build and lint: `cd cli && cargo clippy -p linear-client -p jira-client --all-targets`
-- [ ] `resolve_scope` and search tests pass: `cd cli && cargo nextest run -p linear-client resolve_scope search`
-- [ ] `CatalogueTeam` tests pass: `cd cli && cargo nextest run -p linear-client catalogue_team`
-- [ ] The `tracker` public-api snapshot is regenerated and verified: `mise run public-api:update && mise run public-api:check`
-- [ ] The pre-flight refusal and e2e regression pass: `cd cli && cargo nextest run -p work-adapters sync_run_real_client sync_create`
-- [ ] `RunError::DiscoveryUnconfigured` exit-code test passes: `cd cli && cargo nextest run -p work-cli`
-- [ ] `cli/linear-cli` builds (the `build_with_override` caller compiles): `cd cli && cargo clippy -p linear-cli --all-targets`
-- [ ] Workspace check is green: `mise run cli:check`
-- [ ] Full CLI unit suite passes: `mise run test:unit:cli`
+- [x] `linear-client`/`jira-client` build and lint: `cd cli && cargo clippy -p linear-client -p jira-client --all-targets`
+- [x] `resolve_scope` and search tests pass: `cd cli && cargo nextest run -p linear-client resolve_scope search`
+- [x] `CatalogueTeam` tests pass: `cd cli && cargo nextest run -p linear-client catalogue_team`
+- [x] The `tracker` public-api snapshot is regenerated and verified: `mise run public-api:update && mise run public-api:check`
+- [x] The pre-flight refusal and e2e regression pass: `cd cli && cargo nextest run -p work-adapters sync_run_real_client sync_create`
+- [x] `RunError::DiscoveryUnconfigured` exit-code test passes: `cd cli && cargo nextest run -p work-cli`
+- [x] `cli/linear-cli` builds (the `build_with_override` caller compiles): `cd cli && cargo clippy -p linear-cli --all-targets`
+- [x] Workspace check is green: `mise run cli:check`
+- [x] Full CLI unit suite passes: `mise run test:unit:cli`
 
 #### Manual Verification:
 

--- a/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
+++ b/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
@@ -1,0 +1,906 @@
+---
+type: plan
+id: "2026-08-30-0220-untracked-remote-discovery-on-linear"
+title: "Untracked-Remote Discovery on Linear Implementation Plan"
+date: "2026-08-30T17:33:07+00:00"
+author: "Toby Clemson"
+producer: create-plan
+status: ready
+work_item_id: "work-item:0220"
+parent: "work-item:0220"
+derived_from: ["codebase-research:2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear"]
+tags: [sync, linear, tracker, discovery]
+revision: "0f1624a83df9437999143ce09064485de53666b5"
+repository: "accelerator"
+last_updated: "2026-08-30T20:03:51+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Untracked-Remote Discovery on Linear Implementation Plan
+
+## Overview
+
+Untracked-remote discovery returns zero pulls on Linear for two independent
+reasons: with the scope key unset the discovery gate skips the search silently,
+and with the key set the key is passed to Linear as a team **key** where the
+filter wants the team **UUID**, matching no team. This plan lifts key→UUID
+resolution into a new `resolve_scope` port method that validates the discovery
+scope **before any push**: a missing or unresolvable key refuses the run
+pre-flight (`74`, nothing sent), while a resolved key drives a UUID-bounded
+search. It then makes every proceeding outcome — ran, skipped, transiently
+failed — visible in the sync report so a skip is never again mistaken for an
+empty result.
+
+## Current State Analysis
+
+The discovery gate in `cli/work-adapters/src/sync/run.rs:707-709` enables the
+untracked search only when `!PushOnly && (scope.project.is_some() ||
+scope.all_projects)`. On Linear `scope.project` is built from
+`work.default_project_code` (`cli/work-cli/src/sync.rs:431-438`), typically
+unset, so the gate's `else` branch (`run.rs:723-725`) yields an empty
+`Vec<ExternalId>` with no search and no report line.
+
+Two facts make the "required key" decision collapse the fix:
+
+- The gate **already opens** when the key is set (`scope.project.is_some()`), so
+  the with-key happy path needs no gate or trait change — only the key→UUID
+  resolution.
+- `RemoteTracker::search` has exactly one production caller,
+  `discover_untracked` (`run.rs:425`), reached only when `scope.project` is
+  `Some`. The two other callers are test infrastructure
+  (`cli/tracker-test-support/src/contract.rs:306`,
+  `cli/tracker-test-support/src/seed.rs:188`), both passing explicit scopes.
+  Neither relies on `None` meaning "credential team", so Linear's `search` may
+  require the key outright.
+
+With the key set to a team key like `PP`, Linear's `search`
+(`cli/linear-client/src/client.rs:661-686`) copies it verbatim into
+`Search.team_id`, and `compose` (`cli/linear-client/src/filter.rs:69-70`) emits
+`{"team":{"id":{"eq":"PP"}}}` — a filter Linear evaluates against the team UUID.
+`PP` matches nothing and discovery returns empty, silently, unlike the state
+path which refuses unknown names via `ClientError::UnknownState`. The
+credential-team fallback (`client.rs:666`) exists only as access control, not as
+scope authority, and is the mechanism the work item retires.
+
+The observability gap is total: `read_failure` drives only the exit code
+(`cli/work-cli/src/sync.rs:228`) and is never rendered; a search error folds into
+`read_failure` and an empty `Vec` (`run.rs:718-721`), indistinguishable from a
+completed empty search. `baseline_degradation` is the only degradation currently
+rendered (`sync.rs:454-466`).
+
+### Key Discoveries:
+
+- The with-key defect is the key→UUID trap in `search`
+  (`cli/linear-client/src/client.rs:661-686`); the fix lifts resolution into a
+  pre-flight `resolve_scope` so the same step also validates the scope before any
+  push.
+- `StateResolver` is the port precedent to mirror: trait in
+  `cli/linear-client/src/filter.rs:18-30`, cache-backed `CatalogueStates` in
+  `cli/linear-client/src/catalogue.rs`, `FixedStates` test double, injected as
+  `Box<dyn StateResolver>` (`client.rs:125`, built in `from_config` at
+  `client.rs:164`).
+- `LinearClient.team_key` (`client.rs:124`) serves `in_scope`
+  (`client.rs:193-200`) — identifier-prefix scoping, the `PP` in `PP-42` — a
+  different job from key→UUID resolution. `TeamResolver` is **additive**; it does
+  not replace `team_key`.
+- `resolve_scope` performs no network I/O, so any error it returns is a config
+  fault, distinct from a transient `search` failure without needing a discriminant
+  on `TrackerError` (both are `Retryable`; the port contract forbids `Terminal` on
+  reads, `cli/tracker/src/lib.rs:424`). `prepare_run` runs before the apply/push
+  phase (`run.rs:788`), so refusing an invalid scope there sends nothing — both
+  AC-3's no-key and AC-5's unresolvable-key exit `UNCONFIGURED` (74) honestly.
+  Only a post-resolution transient search failure exits `RETRYABLE` (70).
+- `RemoteTracker::search`'s only production caller is gated on
+  `scope.project.is_some()`; a required key is safe.
+- The public `run()` returns `Result<RunReport, RunError>`; the CLI already
+  renders hard `RunError` variants as clear messages (`sync.rs:491-525`).
+
+## Desired End State
+
+A bidirectional Linear sync with a configured team key discovers untracked team
+issues and reports them as planned pulls, with the search filter carrying the
+resolved team UUID and nothing enumerating the wider workspace. A run with the
+key unset, or set to a key that resolves to no catalogue team, reports the
+reason and exits non-clean rather than returning zero silently. Every run states
+whether discovery ran, was skipped, or failed — and why — distinguishably from a
+search that completed with no results.
+
+Verify by running a bidirectional preview sync against a mocked Linear with a
+seeded untracked issue and observing a `create-from-remote` planned pull plus a
+`discovery ran` report line; and by running with no key and observing a
+pre-flight `discovery unconfigured` refusal — nothing pushed — with a `74` exit.
+
+## What We're NOT Doing
+
+- No `RemoteTracker` capability boolean (`self_bounds_search`). Instead the port
+  gains an operational `resolve_scope` method — a validation/resolution seam, not
+  a capability flag — so each tracker validates its own discovery scope. This is
+  a deliberate expansion of the port surface (public-api-pinned; snapshot regen
+  required) chosen so a config fault is caught *before* any mutation.
+- No change to Jira's search or JQL. `E_JQL_NO_PROJECT`
+  (`cli/jira-client/src/jql.rs:169-174`) stays as the deep guard, but the
+  discovery-path refusal now lives in Jira's `resolve_scope` (which returns the
+  same error class): an unscoped run is refused pre-flight before `search`, so
+  AC-6's "performs no unbounded search" holds. This is a deliberate behavioural
+  change for Jira: an unscoped bidirectional Jira run exits `0` today and `74`
+  after, the intended uniform treatment — a run that cannot discover is a
+  misconfiguration to refuse on either tracker.
+- No multi-team key→UUID map. The catalogue models one team; resolution is a
+  single equality against the catalogue team key.
+- No `all_projects`/all-teams discovery on Linear; that is 0146's scope/config
+  redesign.
+- No rename of `work.default_project_code`. This plan targets the current field;
+  reconciliation with the 0146 `work.key` rename is a stated assumption below.
+- No new exit code. A pre-flight config refusal reuses `UNCONFIGURED` (74),
+  whose "nothing was sent" invariant holds because `prepare_run` aborts before
+  the apply/push phase (`run.rs:788`).
+
+## Implementation Approach
+
+The fix validates the discovery scope **before any side effect**. A missing or
+unresolvable key is a configuration fault caught pre-flight in `prepare_run`,
+which aborts the whole run before the push side executes — so nothing is sent and
+`UNCONFIGURED` (74) is honest. Only a genuine transient search failure (network),
+which happens after the scope is validated, degrades gracefully and exits
+`RETRYABLE` (70). This is why the fault classes need separating at their source:
+resolution (deterministic, local) is lifted into a new `resolve_scope` port
+method, distinct from `search` (network).
+
+Two test-driven phases. **Phase 1** is the working fix: the `TeamResolver` +
+`resolve_scope` machinery, the pre-flight call in `prepare_run` that refuses an
+invalid scope with `RunError::DiscoveryUnconfigured`, and a `search` that consumes
+the pre-resolved scope. It satisfies AC-1..AC-6 and AC-8. **Phase 2** is
+observability on top: a `DiscoveryStatus` report line for the runs that proceed
+(ran / push-only / transient-failure), satisfying AC-7. Phase 2 builds on Phase
+1's gate shape, so it merges after; Phase 1 is self-contained and shippable
+alone (transient search errors fold into the existing `read_failure` path until
+Phase 2 gives them a line).
+
+## Phase 1: Discovery validates its scope pre-flight and refuses an invalid one
+
+### Overview
+
+Introduce a `TeamResolver` port mirroring `StateResolver` and a catalogue-backed
+implementation injected into `LinearClient`. Add a `resolve_scope` method to the
+`RemoteTracker` port: a deterministic, local step that resolves provider identity
+(Linear's team key → UUID) and validates presence, distinct from the network
+`search`. Call `resolve_scope` in `prepare_run` before the push side runs, and
+refuse an invalid scope with a new `RunError::DiscoveryUnconfigured` that aborts
+the run — so a config fault sends nothing and exits `74`. `search` then consumes
+the pre-resolved scope, so Linear's `search` uses the resolved UUID directly and
+drops the credential-team fallback.
+
+### Changes Required:
+
+#### 1. The `TeamResolver` port and test double
+
+**File**: `cli/linear-client/src/filter.rs`
+**Changes**: Add the trait beside `StateResolver`, and a fixed test double beside
+`FixedStates`.
+
+```rust
+pub trait TeamResolver {
+    fn resolve(&self, key: &str) -> Option<String>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FixedTeam(pub std::collections::BTreeMap<String, String>);
+
+impl TeamResolver for FixedTeam {
+    fn resolve(&self, key: &str) -> Option<String> {
+        self.0.get(key.trim()).cloned()
+    }
+}
+```
+
+The map shape mirrors `FixedStates`; production resolution is single-team
+(`CatalogueTeam` holds one pair), so a `FixedTeam` only ever carries one entry.
+
+#### 2. The catalogue-backed resolver
+
+**File**: `cli/linear-client/src/catalogue.rs`
+**Changes**: Add `CatalogueTeam`, reading `/team/key` and `/team/id` from the
+single-team catalogue, resolving a key to the UUID only when it matches the
+catalogue team key.
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub struct CatalogueTeam {
+    key: Option<String>,
+    id: Option<String>,
+}
+
+impl CatalogueTeam {
+    #[must_use]
+    pub fn load(integrations_root: &Path) -> Self {
+        let path = integrations_root.join("linear/catalogue.json");
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+            .map(|catalogue| Self::from_catalogue(&catalogue))
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn from_catalogue(catalogue: &Value) -> Self {
+        Self {
+            key: pointer_string(catalogue, "/team/key"),
+            id: pointer_string(catalogue, "/team/id"),
+        }
+    }
+}
+
+impl TeamResolver for CatalogueTeam {
+    fn resolve(&self, key: &str) -> Option<String> {
+        match (&self.key, &self.id) {
+            (Some(team_key), Some(team_id)) if team_key.trim() == key.trim() => {
+                Some(team_id.clone())
+            }
+            _ => None,
+        }
+    }
+}
+```
+
+`CatalogueTeam::load` is the third catalogue reader in the crate (after
+`CatalogueStates::load` and the `auth.rs` team reads), and `from_catalogue` reads
+two pointers. Extract a shared `pointer_string(&Value, &str) -> Option<String>`
+helper and route `from_catalogue` through it rather than inlining; the
+`read_to_string / from_str / unwrap_or_default` load shape stays copied from
+`CatalogueStates::load` for now. `pointer_string` must mirror `auth.rs`'s
+`catalogue_field` and filter empty strings (`.filter(|value| !value.is_empty())`),
+so an empty `/team/key` reads as `None` — this keeps the flagged `auth.rs`
+consolidation (a clean follow-up, out of scope) behaviour-preserving and stops
+`CatalogueTeam` resolving on a blank key.
+
+#### 3. Inject the resolver into `LinearClient`
+
+**File**: `cli/linear-client/src/client.rs`
+**Changes**: Add a `teams: Box<dyn TeamResolver>` field beside `states`
+(`client.rs:125`), extend `new` to take it, and build `CatalogueTeam::load` in
+`from_config` (`client.rs:156-165`).
+
+```rust
+pub struct LinearClient {
+    transport: Transport,
+    upload: UploadTransport,
+    team_key: Option<String>,
+    teams: Box<dyn TeamResolver>,
+    states: Box<dyn StateResolver>,
+}
+```
+
+```rust
+let team_key = crate::auth::catalogue_team_key(integrations_root);
+let teams = crate::catalogue::CatalogueTeam::load(integrations_root);
+let states = CatalogueStates::load(integrations_root);
+Ok(Self::new(transport, upload, team_key, Box::new(teams), Box::new(states)))
+```
+
+`team_key` stays: `in_scope` (`client.rs:193-200`) still needs it for the
+identifier-prefix partition in `fetch_all`.
+
+#### 4. Add `resolve_scope` and a `ScopeError` to the `RemoteTracker` port
+
+**Files**: `cli/tracker/src/lib.rs`; all **six** `impl RemoteTracker` blocks — the
+two production clients (`LinearClient`, `JiraClient`) and the four test doubles
+`RecordingTracker` (`cli/tracker-test-support/src/lib.rs:203`), `FixedTracker`
+(`cli/tracker/tests/port.rs:65`), `Fake` (`cli/work-adapters/tests/sync_apply.rs:102`),
+and `MarkerObservingTracker` (`cli/work-adapters/tests/sync_create.rs:979`);
+`cli/tracker/tests/fixtures/public-api.txt`.
+**Changes**: Add a required method beside `search`, and a dedicated `ScopeError`
+type for its failure. `resolve_scope` performs no network I/O; a `ScopeError` is,
+by construction, a configuration fault — carried by its own type rather than
+overloading `TrackerError::Retryable`, so it can never be routed through
+`for_tracker_error` (which maps every `Retryable` to `70`) and mis-exit as a
+transient failure.
+
+```rust
+/// A discovery scope that names no valid search target for this tracker — a
+/// missing or unresolvable key. A configuration fault, distinct from a transient
+/// read failure; the caller surfaces it before any mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopeError {
+    pub detail: String,
+}
+
+/// Resolves and validates a discovery `scope` for this tracker, without any
+/// network call. Substitutes provider identity (e.g. a team key for its UUID)
+/// and returns the scope ready for `search`.
+///
+/// # Errors
+///
+/// [`ScopeError`] when the scope names no valid target. It resolves locally and
+/// mutates nothing, so it never reports a transient or terminal failure.
+fn resolve_scope(
+    &self,
+    scope: &SearchScope,
+) -> Result<SearchScope, ScopeError>;
+```
+
+The four test doubles return `Ok(scope.clone())` (they perform no resolution);
+`RecordingTracker` also gains a `refusing_scope(ScopeError)` builder (mirroring
+`failing_search`) so a run can be driven into the pre-flight refusal.
+`resolve_scope` is a required method, matching the trait's uniform all-required
+style. Both the method and `ScopeError` change `tracker`'s public API, so
+regenerate its snapshot with `mise run public-api:update` and verify with `mise
+run public-api:check` (there is no `cargo test --test public_api` target).
+
+#### 5. Linear `resolve_scope`, and a `search` that consumes the resolved scope
+
+**File**: `cli/linear-client/src/client.rs`
+**Changes**: Implement `resolve_scope` to require `scope.project`, resolve it to
+the UUID via the injected `teams`, and refuse an unresolved key with a `ScopeError`.
+`search` then takes the resolved UUID — but **keeps a defensive refusal** for a
+`None` team id.
+
+```rust
+fn resolve_scope(
+    &self,
+    scope: &SearchScope,
+) -> Result<SearchScope, ScopeError> {
+    let Some(key) = scope.project.as_deref() else {
+        return Err(ScopeError {
+            detail: "E_SEARCH_NO_TEAM: discovery needs a team key; set \
+                     work.default_project_code, or run --push-only to push \
+                     without discovery"
+                .to_owned(),
+        });
+    };
+    let Some(team_id) = self.teams.resolve(key) else {
+        return Err(ScopeError {
+            detail: format!(
+                "E_SEARCH_UNKNOWN_TEAM: team key {key:?} resolves to no team \
+                 in the catalogue; check work.default_project_code matches the \
+                 catalogue team key, or refresh linear/catalogue.json"
+            ),
+        });
+    };
+    Ok(SearchScope {
+        project: Some(team_id),
+        ..scope.clone()
+    })
+}
+
+fn search(&self, scope: &SearchScope) -> Result<Discovery, TrackerError> {
+    let Some(team_id) = scope.project.clone() else {
+        return Err(TrackerError::Retryable {
+            detail: "E_SEARCH_UNRESOLVED_SCOPE: search needs a resolved team id; \
+                     call resolve_scope first"
+                .to_owned(),
+        });
+    };
+    let mut search = Search {
+        team_id: Some(team_id),
+        ..Search::default()
+    };
+    for (field, value) in &scope.filters {
+        match field.as_str() {
+            "state" => search.state = Some(value.clone()),
+            "assignee" => search.assignee = Some(value.clone()),
+            "label" => search.label = Some(value.clone()),
+            "text" => search.text = Some(value.clone()),
+            _ => {}
+        }
+    }
+    let (index, truncated) = self.page_all(&search);
+    Ok(Discovery {
+        found: index
+            .into_iter()
+            .map(|(id, stamp)| (ExternalId::new(id), stamp))
+            .collect(),
+        complete: truncated.is_none(),
+    })
+}
+```
+
+The defensive `None` guard is load-bearing, not decorative. Dropping the old
+credential-team fallback (`.or_else(|| Some(self.credentials().team_id))`) means a
+`None` `team_id` would otherwise reach `compose` (`filter.rs:69`), which emits an
+**empty** filter — a workspace-wide enumeration, the 997+-issue flood this epic
+exists to prevent, not an empty result. The guard makes an unresolved scope
+reaching `search` refuse rather than flood, mirroring Jira's `E_JQL_NO_PROJECT`
+deep guard. In the wired flow `resolve_scope` guarantees a UUID, so the guard is
+defence-in-depth for any direct caller.
+
+#### 6. Jira `resolve_scope`
+
+**File**: `cli/jira-client/src/client.rs`
+**Changes**: Implement `resolve_scope` to validate project presence, returning
+the scope unchanged (Jira's JQL uses the project key directly) or the existing
+`E_JQL_NO_PROJECT` error when both `project` and `all_projects` are unset. This
+moves the discovery-path refusal ahead of `search`; the `compose` guard in
+`jql.rs:169-174` stays as defence for any direct `search` call.
+
+```rust
+fn resolve_scope(
+    &self,
+    scope: &SearchScope,
+) -> Result<SearchScope, ScopeError> {
+    if scope.project.is_none() && !scope.all_projects {
+        return Err(ScopeError {
+            detail: "E_JQL_NO_PROJECT: specify a project or all_projects, \
+                     or run --push-only to push without discovery"
+                .to_owned(),
+        });
+    }
+    Ok(scope.clone())
+}
+```
+
+#### 7. Call `resolve_scope` pre-flight in `prepare_run`
+
+**File**: `cli/work-adapters/src/sync/run.rs:707-725`, plus `RunError`
+(`run.rs:44`) and its CLI rendering (`cli/work-cli/src/sync.rs:491-524`).
+**Changes**: Before discovery, resolve the scope; refuse an invalid one with a new
+hard `RunError::DiscoveryUnconfigured { detail }`. Because `prepare_run` runs
+before the apply/push phase (`run.rs:788`), the refusal sends nothing. A transient
+`search` failure still folds into the existing `read_failure` path (Phase 2 gives
+it a report line).
+
+The call sits at the existing gate (`run.rs:707`), which is **after**
+`fetch::gather` (`run.rs:671`) has issued its tracked-item reads. The "nothing was
+sent" invariant is about mutations, so it holds regardless — but a deterministic,
+local config fault still pays a full remote gather before being refused. Hoisting
+the `resolve_scope` refusal above `fetch::gather` for non-`PushOnly` runs would
+fail fast and save that round-trip; keeping it at the gate keeps the discovery
+logic in one place. Hoist it unless the gate-locality is worth the wasted gather.
+
+```rust
+let untracked = if matches!(request.direction, SyncDirection::PushOnly) {
+    Vec::new()
+} else {
+    let resolved = ports
+        .tracker
+        .resolve_scope(&request.scope)
+        .map_err(|error| RunError::DiscoveryUnconfigured {
+            detail: error.detail,
+        })?;
+    match discover_untracked(ports.tracker, &resolved, request.items) {
+        Ok(discovered) if !discovered.complete => {
+            return Err(RunError::DiscoveryIncomplete {
+                found: discovered.ids.len(),
+            });
+        }
+        Ok(discovered) => discovered.ids,
+        Err(error) => {
+            read_failure = read_failure.or(Some(error));
+            Vec::new()
+        }
+    }
+};
+```
+
+`ScopeError` maps to `RunError` by a plain field move — no `TrackerError`
+destructure, and no way for the config fault to leak into the transient
+`for_tracker_error` path. This `resolve_scope` refusal precedes the write-bound
+`RunError::Refused` check (`run.rs:734`), so a run that is both unconfigured and
+over-threshold surfaces the config fault first — the deliberate ordering, since a
+scope the operator must fix outranks a bound they can raise.
+
+Add `DiscoveryUnconfigured { detail: String }` to `RunError`, and a CLI arm
+mapping it to `exit_codes::UNCONFIGURED` (74) — mirroring the existing
+`RunError::DiscoveryIncomplete` arm (`sync.rs:509`). Frame the rendered message
+in operator language like its siblings ("refused: discovery is unconfigured — …"),
+keeping the `E_SEARCH_*` / `E_JQL_*` sentinel inside the `detail` it wraps rather
+than leading with it. 74's "nothing was sent" invariant holds: no apply ran.
+
+#### 8. Update every `LinearClient::new` caller
+
+**Files**: all five construction sites, listed below.
+**Changes**: Inject a `TeamResolver` at each. The one production site beyond
+`from_config` is `build_with_override` (`cli/linear-cli/src/context.rs:182`),
+which builds a client directly for the endpoint-override path — inject
+`CatalogueTeam::load(integrations_root)` there, mirroring `from_config`, **not** a
+test double, or the override discovery path would refuse every key.
+
+- `cli/linear-cli/src/context.rs:182` (`build_with_override`) — production:
+  `CatalogueTeam::load(integrations_root)`.
+- `cli/linear-client/tests/support/client.rs:68-73` (`client_for`) — `FixedTeam`
+  mapping `TEAM_KEY → TEAM_ID` (constants at `support/client.rs:16-17`), so the
+  search suites resolve.
+- `cli/linear-client/tests/support/client.rs:92-97`
+  (`client_with`/`client_with_states`) — take or default a resolver as their
+  existing signatures dictate.
+- `cli/linear-client/tests/contract.rs:146` — a defaulted `FixedTeam` unless the
+  case exercises `search`.
+- `cli/work-adapters/tests/sync_run_real_client.rs:179` — inject a `FixedTeam`
+  mapping `ENG → TEAM_ID`, and migrate the shared `execute` harness (`~:211-247`).
+  This is the load-bearing test fix: `execute` today hardcodes `direction:
+  Bidirectional`, `scope: SearchScope::default()`, and `run(...).unwrap_or_else(||
+  panic!(...))`. After Change 7, an unscoped bidirectional run refuses
+  (`DiscoveryUnconfigured`), so the five existing callers (jira/linear classify,
+  the two truncated-read tests, the dossier test) would panic. Give `execute`
+  `scope` and `direction` parameters and a `Result<RunReport, RunError>` return;
+  migrate each existing caller to pass a resolvable scope (or `PushOnly` where the
+  case does not exercise discovery) and `.expect(...)` the report. The
+  `TEAM_KEY`/`TEAM_ID` constants are not visible from the `work-adapters` crate, so
+  declare local constants there. Verify with `cargo nextest run -p work-adapters
+  sync_run_real_client`.
+
+### Test-Driven Steps:
+
+1. **Red** — `cli/linear-client/tests/` `resolve_scope`: `SearchScope { project:
+   Some(TEAM_KEY), .. }` with a `FixedTeam` mapping `TEAM_KEY → TEAM_ID` returns
+   `Ok` with `project == Some(TEAM_ID)` (the UUID, not `ENG`). Fails today:
+   `resolve_scope` does not exist.
+2. **Red** — the same: `SearchScope { project: Some("ZZ"), .. }` with a
+   `FixedTeam` that knows only `ENG` returns `Err(TrackerError::Retryable)` whose
+   detail contains `E_SEARCH_UNKNOWN_TEAM`; `SearchScope { project: None, .. }`
+   returns `Err` whose detail contains `E_SEARCH_NO_TEAM`.
+3. **Red** — `cli/linear-client/tests/search_projection.rs`: a `MockServer`
+   `search` over a **pre-resolved** `SearchScope { project: Some(TEAM_ID), .. }`
+   asserts that **every** captured body carries `{"team":{"id":{"eq":TEAM_ID}}}`
+   via `server.bodies(...)` — the positive UUID projection and the negative "no
+   page enumerates the wider workspace" (AC-2) in one assertion.
+4. **Red** — `cli/linear-client/tests/` unit coverage for `CatalogueTeam`:
+   matching key → `Some(uuid)`; non-matching key → `None`; absent catalogue →
+   `None`. Mirror `cli/linear-client/tests/auth.rs`'s `with_catalogue` idiom.
+5. **Red** — Jira `resolve_scope`: `None`/`!all_projects` → `Err` containing
+   `E_JQL_NO_PROJECT`; a set project → `Ok(scope)` unchanged.
+6. **Red** — `cli/work-adapters/tests/sync_create.rs`: a bidirectional run over a
+   `RecordingTracker` whose `resolve_scope` refuses (a `refusing_scope(error)`
+   seam, mirroring `failing_search`) returns `Err(RunError::DiscoveryUnconfigured)`
+   **and fires no `Call::Search` and no push `Call`** — proving nothing was sent.
+   A `None`-scope real-tracker path is covered end to end in step 8.
+7. **Red** — `cli/work-cli/src/sync.rs`: the `RunError::DiscoveryUnconfigured`
+   render arm emits a message carrying the `detail`, and `run` exits
+   `exit_codes::UNCONFIGURED` (74).
+8. **Red** — the AC-1/AC-4/AC-8 end-to-end regression, in
+   `cli/work-adapters/tests/sync_run_real_client.rs` (parameterised per Change 8):
+   drive `run()` in preview over a `MockServer` seeded with one untracked team
+   issue and `SearchScope { project: Some(TEAM_KEY), .. }`. **The load-bearing red
+   assertion is the captured body carrying the resolved `TEAM_ID`** — a
+   `MockServer` routes by method+path and does not evaluate the team filter, so
+   the seeded issue would surface even with the raw key; today the body carries
+   `ENG`, which is what fails. Also assert the `create-from-remote` row. A sibling
+   case: a `None`-scope bidirectional run returns
+   `Err(RunError::DiscoveryUnconfigured)` (via `execute`'s new `Result` return) and
+   records **zero** `POST /graphql` hits against the mock — Linear posts search and
+   every mutation to the same `/graphql` route, so "nothing was sent" is checkable
+   only as zero requests, not as "no push".
+9. **Green** — implement changes 1-8 above.
+10. **Refactor** — land the shared `pointer_string` helper from Change 2.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] `linear-client`/`jira-client` build and lint: `cd cli && cargo clippy -p linear-client -p jira-client --all-targets`
+- [ ] `resolve_scope` and search tests pass: `cd cli && cargo nextest run -p linear-client resolve_scope search`
+- [ ] `CatalogueTeam` tests pass: `cd cli && cargo nextest run -p linear-client catalogue_team`
+- [ ] The `tracker` public-api snapshot is regenerated and verified: `mise run public-api:update && mise run public-api:check`
+- [ ] The pre-flight refusal and e2e regression pass: `cd cli && cargo nextest run -p work-adapters sync_run_real_client sync_create`
+- [ ] `RunError::DiscoveryUnconfigured` exit-code test passes: `cd cli && cargo nextest run -p work-cli`
+- [ ] `cli/linear-cli` builds (the `build_with_override` caller compiles): `cd cli && cargo clippy -p linear-cli --all-targets`
+- [ ] Workspace check is green: `mise run cli:check`
+- [ ] Full CLI unit suite passes: `mise run test:unit:cli`
+
+#### Manual Verification:
+
+- [ ] Against a real workspace with `work.default_project_code` set to the team
+      key and a seeded untracked issue, `accelerator work sync --preview` lists
+      the issue as a `create-from-remote` pull.
+- [ ] The emitted GraphQL body (captured via a proxy or debug log) carries the
+      team UUID in `{team:{id:{eq:…}}}`, not the raw key.
+- [ ] A bidirectional run with the key unset refuses with a `discovery
+      unconfigured` message, exits `74`, and sends no push (verify no create hits
+      the remote).
+
+---
+
+## Phase 2: Discovery outcome is visible in the report
+
+### Overview
+
+Thread a `DiscoveryStatus` through the report for the runs that get **past** the
+Phase 1 pre-flight check, so a push-only skip, a completed search, and a transient
+search failure are each visible and distinct from an empty result. Config
+refusals never reach here — Phase 1 aborts them as `RunError::DiscoveryUnconfigured`
+before the report exists — so this status has no `Unconfigured` variant.
+
+### Changes Required:
+
+#### 1. The `DiscoveryStatus` type
+
+**File**: `cli/work-adapters/src/sync/run.rs`
+**Changes**: Add the enum near `RunReport` (`run.rs:123`) and a field on both
+`PreparedRun` (`run.rs:639-649`) and `RunReport` (`run.rs:123-129`).
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryStatus {
+    Ran { found: usize },
+    SkippedPushOnly,
+    Failed { detail: String },
+}
+```
+
+`Failed` is a transient `search` failure (network) — the only error that reaches
+this layer, since a config fault was refused pre-flight in Phase 1. It maps to
+`RETRYABLE` (70), the fate the taxonomy assigns a failed read. `SkippedPushOnly`
+and `Ran` are clean.
+
+#### 2. Set the status where the gate stands
+
+**File**: `cli/work-adapters/src/sync/run.rs:707-725`
+**Changes**: Extend Phase 1's discovery block (Change 7) to produce a
+`DiscoveryStatus` alongside `untracked`, replacing the `read_failure` fold with a
+`Failed` status. The pre-flight `resolve_scope` refusal and the incomplete case
+stay as hard `RunError`s.
+
+The `Failed` detail is the tracker error's inner `detail`, not `error.to_string()`:
+`TrackerError`'s `Display` prepends "tracker call failed with no remote change: …",
+which would read as double-labelled in the report line. Pull the inner string so
+the sentinel stands alone. Rather than an inline `let Retryable | Terminal = error`
+destructure, add a `TrackerError::into_detail(self) -> String` accessor on the enum
+and call it here; `cli/work-cli/src/create.rs:416` already hand-rolls this exact
+extraction, so the accessor centralises the two-variant exhaustiveness in one place.
+
+```rust
+let (untracked, discovery) = if matches!(
+    request.direction,
+    SyncDirection::PushOnly
+) {
+    (Vec::new(), DiscoveryStatus::SkippedPushOnly)
+} else {
+    let resolved = ports
+        .tracker
+        .resolve_scope(&request.scope)
+        .map_err(|error| RunError::DiscoveryUnconfigured {
+            detail: error.detail,
+        })?;
+    match discover_untracked(ports.tracker, &resolved, request.items) {
+        Ok(discovered) if !discovered.complete => {
+            return Err(RunError::DiscoveryIncomplete {
+                found: discovered.ids.len(),
+            });
+        }
+        Ok(discovered) => {
+            let found = discovered.ids.len();
+            (discovered.ids, DiscoveryStatus::Ran { found })
+        }
+        Err(error) => (
+            Vec::new(),
+            DiscoveryStatus::Failed {
+                detail: error.into_detail(),
+            },
+        ),
+    }
+};
+```
+
+Carry `discovery` through `PreparedRun` into both the preview and apply
+`RunReport` constructions (`run.rs:806-810,869-873`).
+
+#### 3. A `failing_search` seam on `RecordingTracker`
+
+**File**: `cli/tracker-test-support/src/lib.rs`
+**Changes**: Add a `failing_search(TrackerError)` builder mirroring
+`failing_show`/`failing_preview` (`lib.rs:153-165`), and have `search`
+(`lib.rs:315`) return the configured error instead of unconditionally `Ok`. The
+existing `discovering(found, complete)` seam stays for the success path.
+
+`RecordingTracker` today has no way to make `search` fail, so the Phase 2 error
+path (`Failed`, and that a search error no longer folds into `read_failure`) has
+no test double to drive. The error must be `Retryable` or `Terminal` to match the
+port contract — the removed credential fallback is gone.
+
+#### 4. Render the discovery line
+
+**File**: `cli/work-cli/src/sync.rs:172-205`
+**Changes**: In `render_report`, emit one discovery line after the item lines and
+before the summary, without disturbing the summary's own emit condition.
+
+```rust
+let discovery_line = match &report.discovery {
+    DiscoveryStatus::Ran { found } => {
+        format!("#\tdiscovery\tran\tfound={found}")
+    }
+    DiscoveryStatus::SkippedPushOnly => {
+        "#\tdiscovery\tskipped\tpush-only".to_owned()
+    }
+    DiscoveryStatus::Failed { detail } => {
+        format!("#\tdiscovery\tfailed\t{}", single_line(detail))
+    }
+};
+lines.sort();
+let summary_needed = synced_count > 0 || lines.is_empty();
+lines.push(discovery_line);
+if summary_needed {
+    lines.push(format!("#\tsummary\tsynced\t{synced_count}"));
+}
+```
+
+Two corrections to the current shape. `lines.sort()` does not order the discovery
+line relative to the summary — the summary is pushed after the sort — so append
+the discovery line explicitly after the sort to land it below the item lines and
+above the summary. And capture `summary_needed` before pushing the discovery line:
+an always-present discovery line makes `lines.is_empty()` false, which would
+otherwise drop the `#\tsummary\tsynced\t0` line an empty run emits today.
+
+`single_line` is a small helper replacing tab, newline, and carriage return with a
+space, so a transport `detail` cannot break the single-record TSV format.
+
+#### 5. Drive the exit code
+
+**File**: `cli/work-cli/src/sync.rs:207-233`
+**Changes**: In `exit_code_for_report`, fold a `Failed` discovery into the
+existing `RETRYABLE` (70) arm alongside `any_retryable || read_failure.is_some()`.
+`Ran` and `SkippedPushOnly` stay clean. No new precedence: a transient discovery
+failure is exactly a failed read, which the taxonomy already sends to 70.
+
+```rust
+} else if any_retryable
+    || report.read_failure.is_some()
+    || matches!(report.discovery, DiscoveryStatus::Failed { .. })
+{
+    exit_codes::RETRYABLE
+} else {
+    exit_codes::CLEAN
+}
+```
+
+The config-fault code (`UNCONFIGURED`, 74) is emitted in Phase 1 from
+`RunError::DiscoveryUnconfigured`, not here — so `exit_code_for_report`, which only
+runs for a successful `RunReport`, never needs to know about it.
+
+#### 6. Reconcile the exit-code documentation
+
+**Files**: `cli/work-cli/src/exit_codes.rs`, `skills/work/sync-work-items/SKILL.md`
+**Changes**: `UNCONFIGURED` (74) now has a second source — a pre-flight discovery
+`resolve_scope` refusal, not only tracker `SelectionError`. Its "nothing was sent"
+invariant **still holds** (the refusal aborts before apply). In `exit_codes.rs`,
+extend the `74` doc line to enumerate both sources without weakening the clause,
+**and** amend the `72–74` band header (`~:34-36`), which currently attributes the
+band solely to `SelectionError` — it must now name the pre-flight discovery
+refusal too, or the authoritative table drifts from the code. In
+`skills/work/sync-work-items/SKILL.md`, update **both** places 74 is documented —
+the Step 0 config-gate branch (`~:51-57`) and the Step 2 exit-code list
+(`~:104-118`) — so each names both the credential/selection fault and the
+discovery-scope fault (and, for Step 0, the `--push-only` escape hatch); add the
+new `#\tdiscovery` report line to the report description. The `70` entry gains "or
+a discovery search failed transiently".
+
+### Test-Driven Steps:
+
+1. **Red** — `cli/work-adapters/tests/sync_create.rs`: a push-only run yields
+   `report.discovery == SkippedPushOnly` and fires no `Call::Search` (mirror the
+   push-only assertion at `sync_create.rs:390`).
+2. **Red** — a scoped run over a `RecordingTracker.discovering(found, true)`
+   yields `Ran { found }` with the untracked count.
+3. **Red** — a scoped run over a `RecordingTracker.failing_search(Retryable)`
+   yields `Failed { detail }` where `detail` equals the raw injected inner string
+   (no `Display` prefix), and `report.read_failure` is `None`. Depends on the
+   seam in Change 3.
+4. **Red** — `cli/work-cli/src/sync.rs` tests: `render_report` emits the three
+   discovery lines (`ran`, `push-only`, `failed`); the `failed` line **contains
+   the injected `detail` substring**; the `#\tsummary\tsynced\t0` line survives an
+   empty run; `single_line` strips tab and newline from a `detail`;
+   `exit_code_for_report` returns `RETRYABLE` for `Failed` and clean for
+   `SkippedPushOnly` and `Ran`.
+5. **Green** — implement changes 1-4.
+6. **Refactor** — collapse the two `RunReport` constructions (preview and apply,
+   `run.rs:806,869`) into a shared `RunReport::from_prepared(...)` builder now
+   that the added `discovery` field makes a sixth duplicated field.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] `work-adapters` and `work-cli` build and lint: `mise run cli:check`
+- [ ] Discovery-status run tests pass: `cd cli && cargo nextest run -p work-adapters discovery`
+- [ ] Render/exit-code tests pass: `cd cli && cargo nextest run -p work-cli render_report`
+- [ ] Full CLI unit suite passes: `mise run test:unit:cli`
+- [ ] Read-only aggregate is green: `mise run check`
+- [ ] The updated `skills/work/sync-work-items/SKILL.md` exit-code list matches
+      `exit_codes.rs` (checked by eye — there is no automated drift check).
+
+#### Manual Verification:
+
+- [ ] A normal keyed run prints `discovery ran found=N` and exits `0`.
+- [ ] A run whose discovery search fails transiently prints a `discovery failed`
+      line and exits `70`.
+- [ ] A run with zero reported items still prints a `#\tsummary\tsynced\t0` line.
+      (The no-key `74` refusal is a Phase 1 concern, verified there.)
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `CatalogueTeam` resolution: match, non-match, absent catalogue (Phase 1).
+- Linear `resolve_scope`: UUID substitution on a matching key,
+  `E_SEARCH_UNKNOWN_TEAM` on an unresolved key, `E_SEARCH_NO_TEAM` on `None`; and
+  `search` projects the pre-resolved UUID into every emitted filter (Phase 1).
+- Jira `resolve_scope`: `E_JQL_NO_PROJECT` on an unscoped scope, `Ok` unchanged on
+  a set project (Phase 1).
+- `prepare_run` pre-flight: a refusing `resolve_scope` returns
+  `RunError::DiscoveryUnconfigured` with no `Call::Search` and no push; the CLI
+  maps it to `74` (Phase 1).
+- `DiscoveryStatus` per branch — `Ran`, `SkippedPushOnly`, `Failed` — with the
+  `Failed` `detail` carrying the raw inner string, and a search error not
+  populating `read_failure` (Phase 2). The `Failed` case uses the new
+  `RecordingTracker.failing_search` seam.
+- `render_report` lines (three lines, the `failed` line carrying the detail, the
+  preserved empty-run summary, `single_line` whitespace stripping) and
+  `exit_code_for_report` — `70` for `Failed`, clean otherwise (Phase 2).
+
+### Integration Tests:
+
+- The AC-1/AC-4/AC-8 regression: a mocked-Linear bidirectional discovery with the
+  key set surfaces the untracked issue as a `create-from-remote` pull, driven
+  through `run()` in `cli/work-adapters/tests/sync_run_real_client.rs`. The
+  load-bearing assertion is the captured body carrying the resolved UUID — a
+  `MockServer` does not evaluate the team filter, so the raw-key body is what
+  fails today.
+
+**AC-7 coverage note.** Because a no-key/unknown-key run is now a hard
+`RunError::DiscoveryUnconfigured` (not a soft report status), AC-7's
+"report states it was skipped and why" splits across two mechanisms: the
+`#\tdiscovery` report line covers the `ran` / `push-only` / transient-`failed`
+outcomes (Phase 2), while the config-fault case is covered by the Phase 1 render
+test asserting the `74` refusal message names the key. The distinguishability of a
+completed-empty search (`Ran { found: 0 }`) from a skip and from a config refusal
+is therefore asserted across both phases, not Phase 2 alone.
+
+### Manual Testing Steps:
+
+1. Set `work.integration: linear`, populate `catalogue.json`, set
+   `work.default_project_code` to the team key.
+2. Ensure a team issue has no local work item.
+3. `accelerator work sync --preview` — expect the issue as a `create-from-remote`
+   pull and `discovery ran found>=1`.
+4. Unset the key and rerun — expect a pre-flight `discovery unconfigured` refusal,
+   exit `74`, and **no push applied** (nothing sent).
+5. Set the key to a value absent from the catalogue — expect the same pre-flight
+   refusal naming the key, exit `74`, nothing sent.
+
+## Performance Considerations
+
+`CatalogueTeam::load` reads one small JSON file per client construction, matching
+`CatalogueStates::load`; negligible. Discovery still issues one bounded team
+search. No new remote calls.
+
+## Migration Notes
+
+No config or on-disk migration — the plan reads the existing
+`work.default_project_code` field and writes no new artefacts.
+
+**Behavioural contract change, release-note it.** An unconfigured discovery scope
+now refuses a bidirectional or pull-only run pre-flight (exit `74`) where it
+completed cleanly (exit `0`) before — on **both** trackers, so an unscoped Jira
+run shifts `0 → 74`. Exit `74`'s meaning broadens from selection/credential faults
+to also cover a per-run discovery-scope fault. Any wrapper or CI job that treated a
+keyless `work sync` as a clean success will newly see `74`; the workaround is to
+set the key or run `--push-only`. Cross-reference the parent epic **0146**, whose
+`work.key` rename touches the same field and must account for this exit-code shift.
+
+## Assumptions
+
+- Discovery on Linear is intended, and the configured key is the scope authority;
+  the credentialed team is access control only.
+- This plan targets `work.default_project_code`. The 0146 rename to `work.key`
+  and layered `<tracker>.<entity>_key` ownership reads the same field; whichever
+  ships second reconciles — if the rename lands first, retarget the reader; if
+  this lands first, the rename accounts for `CatalogueTeam`'s consumer and the
+  scope construction at `cli/work-cli/src/sync.rs:431`.
+- Team-key matching in the resolver is trimmed exact (not case-folded).
+  `in_scope`'s identifier-prefix comparison (`client.rs:198`) is exact but
+  **untrimmed** (`prefix == key.as_str()`), so the resolver is the more lenient
+  of the two. Both derive the key from the same catalogue `/team/key`; for a
+  well-formed key with no surrounding whitespace they agree, and a
+  whitespace-bearing catalogue key is out of scope for this fix.
+
+## References
+
+- Original work item: `meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md`
+- Related research: `meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md`
+- Port precedent: `cli/linear-client/src/filter.rs:18-40`, `cli/linear-client/src/catalogue.rs`
+- Discovery gate: `cli/work-adapters/src/sync/run.rs:707-725`
+- Key→UUID seam (moves into `resolve_scope`): `cli/linear-client/src/client.rs:661-686`
+- Pre-flight abort point (`prepare_run` before apply): `cli/work-adapters/src/sync/run.rs:788`
+- Exit-code taxonomy: `cli/work-cli/src/exit_codes.rs`
+- Parent epic: `meta/work/0146-work-item-sync-enhancements.md`

--- a/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
+++ b/meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md
@@ -1,15 +1,15 @@
 ---
-type: plan
+type: "plan"
 id: "2026-08-30-0220-untracked-remote-discovery-on-linear"
 title: "Untracked-Remote Discovery on Linear Implementation Plan"
 date: "2026-08-30T17:33:07+00:00"
 author: "Toby Clemson"
-producer: create-plan
-status: done
+producer: "create-plan"
+status: "done"
 work_item_id: "work-item:0220"
 parent: "work-item:0220"
 derived_from: ["codebase-research:2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear"]
-tags: [sync, linear, tracker, discovery]
+tags: ["sync", "linear", "tracker", "discovery"]
 revision: "0f1624a83df9437999143ce09064485de53666b5"
 repository: "accelerator"
 last_updated: "2026-08-30T20:03:51+00:00"

--- a/meta/prs/88-description.md
+++ b/meta/prs/88-description.md
@@ -1,17 +1,17 @@
 ---
-type: pr-description
+type: "pr-description"
 id: "88"
 title: "Bound Linear untracked discovery to the configured team"
 date: "2026-08-30T23:33:36+00:00"
 author: "Toby Clemson"
-producer: describe-pr
-status: complete
+producer: "describe-pr"
+status: "complete"
 work_item_id: "work-item:0220"
 parent: "work-item:0220"
 relates_to: ["work-item:0146"]
 pr_url: "https://github.com/atomicinnovation/accelerator/pull/88"
 pr_number: 88
-tags: [sync, linear, jira, tracker, discovery]
+tags: ["sync", "linear", "jira", "tracker", "discovery"]
 revision: "65916547e336fffe5244219d1385427c0e00a14a"
 repository: "accelerator"
 last_updated: "2026-08-30T23:33:36+00:00"

--- a/meta/prs/88-description.md
+++ b/meta/prs/88-description.md
@@ -1,0 +1,59 @@
+---
+type: pr-description
+id: "88"
+title: "Bound Linear untracked discovery to the configured team"
+date: "2026-08-30T23:33:36+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+work_item_id: "work-item:0220"
+parent: "work-item:0220"
+relates_to: ["work-item:0146"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/88"
+pr_number: 88
+tags: [sync, linear, jira, tracker, discovery]
+revision: "65916547e336fffe5244219d1385427c0e00a14a"
+repository: "accelerator"
+last_updated: "2026-08-30T23:33:36+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Bound Linear untracked discovery to the configured team
+
+## Summary
+
+Untracked-remote discovery returned zero pulls on Linear for two independent reasons: with the scope key unset the discovery gate skipped the search silently, and with the key set it was handed to Linear as a team **key** where the filter wanted the team **UUID**, matching no team. This PR lifts key→UUID resolution into a new `resolve_scope` port method that validates the discovery scope before any push — a missing or unresolvable key refuses the run pre-flight (exit `74`, nothing sent), a resolved key drives a UUID-bounded search — and makes every discovery outcome (ran, skipped, transiently failed) visible in the sync report so a skip is never again mistaken for an empty result.
+
+## Changes
+
+- Added `resolve_scope` and a dedicated `ScopeError` to the `RemoteTracker` port — a deterministic, local resolution-and-validation step distinct from the network `search`, so a config fault can never be routed through the transient-failure exit path. Public-api snapshot regenerated.
+- Linear: introduced a `TeamResolver` port plus a catalogue-backed `CatalogueTeam` resolver injected into `LinearClient`; `resolve_scope` maps the configured team key to its UUID and refuses an unknown or absent key (`E_SEARCH_NO_TEAM` / `E_SEARCH_UNKNOWN_TEAM`). `search` now consumes the resolved UUID and drops the credential-team fallback, keeping a defensive guard so an unresolved scope can never reach Linear's empty, workspace-wide filter.
+- Jira: `resolve_scope` moves the `E_JQL_NO_PROJECT` refusal ahead of `search`, so an unscoped bidirectional Jira run is refused pre-flight rather than issuing an unbounded search.
+- Pre-flight refusal in `prepare_run`: an invalid scope aborts as `RunError::DiscoveryUnconfigured` before the apply/push phase, rendered by the CLI as exit `74` with nothing sent.
+- Discovery observability: a `DiscoveryStatus` (ran / skipped-push-only / transiently-failed) threaded through the report and rendered as a `#\tdiscovery` line; a transient search failure now drives exit `70` distinctly instead of folding silently into an empty result.
+- Docs: the exit-code taxonomy (`exit_codes.rs`) and the `sync-work-items` skill reconciled for `74`'s second source and the new report line.
+- Meta: the full 0220 lifecycle (research, plan, two reviews, validation) plus a decomposition of epic 0146 into children 0228/0229/0230 (layered configuration-key model, per-tracker pull scope, tracker-owned work-item id generation).
+
+## Context
+
+- Work item: `meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md`
+- Plan: `meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md`
+- Research: `meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md`
+- Validation: `meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md`
+- Parent epic: `meta/work/0146-work-item-sync-enhancements.md`
+
+## Testing
+
+- [x] `mise run test:unit:cli` — full CLI unit suite green, 0 failures
+- [x] `mise run cli:check` — workspace rustfmt + clippy clean
+- [x] `mise run public-api:check` — regenerated `tracker` snapshot matches
+- [ ] Manual: against a real Linear workspace with the team key set and a seeded untracked issue, `work sync --preview` lists it as a `create-from-remote` pull and the emitted GraphQL body carries the team UUID in `{team:{id:{eq:…}}}`
+- [ ] Manual: a key-unset (or unknown-key) run refuses pre-flight with a `discovery unconfigured` message, exits `74`, and sends no push
+
+## Notes for Reviewers
+
+- Behavioural contract change to release-note: an unconfigured discovery scope now refuses a bidirectional or pull-only run pre-flight (exit `74`) where it completed cleanly (exit `0`) before — on **both** trackers, so an unscoped Jira run shifts `0 → 74`. The escape hatch is setting the key or running `--push-only`.
+- The port surface grew deliberately (`resolve_scope` + `ScopeError`); the public-api snapshot regeneration is the intended diff, not drift.
+- Follow-up debt: the two `RunReport` constructions were left un-collapsed (the optional `from_prepared` refactor was deferred); both thread the new `discovery` field correctly.
+- The 0146 decomposition (0228/0229/0230) rides along because the plan's scope-authority decisions map onto that epic's config redesign; reconciliation of the `work.default_project_code` → `work.key` rename is recorded in the plan's Assumptions.

--- a/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
+++ b/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
@@ -1,15 +1,15 @@
 ---
-type: codebase-research
+type: "codebase-research"
 id: "2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear"
 title: "Research: Untracked-Remote Discovery Never Runs on Linear (0220)"
 date: "2026-08-30T17:00:35+00:00"
 author: "Toby Clemson"
-producer: research-codebase
-status: complete
+producer: "research-codebase"
+status: "complete"
 topic: "Why untracked-remote discovery is skipped on Linear and where the gate, scope, and key resolution live"
 work_item_id: "0220"
 parent: "work-item:0220"
-tags: [research, codebase, sync, linear, tracker, discovery]
+tags: ["research", "codebase", "sync", "linear", "tracker", "discovery"]
 revision: "3cc3fe422551f0fd064105dc12e2f1f6082a67c5"
 repository: "accelerator"
 last_updated: "2026-08-30T17:00:35+00:00"

--- a/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
+++ b/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
@@ -6,6 +6,7 @@ date: "2026-08-30T17:00:35+00:00"
 author: "Toby Clemson"
 producer: research-codebase
 status: complete
+topic: "Why untracked-remote discovery is skipped on Linear and where the gate, scope, and key resolution live"
 work_item_id: "0220"
 parent: "work-item:0220"
 tags: [research, codebase, sync, linear, tracker, discovery]

--- a/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
+++ b/meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md
@@ -1,0 +1,320 @@
+---
+type: codebase-research
+id: "2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear"
+title: "Research: Untracked-Remote Discovery Never Runs on Linear (0220)"
+date: "2026-08-30T17:00:35+00:00"
+author: "Toby Clemson"
+producer: research-codebase
+status: complete
+work_item_id: "0220"
+parent: "work-item:0220"
+tags: [research, codebase, sync, linear, tracker, discovery]
+revision: "3cc3fe422551f0fd064105dc12e2f1f6082a67c5"
+repository: "accelerator"
+last_updated: "2026-08-30T17:00:35+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Research: Untracked-Remote Discovery Never Runs on Linear (0220)
+
+**Date**: 2026-08-30T17:00:35+00:00
+**Author**: Toby Clemson
+**Git Commit**: 3cc3fe422551f0fd064105dc12e2f1f6082a67c5
+**Branch**: working copy (no bookmark), workspace `ticket-management`
+**Repository**: accelerator
+
+## Research Question
+
+Ground the bug in `meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md`
+against the live codebase: verify every cited site, confirm the mechanism, and
+surface anything the work item mis-states or omits that a plan must account for.
+
+## Summary
+
+The work item is accurate on mechanism and mostly accurate on sites. The
+discovery gate at `cli/work-adapters/src/sync/run.rs:707-709` disables
+untracked-remote discovery unless `scope.project.is_some() || scope.all_projects`,
+and `scope.project` is `None` on Linear because the config key
+`work.default_project_code` is typically unset. The gate encodes Jira's JQL
+"no project = unbounded" semantics, which Linear does not share — Linear
+self-bounds to the credentialed team. Both the empty-`else` skip and a completed
+search that finds nothing collapse to the same empty `Vec<ExternalId>`, so the
+report cannot tell them apart. All confirmed.
+
+Three corrections and one sharpening matter for planning:
+
+- **The scope type is `tracker::SearchScope`, not `SyncScope`.** No `SyncScope`
+  type exists anywhere in `cli/`. The work item and its Technical Notes call the
+  runtime carrier "scope" loosely; the concrete type is `SearchScope`
+  (`cli/tracker/src/lib.rs:244-255`), and `SyncRequest.scope` holds it.
+- **There is no general team-key→UUID map in the catalogue.** The catalogue
+  models exactly *one* team, exposing `/team/key` and `/team/id` as two
+  independent field reads. The fix is not "look up an arbitrary key"; it is
+  "recognise that `scope.project` names the one configured team, and substitute
+  that team's UUID". `LinearClient` already holds `team_key` at
+  `client.rs:124/156` for exactly this comparison.
+- **The `RemoteTracker` trait has zero capability methods today and zero default
+  methods.** Adding `self_bounds_search(&self) -> bool` either forces an impl in
+  all five `impl RemoteTracker` blocks (matching the all-required style) or
+  introduces the trait's first default method. This is a design choice the plan
+  must make explicitly.
+- **The regression-test gap is real and precise.** No mocked-Linear test
+  exercises the untracked-search sync path. `sync_run_real_client.rs:238-243`
+  documents that the default scope disables discovery, so it deliberately never
+  searches. The new test combines two existing idioms rather than copying one.
+
+## Detailed Findings
+
+### The discovery gate and scope construction
+
+The gate is in `prepare_run` (`cli/work-adapters/src/sync/run.rs:659`),
+lines 707-725:
+
+```rust
+let discovery_enabled =
+    !matches!(request.direction, SyncDirection::PushOnly)
+        && (request.scope.project.is_some() || request.scope.all_projects);
+let untracked = if discovery_enabled {
+    match discover_untracked(ports.tracker, &request.scope, request.items) {
+        Ok(discovered) if !discovered.complete =>
+            return Err(RunError::DiscoveryIncomplete { found: discovered.ids.len() }),
+        Ok(discovered) => discovered.ids,
+        Err(error) => { read_failure = read_failure.or(Some(error)); Vec::new() }
+    }
+} else {
+    Vec::new()
+};
+```
+
+`request.direction` is `SyncDirection` (`cli/work/src/sync/decide.rs:6-10`;
+variants `Bidirectional`, `PushOnly`, `PullOnly`). The gate suppresses discovery
+only for `PushOnly` — so the bug requires a bidirectional or pull-only run, as
+the work item's reproduction states. `discover_untracked`
+(`run.rs:420-441`) calls `tracker.search(scope)` and subtracts the local
+`external_id` set from the remote `found` set.
+
+The scope is built in `cli/work-cli/src/sync.rs:431-438`:
+
+```rust
+let default_project =
+    crate::config::effective_nonempty(config, "work.default_project_code")
+        .unwrap_or_default();
+let scope = tracker::SearchScope {
+    project: (!default_project.is_empty()).then_some(default_project),
+    all_projects: false,
+    filters: Vec::new(),
+};
+```
+
+`scope.project` is the raw config string, passed straight through to the
+tracker's `search` with no id resolution. `all_projects` is hardcoded `false`.
+
+**Correction — the type.** `SearchScope` is defined at
+`cli/tracker/src/lib.rs:244-255` with fields `project: Option<String>`,
+`all_projects: bool`, `filters: Vec<(String, String)>`. Its doc records the
+precedence: when both `project` and `all_projects` are set, `project` wins.
+`SyncRequest.scope` (`run.rs:101`) carries it. Grep for `SyncScope` returns
+nothing — the work item's naming is informal.
+
+### No report line distinguishes skip from empty
+
+The empty-`else` (`run.rs:723-725`) and a completed search returning an empty set
+(`run.rs:717`, `Ok(discovered) => discovered.ids` with `ids` empty) produce the
+identical value: an empty `untracked: Vec<ExternalId>`. `render_report`
+(`cli/work-cli/src/sync.rs:172-205`) iterates only `report.reported`; untracked
+issues surface only as `create-from-remote` rows. With an empty set, no
+discovery row is emitted in either case. The only discovery-specific message is
+the *failure* path `RunError::DiscoveryIncomplete` (`sync.rs:509-517`), which
+fires only when a search was truncated. This confirms the observability gap the
+work item folds in — the silence is what kept the defect invisible.
+
+### The tracker port has no capability surface
+
+`RemoteTracker` (`cli/tracker/src/lib.rs:321`) declares seven required methods —
+`create`, `update`, `show`, `fetch_all`, `search` (`:427`), `preview_create`,
+`validate_update` — all operation-performing, all ending in `;` with no default
+body. There is no introspection or capability method anywhere on the trait, and
+no default method precedent to copy. `search` takes `&SearchScope` and returns
+`Discovery { found, complete }`.
+
+Five impls exist: `JiraClient` (`cli/jira-client/src/client.rs:469`),
+`LinearClient` (`cli/linear-client/src/client.rs:585`), and three test doubles —
+`RecordingTracker` (`cli/tracker-test-support/src/lib.rs:203`), `FixedTracker`
+(`cli/tracker/tests/port.rs:65`), `Fake` (`cli/work-adapters/tests/sync_apply.rs:102`).
+
+**Design choice for the plan.** A `self_bounds_search(&self) -> bool` capability
+sits naturally right after `search` (`lib.rs:427`). As a *required* method it
+matches the trait's uniform style but touches all five impls. As a *default*
+method (`{ false }`) it touches only Linear's impl but becomes the trait's first
+default — a style divergence. Either sets a new precedent; there is nothing to
+imitate.
+
+The registry (`cli/work-cli/src/tracker_registry.rs:167-187`) matches on the
+`work.integration` string: `jira` and `linear` are wired; `trello` and
+`github-issues` are recognised but return `SelectionError::NotAvailable`. So two
+trackers ship; a future self-bounding adapter would hit this same gate.
+
+### Linear self-bounds, but the key never becomes a UUID
+
+`LinearClient::search` (`cli/linear-client/src/client.rs:661-666`):
+
+```rust
+fn search(&self, scope: &SearchScope) -> Result<Discovery, TrackerError> {
+    let mut search = Search {
+        team_id: scope
+            .project
+            .clone()
+            .or_else(|| Some(self.credentials().team_id.clone())),
+        ..Search::default()
+    };
+```
+
+Two branches feed the same `Search.team_id` field with different *kinds* of
+value. `scope.project` is used verbatim (a team **key**, e.g. `"PP"`); the
+fallback `credentials().team_id` is a genuine team **UUID** resolved at
+construction via `resolve_team` (`auth.rs:81`, reading catalogue pointer
+`/team/id`). `compose` (`cli/linear-client/src/filter.rs:64-71`) emits whatever
+it holds into `{"team": {"id": {"eq": team}}}`, which Linear compares against the
+team UUID. So `"PP"` matches no team, discovery returns empty, and — unlike the
+state path, which refuses unknown names via `ClientError::UnknownState`
+(`filter.rs:72-80`) — nothing errors. This is the "compounding trap": the fix
+that only flips the gate would still return zero, silently, for a second reason.
+
+**Correction — no arbitrary key→UUID lookup exists.** The catalogue
+(`<integrations_root>/linear/catalogue.json`) models one team.
+`catalogue_team_key` (`auth.rs:97`, pointer `/team/key`) and `catalogue_team`
+(`auth.rs:101`, pointer `/team/id`) are independent single-field reads; there is
+no `key == "PP" → id` function. The resolution the fix needs is: treat a
+`scope.project` equal to the catalogue team key as the configured team and
+substitute its UUID (equivalently, fall through to `credentials().team_id`). The
+seam is the single assignment at `client.rs:663-666`. `LinearClient` already
+holds `team_key: Option<String>` (`client.rs:124`, populated at `client.rs:156`),
+so the comparison value is in hand. A key that matches no catalogue team must
+surface as an error, not an empty result (AC 5).
+
+### Jira's gate is correct — for Jira
+
+`compose` in `cli/jira-client/src/jql.rs:169-174` refuses an unscoped query:
+
+```rust
+if search.project.is_none() && !search.all_projects {
+    return Err(ClientError::BadJql {
+        reason: "E_JQL_NO_PROJECT: specify a project or all_projects".to_owned(),
+    });
+}
+```
+
+`compose` emits `project = <quoted>` only when `search.project` is `Some`
+(`jql.rs:177-179`); an absent project produces genuinely unbounded JQL — every
+issue the credentials can see. So the refusal is correct *for Jira specifically*.
+`JiraClient::search` (`client.rs:591-593`) delegates to `discover`
+(`client.rs:265-285`), which copies the scope field-for-field into `jql::Search`
+and calls `compose`. The gate's correctness rests entirely on Jira's semantics,
+which is precisely why moving it behind a tracker capability is the right shape.
+
+### Test idioms for the regression
+
+The discovery gate is exercised in `cli/work-adapters/tests/sync_create.rs`
+against `RecordingTracker`, seeded via `.discovering(found, complete)`
+(`tracker-test-support/src/lib.rs:165-173`). Representative cases: a push-only
+run asserts no `Call::Search` fired (`sync_create.rs:390`); an over-threshold set
+yields `RunError::Refused` (`:318`); a scoped pull-only happy path (`:437`); an
+incomplete discovery is refused (`:481`). The enabling tests use a `scoped()`
+helper returning `SearchScope { project: Some("ENG"), .. }` (`:242`).
+
+Mocked Linear uses `http_test_support::MockServer` with `client_for(&server,
+config)` (`cli/linear-client/tests/support/client.rs:37`, constants
+`TEAM_KEY = "ENG"` / `TEAM_ID` UUID). `search_projection.rs:40-101` registers a
+paged `Route::Sequence`, runs `search_detailed`, then asserts on
+`server.bodies(...)`. Filter shape is pinned by a committed TSV fixture
+`cli/linear-client/tests/fixtures/issue-filter.txt` — the team row is
+`team	team=T1	{"team":{"id":{"eq":"T1"}}}`, and a coverage guard
+(`filter.rs:80-98`) fails if any family loses its row. Catalogue resolution is
+tested in `cli/linear-client/tests/auth.rs` via a `with_catalogue` helper writing
+`{"team":{"id":"…","key":"ENG"}}`.
+
+**The gap.** `sync_run_real_client.rs:238-243` is Jira-backed and documents that
+the default scope disables discovery, so it never searches. No test drives the
+untracked-search sync path against a mocked Linear. The AC-8 regression test is
+new coverage combining the `MockServer`/`client_for` idiom with `sync_create.rs`
+gate assertions — there is no single template to copy.
+
+## Code References
+
+- `cli/work-adapters/src/sync/run.rs:707-725` — the discovery gate and empty-`else`
+- `cli/work-adapters/src/sync/run.rs:420-441` — `discover_untracked`
+- `cli/work-adapters/src/sync/run.rs:101` — `SyncRequest.scope: SearchScope`
+- `cli/work-cli/src/sync.rs:431-438` — scope construction from `work.default_project_code`
+- `cli/work-cli/src/sync.rs:172-205` — `render_report` (no skip-vs-empty distinction)
+- `cli/tracker/src/lib.rs:244-255` — `SearchScope` definition (not `SyncScope`)
+- `cli/tracker/src/lib.rs:321,427` — `RemoteTracker` trait and `search`
+- `cli/work-cli/src/tracker_registry.rs:167-187` — tracker dispatch (jira/linear wired)
+- `cli/linear-client/src/client.rs:661-666` — the key→UUID seam (raw pass-through)
+- `cli/linear-client/src/client.rs:124,156` — `team_key` already held
+- `cli/linear-client/src/filter.rs:64-71` — `{team:{id:{eq}}}` emission
+- `cli/linear-client/src/auth.rs:81,97,101` — catalogue readers (single team)
+- `cli/jira-client/src/jql.rs:169-174` — `E_JQL_NO_PROJECT` refusal
+- `cli/work-adapters/tests/sync_create.rs:242,318,390,437,481` — gate test idioms
+- `cli/work-adapters/tests/sync_run_real_client.rs:238-243` — documents the default-scope skip
+- `cli/linear-client/tests/fixtures/issue-filter.txt:17` — team filter-shape row
+
+## Architecture Insights
+
+- **The gate lives in tracker-agnostic code but encodes one tracker's law.** The
+  clean fix moves the "must this search be project-scoped?" question behind a
+  `RemoteTracker` capability, so each provider answers for itself. This mirrors
+  the existing division: the `tracker` crate is a pure port, provider law lives
+  in the client crates.
+- **Two kinds of team identity flow through one field.** `Search.team_id`
+  carries a UUID on the fallback branch and a key on the scoped branch. The
+  asymmetry with the state path — which *does* resolve names to UUIDs and refuses
+  unknowns — is the root of the silent failure. Bringing team resolution up to
+  the state path's standard (resolve-or-refuse) is the principled fix.
+- **The catalogue is a single-team artifact.** Any design that assumes a
+  multi-team key→UUID map is over-built for today's model. The 0146 config-model
+  redesign (`work.key`, layered `<tracker>.<entity>_key`) may change this; 0220
+  deliberately targets the current single field.
+
+## Historical Context
+
+- `meta/research/codebase/2026-08-11-0204-remote-tracker-port.md` and
+  `meta/plans/2026-08-11-0204-remote-tracker-port.md` — the port's original
+  design; the seven-method shape and dyn-compatibility rationale originate here.
+- `meta/research/codebase/2026-08-12-0194-tracker-crate-and-remote-sync-engine.md`
+  — the sync engine and `SearchScope`/`Discovery` surface.
+- `meta/research/codebase/2026-08-17-0210-provider-client-crates-over-the-tracker-port.md`
+  — Jira/Linear client crates; where `compose` and the catalogue readers landed.
+- `meta/decisions/ADR-0044-remote-work-item-identity-in-external-id.md` — remote
+  identity lives in `external_id`; relevant to the id-vs-key distinction 0220
+  turns on.
+- `meta/decisions/ADR-0045-skills-vs-cli-division-of-labour.md` — why the gate
+  belongs in the CLI/port, not the skill.
+- `meta/work/0146-work-item-sync-enhancements.md` — parent epic owning the
+  `work.key` / `<tracker>.<entity>_key` config-model redesign; no research or
+  plan artifact yet.
+
+Auto-memory corroborates the symptom: "Sync untracked-pull scope — the whole
+multi-team Linear workspace floods (997+); abort the gate, only push." That note
+records the flood 0220's required-key design prevents.
+
+## Related Research
+
+- 0204 (remote tracker port), 0194 (tracker crate + sync engine), 0210 (provider
+  client crates), 0211 (integration binaries / Linear-Jira wiring), 0213
+  (conflict-resolution flow). 0220 is the first shippable child of 0146.
+
+## Open Questions
+
+- **Capability method shape** — required (touch five impls) or default (trait's
+  first default method, touch one)? A plan decision, not a code fact.
+- **Where team-key→UUID resolution sits** — inline comparison against
+  `self.team_key` at `client.rs:663`, or a new `TeamResolver` port mirroring
+  `StateResolver`? The inline form is smaller; the port form matches the state
+  precedent and is more testable. ❓ Needs the plan's call.
+- **Config-model ordering with 0146** — 0220 reads `work.default_project_code`;
+  whichever of {0220, the `work.key` rename} lands second must reconcile. Not a
+  code question, but the plan should state the assumption.
+- **`all_projects` on Linear** — hardcoded `false` and untouched by this fix. Is
+  a Linear "all teams" discovery ever wanted, or is single-team-required the
+  permanent contract? Out of 0220's scope; flag for 0146.

--- a/meta/reviews/plans/2026-08-30-0220-untracked-remote-discovery-on-linear-review-1.md
+++ b/meta/reviews/plans/2026-08-30-0220-untracked-remote-discovery-on-linear-review-1.md
@@ -1,0 +1,519 @@
+---
+type: plan-review
+id: "2026-08-30-0220-untracked-remote-discovery-on-linear-review-1"
+title: "Plan Review: Untracked-Remote Discovery on Linear"
+date: "2026-08-30T17:48:07+00:00"
+author: "Toby Clemson"
+producer: review-plan
+status: complete
+parent: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
+target: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: [architecture, correctness, code-quality, test-coverage, compatibility, usability]
+review_number: 1
+review_pass: 3
+tags: [sync, linear, tracker, discovery]
+last_updated: "2026-08-30T20:02:07+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Untracked-Remote Discovery on Linear
+
+**Verdict:** REVISE
+
+The plan is well-grounded — its `TeamResolver` port mirrors the established
+`StateResolver` precedent, its `DiscoveryStatus` enum makes the previously silent
+skip observable, and its two-phase merge-order claims hold under the real code.
+It carries three confirmed defects that must be fixed before implementation: a
+production `LinearClient::new` caller it never wires, a `render_report` change
+that drops the `#\tsummary` line on empty runs, and a Phase 2 Red step that
+cannot be written because the test double it targets has no search-failure seam.
+Layered over these, five of six lenses independently flagged the same design
+error: permanent config faults are labelled transient/retryable when an
+`UNCONFIGURED` exit code already exists for exactly this case.
+
+### Cross-Cutting Themes
+
+- **Config faults mislabelled as transient** (flagged by: architecture,
+  code-quality, usability, correctness) — an unset or unresolvable team key is
+  returned as `TrackerError::Retryable` and then folded into the `RETRYABLE` (70)
+  exit arm. Neither retries to success. `exit_codes::UNCONFIGURED` (74) already
+  exists and is documented as "the tracker is wired but its configuration is
+  missing … nothing was sent — fix the config"; verified in use at
+  `sync.rs:381`. This is the single most-reinforced issue in the review.
+- **`render_report` ordering drops the summary on empty runs** (flagged by:
+  correctness, usability) — the plan pushes the discovery line before
+  `lines.sort()` (`sync.rs:200`), which makes `lines.is_empty()` false, so the
+  `if synced_count > 0 || lines.is_empty()` guard (`sync.rs:201`) stops emitting
+  `#\tsummary\tsynced\t0`. Confirmed against the code — a real regression to the
+  rendered output.
+- **`LinearClient::new` caller set is under-enumerated** (flagged by:
+  compatibility) — the plan wires only `from_config` and the test support file.
+  A production caller, `build_with_override` at `cli/linear-cli/src/context.rs:182`,
+  constructs `LinearClient::new` directly and is confirmed present. Following the
+  plan's `FixedTeam` guidance there would resolve nothing and refuse every key.
+
+### Tradeoff Analysis
+
+- **Error-taxonomy purity vs the fixed `search` contract**: the port `search`
+  contract forbids `Terminal` (a read never mutates), so a permanent config fault
+  has no honest variant and is forced through `Retryable`. Architecture suggests
+  evolving the read taxonomy; that is larger than 0220. The pragmatic resolution
+  is to keep `Retryable` at the port but map it to `UNCONFIGURED` at the exit
+  boundary, so the process signal is correct even while the type is a best-fit.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Compatibility**: Omitted production `LinearClient::new` caller
+  **Location**: Phase 1, Change 5
+  `build_with_override` (`cli/linear-cli/src/context.rs:182`) constructs
+  `LinearClient::new` directly, not via `from_config`. Confirmed. Change 3 wires
+  the resolver only into `from_config`, so this override/loopback discovery path
+  would either fail to compile or, if given a `FixedTeam` per the plan's test
+  guidance, silently refuse every key.
+
+- 🟡 **Usability / Architecture / Code-Quality / Correctness**: Config faults
+  routed to `RETRYABLE` when `UNCONFIGURED` (74) fits
+  **Location**: Phase 2, Change 4; Phase 1, Change 4
+  `Skipped(NoScopeKey)` and the resolution-failure `Failed` are folded into the
+  `RETRYABLE` arm. `exit_codes::UNCONFIGURED` (74) exists and means exactly "fix
+  the config, nothing was sent". Automation reading exit 70 is told to retry a
+  fault only a config edit resolves.
+
+- 🟡 **Test Coverage**: No `failing_search` seam blocks Phase 2 Red step 4
+  **Location**: Phase 2, Test-Driven Steps, step 4
+  `RecordingTracker` exposes `failing_update/create/preview/show` and
+  `discovering`, but no search-failure seam (confirmed). The step asserting a
+  search error yields `Failed` with `read_failure == None` cannot be written
+  without adding one, and the plan's Changes touch only `run.rs`/`sync.rs`.
+
+- 🟡 **Test Coverage**: The AC-8 end-to-end regression is narrative-only
+  **Location**: Testing Strategy → Integration Tests; Phase 1 Red step 1
+  Phase 1 Red step 1 is labelled "the AC-8 regression test" but only checks the
+  client's UUID substitution, not the sync path producing a `create-from-remote`
+  pull. The genuine end-to-end regression (AC-1/AC-4/AC-8) appears only in prose
+  and in no phase's automated Success Criteria.
+
+- 🟡 **Compatibility**: Stale exit-code documentation in the sync skill
+  **Location**: Phase 2, Change 4
+  `skills/work/sync-work-items/SKILL.md` documents exit 70 as "a read failed".
+  Broadening 70 to cover a no-scope-key skip makes that doc wrong. No phase
+  updates it. (Resolves toward the `UNCONFIGURED` remap above.)
+
+- 🟡 **Compatibility**: Jira's no-project run newly exits non-zero
+  **Location**: Phase 2, Change 2
+  The `NoScopeKey` skip branch applies to both trackers; a Jira bidirectional run
+  with no project configured exits 0 today and non-zero after. The plan frames
+  the required-key/non-clean-exit decision as Linear-only. Confirm this is
+  intended, or scope it to key-requiring trackers.
+
+- 🟡 **Usability**: `Failed { detail }` double-wraps the `TrackerError` Display
+  **Location**: Phase 2, Change 2 & 3
+  `error.to_string()` on a `Retryable` renders as "tracker call failed with no
+  remote change: E_SEARCH_…", so the failure line is triple-labelled and claims a
+  remote change that never happened. A real network detail may carry tabs or
+  newlines, breaking the single-line TSV. Render the inner detail and normalise
+  whitespace.
+
+#### Minor
+
+- 🔵 **Correctness / Usability**: Discovery line placement is non-deterministic
+  **Location**: Phase 2, Change 3
+  Pushing before the sort sorts the `#\tdiscovery` line to the top, above item
+  rows, not adjacent to the summary the wording implies — and drops the summary
+  on empty runs (see theme). Push after the summary-guard block, or drop the
+  `|| lines.is_empty()` guard.
+
+- 🔵 **Architecture / Code-Quality**: Single-team identity now read from the
+  catalogue in three places
+  **Location**: Phase 1, Changes 2-3
+  `CatalogueTeam` re-derives `/team/key` and `/team/id` that `team_key` and
+  `credentials().team_id` already hold at construction. Consider building the
+  resolver from the in-hand pair rather than a third disk reader.
+
+- 🔵 **Code-Quality**: `pointer_string` and the `RunReport` builder extractions
+  are left conditional
+  **Location**: Phase 1 step 6; Phase 2 step 7
+  Both are well-motivated (a third catalogue reader; a sixth field added to two
+  duplicated `RunReport` literals). Commit to them rather than deferring to a
+  maybe-refactor.
+
+- 🔵 **Architecture / Code-Quality**: Two no-key guards, the inner effectively
+  unreachable
+  **Location**: Phase 2 Change 2 vs Phase 1 Change 4
+  The gate short-circuits to `Skipped(NoScopeKey)` before `search`, so
+  `E_SEARCH_NO_TEAM` is unreachable in the wired flow (`all_projects` is
+  hardcoded `false`). Keep it as port defence, but state that it is secondary.
+
+- 🔵 **Architecture**: Jira's `E_JQL_NO_PROJECT` guard becomes unreachable in the
+  discovery path
+  **Location**: What We're NOT Doing; Phase 2 Change 2
+  AC-6 is phrased as a JQL refusal, but the gate now yields a generic
+  `no-scope-key` skip before `search`. Reconcile AC-6's wording and keep a direct
+  unit test on `compose`'s `E_JQL_NO_PROJECT`.
+
+- 🔵 **Test Coverage**: AC-6 (Jira no-project) and AC-2 (bounding) have weak
+  named coverage
+  **Location**: Phase 2 Change 2; Phase 1 Red step 1
+  No step names the Jira no-project test; AC-2's "no request enumerates the wider
+  workspace" is asserted only positively (presence of the team constraint), so a
+  second unbounded page would pass.
+
+- 🔵 **Correctness**: Stated trim invariant is inaccurate
+  **Location**: Assumptions; Phase 1 Change 2
+  `CatalogueTeam::resolve` trims both sides; `in_scope` compares untrimmed
+  (`prefix == key.as_str()`, confirmed). A whitespace-bearing catalogue key would
+  make discovery and fetch-classification disagree. Correct the assumption text
+  or align the comparisons.
+
+- 🔵 **Usability**: `E_SEARCH_UNKNOWN_TEAM` states the symptom without a remedy
+  **Location**: Phase 1 Change 4
+  Its sibling names the fix ("set work.default_project_code"); this one does not.
+  Add a next step (check the key matches the catalogue team key, or refresh
+  `linear/catalogue.json`).
+
+#### Suggestions
+
+- 🔵 **Code-Quality**: `FixedTeam(BTreeMap)` over-models the single-team domain
+  **Location**: Phase 1 Change 1
+  The double expresses multi-team resolution the catalogue never has. Model it as
+  a single `(key, id)` pair, or note the map is a deliberate `FixedStates` mirror
+  holding one entry.
+
+- 🔵 **Architecture**: `Failed { detail: String }` flattens the structured error
+  **Location**: Phase 2 Change 1
+  Carrying the `TrackerError` (or a small enum) would let the renderer and exit
+  logic branch on kind from one source, rather than parallel `matches!` arms.
+
+- 🔵 **Usability**: `ran\tfound=N` diverges from the bare-value `summary\t{count}`
+  **Location**: Phase 2 Change 3
+  Consider `#\tdiscovery\tran\t{found}` to mirror the summary line, or accept the
+  label deliberately.
+
+### Strengths
+
+- ✅ `TeamResolver` faithfully mirrors the `StateResolver` port — trait +
+  `FixedTeam` double + catalogue-backed impl injected as `Box<dyn …>` and built
+  in `from_config` — keeping provider law in the client crate.
+- ✅ The boolean gate plus empty-`else` becomes a single match producing both the
+  untracked set and an explicit `DiscoveryStatus`, killing the skip-vs-empty
+  ambiguity at its source; `Ran { found: 0 }` is now visibly distinct from a skip.
+- ✅ Both two-phase merge-order claims verified against the code: Phase 1 alone
+  folds a resolution failure into `read_failure` for a non-clean exit; Phase 2
+  alone reports the raw-key trap honestly as `ran found=0`.
+- ✅ Routing discovery-search errors off `read_failure` is confirmed non-lossy —
+  its only work-cli consumer is the exit-code check, and fetch-originated values
+  are untouched.
+- ✅ The de Morgan rewrite of the discovery gate is logically equivalent to the
+  original; no discovery case is silently dropped or newly enabled.
+- ✅ `linear-client` is public-api-exempt (adapter), so the new `pub` items and
+  the changed `new` signature need no snapshot update; the `tracker` port
+  signature and the `issue-filter.txt` fixture are correctly untouched.
+- ✅ Nearly every cited test idiom exists and is accurately described
+  (`scoped()`, `discovering`, `client_for`/`TEAM_KEY`/`TEAM_ID`, `with_catalogue`,
+  `server.bodies`, the filter-family coverage guard).
+
+### Recommended Changes
+
+1. **Wire the resolver into every `LinearClient::new` caller** (addresses:
+   omitted production caller, further test sites) — enumerate the five confirmed
+   sites: `support/client.rs` (×2), `contract.rs`, `sync_run_real_client.rs`, and
+   `linear-cli/src/context.rs:182`. Inject `CatalogueTeam::load(integrations_root)`
+   at `build_with_override` (mirroring `from_config`), and state the resolver each
+   test site carries.
+
+2. **Map config faults to `UNCONFIGURED` (74)** (addresses: exit-code theme,
+   stale skill doc) — route `Skipped(NoScopeKey)` and the resolution-failure
+   `Failed` to `exit_codes::UNCONFIGURED`, reserving `RETRYABLE` for transient
+   search failures. Then update `skills/work/sync-work-items/SKILL.md`'s exit-code
+   list and add the `#\tdiscovery` line to its report documentation.
+
+3. **Fix the `render_report` ordering and summary guard** (addresses: summary
+   drop, non-deterministic placement) — push the discovery line after the
+   summary-guard block (or drop `|| lines.is_empty()` and emit the summary
+   unconditionally), so the `#\tsummary` line survives empty runs and the
+   `[items] / discovery / summary` order is deterministic.
+
+4. **Add a `failing_search` seam and promote the AC-8 regression to a Red step**
+   (addresses: both test-coverage majors) — add `failing_search(TrackerError)` to
+   `RecordingTracker` as an explicit Phase 2 change, and add a red-first
+   end-to-end test driving `run()` over a mocked Linear with a seeded untracked
+   issue, asserting a `create-from-remote` row and `DiscoveryStatus::Ran
+   { found >= 1 }`, wired into the phase's automated Success Criteria.
+
+5. **Render the inner error detail, not the wrapped Display** (addresses: Failed
+   line double-wrap) — put the `E_SEARCH_…` detail into the `failed` line and
+   normalise tabs/newlines so it stays one TSV record.
+
+6. **Confirm or scope the Jira exit-code change** (addresses: Jira non-zero exit)
+   — state explicitly whether an unscoped Jira bidirectional run should newly exit
+   non-zero, and add a Red step pinning `Skipped(NoScopeKey)` + no `Call::Search`
+   for Jira, plus a direct `E_JQL_NO_PROJECT` unit guard.
+
+7. **Commit the deferred extractions and correct the trim invariant** (addresses:
+   conditional refactors, inaccurate assumption, minor smells) — commit to
+   `pointer_string` and a `RunReport::from_prepared` builder; correct the
+   Assumptions text on `in_scope` trimming; add a remedy to `E_SEARCH_UNKNOWN_TEAM`.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: Architecturally well-grounded — mirrors the `StateResolver` port,
+centralises the discovery decision into one match, and introduces rich domain
+vocabulary. The dominant structural risk is the error model forcing a permanent
+misconfiguration through `Retryable`; secondary concerns are catalogue cohesion
+(single-team identity read in three places), Jira's deep guard becoming
+unreachable, and the config-skip/transient-failure collapse in the exit arm.
+
+**Strengths**:
+- `TeamResolver` mirrors the `StateResolver` precedent, preserving the
+  pure-port/adapter separation.
+- The discovery decision is refactored into a single match producing both the set
+  and an explicit `DiscoveryStatus`.
+- `DiscoveryStatus::{Ran, Skipped, Failed}` is threaded end-to-end.
+- Dropping the capability method and the credential-team fallback is explicitly
+  reasoned and justified against the sole production caller.
+- Resolution logic is pure and injectable via `FixedTeam`.
+
+**Findings**:
+- (major, medium) Permanent key-misconfiguration modelled as a `Retryable` error;
+  the taxonomy cannot express a permanent read failure. Suggest a follow-up to add
+  a config-fault/terminal-for-reads discriminant.
+- (minor, medium) Single-team identity resolved from the catalogue in three places
+  (`CatalogueTeam`, `team_key`, `credentials().team_id`); consider building the
+  resolver from the already-resolved pair.
+- (minor, medium) Jira's `E_JQL_NO_PROJECT` guard becomes unreachable in the
+  discovery path; reconcile AC-6 wording and keep a direct `compose` unit test.
+- (minor, medium) `NoScopeKey` (permanent) folded into the same `RETRYABLE` arm as
+  transient failures; consider a distinct non-clean class.
+- (suggestion, low) `Failed { detail: String }` flattens the structured
+  `TrackerError` at the report boundary.
+
+### Correctness
+
+**Summary**: Core logic is sound — the rewritten gate is a correct de Morgan
+transformation of the original, both merge-order claims hold under the real code,
+and routing search errors off `read_failure` is non-lossy. Remaining concerns are
+edge-case interactions and two under-specified semantics.
+
+**Strengths**:
+- The replacement gate is logically equivalent to the original boolean gate.
+- Both merge-order claims verified against the code.
+- Moving discovery-search errors off `read_failure` is verified non-lossy.
+
+**Findings**:
+- (minor, medium) The discovery line pushed before `lines.sort()` makes
+  `lines.is_empty()` false, so an empty run no longer emits `#\tsummary\tsynced\t0`.
+  Push after the summary guard or drop `|| lines.is_empty()`.
+- (minor, medium) `Skipped(NoScopeKey)` and `Failed` folded into `RETRYABLE`;
+  neither is transient. Map to a terminal-but-non-clean code or document.
+- (minor, low) The stated trim invariant is inaccurate: `resolve` trims, `in_scope`
+  compares untrimmed; a whitespace-bearing key would diverge.
+
+### Code Quality
+
+**Summary**: Well-structured, models the outcome as an explicit domain type, and
+mirrors the `StateResolver` port. Concerns: a third near-duplicate catalogue
+reader, a test double that over-models the single-team domain, the
+retryable/exit-code categorisation, and two well-motivated refactors left soft.
+
+**Strengths**:
+- Replaces the silent empty-`else`/empty-`Vec` path with an explicit
+  `DiscoveryStatus`, making the ambiguity unrepresentable.
+- `TeamResolver` is consistent with an established, testable pattern.
+- The search rewrite removes the two-kinds-of-value-in-one-field smell.
+- No code comments introduced, consistent with the repo's low-comment convention.
+- TDD steps are specified red-first with concrete assertions.
+
+**Findings**:
+- (minor, high) `CatalogueTeam::load` is the third near-identical catalogue reader;
+  the `pointer_string` extraction is left conditional despite two uses. Commit to a
+  shared helper.
+- (minor, medium) `FixedTeam(BTreeMap)` models a multi-team map the domain never
+  has; model the single-team shape or note the deliberate mirror.
+- (minor, medium) Missing/unresolvable key surfaced as `Retryable` and folded into
+  `RETRYABLE`; the observability signal points away from the config fix.
+- (minor, medium) Two no-key guards (gate + `search`); the inner is effectively
+  unreachable in the wired flow — state it is defensive.
+- (suggestion, medium) A sixth field added to two duplicated `RunReport` literals;
+  commit to a `from_prepared` builder now.
+
+### Test Coverage
+
+**Summary**: Unusually well-grounded in existing idioms — nearly every cited seam
+exists and is accurately described, and the Phase 1 port-search Red steps are
+genuine red-first tests. Two gaps undercut it: the Phase 2 read_failure Red step
+cannot be written (no search-failure seam), and the headline end-to-end regression
+is narrative-only. AC-6 also has no named test.
+
+**Strengths**:
+- Phase 1 Red steps 1-3 are genuine red-first tests; the port `search` has no
+  direct coverage today and the error arms return `Ok` currently.
+- Cited idioms are accurate (`scoped()`, `discovering`, `client_for` constants,
+  `with_catalogue`, `server.bodies`, the filter-family guard).
+- Phase 2 gives `DiscoveryStatus` thorough per-branch coverage plus render/exit
+  assertions.
+
+**Findings**:
+- (major, high) No `failing_search` seam on `RecordingTracker`, blocking the
+  read_failure Red step; add `failing_search(TrackerError)` as an explicit change.
+- (major, medium) AC-8/AC-1/AC-4 end-to-end regression is narrative-only, not a Red
+  step, and absent from Success Criteria; promote it.
+- (minor, medium) AC-6 (Jira no-project) has no named test and the gate rewrite
+  changes its outcome untested.
+- (minor, low) AC-2's bounding guarantee is asserted only positively; a second
+  unbounded page would pass.
+
+### Compatibility
+
+**Summary**: Two deliberate contract changes on the Linear discovery path and a
+Phase 2 exit-code change that turns previously-clean no-scope runs non-zero. The
+`Retryable`-vs-`Terminal` contract is honoured and `linear-client` is public-api
+exempt, but the plan under-enumerates the `new` callers (omitting a production
+composition root) and leaves the sync skill's exit-code docs stale.
+
+**Strengths**:
+- `linear-client` is public-api exempt, so the new items and changed signature
+  need no snapshot update; the plan correctly omits one.
+- The `tracker` crate's `search` signature/doc stay unchanged.
+- Both refusal errors return `Retryable`, honouring the port contract.
+- The `issue-filter.txt` fixture is unaffected — resolution sits upstream of
+  `compose`.
+
+**Findings**:
+- (major, high) `build_with_override` (`cli/linear-cli/src/context.rs:182`)
+  constructs `LinearClient::new` directly and is not wired; a `FixedTeam` there
+  would refuse every key. Inject `CatalogueTeam::load`.
+- (major, high) Exit 70 is documented narrowly in
+  `skills/work/sync-work-items/SKILL.md:112`; the plan updates no skill doc.
+- (major, medium) The `NoScopeKey` non-clean exit applies to Jira too — an
+  unscoped Jira bidirectional run now exits non-zero. Confirm or scope it.
+- (minor, medium) Two further `new` sites (`contract.rs:146`,
+  `sync_run_real_client.rs:179`) get no resolver guidance; enumerate all five.
+
+### Usability
+
+**Summary**: The central goal — distinguishing an invisible skip from an empty
+search — is well served by the four `#\tdiscovery` lines and `Ran { found=0 }`.
+The weak spots are the error-exit semantics (a config fault mapped to `RETRYABLE`
+when `UNCONFIGURED` (74) exists) and the failure line double-wrapping the
+`TrackerError` Display.
+
+**Strengths**:
+- The `Ran/Skipped/Failed` split directly kills the invisible failure.
+- The lines reuse the established `#\t<category>\t<key>\t<value>` sentinel shape.
+- `E_SEARCH_NO_TEAM` names the exact config field, repeated in the report line.
+
+**Findings**:
+- (major, high) `Skipped(NoScopeKey)`/`Failed` mapped to `RETRYABLE`; the
+  `UNCONFIGURED` (74) code matches these cases exactly. Remap.
+- (major, high) `Failed { detail: error.to_string() }` double-wraps the `Retryable`
+  Display into a misleading, triple-labelled line; a real detail with tabs/newlines
+  breaks the TSV. Render the inner detail and normalise whitespace.
+- (minor, medium) `E_SEARCH_UNKNOWN_TEAM` states the symptom without a remedy,
+  unlike its sibling.
+- (minor, medium) `lines.sort()` does not order discovery vs summary as the plan
+  claims; a pre-sort push drops the summary on empty runs and lands the line above
+  item rows. Insert explicitly.
+- (suggestion, low) `ran\tfound=N` diverges from the bare-value `summary\t{count}`
+  in the same column.
+
+## Re-Review (Pass 2) — 2026-08-30T19:18:15+00:00
+
+**Verdict:** REVISE
+
+All six lenses re-ran against the revised plan. Every Pass 1 finding is resolved
+and confirmed against the code. The re-review surfaced one convergent new major —
+introduced by the Pass 1 exit-code fix — that four lenses flagged independently,
+plus a test-coverage major and assorted minors. The plan was then revised again
+(the pre-flight redesign below) to address them; that redesign has not itself been
+re-reviewed.
+
+### Previously Identified Issues
+
+- ✅ **Compatibility**: Omitted production caller `context.rs:182` — Resolved (grep confirms all five sites enumerated).
+- ✅ **Test Coverage**: `failing_search` seam missing — Resolved (mirrors `failing_show`, implementable).
+- ✅ **Test Coverage**: AC-8 regression narrative-only — Resolved (now a Red step; rationale further corrected this pass).
+- ✅ **Usability**: `Failed` double-wraps Display — Resolved (inner detail + `single_line`).
+- ✅ **Correctness/Usability**: render ordering / summary drop — Resolved (correctness confirms the reorder is correct).
+- ✅ **Compatibility**: stale SKILL.md exit-code doc — Resolved (Change 6; broadened this pass to both doc sites).
+- ✅ All Pass 1 minors (E_SEARCH remedy, AC-6 test, AC-2 negative, `pointer_string`, `RunReport` builder, `FixedTeam` note, trim invariant) — Resolved.
+
+### New Issues Introduced
+
+- 🔴 **Usability / Architecture / Correctness / Compatibility**: exit 74 for the no-key skip breaks its "nothing was sent" invariant — a bidirectional no-key run pushes before exiting 74; 74 is a pre-run-abort-only code. Convergent, high/medium confidence. **Addressed** by the pre-flight redesign: config faults now refuse in `prepare_run` before the push (`RunError::DiscoveryUnconfigured` → 74, nothing sent); transient failures → 70.
+- 🟡 **Test Coverage**: the AC-8 e2e "issue never surfaces" rationale is invalid against a `MockServer` (which does not evaluate the team filter). **Addressed** — the load-bearing red assertion is now the captured-body UUID, and the `execute` harness is noted to need a scope/direction parameter.
+- 🔵 **Code Quality**: shared gate message said "team key" (Linear-specific) for a Jira run. **Addressed** — each tracker's `resolve_scope` now owns its own message (Jira: `E_JQL_NO_PROJECT`).
+- 🔵 **Code Quality**: `pointer_string` empty-string contract unspecified. **Addressed** — mirrors `catalogue_field`'s non-empty filter.
+- 🔵 **Compatibility**: unscoped Jira exit `0 → 74` is a contract change — flag in release notes (still applies; now via the pre-flight refusal).
+
+### Assessment
+
+The redesign the user chose — validate the discovery scope pre-flight via a new
+`resolve_scope` port method and refuse an invalid one before any push — resolves
+the convergent exit-code major at its root rather than papering over it: 74 is now
+honest ("nothing was sent"), 70 is reserved for genuine transient failures, and no
+discriminant or new exit code is needed. It expands the plan (a public-api-pinned
+port method, a new `RunError` variant, five `resolve_scope` impls) and reverses the
+plan's former "no hard-abort" stance. A confirming review pass over the revised
+Phases 1-2 is warranted before implementation, focused on the new port method and
+the pre-flight control flow.
+
+---
+*Re-review generated by /accelerator:review-plan*
+
+## Re-Review (Pass 3) — 2026-08-30T20:02:07+00:00
+
+**Verdict:** APPROVE
+
+A confirming pass over the pre-flight redesign ran all six lenses. The redesign's
+core is endorsed across lenses (clean `resolve_scope`/`search` split, honest 74
+before apply, no exit-code double-count). The pass surfaced one design major
+converged by two lenses, three high-confidence contract/test majors, and several
+minors — all now addressed in-plan. One item is an explicitly accepted product
+tradeoff rather than a fix (below).
+
+### Previously Identified Issues (Pass 2)
+
+- ✅ All Pass 2 findings resolved and confirmed against the code (the exit-74
+  invariant, render ordering, `Failed` double-wrap, caller enumeration, seams).
+
+### New Issues Introduced (Pass 3) — resolution
+
+- 🔴 **Compatibility/Correctness**: dropping Linear `search`'s credential fallback turned a `None` scope into an unbounded workspace **flood** (not "empty"). **Fixed** — `search` keeps a defensive `None` refusal (`E_SEARCH_UNRESOLVED_SCOPE`), mirroring Jira's deep guard; the rationale is corrected.
+- 🔴 **Compatibility**: the public-api regen command was fabricated (`cargo test --test public_api`). **Fixed** — now `mise run public-api:update` / `:check`.
+- 🔴 **Test Coverage**: a sixth `RemoteTracker` impl (`MarkerObservingTracker`) was omitted; a required method breaks compilation. **Fixed** — all six impls enumerated in Change 4.
+- 🔴 **Test Coverage**: the five existing `sync_run_real_client` tests break under the unconditional pre-flight refusal (`execute` panics). **Fixed** — Change 8 migrates the harness (a `Result` return + `scope`/`direction` params) and every caller.
+- 🔴 **Architecture / Code-Quality**: the config-vs-transient fault class was carried by call-site position, risking a `for_tracker_error` misroute. **Fixed** — a dedicated `ScopeError` type carries the config fault; the `resolve_scope` map no longer destructures `TrackerError`.
+- 🟡 **Usability**: the refusal never surfaced the `--push-only` escape hatch, and `E_SEARCH_*` sentinels leaked into the operator message. **Fixed** — messages name `--push-only`; the render arm gets a "refused:" framing.
+- 🟡 **Compatibility**: the unscoped-Jira `0→74` shift and 74's broadened meaning needed capture. **Fixed** — a Migration Notes release-note line, cross-referencing 0146; the exit_codes.rs band header and both SKILL.md sites updated.
+- 🔵 Minors — `pointer_string` empty filter, `TrackerError::into_detail` accessor, resolve_scope-vs-write-bound precedence, fail-fast ordering vs `fetch::gather`, AC-7 observability split — all noted or applied.
+
+### Accepted Tradeoff (not a fix)
+
+- 🟡 **Usability/Correctness (high confidence)**: the pre-flight hard-abort refuses the *whole* run — blocking the tracked-item push/pull for a discovery-only misconfiguration; pull-only is also blocked. The user chose this deliberately over the soft-degrade alternative, accepting that a keyless bidirectional/pull-only run refuses (with `--push-only` as the escape hatch) in exchange for a clean 74/70 taxonomy. Documented in "What We're NOT Doing" and Migration Notes.
+
+### Assessment
+
+The design has converged and is implementation-ready. Every finding across three
+passes is resolved except the whole-run-abort behaviour, which is a deliberate,
+now-documented product decision rather than a defect. The Pass 3 fixes are targeted
+and code-verified (public-api tasks, the six impls, the flood mechanism, the write
+bound all checked against the tree) but were not themselves put through a fourth
+lens pass; a final skim of the `resolve_scope`/`ScopeError` port change during
+implementation is the only residual diligence.
+
+---
+*Re-review generated by /accelerator:review-plan*

--- a/meta/reviews/plans/2026-08-30-0220-untracked-remote-discovery-on-linear-review-1.md
+++ b/meta/reviews/plans/2026-08-30-0220-untracked-remote-discovery-on-linear-review-1.md
@@ -1,19 +1,19 @@
 ---
-type: plan-review
+type: "plan-review"
 id: "2026-08-30-0220-untracked-remote-discovery-on-linear-review-1"
 title: "Plan Review: Untracked-Remote Discovery on Linear"
 date: "2026-08-30T17:48:07+00:00"
 author: "Toby Clemson"
-producer: review-plan
-status: complete
+producer: "review-plan"
+status: "complete"
 parent: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
 target: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
 reviewer: "Toby Clemson"
 verdict: "APPROVE"
-lenses: [architecture, correctness, code-quality, test-coverage, compatibility, usability]
+lenses: ["architecture", "correctness", "code-quality", "test-coverage", "compatibility", "usability"]
 review_number: 1
 review_pass: 3
-tags: [sync, linear, tracker, discovery]
+tags: ["sync", "linear", "tracker", "discovery"]
 last_updated: "2026-08-30T20:02:07+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1

--- a/meta/reviews/work/0220-untracked-remote-discovery-never-runs-on-linear-review-1.md
+++ b/meta/reviews/work/0220-untracked-remote-discovery-never-runs-on-linear-review-1.md
@@ -1,0 +1,228 @@
+---
+type: work-item-review
+id: "0220-untracked-remote-discovery-never-runs-on-linear-review-1"
+title: "Work Item Review: Untracked-Remote Discovery Never Runs on Linear"
+date: "2026-08-30T14:50:49+00:00"
+author: Toby Clemson
+producer: review-work-item
+status: complete
+parent: "work-item:0146"
+target: "work-item:0220"
+work_item_id: "0220"
+reviewer: Toby Clemson
+verdict: APPROVE
+lenses: [clarity, completeness, dependency, scope, testability]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-08-30T16:50:38+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+## Work Item Review: Untracked-Remote Discovery Never Runs on Linear
+
+**Verdict:** REVISE
+
+This is a strong, tightly-argued bug work item — complete in structure, well-scoped to a single defect with clean edges against parent epic 0146, and highly testable with code-anchored referents and Given/When/Then criteria. Two major findings hold it back from approval: an internal-consistency tension between the Context (Linear search is "already bounded") and the Fix/AC requirement to hard-fail when the key is unset, and a real ordering coupling to the sibling config-model rename that the Dependencies section records as "none". Both are documentation-consistency fixes, not scope or design problems.
+
+### Cross-Cutting Themes
+
+- **The `default_project_code` / key / team concept is under-specified across sections** (flagged by: clarity, dependency, testability) — the same value is called `work.default_project_code`, `scope.project`, a "key", and a "team key", carries a future rename to `work.key`, and must resolve to a team UUID. Clarity flags the overloaded naming and the unnamed field in Assumptions; dependency flags the missing coupling to the sibling that renames it; testability flags "correctly bounded" restating intent instead of naming the resolved-UUID observable. Sharpening this one concept resolves findings in three lenses.
+- **Self-bounding semantics need stating up front** (flagged by: clarity, testability) — the Context frames Linear's search as inherently safe (credentialed-team fallback), which reads as licensing key-optional discovery, yet the Fix and AC3 mandate a config error when the key is unset. The reconciliation ("credentialed team is access control, not scope authority") lives only in Assumptions, after the apparent contradiction.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Clarity**: Context "already bounded" contradicts Fix/AC "require the key"
+  **Location**: Context / Requirements (Fix shape) / Acceptance Criteria
+  The Context argues Linear discovery is inherently safe because the client falls back to the credentialed team and "was already bounded", implying discovery can run with no configured key — yet Fix shape #2 and AC3 require a config error when the key is unset. The reconciliation (credentialed team is access control, not scope authority) appears only later, in Assumptions.
+
+- 🟡 **Dependency**: Sibling config-model rename coupling absent from Dependencies
+  **Location**: Dependencies
+  Requirements and Drafting Notes describe a sibling config-model child under 0146 that renames `work.default_project_code` → `work.key`, the exact field this fix reads, yet Dependencies records "Blocked by: none. Blocks: none." Whichever item ships second must adapt, but the ordering coupling is invisible to anyone scheduling the two.
+
+#### Minor
+
+- 🔵 **Clarity**: "project" / "key" / "team" used near-interchangeably for one value
+  **Location**: Requirements (Fix shape) / Technical Notes
+  The config field is `work.default_project_code`, the runtime field `scope.project`, but on Linear the value is a team key resolving to a team UUID. The reader must hold three names for one concept to follow the Fix shape — the very conflation the bug arises from.
+
+- 🔵 **Dependency**: `relates_to` links (0194, 0204) uncharacterised
+  **Location**: Dependencies
+  Frontmatter and References list `relates_to: 0194, 0204`, but neither Dependencies nor the body states whether either is an upstream prerequisite, a downstream consumer, or merely adjacent — so a related item that is actually an ordering constraint would be missed at planning time.
+
+- 🔵 **Testability**: "never enumerates the wider workspace" lacks a defined observable
+  **Location**: Acceptance Criteria
+  AC2's negative ("never enumerates the wider workspace") has no stated observable. A tester could confirm the keyed team's issues appear yet be unable to prove the search did not touch the wider workspace.
+
+- 🔵 **Testability**: "search is correctly bounded" uses a subjective qualifier
+  **Location**: Acceptance Criteria
+  AC4 ends with "the search is correctly bounded", where "correctly" has no defined threshold — it restates intent rather than a checkable outcome.
+
+#### Suggestions
+
+- 🔵 **Scope**: Cross-tracker observability fix folded into a Linear-specific bug
+  **Location**: Acceptance Criteria
+  AC6 (skipped runs must be distinguishable from empty searches) is a tracker-agnostic observability improvement governing Jira too, while the rest of the item is Linear-specific. The Drafting Notes justify folding it in; no change required if the team accepts that.
+
+- 🔵 **Clarity**: Assumptions cites "the field's doc comment" without naming the field
+  **Location**: Assumptions
+  The first Assumption references a doc comment without naming `work.default_project_code`, forcing the reader to infer the referent among several fields in play.
+
+- 🔵 **Dependency**: Catalogue key→UUID mapping is an unnamed data prerequisite
+  **Location**: Requirements
+  The fix depends on `catalogue.json` carrying the team key→UUID mapping. If absent or stale, resolution silently yields no team and reproduces zero-pulls for a third reason — worth naming as a runtime precondition.
+
+- 🔵 **Testability**: First criterion relies on an unstated precondition
+  **Location**: Acceptance Criteria
+  AC1 depends on an untracked remote issue existing (stated only in Reproduction). Read standalone it could pass vacuously against a team with no untracked issues.
+
+### Strengths
+
+- ✅ Complete bug specification: reproduction gives config keys, precondition, exact command (`accelerator work sync --preview`), and distinct Expected/Actual outcomes, plus a dated environment observation.
+- ✅ Frontmatter fully populated with recognised values (`kind: bug`, `status: draft`, `priority: medium`) and parent/relates_to/external_id linkage.
+- ✅ Well-scoped: the two "coupled changes" are demonstrated interdependent (the Compounding trap shows the gate fix fails silently without the key→UUID resolution), and the broader config redesign is explicitly deferred to 0146.
+- ✅ Acceptance criteria in Given/When/Then form with named trackers and observable outcomes, including an explicit regression-test criterion with a falsifiability requirement (must fail against the current gate).
+- ✅ The Compounding trap section pre-empts the plausible misreading that passing the raw key would work, and explains exactly why it fails.
+- ✅ Actors and triggers named actively ("the gate reads", "the JQL builder refuses", "the client falls back") rather than hidden behind passive constructions.
+
+### Recommended Changes
+
+1. **State the credentialed-team-is-access-control point up front in Context** (addresses: Context "already bounded" contradicts Fix/AC; Self-bounding semantics theme)
+   Add a sentence in Context clarifying the credentialed-team fallback is access control, not the intended scope authority, so the later "require the key" rule reads as consistent rather than contradictory. This pulls the Assumptions reconciliation forward to where the tension arises.
+
+2. **Record the config-model rename coupling in Dependencies** (addresses: Sibling config-model rename coupling absent)
+   Replace "Blocked by: none. Blocks: none." with a note naming the config-model sibling under 0146, stating 0220 deliberately targets the current `work.default_project_code` field and the rename item must reconcile this consumer. Characterise 0194 and 0204 while there (e.g. "related, no blocking relationship").
+
+3. **Add a one-line glossary for the key concept** (addresses: overloaded project/key/team naming; Assumptions unnamed field; key concept theme)
+   Early in Requirements or Technical Notes, define once: "key" denotes the value in `work.default_project_code` / `scope.project` — a team key on Linear, a project key on Jira. Name the field explicitly in the first Assumption too.
+
+4. **Anchor the two vague acceptance criteria to concrete observables** (addresses: "never enumerates" lacks observable; "correctly bounded" subjective; first criterion vacuous precondition)
+   AC2: assert the emitted Linear filter carries `{team:{id:{eq:<UUID>}}}` for the resolved team UUID. AC4: assert the resolved UUID (not the raw key `PP`) appears in the filter. AC1: fold "at least one team issue with no local work item" into the Given so it cannot pass vacuously.
+
+5. **Optionally record the catalogue mapping as a runtime prerequisite** (addresses: catalogue key→UUID data prerequisite)
+   Note in Dependencies or Assumptions that the catalogue must carry the team key→UUID mapping, and confirm behaviour when the key is present in config but absent from the catalogue.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: An unusually clear, tightly-argued bug work item: the defect, its two independent causes, and the fix shape are all expressed with named actors and code-anchored referents, and the Acceptance Criteria use explicit given/when/then form. The one genuine clarity risk is an internal-consistency tension between the Context's claim that the Linear search is "already bounded" and the Fix/AC requirement to hard-fail when the key is unset — reconciled only late, in Assumptions. Overloaded "project"/"key" terminology adds minor friction but is largely explained in place.
+
+**Strengths**:
+- Acceptance Criteria use explicit given/when/then form with named trackers and observable outcomes, leaving little room for interpretation.
+- The "Compounding trap" section pre-empts a plausible misreading (that passing the raw key would work) and explains exactly why it fails.
+- Actors and triggers are consistently named — "the gate reads", "the JQL builder refuses", "the client falls back" — rather than hidden behind passive constructions.
+
+**Findings**:
+- 🟡 **major** (confidence: medium) — _Context / Requirements (Fix shape) / Acceptance Criteria_. The Context argues the Linear search is inherently safe because it "falls back to the credentialed team" and "was already bounded; the gate suppressed one that was never at risk of flooding" — implying discovery can safely run even with no configured key. But Fix shape #2 and AC3 require the run to raise a config error when the key is unset. A reader reaching the Fix section can reasonably ask: if the client already bounds itself to the credentialed team, why is the key mandatory? The reconciliation exists only in Assumptions ("the configured key is the scope authority; the credentialed team provides … access control, not the scope"), which appears after the apparent contradiction. Impact: an implementer could read Context as licensing key-optional discovery and Fix/AC as mandating key-required discovery. Suggestion: state up front in Context that the credentialed-team fallback is access control rather than the intended scope authority.
+- 🔵 **minor** (confidence: medium) — _Requirements (Fix shape) / Technical Notes_. The terms "project", "key", and "team" are used near-interchangeably around one value: the config field is `work.default_project_code`, the runtime field is `scope.project`, yet on Linear this holds a team key (e.g. `PP`) that must resolve to a team UUID. The reader must hold three names for one concept to follow the Fix shape and Compounding trap. Impact: raises the chance an implementer conflates a Jira project scope with a Linear team scope — precisely the confusion the bug arises from. Suggestion: add a one-line glossary note early.
+- 🔵 **suggestion** (confidence: medium) — _Assumptions_. The first Assumption cites "the field's doc comment" without naming which field, forcing the reader to infer it is `work.default_project_code`. Suggestion: name the field explicitly.
+
+### Completeness
+
+**Summary**: Exemplary from a completeness standpoint: every expected section is present and substantively populated, and the frontmatter is complete with a recognised kind, status, and priority. As a bug it carries the full reproduction unit — configuration input, action, expected outcome, and actual outcome — plus environment observation, seven specific acceptance criteria, and populated Context, Dependencies, and Assumptions. No completeness gaps rise to a reportable finding.
+
+**Strengths**:
+- The bug's reproduction is complete as a single logical unit: numbered setup/input, the concrete action (`accelerator work sync --preview`), an explicit Expected outcome, and an explicit Actual outcome, plus a dated environment observation.
+- Frontmatter is fully populated with recognised values — `kind: bug`, `status: draft`, `priority: medium`, plus parent/relates_to linkage and external_id.
+- The Summary is a single, unambiguous statement of the defect, and the Context explains the underlying forces (Jira-derived gate semantics vs. Linear's self-bounding search).
+- Acceptance Criteria are numerous and specific, covering the Linear happy path, boundedness, the config-error path, key→UUID resolution, Jira non-regression, observability of skipped discovery, and a regression test.
+- Optional sections (Dependencies, Assumptions) are populated rather than left blank, and Drafting Notes justifies the absence of an Open Questions section (the two former questions were resolved and moved to the parent).
+
+**Findings**:
+_None._
+
+### Dependency
+
+**Summary**: The work item captures its parent epic (0146) and deliberately decouples itself from the config-model rename by pinning to the current `work.default_project_code` field, which is good dependency hygiene. However, the Dependencies section is marked entirely "none" despite the body describing a sibling work item that renames the very field this fix relies on — an ordering/coupling relationship that is not recorded. The `relates_to` links (0194, 0204) are also left uncharacterised, and the internal catalogue key→UUID resolution is a real data prerequisite worth surfacing.
+
+**Strengths**:
+- Explicitly decouples from the config-model rename by pinning to the current `work.default_project_code` field, avoiding a hard blocker on the sibling item.
+- Parent epic (0146) is captured in both frontmatter and References, and the Drafting Notes explain the reparenting from 0171.
+- The "Compounding trap" section makes the internal key→UUID resolution dependency explicit, preventing a silent second-order failure.
+- Acceptance Criteria pins Jira's behaviour as unchanged, protecting the other tracker's contract from regression.
+
+**Findings**:
+- 🟡 **major** (confidence: medium) — _Dependencies_. The Requirements and Drafting Notes describe a sibling configuration-model child under 0146 that renames `work.default_project_code` → `work.key` and introduces layered `<tracker>.<entity>_key` ownership — the exact field this fix reads. Yet the Dependencies section records "Blocked by: none. Blocks: none.", so this bidirectional ordering coupling is invisible to anyone scheduling the two items. Impact: if the rename lands first, 0220's implementation goes stale mid-flight; if 0220 lands first, the rename must account for this new consumer — neither team sees the coupling. Suggestion: add an ordering note in Dependencies naming the config-model sibling under 0146.
+- 🔵 **minor** (confidence: medium) — _Dependencies_. The frontmatter and References list `relates_to: 0194, 0204`, but the Dependencies section and body never state the nature or direction of these relationships. Impact: a related item that is actually an ordering constraint or waiting consumer would be missed at planning time. Suggestion: briefly characterise 0194 and 0204.
+- 🔵 **suggestion** (confidence: low) — _Requirements_. The fix depends on `catalogue.json` containing a team key→UUID mapping for the configured key; the AC assumes "a populated catalogue" but Dependencies does not name catalogue population/staleness as a precondition. Impact: if the catalogue lacks the team key or is stale, resolution silently yields no team and reproduces the zero-pulls symptom for a third reason. Suggestion: note the catalogue mapping as an explicit runtime prerequisite and confirm behaviour when the key is in config but absent from the catalogue.
+
+### Scope
+
+**Summary**: A well-scoped, coherent bug fix: a single defect (untracked-remote discovery suppressed on Linear) with clearly delineated boundaries. The two "coupled changes" in the Fix shape are genuinely interdependent rather than independently deliverable — the Compounding trap section explicitly justifies why the gate change and the key→UUID resolution must ship together. The broader scope/config redesign is deliberately and explicitly deferred to the parent epic 0146, giving this item clean edges as "its first, shippable child".
+
+**Strengths**:
+- The Summary, Requirements, and Acceptance Criteria all describe the same scope — one tracker-aware discovery defect — with no drift between sections.
+- The two changes in the Fix shape are demonstrated to be coupled, not bundled: the Compounding trap shows the gate fix fails silently without the key→UUID resolution.
+- Adjacent scope (the config field rename, per-tracker pull scope, filter schema) is explicitly excluded and attributed to parent epic 0146.
+- Kind selection (bug vs task) is deliberately reasoned in Drafting Notes, and the item is sized appropriately for a bug.
+
+**Findings**:
+- 🔵 **suggestion** (confidence: medium) — _Acceptance Criteria_. AC6 ("Given any run where discovery does not execute, then the report states it was skipped and why") is a tracker-agnostic observability improvement that also governs Jira runs, whereas the rest of the item is a Linear-specific discovery defect. It is a candidate for a separately deliverable concern, though the Drafting Notes explicitly justify folding it in on the grounds that the silent skip is what kept the defect invisible. Impact: low. Suggestion: no change required if the team accepts the justification; if a narrower slice is preferred, extract the generic skip-reporting behaviour as a sibling under 0146.
+
+### Testability
+
+**Summary**: Strongly testable: the reproduction fully specifies configuration, action, expected, and actual outcomes, and six of seven acceptance criteria are framed as Given/When/Then with observable results, including a dedicated regression-test criterion and an observability criterion that closes the silent-skip gap. The main gaps are a couple of criteria that assert negatives or use the word "correctly" without naming the concrete observable a verifier would inspect. No criterion is tautological or unbounded in a way that would prevent a definitive pass/fail.
+
+**Strengths**:
+- The Reproduction block gives a complete, executable trigger (config keys, precondition of an unpulled remote issue, and the exact command) with distinct Expected and Actual outcomes.
+- Acceptance Criteria are expressed as observable behaviours (Given/When/Then) rather than implementation instructions.
+- The Jira-unchanged criterion pins down the negative-space behaviour so a verifier can confirm no regression on the sibling tracker.
+- A regression-test criterion is explicit and includes the falsifiability requirement that it must fail against the current gate.
+- The observability criterion turns the Summary's core complaint into a verifiable report-output check.
+
+**Findings**:
+- 🔵 **minor** (confidence: medium) — _Acceptance Criteria_. AC2 asserts discovery is "bounded to the keyed team and never enumerates the wider workspace", but a negative like "never enumerates" has no stated observable a verifier can inspect. Impact: a tester could confirm the keyed team's issues appear yet be unable to prove the search did not touch the wider workspace. Suggestion: anchor it to a concrete observable, e.g. the emitted Linear search filter carries `{team:{id:{eq:…}}}` for the resolved team UUID.
+- 🔵 **minor** (confidence: medium) — _Acceptance Criteria_. The key→UUID criterion (AC4) ends with "the search is correctly bounded", where "correctly" is subjective with no defined threshold. Impact: two verifiers could disagree on whether bounding is "correct". Suggestion: replace with the concrete observable — the resolved team UUID (not the raw key `PP`) appears in the search filter, and untracked issues from that team are returned.
+- 🔵 **suggestion** (confidence: low) — _Acceptance Criteria_. AC1 ("untracked remote issues … are discovered and reported") depends on at least one untracked remote issue existing, stated only in the Reproduction block. Impact: read standalone, the criterion could pass vacuously against a team with no untracked issues. Suggestion: fold the precondition into the Given.
+
+## Re-Review (Pass 2) — 2026-08-30
+
+**Verdict:** COMMENT
+
+The five recommended changes were applied to the work item. Both pass-1 majors are resolved, along with all four minors and three of the four suggestions; the scope suggestion (AC6) was accepted as folded-in and left unchanged. Re-review across clarity, dependency, scope, and testability surfaces one new major and a handful of minors/suggestions — most as a direct, foreseeable consequence of the edits (the Dependencies note added a third failure mode and named a sibling descriptively). The item is now acceptable; the new major is a one-line acceptance-criterion gap worth closing.
+
+### Previously Identified Issues
+
+- 🟡 **Clarity** (major): Context "already bounded" contradicts Fix/AC "require the key" — **Resolved**. The Context now states the credentialed-team fallback is access control, not the scope authority, before the Fix's require-the-key rule; clarity re-review flags no consistency tension.
+- 🟡 **Dependency** (major): Sibling config-model rename coupling absent from Dependencies — **Resolved**. The ordering coupling is now documented with the ship-order reconciliation rule and praised as unusually well-mapped.
+- 🔵 **Clarity** (minor): "project"/"key"/"team" used near-interchangeably — **Resolved**. The Fix shape now defines "key" once; the glossary is called out as a strength.
+- 🔵 **Dependency** (minor): `relates_to` links (0194, 0204) uncharacterised — **Resolved**. Both are now characterised as thematically adjacent, no blocking relationship.
+- 🔵 **Testability** (minor): "never enumerates the wider workspace" lacks an observable — **Resolved**. AC2 now asserts the `{team:{id:{eq:…}}}` filter for the resolved UUID.
+- 🔵 **Testability** (minor): "search is correctly bounded" subjective — **Resolved**. AC4 now asserts the resolved UUID (not the raw key) appears in the filter.
+- 🔵 **Clarity** (suggestion): Assumptions cites "the field's doc comment" without naming the field — **Resolved**. Named as `work.default_project_code`.
+- 🔵 **Dependency** (suggestion): Catalogue key→UUID mapping is an unnamed prerequisite — **Resolved**. Now a runtime-prerequisite line in Dependencies, including the stale/absent failure mode.
+- 🔵 **Testability** (suggestion): AC1 relies on an unstated precondition — **Resolved**. Precondition folded into AC1's Given.
+- 🔵 **Scope** (suggestion): Cross-tracker observability (AC6) folded into a Linear-specific bug — **Still present** (accepted). Re-review reaffirms it is defensible as folded-in; no split required.
+
+### New Issues Introduced
+
+- 🟡 **Testability** (major): Catalogue-miss failure mode has no acceptance criterion. The Dependencies edit added a third silent-zero-pulls case (key present in config but absent/stale in `catalogue.json`, which the fix "must surface as an error"), but AC3 covers only the *unset* key and AC4 only a *resolvable* key. A verifier could pass all criteria while the catalogue-miss case still returns zero pulls silently. Suggested AC: "Given a configured Linear key that resolves to no team in the catalogue (absent or stale), when a sync runs, then the run reports a resolution error naming the unresolved key, rather than returning zero pulls silently."
+- 🔵 **Testability + Clarity** (minor, both lenses): Reproduction omits the sync direction the bug depends on. Step 3 runs `accelerator work sync --preview`, but the gate is direction-sensitive (`!matches!(request.direction, SyncDirection::PushOnly)`) and the ACs speak of a *bidirectional* sync; `--preview` is a mode, not a direction. State the direction explicitly.
+- 🔵 **Dependency** (minor) / **Clarity** (suggestion): The sibling config-model child is named descriptively three times but never given a work-item ID. Cite its ID (and add to `relates_to`), or state it is not yet created so the coupling is a tracked follow-up.
+- 🔵 **Dependency** (suggestion, low): Linear credential/API access is implied by the reproduction but not captured as a coupling. State whether tests run against mocked Linear responses, or add credential/API access as a test-environment prerequisite.
+- 🔵 **Testability** (suggestion, low): AC5's "discovery behaviour is unchanged" is broad; drop "unchanged" and keep only the enumerated checkable outcomes (project required, unbounded search refused).
+- 🔵 **Clarity** (suggestion, low): JQL used without expansion on first use — safe to leave if Jira fluency is assumed.
+
+### Assessment
+
+The work item is ready for implementation as-is (COMMENT). Pass 2 has one major and no criticals — below the REVISE threshold. The single major is a genuine one-line gap: the catalogue-miss case is now documented as a requirement in Dependencies but is not pinned by an acceptance criterion, so closing it (add the unresolvable-key AC) is recommended before planning. The sync-direction and sibling-ID minors are cheap, high-value clarifications; the remaining suggestions are optional polish.
+
+### Verdict Update — 2026-08-30
+
+**Verdict:** APPROVE (reviewer override of the pass-2 COMMENT)
+
+All pass-2 findings were subsequently addressed in the work item: the catalogue-miss acceptance criterion was added, the reproduction states the bidirectional direction, the sibling config-model item is flagged as living in parent epic 0146, the Linear credential coupling is captured as a mocked-test prerequisite, AC5 was reworded to enumerated outcomes, and JQL is expanded on first use. With no outstanding findings, the reviewer approves the work item for planning.
+
+---
+*Re-review generated by /accelerator:review-work-item*

--- a/meta/reviews/work/0220-untracked-remote-discovery-never-runs-on-linear-review-1.md
+++ b/meta/reviews/work/0220-untracked-remote-discovery-never-runs-on-linear-review-1.md
@@ -1,22 +1,22 @@
 ---
-type: work-item-review
+type: "work-item-review"
 id: "0220-untracked-remote-discovery-never-runs-on-linear-review-1"
 title: "Work Item Review: Untracked-Remote Discovery Never Runs on Linear"
 date: "2026-08-30T14:50:49+00:00"
-author: Toby Clemson
-producer: review-work-item
-status: complete
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
 parent: "work-item:0146"
 target: "work-item:0220"
 work_item_id: "0220"
-reviewer: Toby Clemson
-verdict: APPROVE
-lenses: [clarity, completeness, dependency, scope, testability]
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
 review_number: 1
 review_pass: 2
 tags: []
 last_updated: "2026-08-30T16:50:38+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md
+++ b/meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md
@@ -1,14 +1,14 @@
 ---
-type: plan-validation
+type: "plan-validation"
 id: "2026-08-30-0220-untracked-remote-discovery-on-linear-validation"
 title: "Validation Report: Untracked-Remote Discovery on Linear"
 date: "2026-08-30T23:24:29+00:00"
 author: "Toby Clemson"
-producer: validate-plan
-status: complete
+producer: "validate-plan"
+status: "complete"
 result: "pass"
 target: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
-tags: [sync, linear, tracker, discovery]
+tags: ["sync", "linear", "tracker", "discovery"]
 last_updated: "2026-08-30T23:24:29+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1

--- a/meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md
+++ b/meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md
@@ -1,0 +1,81 @@
+---
+type: plan-validation
+id: "2026-08-30-0220-untracked-remote-discovery-on-linear-validation"
+title: "Validation Report: Untracked-Remote Discovery on Linear"
+date: "2026-08-30T23:24:29+00:00"
+author: "Toby Clemson"
+producer: validate-plan
+status: complete
+result: "pass"
+target: "plan:2026-08-30-0220-untracked-remote-discovery-on-linear"
+tags: [sync, linear, tracker, discovery]
+last_updated: "2026-08-30T23:24:29+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Untracked-Remote Discovery on Linear
+
+Both phases are fully implemented across three commits and every automated gate
+is green. The implementation follows the plan's change list faithfully; three
+benign deviations, all documented below, do not affect correctness.
+
+### Implementation Status
+
+✓ Phase 1: Discovery validates its scope pre-flight and refuses an invalid one — fully implemented (`zltwztst`)
+✓ Phase 2: Discovery outcome is visible in the report — fully implemented (`skrntktv`)
+✓ Cleanup: stale planning references removed from code comments (`vrtxpxrs`)
+
+### Automated Verification Results
+
+✅ `mise run test:unit:cli` — pass, 0 failures (211.93s, exit 0)
+✅ `mise run cli:check` — pass, workspace rustfmt + clippy clean (31.85s, exit 0)
+✅ `mise run public-api:check` — pass, `tracker` snapshot matches regenerated API (163.97s, exit 0)
+
+The `tracker` public-api fixture carries the three new surfaces the plan
+mandated: `ScopeError`, `RemoteTracker::resolve_scope`, and
+`TrackerError::into_detail`.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- `TeamResolver` port + `FixedTeam` double added beside `StateResolver` (`cli/linear-client/src/filter.rs`).
+- `CatalogueTeam` catalogue-backed resolver reading `/team/key` + `/team/id` (`cli/linear-client/src/catalogue.rs`), injected into `LinearClient` and built in both `from_config` and `build_with_override` (`cli/linear-cli/src/context.rs:182`).
+- `resolve_scope` + `ScopeError` added to the `RemoteTracker` port and all six impls; snapshot regenerated (`cli/tracker/tests/fixtures/public-api.txt`).
+- Linear `resolve_scope` resolves key→UUID and refuses with `E_SEARCH_NO_TEAM` / `E_SEARCH_UNKNOWN_TEAM`; `search` consumes the resolved scope and keeps the defensive `None` guard (`E_SEARCH_UNRESOLVED_SCOPE`).
+- Jira `resolve_scope` refuses an unscoped run with `E_JQL_NO_PROJECT` (`cli/jira-client/src/client.rs:592`).
+- Pre-flight `resolve_scope` call in `prepare_run` maps a fault to `RunError::DiscoveryUnconfigured`, rendered to exit `74` (`cli/work-cli/src/sync.rs:546`).
+- Phase 2 `DiscoveryStatus` enum (`Ran`/`SkippedPushOnly`/`Failed`), the `#\tdiscovery` render line, `single_line` sanitiser, `Failed`→`RETRYABLE` (70) exit drive, and the `RecordingTracker.failing_search` seam.
+- Doc reconciliation: `exit_codes.rs` 74 band + line, `skills/work/sync-work-items/SKILL.md` Step 0/Step 2, and the `sync-report.golden` `discovery ran found=0` line.
+
+#### Deviations from Plan:
+
+- `ScopeError` gained `Display` + `std::error::Error` impls beyond the plan's `Debug`/`Clone`/`PartialEq`/`Eq` sketch (`cli/tracker/src/lib.rs:301-311`). Improvement — a proper error type; reflected in the snapshot.
+- The Phase 2 discovery render is extracted into a named `discovery_line(&DiscoveryStatus)` helper (`cli/work-cli/src/sync.rs:179`) rather than the inline `match` the plan drafted. Stylistic improvement.
+- The `resolve_scope` call sits at the existing gate (after `fetch::gather`), not hoisted above it. The plan explicitly left this to author judgement ("Hoist it unless the gate-locality is worth the wasted gather"); gate-locality was kept.
+
+#### Potential Issues:
+
+- ⚠️ Phase 2's optional step-6 refactor was **not** done: the two `RunReport { .. }` constructions (`cli/work-adapters/src/sync/run.rs:847,911`) were not collapsed into a shared `from_prepared` builder. Both thread the new `discovery` field correctly, so this is duplication debt, not a defect. The plan flagged it as a refactor-when-convenient step.
+- A non-`PushOnly` run with an invalid scope still pays a full remote `fetch::gather` before the pre-flight refusal fires. Consistent with the kept gate-locality above; correctness ("nothing was sent") holds because the abort precedes the apply/push phase.
+
+### Manual Testing Required:
+
+1. Real-workspace discovery (Phase 1, AC-1/AC-2):
+  - [ ] With `work.default_project_code` set to the team key and a seeded untracked issue, `accelerator work sync --preview` lists it as a `create-from-remote` pull.
+  - [ ] The emitted GraphQL body carries the team **UUID** in `{team:{id:{eq:…}}}`, not the raw key.
+
+2. Pre-flight refusal (Phase 1, AC-3/AC-5):
+  - [ ] A bidirectional run with the key unset refuses with a `discovery unconfigured` message, exits `74`, and sends no push.
+  - [ ] A key absent from the catalogue produces the same refusal, naming the key.
+
+3. Report visibility (Phase 2, AC-7):
+  - [ ] A normal keyed run prints `discovery ran found=N` and exits `0`.
+  - [ ] A transiently failing discovery search prints a `discovery failed` line and exits `70`.
+
+### Recommendations:
+
+- Land the deferred `RunReport::from_prepared` builder in a follow-up to retire the two-site construction duplication; low-risk, no behaviour change.
+- Release-note the exit-code contract change per the plan's Migration Notes: an unconfigured discovery scope now shifts `0 → 74` on **both** trackers (an unscoped Jira run included). Cross-reference epic 0146, whose `work.key` rename touches the same `work.default_project_code` field.
+- Run the manual checks against a live Linear workspace before merge; they cover the one thing the `MockServer` cannot — that the resolved UUID actually filters the remote search.

--- a/meta/work/0146-work-item-sync-enhancements.md
+++ b/meta/work/0146-work-item-sync-enhancements.md
@@ -9,8 +9,9 @@ status: "draft"
 kind: "epic"
 priority: "medium"
 source: "note:2026-06-22-ideas-backlog"
-tags: []
-last_updated: "2026-06-22T23:41:03+00:00"
+relates_to: ["work-item:0171"]
+tags: ["sync", "linear", "jira", "tracker", "scoping", "configuration"]
+last_updated: "2026-08-30T14:24:46+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 external_id: "PP-167"
@@ -25,62 +26,227 @@ external_id: "PP-167"
 
 ## Summary
 
-Enhance work item synchronisation with remote trackers (Jira/Linear) by adding
-richer field mapping, relationship handling, and scoping controls.
+Enhance work item synchronisation with remote trackers (Jira/Linear) with richer
+field mapping, relationship handling, and — the theme that now dominates this
+epic — a corrected scope-and-configuration model. Discovery, creation, and pulls
+must be bounded by an explicit, tracker-appropriate scope, configured once and
+validated at config time, rather than by a Jira-shaped assumption hard-coded into
+tracker-agnostic engine code.
 
 ## Context
 
-Extracted from the ideas backlog note
-(`meta/notes/2026-06-22-ideas-backlog.md`). Work item sync exists but maps a
-limited set of fields and lacks relationship and scoping controls.
+Extracted originally from the ideas backlog note
+(`meta/notes/2026-06-22-ideas-backlog.md`) as a thin set of mapping/relationship
+candidates. The concrete driver for the scoping work is bug 0220: untracked-remote
+discovery is silently skipped on Linear because the discovery gate demands
+`scope.project`, which only Jira genuinely needs. Investigating that bug surfaced
+a deeper design problem in how tracker scope and the work-item key are modelled
+and configured.
+
+Three structural findings frame the scoping work:
+
+- **The gate encodes one tracker's semantics for all.** `discovery_enabled =
+  scope.project.is_some() || scope.all_projects` (`cli/work-adapters/src/sync/run.rs`)
+  is Jira's `E_JQL_NO_PROJECT` constraint (`cli/jira-client/src/jql.rs`) hoisted
+  into tracker-agnostic code. Linear's client self-bounds to a team, so the gate
+  suppresses a search that was never at risk of flooding.
+- **`default_project_code` is misnamed and overloaded.** Its real job is the key a
+  tracker stamps on issue identifiers — a Jira *project* key, a Linear *team* key —
+  i.e. the key of the entity that owns the issue-number sequence. It is not a
+  "project", and its second, accidental role as the sync scope is what let the bug
+  hide.
+- **The key concept and the integration concept live at different layers.** The
+  tracker-native key (`linear.team_key` / `jira.project_key`) is meaningful to the
+  standalone integration skills with no work-management framework present; the
+  work-item prefix (`work.key`) is the work layer's view of that same key. The
+  dependency must run work → integration, never the reverse, so integration skills
+  can be packaged independently in future.
 
 ## Requirements
 
-Candidate child work items captured for decomposition during refinement:
+### Existing candidates (field mapping and relationships)
 
 - Add **status** mapping to work item synchronisation.
 - Add **kind** mapping to work item synchronisation.
 - Add **priority** mapping to work item synchronisation.
-- Establish **parent-child relationships** between work items on
-  synchronisation.
-- **Restrict** work item sync based on configured labels or projects.
+- Establish **parent-child relationships** between work items on synchronisation.
+- **Restrict** work item sync based on configured labels or projects — realised by
+  the per-tracker pull-scope child below.
+
+### Scope-and-configuration redesign (children)
+
+- **Tracker-aware discovery gate** — replace the `scope.project.is_some()` gate
+  with a tracker capability so a self-bounding client (Linear) enables discovery,
+  while a project-requiring client (Jira) still refuses an unbounded search.
+  Bound Linear discovery to the configured key's team and require the key; a loud
+  error replaces the silent zero-pulls. This is the fix for **0220** and the first
+  child to ship.
+- **Configuration key model** — rename `work.default_project_code` → `work.key`
+  and the `id_pattern` placeholder `{project}` → `{key}`. Introduce the layered
+  ownership: `linear.team_key` / `jira.project_key` is the canonical,
+  integration-owned key; `work.key` derives from it when a tracker is configured,
+  and is set directly only in tracker-less repos. Setting both is a
+  config-validation error. Provide a migration / read-time alias. `init-linear` /
+  `init-jira` write the key they discover.
+- **Per-tracker pull scope** — a per-tracker `pull` block: `additional_teams` /
+  `additional_projects` (broaden beyond the creation entity), `all_teams` /
+  `all_projects` (whole accessible workspace, mutually exclusive with the
+  `additional_*` list), and a generic `filters` bag. Each tracker declares a
+  filter schema so required keys fail at config time rather than at sync time.
+- **Tracker-owned ID generation** — optionally let a configured tracker mint the
+  work-item ID (stub-create remote, adopt its identifier locally so `id ==
+  external_id`), and codify the `id`-immutability boundary: immutable once synced,
+  provisional-and-rewritable before first push. The largest and least urgent
+  child.
+
+## Design
+
+The target scope-and-configuration model, common to both trackers.
+
+**Two distinct concepts, separated.** The *creation home* is the single entity new
+items are minted into (one Jira project / one Linear team); it also sets those
+items' key. The *pull scope* is the set of entities discovery enumerates; it always
+includes the creation home and may be broader. The old field conflated them.
+
+**The key is primary; the tracker entity is resolved from it.** `work.key` (or the
+integration-owned key it derives from) is the fundamental value — it exists even
+with no tracker, as the local ID prefix. When a tracker is configured, its entity
+is resolved from the key: Jira by identity (the key *is* the project key), Linear
+by catalogue lookup (team key → team UUID).
+
+**Scope comes from the key; the credential is access control.** Linear discovery is
+bounded to the keyed team and requires the key, exactly as Jira requires a project.
+The credentialed team from `catalogue.json` provides the key → UUID resolution table
+and the access-control boundary (which teams are reachable) — never the scope.
+
+**Unbounded is always opt-in and loud.** With the key always contributing the
+creation entity to scope, the "no project" condition that produced 0220 becomes
+unreachable through config. The only route to a whole-workspace search is an
+explicit `all_projects` / `all_teams`, backstopped by `max_pulls`.
+
+Config shape:
+
+```yaml
+# Linear-backed repo
+work:
+  id_pattern: "{key}-{number:04d}"   # {key} resolves from linear.team_key
+linear:
+  team_key: "PP"                     # canonical, required; resolves to UUID via catalogue
+  pull:
+    additional_teams: ["XX"]
+    all_teams: false
+    filters: { label: "sync" }
+
+# Jira-backed repo
+work:
+  id_pattern: "{key}-{number:04d}"
+jira:
+  project_key: "PROJ"                # canonical, required; satisfies the JQL project requirement
+  pull:
+    additional_projects: ["OTHER"]
+    all_projects: false
+    filters: { label: "sync" }
+
+# Tracker-less repo
+work:
+  key: "PROJ"
+  id_pattern: "{key}-{number:04d}"
+```
+
+`all_projects` / `all_teams` semantics: Jira omits the JQL `project =` clause,
+searching every accessible project; Linear drops the team filter and suppresses the
+credentialed-team fallback, searching every accessible team. Internally the port
+carries one entity-neutral boolean; each adapter interprets it, and the config
+surface uses each tracker's vocabulary.
 
 ## Acceptance Criteria
 
 - [ ] Status, kind, and priority are mapped bidirectionally during sync.
 - [ ] Parent-child relationships are established/maintained on sync.
-- [ ] Sync can be restricted to configured labels or projects.
+- [ ] Discovery is bounded by an explicit tracker-appropriate scope derived from the
+      configured key, and never by a hard-coded per-tracker assumption in engine
+      code.
+- [ ] With no configured scope, a self-bounding tracker (Linear) still runs
+      discovery bounded to the keyed entity; a project-requiring tracker (Jira)
+      reports a config error rather than an unbounded or silently-empty search.
+- [ ] A whole-workspace search happens only when `all_projects` / `all_teams` is
+      explicitly set; the default is bounded.
+- [ ] The tracker-native key (`linear.team_key` / `jira.project_key`) is usable by
+      the integration skills with no `work.*` present; `work.key` derives from it
+      when a tracker is configured, and setting both is a config-validation error.
+- [ ] Pulls can be broadened by configured `additional_*` entities, `filters`, or a
+      whole-workspace flag, each validated per tracker at config time.
 
 ## Open Questions
 
-- How are mappings configured per tracker (Jira vs. Linear)?
-- What is the conflict-resolution policy when local and remote values diverge?
+- What is the conflict-resolution policy when local and remote values diverge on a
+  mapped field (status/kind/priority)?
+- Under tracker-owned ID generation, how is offline / tracker-unreachable creation
+  handled — block creation, or mint a provisional `key`-prefixed ID and rewrite it
+  on first push (relaxing `id` immutability for unsynced items only)?
+
+Resolved during refinement (2026-08-30):
+
+- *How are scope/mappings configured per tracker?* — via per-tracker `pull` blocks
+  with a per-tracker filter schema; the base key is the integration-owned
+  `<tracker>.<entity>_key`, from which `work.key` derives.
 
 ## Dependencies
 
-- Blocked by: None identified yet.
-- Blocks: None identified yet.
+- Blocked by: none.
+- Blocks: none.
 
 ## Assumptions
 
-- Builds on the existing `/sync-work-items` skill and the `external_id`
+- Builds on the existing `/sync-work-items` engine and the `external_id`
   remote-key convention.
+- The key configured for a tracker names an entity the credential can write to;
+  a mismatch is an authz/config error, not a silent fallback.
 
 ## Technical Notes
 
-- Relates to the work-management integration and sync-work-items skill.
+- The port already models arbitrary filters (`SearchScope.filters:
+  Vec<(String, String)>` in `cli/tracker/src/lib.rs`) — promote it to the primary
+  scoping mechanism and demote `project` to one filter among many.
+- Linear already resolves a team key → UUID via the catalogue
+  (`cli/linear-client/src/auth.rs`), and already falls back to the credentialed
+  team at search time (`cli/linear-client/src/client.rs`); the scoping child routes
+  the configured key through the existing resolver rather than building new
+  machinery.
+- Only Jira and Linear are wired trackers today
+  (`cli/work-cli/src/tracker_registry.rs`); Trello and GitHub Issues are `0181`.
+  A future self-scoping adapter (e.g. single-repo GitHub Issues) would hit the same
+  gate defect the tracker-aware gate prevents.
+
+## Stories
+
+- 0220 — Tracker-aware discovery gate (fixes silent Linear untracked pulls);
+  reparented here.
+- 0228 — Configuration key model (`work.key` rename + layered
+  `<tracker>.<entity>_key` ownership + migration).
+- 0229 — Per-tracker pull scope (`additional_*`, `all_*`, `filters`, config-time
+  schema).
+- 0230 — Tracker-owned work-item ID generation (stub-mint; `id`-immutability
+  boundary).
+- TBD (existing candidates) — status / kind / priority mapping; parent-child
+  relationships on sync.
 
 ## Drafting Notes
 
-- Created as a new epic per the user's instruction to contain source candidates
-  21–25 (status / kind / priority mapping, parent-child relationships, and
-  label/project sync restriction), captured here as child candidates rather than
-  as separate work items.
-
-> Extracted from source documents without interactive enrichment.
-> Acceptance criteria, dependencies, and kind may need refinement before
-> promoting from `draft` to `ready`.
+- Enriched 2026-08-30 from an interactive design session driven by bug 0220. The
+  epic was previously a thin extract; the scope-and-configuration model, the config
+  shape, and the child breakdown are new.
+- Key naming settled on `work.key` (not `default_project_code` / `id_key`) because
+  the value identifies the tracker entity, of which the ID prefix is one
+  consequence.
+- Ownership inverted relative to the first proposal: the integration section owns
+  the canonical key and `work.key` derives from it, so integration skills never
+  depend on `work.*` and can be packaged independently.
+- Linear scope required and taken from the key, with the credential reframed as
+  access control — a deliberate departure from defaulting scope to the credentialed
+  team.
 
 ## References
 
 - Source: `meta/notes/2026-06-22-ideas-backlog.md`
+- Related: 0171, 0220

--- a/meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md
+++ b/meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md
@@ -5,53 +5,63 @@ title: "Untracked-Remote Discovery Never Runs on Linear"
 date: "2026-08-22T22:38:58+00:00"
 author: "Toby Clemson"
 producer: "create-work-item"
-status: "draft"
+status: "ready"
 kind: "bug"
 priority: "medium"
-parent: "work-item:0171"
+parent: "work-item:0146"
 relates_to: ["work-item:0194", "work-item:0204"]
 external_id: "PP-749"
 tags: ["sync", "linear", "tracker", "correctness"]
-last_updated: "2026-08-22T22:38:58+00:00"
+last_updated: "2026-08-30T15:03:24+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 # 0220: Untracked-Remote Discovery Never Runs on Linear
 
 **Kind**: Bug
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
 Untracked-remote discovery is skipped entirely when the active tracker is Linear.
-The gate that bounds discovery demands a configured project scope, but the Linear
-client already bounds its own search to the credentialed team. The gate
-short-circuits before the client is ever consulted, so a bidirectional sync
-reports zero untracked pulls without having searched — indistinguishable in the
-report from a search that ran and found nothing.
+The discovery gate demands a configured project scope, a constraint only Jira
+genuinely has; the Linear client bounds its own search to a team. The gate
+short-circuits before the client is consulted, so a bidirectional sync reports
+zero untracked pulls without having searched — indistinguishable in the report
+from a search that ran and found nothing.
 
 ## Context
 
-The scope is built in `cli/work-cli/src/sync.rs:431` from
-`work.default_project_code`, with `all_projects` hardcoded to `false` and no flag
-to set it. The gate then reads it in `cli/work-adapters/src/sync/run.rs:707`:
+The scope is built in `cli/work-cli/src/sync.rs:434-438` from
+`work.default_project_code`, with `all_projects` hardcoded `false`. The gate reads
+it in `cli/work-adapters/src/sync/run.rs:707-709`:
 
     let discovery_enabled =
         !matches!(request.direction, SyncDirection::PushOnly)
             && (request.scope.project.is_some() || request.scope.all_projects);
 
 With the key unset the gate is false and the `else` branch yields an empty vector
-silently — no report line, no warning.
+silently (`run.rs:723-725`) — no report line, no warning, no `search` call.
 
-The gate encodes Jira's semantics. Jira's JQL builder genuinely refuses without a
-project (`E_JQL_NO_PROJECT`, `cli/jira-client/src/jql.rs:169`), so an unset
-project there does mean unbounded, and the gate is correct. Linear is the
-opposite: its search falls back to the credentialed team
-(`cli/linear-client/src/client.rs:441`), which resolves from
-`.accelerator/state/integrations/linear/catalogue.json`. The search was already
-bounded; the gate suppressed one that was never at risk of flooding.
+The gate encodes Jira's semantics. Jira's JQL (Jira Query Language) builder refuses without a project
+(`E_JQL_NO_PROJECT`, `cli/jira-client/src/jql.rs:169-174`), so an unset project
+there does mean unbounded and the gate is correct. Linear is the opposite: its
+search falls back to the credentialed team (`cli/linear-client/src/client.rs:663-666`),
+resolved from `catalogue.json`. The search was already bounded; the gate suppressed
+one that was never at risk of flooding.
+
+That credentialed-team fallback is access control, not the intended scope
+authority. This fix makes the configured key the scope authority and requires it,
+so an unkeyed run is a misconfiguration to report rather than a search to run
+silently against whatever team the credential happens to reach — which is why the
+Fix shape below both enables Linear discovery *and* hard-fails when the key is
+unset.
+
+The tracker port already carries the seam for a tracker-aware fix: the trait is at
+`cli/tracker/src/lib.rs:321`, `search` at `:427`, and only Jira and Linear are
+wired (`cli/work-cli/src/tracker_registry.rs`).
 
 Observed 2026-08-22 in this repo: `work.integration: linear`, no
 `work.default_project_code`, catalogue team `PP` / Product Pod. A full
@@ -63,90 +73,130 @@ bidirectional sync reported 0 pulls while unpulled remote issues existed.
 
 1. Configure `work.integration: linear` with a populated catalogue and no
    `work.default_project_code`.
-2. Ensure at least one issue in the credentialed team has no local work item.
-3. Run `accelerator work sync --preview`.
+2. Ensure at least one issue in the team has no local work item.
+3. Run a bidirectional (default, non-push-only) sync in preview:
+   `accelerator work sync --preview`. The gate short-circuits on `PushOnly`, so the
+   direction must be bidirectional for the defect to be exercised.
 
 **Expected** — the untracked issue is discovered and reported as a planned pull,
-with the search bounded to the credentialed team.
+with the search bounded to the keyed team.
 
-**Actual** — the run reports zero pulls. Discovery never executed, and nothing in
-the report or on stderr distinguishes that from a completed search.
+**Actual** — the run reports zero pulls. Discovery never executed, and nothing
+distinguishes that from a completed search.
 
-**Compounding trap** — the obvious remedy does not work. `scope.project` is passed
-straight through as `team_id`, and `cli/linear-client/src/filter.rs:70` builds
+**Fix shape** — throughout, *key* denotes the single value held in
+`work.default_project_code` (config) and `scope.project` (runtime): a project key
+on Jira, a team key on Linear. Two coupled changes:
+
+1. Make the discovery gate tracker-aware: replace `scope.project.is_some()` with a
+   port capability ("does this tracker self-bound its search?"), so Linear enables
+   discovery with `scope.project` unset while Jira still refuses an unbounded
+   search.
+2. Bound Linear discovery to the configured key's team and require the key.
+   `scope.project` holds a team *key* (e.g. `PP`); resolve it to the team UUID via
+   the catalogue before it reaches the filter (`cli/linear-client/src/filter.rs:69-70`
+   wants the UUID — passing the raw key matches no team, the compounding trap
+   below). When the key is unset, report a config error rather than an empty
+   result.
+
+This item uses the current config field `work.default_project_code`; the rename to
+`work.key` and the layered `<tracker>.<entity>_key` ownership are the sibling
+configuration-model child under 0146.
+
+**Compounding trap** — the obvious remedy fails silently. `scope.project` is passed
+straight through as `team_id`, and `filter.rs:69-70` builds
 `{"team": {"id": {"eq": …}}}`, which wants the team UUID. Setting
 `work.default_project_code: PP` matches no team and yields zero untracked again,
-silently, for a second reason.
+for a second reason — hence the key→UUID resolution above.
 
 ## Acceptance Criteria
 
-- [ ] Given `work.integration: linear`, a populated catalogue, and no
-      `work.default_project_code`, when a bidirectional sync runs, then untracked
-      remote issues in the credentialed team are discovered and reported.
-- [ ] Given the same configuration, when discovery runs, then it is bounded to the
-      credentialed team and never enumerates the wider workspace.
-- [ ] Given `work.integration: jira` and no `work.default_project_code`, when a
-      sync runs, then discovery remains bounded — no regression to an unbounded
-      search.
-- [ ] Given any run where discovery does not execute, then the report states that
-      it was skipped and why, distinguishable from a search that completed with no
-      results.
-- [ ] Given `work.default_project_code` set to a value the tracker cannot resolve
-      to a scope, then the run reports that rather than returning an empty result
-      set silently.
-- [ ] A regression test covers the Linear-with-no-project-code path and fails
+- [ ] Given `work.integration: linear`, a populated catalogue, a configured key,
+      and at least one team issue with no local work item, when a bidirectional
+      sync runs, then that issue is discovered and reported as a planned pull.
+- [ ] Given the same configuration, when discovery runs, then the emitted Linear
+      search filter carries the `{team: {id: {eq: …}}}` constraint for the resolved
+      team UUID, and no request enumerates the wider workspace.
+- [ ] Given `work.integration: linear` and no configured key, when a sync runs,
+      then the run reports a config error naming the missing key, rather than
+      returning zero pulls silently.
+- [ ] Given a configured Linear key that is a team key (not a UUID), when discovery
+      runs, then the resolved team UUID — not the raw key (e.g. `PP`) — appears in
+      the search filter, and untracked issues from that team are returned.
+- [ ] Given a configured Linear key that resolves to no team in the catalogue
+      (absent or stale), when a sync runs, then the run reports a resolution error
+      naming the unresolved key, rather than returning zero pulls silently.
+- [ ] Given `work.integration: jira` with no project configured, when a sync runs,
+      then discovery refuses (`E_JQL_NO_PROJECT`) and performs no unbounded search.
+- [ ] Given any run where discovery does not execute, then the report states it was
+      skipped and why, distinguishable from a search that completed with no results.
+- [ ] A regression test covers the Linear-with-configured-key path and fails
       against the current gate.
-
-## Open Questions
-
-- Should `work.default_project_code` accept a Linear team key (`PP`) as well as a
-  UUID, or should Linear scoping be config-free and always derive from the
-  catalogue?
-- Does the same gate mis-fire for any other tracker whose client self-scopes?
 
 ## Dependencies
 
-- Blocked by: none
-- Blocks: none
+- Blocked by: none.
+- Blocks: none.
+- Ordering coupling (not a hard blocker): the configuration-model redesign that
+  renames `work.default_project_code` → `work.key` and introduces layered
+  `<tracker>.<entity>_key` ownership reads the exact field this fix reads. It is not
+  yet split into its own work item — the redesign currently lives in parent epic
+  0146 and must be tracked there. 0220 deliberately targets the current field so
+  neither blocks the other, but whichever ships second must reconcile: if the
+  rename lands first, 0220 retargets to `work.key`; if 0220 lands first, the rename
+  must account for this new consumer.
+- Related, no blocking relationship: 0194 and 0204 are thematically adjacent
+  sync-enhancement items under 0146, not upstream prerequisites or downstream
+  consumers of this fix.
+- Runtime prerequisite: `catalogue.json` must carry the configured team's
+  key → UUID mapping (resolved via `cli/linear-client/src/auth.rs`). A key present
+  in config but absent from or stale in the catalogue resolves to no team and
+  reproduces the zero-pulls symptom for a third reason; the fix must surface that
+  as an error rather than an empty result.
+- Test-environment prerequisite: the regression and acceptance tests run against
+  mocked Linear responses, so live Linear credentials and API access are not a
+  blocker for verification — they are needed only to reproduce the defect manually
+  against a real workspace.
 
 ## Assumptions
 
-- Discovery on Linear is intended behaviour rather than deliberately disabled. The
-  field's own doc comment — "Team/project-scoped by default so the untracked set
-  stays bounded on a shared workspace" — reads as bounding the search, not
-  suppressing it.
-- The credentialed team is the correct default scope when no project code is
-  configured.
+- Discovery on Linear is intended behaviour, not deliberately disabled. The
+  `work.default_project_code` doc comment — "Team/project-scoped by default so the
+  untracked set stays bounded on a shared workspace" — reads as bounding the
+  search, not suppressing it.
+- The configured key is the scope authority; the credentialed team provides key →
+  UUID resolution and access control, not the scope.
 
 ## Technical Notes
 
-Two candidate mechanisms, deliberately not chosen here:
-
-1. Widen the gate to consult the tracker, so a client that bounds its own search
-   enables discovery with `scope.project` unset. Addresses the root asymmetry and
-   holds for future trackers.
-2. Populate `scope.project` from the Linear catalogue team id before the gate
-   reads it. Smaller, but leaves the Jira-shaped assumption in place and overloads
-   a field named "project code" with a UUID.
-
-Sites involved: `cli/work-cli/src/sync.rs:431`,
-`cli/work-adapters/src/sync/run.rs:707`, `cli/linear-client/src/client.rs:441`,
-`cli/linear-client/src/filter.rs:70`, `cli/jira-client/src/jql.rs:169`.
+- Chosen mechanism: a tracker-port capability distinguishing self-bounding trackers
+  (Linear) from project-requiring ones (Jira), replacing the `scope.project`-based
+  gate in tracker-agnostic code. The broader scope/config redesign (per-tracker
+  pull scope, `all_*`, filter schema) is 0146, not this item.
+- Linear already resolves a team key → UUID via the catalogue
+  (`cli/linear-client/src/auth.rs`); route the configured key through that resolver
+  in the sync scope path rather than passing it raw.
+- Sites: `cli/work-adapters/src/sync/run.rs:707`,
+  `cli/work-cli/src/sync.rs:434`, `cli/tracker/src/lib.rs:321`,
+  `cli/linear-client/src/client.rs:663`, `cli/linear-client/src/filter.rs:69`,
+  `cli/linear-client/src/auth.rs`, `cli/jira-client/src/jql.rs:169`.
 
 ## Drafting Notes
 
 - Recorded as `bug` rather than `task`: the code runs correctly and produces a
   wrong result on a configured, supported tracker.
-- The fix mechanism is left open at your direction; both candidates are recorded
-  in Technical Notes rather than one being written into the criteria.
-- The silent-skip observability gap is folded into this item rather than split
-  out — the silence is what kept the defect invisible, so fixing the gate without
-  it would leave the next mis-scoped case equally undetectable.
-- Parent set to `0171` as the live integrations epic. `0194` and `0204` built the
-  engine and port but are `done`, so they are `relates_to` rather than parents.
-- Whether this gate arrived with the fix for the earlier multi-team flood is not
-  established — the investigation read current code, not history.
+- Reparented from 0171 (done) to 0146, the live sync-enhancements epic that now
+  owns the scope-and-configuration redesign; 0220 is its first, shippable child.
+- The two former open questions are resolved and moved to 0146: Linear scoping is
+  keyed and required (credential is access control), and only Jira/Linear are wired
+  trackers today (a future self-scoping adapter would hit the same defect).
+- Fix scoped narrowly to the gate plus the Linear key→UUID resolution it depends
+  on; it uses the current `default_project_code` field, which the config-model
+  sibling renames.
+- The silent-skip observability gap stays folded in — the silence is what kept the
+  defect invisible.
 
 ## References
 
-- Related: 0171, 0194, 0204
+- Parent: 0146
+- Related: 0194, 0204

--- a/meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md
+++ b/meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md
@@ -5,7 +5,7 @@ title: "Untracked-Remote Discovery Never Runs on Linear"
 date: "2026-08-22T22:38:58+00:00"
 author: "Toby Clemson"
 producer: "create-work-item"
-status: "ready"
+status: "done"
 kind: "bug"
 priority: "medium"
 parent: "work-item:0146"
@@ -19,7 +19,7 @@ schema_version: 1
 # 0220: Untracked-Remote Discovery Never Runs on Linear
 
 **Kind**: Bug
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 

--- a/meta/work/0228-layered-configuration-key-model.md
+++ b/meta/work/0228-layered-configuration-key-model.md
@@ -1,18 +1,18 @@
 ---
-type: work-item
+type: "work-item"
 id: "0228"
-title: Layered Configuration Key Model
-date: 2026-08-30T14:35:09+00:00
-author: Toby Clemson
-producer: create-work-item
-status: draft
-kind: task
-priority: high
+title: "Layered Configuration Key Model"
+date: "2026-08-30T14:35:09+00:00"
+author: "Toby Clemson"
+producer: "create-work-item"
+status: "draft"
+kind: "task"
+priority: "high"
 parent: "work-item:0146"
 relates_to: ["work-item:0220"]
-tags: [configuration, work-management, migration, tracker]
-last_updated: 2026-08-30T14:35:09+00:00
-last_updated_by: Toby Clemson
+tags: ["configuration", "work-management", "migration", "tracker"]
+last_updated: "2026-08-30T14:35:09+00:00"
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 # 0228: Layered Configuration Key Model

--- a/meta/work/0228-layered-configuration-key-model.md
+++ b/meta/work/0228-layered-configuration-key-model.md
@@ -8,8 +8,8 @@ producer: create-work-item
 status: draft
 kind: task
 priority: high
-parent: work-item:0146
-relates_to: [work-item:0220]
+parent: "work-item:0146"
+relates_to: ["work-item:0220"]
 tags: [configuration, work-management, migration, tracker]
 last_updated: 2026-08-30T14:35:09+00:00
 last_updated_by: Toby Clemson

--- a/meta/work/0228-layered-configuration-key-model.md
+++ b/meta/work/0228-layered-configuration-key-model.md
@@ -1,0 +1,93 @@
+---
+type: work-item
+id: "0228"
+title: Layered Configuration Key Model
+date: 2026-08-30T14:35:09+00:00
+author: Toby Clemson
+producer: create-work-item
+status: draft
+kind: task
+priority: high
+parent: work-item:0146
+relates_to: [work-item:0220]
+tags: [configuration, work-management, migration, tracker]
+last_updated: 2026-08-30T14:35:09+00:00
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+# 0228: Layered Configuration Key Model
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: High
+**Author**: Toby Clemson
+
+## Summary
+
+Rename `work.default_project_code` to `work.key` and the `id_pattern` placeholder
+`{project}` to `{key}`, and introduce layered key ownership. The tracker-native key
+(`linear.team_key` / `jira.project_key`) is the canonical, integration-owned value;
+`work.key` derives from it when a tracker is configured, and is set directly only in
+tracker-less repos.
+
+## Context
+
+`default_project_code` is misnamed: its real job is the key a tracker stamps on
+issue identifiers — a Jira project key, a Linear team key — the key of the entity
+that owns the issue-number sequence, not a "project". It is also overloaded as the
+sync scope, which is what let bug 0220 hide.
+
+Integration skills (search/show for Jira and Linear) must keep working, and may in
+future be packaged independently of the work-management framework. So the dependency
+must run work → integration, never the reverse: integration skills read only their
+own `jira:` / `linear:` section; the work layer reads the integration-owned key.
+
+## Requirements
+
+- Rename `work.default_project_code` → `work.key`; `id_pattern` placeholder
+  `{project}` → `{key}`.
+- Make `linear.team_key` / `jira.project_key` the canonical, integration-owned key,
+  usable by the integration skills with no `work.*` present.
+- Derive `work.key` from the integration key when a tracker is configured; allow it
+  set directly only in tracker-less repos.
+- Setting both the integration key and `work.key` is a config-validation error.
+- Provide a read-time alias and migration for existing `default_project_code` and
+  `{project}` configs.
+- `init-linear` / `init-jira` write the discovered key into the tracker section.
+
+## Acceptance Criteria
+
+- [ ] Given only a `jira:` or `linear:` section with its key and no `work.*`, when
+      an integration skill runs, then it functions without a work-management config.
+- [ ] Given a tracker-backed repo, when the key is set under
+      `<tracker>.<entity>_key` and `work.key` is omitted, then `{key}` in IDs
+      resolves from the integration key.
+- [ ] Given both the integration key and `work.key` are set, then configuration
+      validation fails with a message naming the conflict.
+- [ ] Given an existing config using `default_project_code` / `{project}`, when it
+      is read after this change, then it keeps working via the alias/migration and
+      renders IDs identically.
+
+## Dependencies
+
+- Blocked by: none.
+- Blocks: none.
+
+## Technical Notes
+
+- Sequenced after 0220, which still reads `work.default_project_code`; this item
+  renames that touchpoint.
+- The Linear team key → UUID resolver already exists
+  (`cli/linear-client/src/auth.rs`); this item does not change resolution, only the
+  config field the key is read from and its ownership layer.
+
+## Drafting Notes
+
+- Ownership deliberately inverted so integration skills never depend on `work.*` —
+  chosen over a "work.key overrides the integration key" model, which would couple
+  them in the combined deployment.
+
+## References
+
+- Parent: 0146
+- Related: 0220

--- a/meta/work/0229-per-tracker-pull-scope-configuration.md
+++ b/meta/work/0229-per-tracker-pull-scope-configuration.md
@@ -1,17 +1,17 @@
 ---
-type: work-item
+type: "work-item"
 id: "0229"
-title: Per-Tracker Pull Scope Configuration
-date: 2026-08-30T14:35:09+00:00
-author: Toby Clemson
-producer: create-work-item
-status: draft
-kind: story
-priority: medium
+title: "Per-Tracker Pull Scope Configuration"
+date: "2026-08-30T14:35:09+00:00"
+author: "Toby Clemson"
+producer: "create-work-item"
+status: "draft"
+kind: "story"
+priority: "medium"
 parent: "work-item:0146"
-tags: [sync, scoping, tracker, configuration]
-last_updated: 2026-08-30T14:35:09+00:00
-last_updated_by: Toby Clemson
+tags: ["sync", "scoping", "tracker", "configuration"]
+last_updated: "2026-08-30T14:35:09+00:00"
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 # 0229: Per-Tracker Pull Scope Configuration

--- a/meta/work/0229-per-tracker-pull-scope-configuration.md
+++ b/meta/work/0229-per-tracker-pull-scope-configuration.md
@@ -8,7 +8,7 @@ producer: create-work-item
 status: draft
 kind: story
 priority: medium
-parent: work-item:0146
+parent: "work-item:0146"
 tags: [sync, scoping, tracker, configuration]
 last_updated: 2026-08-30T14:35:09+00:00
 last_updated_by: Toby Clemson

--- a/meta/work/0229-per-tracker-pull-scope-configuration.md
+++ b/meta/work/0229-per-tracker-pull-scope-configuration.md
@@ -1,0 +1,86 @@
+---
+type: work-item
+id: "0229"
+title: Per-Tracker Pull Scope Configuration
+date: 2026-08-30T14:35:09+00:00
+author: Toby Clemson
+producer: create-work-item
+status: draft
+kind: story
+priority: medium
+parent: work-item:0146
+tags: [sync, scoping, tracker, configuration]
+last_updated: 2026-08-30T14:35:09+00:00
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+# 0229: Per-Tracker Pull Scope Configuration
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+As a developer syncing work items, I want to control how broadly a pull discovers
+remote issues per tracker, so that discovery is bounded by an explicit, validated
+scope rather than a hard-coded assumption. Introduce a per-tracker `pull` block:
+`additional_teams` / `additional_projects`, `all_teams` / `all_projects`, and a
+generic `filters` bag, each validated at config time. This realises 0146's existing
+"restrict sync by label/project" requirement.
+
+## Context
+
+The creation entity (from the configured key) is always the implicit base scope; the
+`pull` block only broadens it. `all_teams` / `all_projects` searches the whole
+accessible workspace — Jira omits the JQL `project =` clause, Linear drops the team
+filter and suppresses the credentialed-team fallback — bounded only by `max_pulls`.
+The port already models arbitrary filters (`SearchScope.filters` in
+`cli/tracker/src/lib.rs`); this promotes that seam to the primary mechanism.
+
+## Requirements
+
+- Per-tracker `pull` block with `additional_*` entities, `all_*` flag, and a
+  `filters` bag.
+- The creation entity (keyed project/team) is always included in scope implicitly.
+- `all_*` is mutually exclusive with `additional_*`; specifying both is a config
+  error.
+- Each tracker declares a filter schema (accepted keys, required keys) so an
+  invalid or missing required filter fails at config time, not at sync time.
+- The port carries one entity-neutral "whole workspace" boolean; adapters interpret
+  it; the config surface uses each tracker's vocabulary.
+
+## Acceptance Criteria
+
+- [ ] Given `additional_*` or `filters` are configured, when a pull runs, then
+      discovery is broadened accordingly, still including the keyed entity.
+- [ ] Given `all_teams` / `all_projects` is set, when a pull runs, then discovery
+      spans the whole accessible workspace, bounded by `max_pulls`.
+- [ ] Given both `all_*` and `additional_*` are set, then configuration validation
+      fails.
+- [ ] Given a required filter key is missing or an unsupported key is present, then
+      the failure is reported at `configure`, not at `sync`.
+- [ ] Given no `pull` configuration, when a pull runs, then discovery stays bounded
+      to the keyed entity.
+
+## Dependencies
+
+- Blocked by: the layered configuration key model (sibling under 0146).
+- Blocks: none.
+
+## Technical Notes
+
+- Jira's `project_key` satisfies the JQL project requirement, so `all_projects` is
+  pure opt-in breadth rather than a precondition.
+- Depends on the key model landing first so the base scope resolves from the
+  canonical key.
+
+## Drafting Notes
+
+- Filters modelled as a bag plus a per-tracker schema rather than fully free-form,
+  so tracker-specific required keys (Jira project) have a place to fail early.
+
+## References
+
+- Parent: 0146

--- a/meta/work/0230-tracker-owned-work-item-id-generation.md
+++ b/meta/work/0230-tracker-owned-work-item-id-generation.md
@@ -1,17 +1,17 @@
 ---
-type: work-item
+type: "work-item"
 id: "0230"
-title: Tracker-Owned Work Item ID Generation
-date: 2026-08-30T14:35:09+00:00
-author: Toby Clemson
-producer: create-work-item
-status: draft
-kind: story
-priority: low
+title: "Tracker-Owned Work Item ID Generation"
+date: "2026-08-30T14:35:09+00:00"
+author: "Toby Clemson"
+producer: "create-work-item"
+status: "draft"
+kind: "story"
+priority: "low"
 parent: "work-item:0146"
-tags: [sync, tracker, id-generation]
-last_updated: 2026-08-30T14:35:09+00:00
-last_updated_by: Toby Clemson
+tags: ["sync", "tracker", "id-generation"]
+last_updated: "2026-08-30T14:35:09+00:00"
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 # 0230: Tracker-Owned Work Item ID Generation

--- a/meta/work/0230-tracker-owned-work-item-id-generation.md
+++ b/meta/work/0230-tracker-owned-work-item-id-generation.md
@@ -1,0 +1,83 @@
+---
+type: work-item
+id: "0230"
+title: Tracker-Owned Work Item ID Generation
+date: 2026-08-30T14:35:09+00:00
+author: Toby Clemson
+producer: create-work-item
+status: draft
+kind: story
+priority: low
+parent: work-item:0146
+tags: [sync, tracker, id-generation]
+last_updated: 2026-08-30T14:35:09+00:00
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+# 0230: Tracker-Owned Work Item ID Generation
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Low
+**Author**: Toby Clemson
+
+## Summary
+
+As a developer whose work items live in a remote tracker, I want the tracker to own
+work-item ID generation when configured, so that a work item's local `id` always
+matches its remote identifier (`external_id`). Stub-create the remote issue, adopt
+its identifier locally, and codify the `id`-immutability boundary: immutable once
+synced, provisional-and-rewritable before first push.
+
+## Context
+
+Today the local `id` is minted locally and can differ from `external_id`. Making the
+tracker the source of truth means obtaining the tracker ID before writing the local
+file, so `id` is set once and never rewritten — which resolves the immutability
+tension for the online path. The mechanism reuses the existing atomic
+`work create --push` create-then-write path and its orphan-stub recovery.
+
+## Requirements
+
+- When tracker-owned IDs are enabled and the tracker is reachable, mint the ID by
+  stub-creating the remote issue and adopting its identifier as the local `id`.
+- The minting entity is singular (the keyed project/team), even when the pull scope
+  is broader.
+- Define and enforce the `id`-immutability boundary: immutable once synced;
+  provisional pre-sync IDs may be rewritten on first push.
+
+## Acceptance Criteria
+
+- [ ] Given tracker-owned IDs are enabled and the tracker is reachable, when an item
+      is created, then its `id` equals its `external_id`.
+- [ ] Given an item has been synced, when any later operation runs, then its `id` is
+      never rewritten.
+- [ ] Given the offline policy decided below, when an item is created without tracker
+      reachability, then that policy is applied consistently.
+
+## Open Questions
+
+- Offline / tracker-unreachable creation: block creation, or mint a provisional
+  `key`-prefixed ID and rewrite it on first push (relaxing `id` immutability for
+  unsynced items only)?
+
+## Dependencies
+
+- Blocked by: the layered configuration key model (sibling under 0146).
+- Blocks: none.
+
+## Technical Notes
+
+- Reuses the atomic `work create --push` path (create remote, then write local) and
+  its `pending_push` orphan-stub recovery.
+- Under tracker-owned IDs, `work.key` narrows to the tracker-less and
+  offline-provisional cases; synced items take their key from the tracker.
+
+## Drafting Notes
+
+- Largest and least urgent child; the offline open question may warrant a spike
+  before implementation.
+
+## References
+
+- Parent: 0146

--- a/meta/work/0230-tracker-owned-work-item-id-generation.md
+++ b/meta/work/0230-tracker-owned-work-item-id-generation.md
@@ -8,7 +8,7 @@ producer: create-work-item
 status: draft
 kind: story
 priority: low
-parent: work-item:0146
+parent: "work-item:0146"
 tags: [sync, tracker, id-generation]
 last_updated: 2026-08-30T14:35:09+00:00
 last_updated_by: Toby Clemson

--- a/skills/work/sync-work-items/SKILL.md
+++ b/skills/work/sync-work-items/SKILL.md
@@ -51,11 +51,14 @@ configured.
 
 `trello` and `github-issues` are not built yet; `work sync` exits **72**
 ("not available") for them, which you surface as a clear message. A wired
-tracker (`jira`, `linear`) whose configuration or credentials are missing or
-refused exits **74** ("unconfigured") — surface it as a "fix your config"
-message (nothing was sent), never as a reconciliation prompt. `work sync`
-resolves its own tracker binary, credentials, and hashing; you do not pre-check
-`jq`, `sha256sum`, or the VCS binary.
+tracker (`jira`, `linear`) exits **74** ("unconfigured") when a run cannot
+proceed on its configuration — its credentials are missing or refused, or a
+non-push-only run's discovery scope names no valid target (an unset or
+unresolvable key, e.g. Linear with no `work.default_project_code`). Surface it
+as a "fix your config" message (nothing was sent), never as a reconciliation
+prompt; the escape hatch for the scope case is `--push-only`, which skips
+discovery. `work sync` resolves its own tracker binary, credentials, and
+hashing; you do not pre-check `jq`, `sha256sum`, or the VCS binary.
 
 ## Step 1: Parse mode and flags
 
@@ -102,21 +105,28 @@ is carried inside the engine; you never need to test file cleanliness yourself.
 **new** artefacts on both sides: it creates remote issues from unsynced local
 drafts (bounded by `--max-pushes`, counted as pushes) and pulls untracked remote
 issues into new local files (bounded by `--max-pulls`, counted as pulls).
-Untracked discovery is scoped to the configured project, so it stays bounded on
-a shared multi-team workspace; a truncated or over-budget discovery is a refusal
-with guidance (exit 5), not a silent flood.
+Untracked discovery is scoped to the configured key (a Jira project, a Linear
+team), so it stays bounded on a shared multi-team workspace; a truncated or
+over-budget discovery is a refusal with guidance (exit 5), and an unset or
+unresolvable key is a pre-flight refusal (exit 74), neither a silent flood nor a
+silent skip. The report carries a `#\tdiscovery\t…` line saying whether the
+search **ran** (`found=N`), was **skipped** because the run was push-only, or
+**failed** transiently — so a completed search that found nothing is never
+mistaken for a skip.
 
 **The stdout report is authoritative.** Read it for `unresolved` lines
 regardless of exit code — a `71` run may also carry conflicts. Exit codes: `0`
 clean; `4` items await a human (unresolved conflicts, skipped-dirty pulls,
 remote-absent or indeterminate items); `5` refused (would exceed
-`--max-pulls`/`--max-pushes`, zero writes); `70` a read failed or every per-item
-failure was retryable; `71` a per-item failure was terminal (a whole-item update
-is idempotent, so the hazard is response uncertainty — never auto-retried); `72`
-tracker recognised but no client built; `73` `work.integration` unset or
-unrecognised; `74` wired but unconfigured (nothing sent). Under `--preview` no
-baseline mutation occurs and every planned push carries a locally-validated
-payload check.
+`--max-pulls`/`--max-pushes`, zero writes); `70` a read failed, a discovery
+search failed transiently, or every per-item failure was retryable; `71` a
+per-item failure was terminal (a whole-item update is idempotent, so the hazard
+is response uncertainty — never auto-retried); `72` tracker recognised but no
+client built; `73` `work.integration` unset or unrecognised; `74` wired but a
+run cannot proceed on its config — missing/refused credentials, or a
+non-push-only run whose discovery scope names no valid target (nothing sent;
+set the key or run `--push-only`). Under `--preview` no baseline mutation occurs
+and every planned push carries a locally-validated payload check.
 
 ## Step 3: Conflict resolution (bidirectional only)
 


### PR DESCRIPTION
# [0220] Bound Linear untracked discovery to the configured team

## Summary

Untracked-remote discovery returned zero pulls on Linear for two independent reasons: with the scope key unset the discovery gate skipped the search silently, and with the key set it was handed to Linear as a team **key** where the filter wanted the team **UUID**, matching no team. This PR lifts key→UUID resolution into a new `resolve_scope` port method that validates the discovery scope before any push — a missing or unresolvable key refuses the run pre-flight (exit `74`, nothing sent), a resolved key drives a UUID-bounded search — and makes every discovery outcome (ran, skipped, transiently failed) visible in the sync report so a skip is never again mistaken for an empty result.

## Changes

- Added `resolve_scope` and a dedicated `ScopeError` to the `RemoteTracker` port — a deterministic, local resolution-and-validation step distinct from the network `search`, so a config fault can never be routed through the transient-failure exit path. Public-api snapshot regenerated.
- Linear: introduced a `TeamResolver` port plus a catalogue-backed `CatalogueTeam` resolver injected into `LinearClient`; `resolve_scope` maps the configured team key to its UUID and refuses an unknown or absent key (`E_SEARCH_NO_TEAM` / `E_SEARCH_UNKNOWN_TEAM`). `search` now consumes the resolved UUID and drops the credential-team fallback, keeping a defensive guard so an unresolved scope can never reach Linear's empty, workspace-wide filter.
- Jira: `resolve_scope` moves the `E_JQL_NO_PROJECT` refusal ahead of `search`, so an unscoped bidirectional Jira run is refused pre-flight rather than issuing an unbounded search.
- Pre-flight refusal in `prepare_run`: an invalid scope aborts as `RunError::DiscoveryUnconfigured` before the apply/push phase, rendered by the CLI as exit `74` with nothing sent.
- Discovery observability: a `DiscoveryStatus` (ran / skipped-push-only / transiently-failed) threaded through the report and rendered as a `#\tdiscovery` line; a transient search failure now drives exit `70` distinctly instead of folding silently into an empty result.
- Docs: the exit-code taxonomy (`exit_codes.rs`) and the `sync-work-items` skill reconciled for `74`'s second source and the new report line.
- Meta: the full 0220 lifecycle (research, plan, two reviews, validation) plus a decomposition of epic 0146 into children 0228/0229/0230 (layered configuration-key model, per-tracker pull scope, tracker-owned work-item id generation).

## Context

- Work item: `meta/work/0220-untracked-remote-discovery-never-runs-on-linear.md`
- Plan: `meta/plans/2026-08-30-0220-untracked-remote-discovery-on-linear.md`
- Research: `meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md`
- Validation: `meta/validations/2026-08-30-0220-untracked-remote-discovery-on-linear-validation.md`
- Parent epic: `meta/work/0146-work-item-sync-enhancements.md`

## Testing

- [x] `mise run test:unit:cli` — full CLI unit suite green, 0 failures
- [x] `mise run cli:check` — workspace rustfmt + clippy clean
- [x] `mise run public-api:check` — regenerated `tracker` snapshot matches
- [ ] Manual: against a real Linear workspace with the team key set and a seeded untracked issue, `work sync --preview` lists it as a `create-from-remote` pull and the emitted GraphQL body carries the team UUID in `{team:{id:{eq:…}}}`
- [ ] Manual: a key-unset (or unknown-key) run refuses pre-flight with a `discovery unconfigured` message, exits `74`, and sends no push

## Notes for Reviewers

- Behavioural contract change to release-note: an unconfigured discovery scope now refuses a bidirectional or pull-only run pre-flight (exit `74`) where it completed cleanly (exit `0`) before — on **both** trackers, so an unscoped Jira run shifts `0 → 74`. The escape hatch is setting the key or running `--push-only`.
- The port surface grew deliberately (`resolve_scope` + `ScopeError`); the public-api snapshot regeneration is the intended diff, not drift.
- Follow-up debt: the two `RunReport` constructions were left un-collapsed (the optional `from_prepared` refactor was deferred); both thread the new `discovery` field correctly.
- The 0146 decomposition (0228/0229/0230) rides along because the plan's scope-authority decisions map onto that epic's config redesign; reconciliation of the `work.default_project_code` → `work.key` rename is recorded in the plan's Assumptions.
