### PR TITLE
Extract further-ideas backlog into work items 0231-0274

### DIFF
--- a/meta/notes/2026-06-23-further-ideas-backlog.md
+++ b/meta/notes/2026-06-23-further-ideas-backlog.md
@@ -1,13 +1,13 @@
 ---
-type: note
+type: "note"
 id: "2026-06-23-ideas-backlog"
 title: "Further Ideas Backlog"
 date: "2026-06-23T17:08:56+00:00"
 author: "Toby Clemson"
-producer: create-note
-status: captured
+producer: "create-note"
+status: "captured"
 topic: "Further ideas backlog"
-tags: [backlog, ideas]
+tags: ["backlog", "ideas"]
 revision: "8e0345fc5fd386a3526768c5f3ed790e1b00b26d"
 repository: "miscellaneous"
 last_updated: "2026-06-22T23:49:56+00:00"

--- a/meta/notes/2026-06-23-further-ideas-backlog.md
+++ b/meta/notes/2026-06-23-further-ideas-backlog.md
@@ -1,0 +1,66 @@
+---
+type: note
+id: "2026-06-23-ideas-backlog"
+title: "Further Ideas Backlog"
+date: "2026-06-23T17:08:56+00:00"
+author: "Toby Clemson"
+producer: create-note
+status: captured
+topic: "Further ideas backlog"
+tags: [backlog, ideas]
+revision: "8e0345fc5fd386a3526768c5f3ed790e1b00b26d"
+repository: "miscellaneous"
+last_updated: "2026-06-22T23:49:56+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Further Ideas Backlog
+
+Running backlog of feature, skill, and infrastructure ideas for the
+Accelerator plugin.
+
+* [Bug] Fix font size for inline code in headings
+* [Bug] Render inline code in document detail page title
+* [Story] Add minimum accelerator version constraint and alert user when they need to upgrade
+* [Story] Improve corpus cross-references in code comments and documentation (either ban, or make them fully resolvable)
+* [Story] Allow reviewer profiles so that reviews can be triggered with different lens and config presets
+* [Story] Make /respond-to-pr commit options VCS specific
+* [Story] Mark as migrated to latest migration on first init
+* [Story] Make either configuration or templates authoritative for valid lifecycle states on meta artefacts
+* [Bug] Running visualiser hits a permission block because of dynamic args in invoked command
+* [Bug] `accelerator corpus update` doesn't roundtrip quotes on frontmatter values, causing the model to reject
+* [Bug] `accelerator migrate` detect dirty tree when not dirty
+* [Story] Set model and/or effort on skills
+* [Story] Add full support for ACCELERATOR_BROWSER_AUTH_HEADER in design skills
+* [Task] Normalise datetimes used in filenames etc.
+* [Task] Invoke `accelerator` directly in all skills.
+* [Task] Consider using a library for deamon process management
+* [Task] Retire server.pid in the design commands
+* [Task] Get design-automation integration tests running in CI
+* [Task] Build richer document model and consolidate all document handling onto crate
+* [Task] Push all config lookups down into config crates
+* [Task] Add support for env var overrides in config crates
+* [Task] Federate config definitions into specific domain crates
+* [Task] Survey all CLIs to see what logic can be pushed into the domain crates
+* [Task] Add CLI logging
+* [Story] Allow work item sync skill to merge conflicting chunks
+* [Task] Push work list logic into core crate
+* [Story] Allow /sync-work-item to work with a single work item
+* [Bug] `accelerator help` doesn't show subcommands
+* [Bug] Unify help style
+* [Task] Move `adr` out of the `corpus` subcommand into its own subcommand like `work`.
+* [Story] Remove references to TodoWrite etc. now that it has been disabled
+* [Story] Render screenshots in design inventories in visualiser
+* [Task] Rename `ForeignDirt` to avoid negative connotations
+* [Task] Remove negative assertion tests that are a hangover from the Bash to Rust migration
+* [Task] Collapse `--discoverability-hook` and `--format=hook` into one switch
+* [Task] Remove `thiserror` from the codebase
+* [Task] Move all VCS kind detection into the `vcs*` crates
+* [Task] Rename the `remote-projection` crate to be more tracker or work focused
+* [Task] Remove all references to Bash and exit codes from the Jira and Linear client crates
+* [Task] Move `Filesystem` into a shared crate and use everywhere file system access is required, along with a fake implementation
+* [Task] Rationalise `Surface` / `RemoteTracker` / client specific interfaces into a single unified interface
+* [Task] Move `insecure-local-ok` marker file under `.accelerator`
+* [Task] Introduce domain crate to `linear` and `jira` subcommands
+* [Task] Isolate calls to `gh` into a shared Python module

--- a/meta/prs/91-description.md
+++ b/meta/prs/91-description.md
@@ -1,14 +1,14 @@
 ---
-type: pr-description
+type: "pr-description"
 id: "91"
 title: "Extract further-ideas backlog into work items 0231-0274"
 date: "2026-08-31T12:51:17+00:00"
 author: "Toby Clemson"
-producer: describe-pr
-status: complete
+producer: "describe-pr"
+status: "complete"
 pr_url: "https://github.com/atomicinnovation/accelerator/pull/91"
 pr_number: 91
-tags: [backlog, work-items]
+tags: ["backlog", "work-items"]
 revision: "e6341c463bb9a754114e2a914a48ac98ec906f70"
 repository: "accelerator"
 last_updated: "2026-08-31T12:51:17+00:00"

--- a/meta/prs/91-description.md
+++ b/meta/prs/91-description.md
@@ -1,0 +1,45 @@
+---
+type: pr-description
+id: "91"
+title: "Extract further-ideas backlog into work items 0231-0274"
+date: "2026-08-31T12:51:17+00:00"
+author: "Toby Clemson"
+producer: describe-pr
+status: complete
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/91"
+pr_number: 91
+tags: [backlog, work-items]
+revision: "e6341c463bb9a754114e2a914a48ac98ec906f70"
+repository: "accelerator"
+last_updated: "2026-08-31T12:51:17+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Extract further-ideas backlog into work items 0231-0274
+
+## Summary
+
+Captures a running backlog of 44 feature, bug, and infrastructure ideas as a short-form note, then extracts each one into a structured work item so they enter the normal refinement and planning pipeline.
+
+## Changes
+
+- Adds `meta/notes/2026-06-23-further-ideas-backlog.md`, a running backlog of 44 ideas each tagged with an intended kind (`[Bug]`, `[Story]`, `[Task]`).
+- Adds 44 work items, `0231`–`0274`, one per backlog line — each a source-faithful thin draft with Summary, Context, Requirements, seed acceptance criteria, and (where the source leaves a decision open) Open Questions.
+- Marks every extracted item `status: draft`, `priority: medium`, and carries the verbatim non-enrichment Drafting Note so `/refine-work-item` and reviewers can identify them as needing individual expansion before promotion to `ready`.
+
+## Context
+
+Extracted from `meta/notes/2026-06-23-further-ideas-backlog.md` via `/extract-work-items`. No owning work item — these files are themselves the extracted backlog. Items span the visualiser, the CLI and its config/domain crates, the design skills, work-item sync, help output, and build-system cleanup.
+
+## Testing
+
+- [x] Slug-collision check against the existing 230 work items before allocation — no collisions.
+- [x] IDs `0231`–`0274` allocated in one `accelerator work next-number --count 44` call, preserving presentation order.
+- [ ] Frontmatter schema validation runs in CI's docs lane (not run locally in this session).
+
+## Notes for Reviewers
+
+- These are deliberately thin drafts, not fully-formed specs — intent captured, detail deferred to per-item refinement. Acceptance criteria and kinds may shift during refinement; several kinds are inherited from the source tag and flagged in Drafting Notes where the fit is loose (e.g. `0259` tagged bug but reads as a task).
+- Open Questions carry real unmade decisions worth resolving during refinement: replacement names for `0263` (`ForeignDirt`) and `0268` (`remote-projection`), ban-vs-resolve for `0234`, config-vs-templates authority for `0238`, and precedence ordering for `0251`.
+- A few tasks may grow into epics once refined — `0246`, `0249`, `0253`, `0271`.

--- a/meta/work/0231-fix-inline-code-font-size-in-headings.md
+++ b/meta/work/0231-fix-inline-code-font-size-in-headings.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0231"
 title: "Fix Inline Code Font Size In Headings"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [visualiser, styling]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["visualiser", "styling"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0231-fix-inline-code-font-size-in-headings.md
+++ b/meta/work/0231-fix-inline-code-font-size-in-headings.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0231"
+title: "Fix Inline Code Font Size In Headings"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [visualiser, styling]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0231: Fix Inline Code Font Size In Headings
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Inline code spans rendered inside headings use the wrong font size, so
+monospaced fragments in a heading look out of proportion with the
+surrounding heading text.
+
+## Context
+
+Captured in the further-ideas backlog. The visualiser renders Markdown
+headings that may contain inline `code` spans; the code font size does not
+scale to the heading level.
+
+## Requirements
+
+- Inline code within a heading should render at a size proportional to the
+  heading it sits in, not the body default.
+
+## Acceptance Criteria
+
+- [ ] Inline code in a heading of any level renders at a size that matches
+  the heading's text size.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0232-render-inline-code-in-document-detail-title.md
+++ b/meta/work/0232-render-inline-code-in-document-detail-title.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0232"
 title: "Render Inline Code In Document Detail Page Title"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [visualiser, styling]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["visualiser", "styling"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0232-render-inline-code-in-document-detail-title.md
+++ b/meta/work/0232-render-inline-code-in-document-detail-title.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0232"
+title: "Render Inline Code In Document Detail Page Title"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [visualiser, styling]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0232: Render Inline Code In Document Detail Page Title
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+The document detail page title shows inline code markup as literal
+backticks instead of rendering it as a code span.
+
+## Context
+
+Captured in the further-ideas backlog. Titles containing inline code (e.g.
+a title naming a `command`) are displayed raw on the detail page in the
+visualiser.
+
+## Requirements
+
+- The document detail page title should render inline code spans rather
+  than showing literal backtick syntax.
+
+## Acceptance Criteria
+
+- [ ] A document whose title contains inline code renders that fragment as
+  a code span on the detail page.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0233-minimum-accelerator-version-constraint.md
+++ b/meta/work/0233-minimum-accelerator-version-constraint.md
@@ -1,0 +1,62 @@
+---
+type: work-item
+id: "0233"
+title: "Minimum Accelerator Version Constraint"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [versioning, config]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0233: Minimum Accelerator Version Constraint
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Let a repository declare a minimum Accelerator version and alert the user
+when their installed plugin is older than that constraint, prompting an
+upgrade.
+
+## Context
+
+Captured in the further-ideas backlog. Repos evolve to depend on newer
+plugin behaviour; running an older plugin against them can fail silently or
+misbehave.
+
+## Requirements
+
+- A repository can declare a minimum required Accelerator version.
+- When the installed version is below the declared minimum, the user is
+  alerted and told to upgrade.
+
+## Acceptance Criteria
+
+- [ ] Given a repo declaring a minimum version above the installed version,
+  when Accelerator runs, then the user sees an upgrade alert.
+- [ ] Given a repo whose minimum version is satisfied, no alert is shown.
+
+## Open Questions
+
+- Where does the constraint live — team config, a dedicated file, or plugin
+  metadata?
+- Is the alert advisory only, or does it block skills from running?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0233-minimum-accelerator-version-constraint.md
+++ b/meta/work/0233-minimum-accelerator-version-constraint.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0233"
 title: "Minimum Accelerator Version Constraint"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [versioning, config]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["versioning", "config"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0234-resolvable-corpus-cross-references.md
+++ b/meta/work/0234-resolvable-corpus-cross-references.md
@@ -1,0 +1,62 @@
+---
+type: work-item
+id: "0234"
+title: "Resolvable Corpus Cross-References"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [corpus, documentation]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0234: Resolvable Corpus Cross-References
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Improve corpus cross-references used in code comments and documentation by
+either banning them outright or making them fully resolvable, so references
+never go stale or dangle.
+
+## Context
+
+Captured in the further-ideas backlog. Cross-references to corpus artefacts
+(ADRs, work items, plans) in comments and docs can rot as artefacts move or
+are renumbered.
+
+## Requirements
+
+- Decide a policy: ban corpus cross-references in comments/docs, or make
+  every such reference resolvable and validated.
+- If resolvable: provide a mechanism to resolve and verify references.
+
+## Acceptance Criteria
+
+- [ ] A policy is chosen and enforced consistently.
+- [ ] If references are permitted, an unresolvable reference is detected by
+  tooling.
+
+## Open Questions
+
+- Ban versus resolve — which policy do we adopt?
+- Note: existing guidance discourages stale corpus references in comments;
+  reconcile with that.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0234-resolvable-corpus-cross-references.md
+++ b/meta/work/0234-resolvable-corpus-cross-references.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0234"
 title: "Resolvable Corpus Cross-References"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [corpus, documentation]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["corpus", "documentation"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0235-reviewer-profiles.md
+++ b/meta/work/0235-reviewer-profiles.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0235"
 title: "Reviewer Profiles"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [review, config]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["review", "config"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0235-reviewer-profiles.md
+++ b/meta/work/0235-reviewer-profiles.md
@@ -1,0 +1,61 @@
+---
+type: work-item
+id: "0235"
+title: "Reviewer Profiles"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [review, config]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0235: Reviewer Profiles
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Allow reviewer profiles so reviews can be triggered with different lens and
+configuration presets, letting a user pick a review flavour rather than
+always running the full default lens set.
+
+## Context
+
+Captured in the further-ideas backlog. Review skills run a fixed lens
+catalogue; different situations warrant different lens selections and
+settings.
+
+## Requirements
+
+- Define named reviewer profiles bundling a lens selection and config
+  presets.
+- Let a review be triggered against a chosen profile.
+
+## Acceptance Criteria
+
+- [ ] A user can define a reviewer profile naming its lenses and config.
+- [ ] Triggering a review with a profile applies exactly that profile's
+  lenses and settings.
+
+## Open Questions
+
+- Where are profiles stored — team config, personal config, or both?
+- Do profiles apply to all review skills or a subset?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0236-vcs-specific-respond-to-pr-commit-options.md
+++ b/meta/work/0236-vcs-specific-respond-to-pr-commit-options.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0236"
 title: "VCS-Specific Respond-to-PR Commit Options"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [pr, vcs]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["pr", "vcs"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0236-vcs-specific-respond-to-pr-commit-options.md
+++ b/meta/work/0236-vcs-specific-respond-to-pr-commit-options.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0236"
+title: "VCS-Specific Respond-to-PR Commit Options"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [pr, vcs]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0236: VCS-Specific Respond-to-PR Commit Options
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Make the commit options offered by `/respond-to-pr` specific to the active
+VCS, so the choices presented match what git or jj actually supports.
+
+## Context
+
+Captured in the further-ideas backlog. `/respond-to-pr` currently offers
+commit options that do not map cleanly onto every VCS (e.g. staging
+concepts absent under jj).
+
+## Requirements
+
+- The commit options presented by `/respond-to-pr` adapt to the detected
+  VCS.
+
+## Acceptance Criteria
+
+- [ ] Under git, `/respond-to-pr` offers git-appropriate commit options.
+- [ ] Under jj, it offers jj-appropriate commit options with no
+  git-only concepts.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0237-mark-migrated-to-latest-on-first-init.md
+++ b/meta/work/0237-mark-migrated-to-latest-on-first-init.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0237"
 title: "Mark Migrated To Latest On First Init"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [migration, init]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["migration", "init"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0237-mark-migrated-to-latest-on-first-init.md
+++ b/meta/work/0237-mark-migrated-to-latest-on-first-init.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0237"
+title: "Mark Migrated To Latest On First Init"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [migration, init]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0237: Mark Migrated To Latest On First Init
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+When a repo is first initialised, record it as already migrated to the
+latest migration, so a fresh repo does not appear to have pending
+migrations.
+
+## Context
+
+Captured in the further-ideas backlog. A newly initialised repo starts at
+the current schema; without stamping the latest migration, migration
+tooling may report or attempt to apply migrations that do not apply.
+
+## Requirements
+
+- First init stamps the repo at the latest available migration.
+
+## Acceptance Criteria
+
+- [ ] Given a freshly initialised repo, `accelerator migrate` reports no
+  pending migrations.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0238-single-authority-for-lifecycle-states.md
+++ b/meta/work/0238-single-authority-for-lifecycle-states.md
@@ -1,0 +1,58 @@
+---
+type: work-item
+id: "0238"
+title: "Single Authority For Lifecycle States"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [config, templates, lifecycle]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0238: Single Authority For Lifecycle States
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Make either configuration or templates the single authority for the valid
+lifecycle states of meta artefacts, so status values are defined in one
+place rather than duplicated.
+
+## Context
+
+Captured in the further-ideas backlog. Valid statuses for meta artefacts
+are implied by both templates and configuration; the two can drift.
+
+## Requirements
+
+- Choose one authoritative source (config or templates) for valid lifecycle
+  states.
+- Have all state validation read from that single source.
+
+## Acceptance Criteria
+
+- [ ] Valid lifecycle states are declared in exactly one place.
+- [ ] Producers and validators read valid states from that source.
+
+## Open Questions
+
+- Which is authoritative — configuration or templates?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0238-single-authority-for-lifecycle-states.md
+++ b/meta/work/0238-single-authority-for-lifecycle-states.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0238"
 title: "Single Authority For Lifecycle States"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [config, templates, lifecycle]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["config", "templates", "lifecycle"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0239-visualiser-dynamic-args-permission-block.md
+++ b/meta/work/0239-visualiser-dynamic-args-permission-block.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0239"
 title: "Visualiser Permission Block From Dynamic Args"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [visualiser, permissions]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["visualiser", "permissions"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0239-visualiser-dynamic-args-permission-block.md
+++ b/meta/work/0239-visualiser-dynamic-args-permission-block.md
@@ -1,0 +1,58 @@
+---
+type: work-item
+id: "0239"
+title: "Visualiser Permission Block From Dynamic Args"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [visualiser, permissions]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0239: Visualiser Permission Block From Dynamic Args
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Running the visualiser triggers a permission block because the invoked
+command includes dynamic arguments that do not match a static allow rule.
+
+## Context
+
+Captured in the further-ideas backlog. The command used to launch the
+visualiser interpolates arguments at runtime, so the harness permission
+matcher prompts or blocks instead of allowing it.
+
+## Requirements
+
+- Launching the visualiser should not hit a permission block due to dynamic
+  arguments.
+
+## Acceptance Criteria
+
+- [ ] Starting the visualiser proceeds without a permission prompt or block
+  caused by dynamic command arguments.
+
+## Open Questions
+
+- Fix by stabilising the command shape, or by adjusting the allow rule to
+  tolerate the dynamic portion?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
+++ b/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0240"
+title: "Corpus Update Frontmatter Quote Roundtrip"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [corpus, frontmatter]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0240: Corpus Update Frontmatter Quote Roundtrip
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+`accelerator corpus update` does not preserve quoting on frontmatter values
+across a roundtrip, producing output the model then rejects.
+
+## Context
+
+Captured in the further-ideas backlog. Related to the canonical frontmatter
+quoting work; the update path re-emits frontmatter without honouring the
+canonical quoting standard.
+
+## Requirements
+
+- `accelerator corpus update` must roundtrip frontmatter values with their
+  quoting intact, matching the canonical quoting standard.
+
+## Acceptance Criteria
+
+- [ ] Given a document with quoted frontmatter values, when
+  `accelerator corpus update` runs, then quoting is preserved and the result
+  passes validation.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
+++ b/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0240"
 title: "Corpus Update Frontmatter Quote Roundtrip"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [corpus, frontmatter]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["corpus", "frontmatter"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0241-migrate-false-dirty-tree-detection.md
+++ b/meta/work/0241-migrate-false-dirty-tree-detection.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0241"
 title: "Migrate False Dirty-Tree Detection"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [migration, vcs]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["migration", "vcs"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0241-migrate-false-dirty-tree-detection.md
+++ b/meta/work/0241-migrate-false-dirty-tree-detection.md
@@ -1,0 +1,56 @@
+---
+type: work-item
+id: "0241"
+title: "Migrate False Dirty-Tree Detection"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [migration, vcs]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0241: Migrate False Dirty-Tree Detection
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+`accelerator migrate` refuses to run, reporting a dirty working tree, when
+the tree is actually clean.
+
+## Context
+
+Captured in the further-ideas backlog. Migration is guarded against a dirty
+tree; the dirtiness check produces a false positive under some conditions
+(possibly VCS-specific).
+
+## Requirements
+
+- The dirty-tree guard must report clean when the working tree is clean.
+
+## Acceptance Criteria
+
+- [ ] Given a clean working tree, `accelerator migrate` proceeds without a
+  dirty-tree refusal.
+
+## Open Questions
+
+- Which VCS and state reproduces the false positive?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0242-set-model-and-effort-on-skills.md
+++ b/meta/work/0242-set-model-and-effort-on-skills.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0242"
 title: "Set Model And Effort On Skills"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [skills, config]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["skills", "config"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0242-set-model-and-effort-on-skills.md
+++ b/meta/work/0242-set-model-and-effort-on-skills.md
@@ -1,0 +1,58 @@
+---
+type: work-item
+id: "0242"
+title: "Set Model And Effort On Skills"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [skills, config]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0242: Set Model And Effort On Skills
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Allow a skill to declare the model and/or reasoning effort it should run
+with, so heavier skills can request a more capable model and lighter ones a
+cheaper one.
+
+## Context
+
+Captured in the further-ideas backlog. Skills currently run under whatever
+model the session uses; per-skill tuning would match cost to task.
+
+## Requirements
+
+- A skill can declare a preferred model and/or effort level.
+- Invocation honours the declared model/effort where the harness allows.
+
+## Acceptance Criteria
+
+- [ ] A skill declaring a model/effort runs under that model/effort.
+- [ ] A skill declaring neither behaves as today.
+
+## Open Questions
+
+- Is model/effort selection honourable from within a skill, or must it be
+  set by the harness at spawn time?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0243-browser-auth-header-support-in-design-skills.md
+++ b/meta/work/0243-browser-auth-header-support-in-design-skills.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0243"
 title: "Browser Auth Header Support In Design Skills"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [design, browser]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["design", "browser"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0243-browser-auth-header-support-in-design-skills.md
+++ b/meta/work/0243-browser-auth-header-support-in-design-skills.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0243"
+title: "Browser Auth Header Support In Design Skills"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [design, browser]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0243: Browser Auth Header Support In Design Skills
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Add full support for `ACCELERATOR_BROWSER_AUTH_HEADER` in the design
+skills, so browser-driven design capture can reach pages behind an
+auth-header gate.
+
+## Context
+
+Captured in the further-ideas backlog. The env var exists but is not fully
+honoured across the design skills' browser automation.
+
+## Requirements
+
+- All design skills that drive a browser pass
+  `ACCELERATOR_BROWSER_AUTH_HEADER` through to the browser session.
+
+## Acceptance Criteria
+
+- [ ] Given `ACCELERATOR_BROWSER_AUTH_HEADER` is set, design skills capture
+  pages that require that header.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0244-normalise-datetimes-in-filenames.md
+++ b/meta/work/0244-normalise-datetimes-in-filenames.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0244"
 title: "Normalise Datetimes In Filenames"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [corpus, consistency]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["corpus", "consistency"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0244-normalise-datetimes-in-filenames.md
+++ b/meta/work/0244-normalise-datetimes-in-filenames.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0244"
+title: "Normalise Datetimes In Filenames"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [corpus, consistency]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0244: Normalise Datetimes In Filenames
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Normalise the datetime formats used in generated filenames (and similar
+places) to a single consistent convention.
+
+## Context
+
+Captured in the further-ideas backlog. Different producers embed datetimes
+into filenames in varying formats.
+
+## Requirements
+
+- Adopt one canonical datetime format for filenames and apply it across all
+  producers.
+
+## Acceptance Criteria
+
+- [ ] All producers that embed a datetime in a filename use the same
+  canonical format.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0245-invoke-accelerator-directly-in-skills.md
+++ b/meta/work/0245-invoke-accelerator-directly-in-skills.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0245"
 title: "Invoke Accelerator Directly In Skills"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [skills, cli]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["skills", "cli"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0245-invoke-accelerator-directly-in-skills.md
+++ b/meta/work/0245-invoke-accelerator-directly-in-skills.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0245"
+title: "Invoke Accelerator Directly In Skills"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [skills, cli]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0245: Invoke Accelerator Directly In Skills
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Have all skills invoke the `accelerator` binary directly rather than through
+any intermediate wrapper, for a uniform and permission-friendly call
+convention.
+
+## Context
+
+Captured in the further-ideas backlog. Skills vary in how they reach the
+CLI; direct invocation is the preferred convention.
+
+## Requirements
+
+- Every skill that shells out to Accelerator invokes the binary directly.
+
+## Acceptance Criteria
+
+- [ ] No skill invokes Accelerator via a wrapper; all call the binary
+  directly.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0246-daemon-process-management-library.md
+++ b/meta/work/0246-daemon-process-management-library.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0246"
 title: "Daemon Process Management Library"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [visualiser, infrastructure]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["visualiser", "infrastructure"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0246-daemon-process-management-library.md
+++ b/meta/work/0246-daemon-process-management-library.md
@@ -1,0 +1,55 @@
+---
+type: work-item
+id: "0246"
+title: "Daemon Process Management Library"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [visualiser, infrastructure]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0246: Daemon Process Management Library
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Evaluate and adopt a library for daemon process management rather than
+hand-rolled process supervision.
+
+## Context
+
+Captured in the further-ideas backlog. The dev/visualiser stack manages
+long-running processes with bespoke logic; a dedicated library could
+replace it.
+
+## Requirements
+
+- Survey candidate libraries for daemon/process supervision.
+- Adopt one to replace the hand-rolled process management if it fits.
+
+## Acceptance Criteria
+
+- [ ] A recommendation (adopt a named library, or keep bespoke with
+  rationale) is produced.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Source phrasing ("consider using a library") suggests an investigative
+  task; may split into a spike plus follow-up.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0247-retire-server-pid-in-design-commands.md
+++ b/meta/work/0247-retire-server-pid-in-design-commands.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0247"
+title: "Retire server.pid In Design Commands"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [design, cleanup]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0247: Retire server.pid In Design Commands
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Remove the `server.pid` file mechanism from the design commands in favour
+of the current process-management approach.
+
+## Context
+
+Captured in the further-ideas backlog. The design commands still track a
+running server via a `server.pid` file.
+
+## Requirements
+
+- Remove reliance on `server.pid` in the design commands.
+
+## Acceptance Criteria
+
+- [ ] The design commands manage the server lifecycle without a
+  `server.pid` file.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Likely relates to daemon process-management work.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0247-retire-server-pid-in-design-commands.md
+++ b/meta/work/0247-retire-server-pid-in-design-commands.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0247"
 title: "Retire server.pid In Design Commands"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [design, cleanup]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["design", "cleanup"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0248-design-automation-integration-tests-in-ci.md
+++ b/meta/work/0248-design-automation-integration-tests-in-ci.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0248"
+title: "Design-Automation Integration Tests In CI"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [design, ci, testing]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0248: Design-Automation Integration Tests In CI
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Get the design-automation integration tests running in CI so the design
+skills' browser automation is covered on every build.
+
+## Context
+
+Captured in the further-ideas backlog. These tests exist but are not run by
+any CI job, leaving a coverage gap.
+
+## Requirements
+
+- Wire the design-automation integration tests into a CI lane.
+
+## Acceptance Criteria
+
+- [ ] The design-automation integration tests run in CI and gate the build.
+
+## Open Questions
+
+- Does CI have the browser/Chromium prerequisites these tests need?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0248-design-automation-integration-tests-in-ci.md
+++ b/meta/work/0248-design-automation-integration-tests-in-ci.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0248"
 title: "Design-Automation Integration Tests In CI"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [design, ci, testing]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["design", "ci", "testing"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0249-richer-document-model-crate.md
+++ b/meta/work/0249-richer-document-model-crate.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0249"
+title: "Richer Document Model Crate"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [corpus, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0249: Richer Document Model Crate
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Build a richer document model and consolidate all document handling onto a
+single crate, so document parsing, frontmatter, and rendering share one
+domain model.
+
+## Context
+
+Captured in the further-ideas backlog. Document handling is spread across
+call sites; a consolidated model would reduce duplication and drift.
+
+## Requirements
+
+- Define a richer document domain model.
+- Route all document handling through the consolidating crate.
+
+## Acceptance Criteria
+
+- [ ] Document handling is served by one crate with a shared model.
+- [ ] Duplicated ad-hoc document parsing is removed.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Large scope; may be an epic once refined.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0249-richer-document-model-crate.md
+++ b/meta/work/0249-richer-document-model-crate.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0249"
 title: "Richer Document Model Crate"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [corpus, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["corpus", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0250-push-config-lookups-into-config-crates.md
+++ b/meta/work/0250-push-config-lookups-into-config-crates.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0250"
+title: "Push Config Lookups Into Config Crates"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [config, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0250: Push Config Lookups Into Config Crates
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move all configuration lookups down into the config crates, so callers ask
+the config layer rather than reading or interpreting config themselves.
+
+## Context
+
+Captured in the further-ideas backlog. Config lookups are scattered across
+CLIs and skills instead of centralised.
+
+## Requirements
+
+- All config lookups go through the config crates' public API.
+
+## Acceptance Criteria
+
+- [ ] No caller reads or parses configuration directly; all use the config
+  crates.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0250-push-config-lookups-into-config-crates.md
+++ b/meta/work/0250-push-config-lookups-into-config-crates.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0250"
 title: "Push Config Lookups Into Config Crates"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [config, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["config", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0251-env-var-overrides-in-config-crates.md
+++ b/meta/work/0251-env-var-overrides-in-config-crates.md
@@ -1,0 +1,58 @@
+---
+type: work-item
+id: "0251"
+title: "Env Var Overrides In Config Crates"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [config, crates]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0251: Env Var Overrides In Config Crates
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Add support for environment-variable overrides in the config crates, so
+configuration values can be overridden from the environment.
+
+## Context
+
+Captured in the further-ideas backlog. Several dev overrides already flow
+through env vars ad hoc; the config crates should model env overrides as a
+first-class precedence layer.
+
+## Requirements
+
+- The config crates resolve an env-var override ahead of file config where
+  present.
+
+## Acceptance Criteria
+
+- [ ] Given an env var is set for a config key, the config crates return the
+  env value in preference to the file value.
+
+## Open Questions
+
+- What is the precedence order across personal config, team config, and env
+  overrides?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0251-env-var-overrides-in-config-crates.md
+++ b/meta/work/0251-env-var-overrides-in-config-crates.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0251"
 title: "Env Var Overrides In Config Crates"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [config, crates]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["config", "crates"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0252-federate-config-into-domain-crates.md
+++ b/meta/work/0252-federate-config-into-domain-crates.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0252"
 title: "Federate Config Into Domain Crates"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [config, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["config", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0252-federate-config-into-domain-crates.md
+++ b/meta/work/0252-federate-config-into-domain-crates.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0252"
+title: "Federate Config Into Domain Crates"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [config, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0252: Federate Config Into Domain Crates
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Federate configuration definitions into the specific domain crates they
+belong to, so each domain owns its own config schema rather than a single
+central definition.
+
+## Context
+
+Captured in the further-ideas backlog. Config keys for many domains are
+defined centrally; ownership should sit with each domain.
+
+## Requirements
+
+- Each domain crate declares the config it owns.
+- The central config layer composes federated definitions.
+
+## Acceptance Criteria
+
+- [ ] A domain's config keys are declared within that domain's crate.
+- [ ] The config surface still resolves all keys through one entry point.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0253-survey-clis-for-domain-crate-logic.md
+++ b/meta/work/0253-survey-clis-for-domain-crate-logic.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0253"
+title: "Survey CLIs For Domain-Crate Logic"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [cli, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0253: Survey CLIs For Domain-Crate Logic
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Survey all CLIs to identify logic currently living in the command layer that
+should be pushed down into the domain crates.
+
+## Context
+
+Captured in the further-ideas backlog. CLIs accreted domain logic that
+belongs in reusable crates; a survey scopes the extraction.
+
+## Requirements
+
+- Review each CLI for domain logic embedded in command handlers.
+- Produce a list of extraction candidates.
+
+## Acceptance Criteria
+
+- [ ] A catalogue of CLI-resident logic that should move into domain crates
+  is produced.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Investigative; likely a spike feeding follow-up extraction tasks.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0253-survey-clis-for-domain-crate-logic.md
+++ b/meta/work/0253-survey-clis-for-domain-crate-logic.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0253"
 title: "Survey CLIs For Domain-Crate Logic"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [cli, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["cli", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0254-add-cli-logging.md
+++ b/meta/work/0254-add-cli-logging.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0254"
 title: "Add CLI Logging"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [cli, observability]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["cli", "observability"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0254-add-cli-logging.md
+++ b/meta/work/0254-add-cli-logging.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0254"
+title: "Add CLI Logging"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [cli, observability]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0254: Add CLI Logging
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Add structured logging to the CLI so its behaviour can be traced and
+diagnosed.
+
+## Context
+
+Captured in the further-ideas backlog. The CLI has limited diagnostic
+output today, making failures hard to investigate.
+
+## Requirements
+
+- Introduce a logging mechanism across the CLI with a controllable level.
+
+## Acceptance Criteria
+
+- [ ] CLI operations emit logs at an appropriate level.
+- [ ] Log verbosity is controllable (e.g. via a flag or env var).
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0255-merge-conflicting-chunks-in-work-item-sync.md
+++ b/meta/work/0255-merge-conflicting-chunks-in-work-item-sync.md
@@ -1,0 +1,55 @@
+---
+type: work-item
+id: "0255"
+title: "Merge Conflicting Chunks In Work-Item Sync"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [work, sync]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0255: Merge Conflicting Chunks In Work-Item Sync
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Allow the work-item sync skill to merge conflicting chunks between local and
+remote state, rather than forcing a whole-item choose-one resolution.
+
+## Context
+
+Captured in the further-ideas backlog. `/sync-work-items` currently resolves
+divergence coarsely; chunk-level merging would preserve non-conflicting
+edits from both sides.
+
+## Requirements
+
+- The sync skill can merge non-conflicting chunks automatically and surface
+  only the truly conflicting ones.
+
+## Acceptance Criteria
+
+- [ ] Given local and remote both changed different chunks of one work item,
+  sync merges both without a full-item conflict.
+- [ ] Genuinely conflicting chunks are surfaced for resolution.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Relates to the existing conflict-flow dossier design.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0255-merge-conflicting-chunks-in-work-item-sync.md
+++ b/meta/work/0255-merge-conflicting-chunks-in-work-item-sync.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0255"
 title: "Merge Conflicting Chunks In Work-Item Sync"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [work, sync]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["work", "sync"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0256-push-work-list-logic-into-core-crate.md
+++ b/meta/work/0256-push-work-list-logic-into-core-crate.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0256"
 title: "Push Work-List Logic Into Core Crate"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [work, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["work", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0256-push-work-list-logic-into-core-crate.md
+++ b/meta/work/0256-push-work-list-logic-into-core-crate.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0256"
+title: "Push Work-List Logic Into Core Crate"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [work, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0256: Push Work-List Logic Into Core Crate
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move the work-list logic (filtering, sorting, hierarchy) down into a core
+crate so it is reusable and tested independently of the command layer.
+
+## Context
+
+Captured in the further-ideas backlog. Work-list logic sits in the command
+surface rather than a shared crate.
+
+## Requirements
+
+- Extract work-list logic into a core crate with its own tests.
+
+## Acceptance Criteria
+
+- [ ] Work-list filtering and hierarchy logic lives in a core crate.
+- [ ] The list command delegates to that crate.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0257-sync-single-work-item.md
+++ b/meta/work/0257-sync-single-work-item.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0257"
 title: "Sync A Single Work Item"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [work, sync]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["work", "sync"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0257-sync-single-work-item.md
+++ b/meta/work/0257-sync-single-work-item.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0257"
+title: "Sync A Single Work Item"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [work, sync]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0257: Sync A Single Work Item
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Allow `/sync-work-items` to operate on a single named work item, rather than
+always reconciling the whole set.
+
+## Context
+
+Captured in the further-ideas backlog. A full sync is heavyweight when the
+user only wants to push or pull one item.
+
+## Requirements
+
+- The sync skill accepts a single work item as its target.
+
+## Acceptance Criteria
+
+- [ ] Given a single work item target, sync reconciles only that item.
+- [ ] The whole-set behaviour remains available when no target is given.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0258-help-show-subcommands.md
+++ b/meta/work/0258-help-show-subcommands.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0258"
 title: "Help Should Show Subcommands"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [cli, help]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["cli", "help"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0258-help-show-subcommands.md
+++ b/meta/work/0258-help-show-subcommands.md
@@ -1,0 +1,50 @@
+---
+type: work-item
+id: "0258"
+title: "Help Should Show Subcommands"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [cli, help]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0258: Help Should Show Subcommands
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+`accelerator help` does not list available subcommands, leaving users
+without a discoverable command index.
+
+## Context
+
+Captured in the further-ideas backlog. Help output omits the subcommand
+list.
+
+## Requirements
+
+- `accelerator help` lists the available subcommands.
+
+## Acceptance Criteria
+
+- [ ] Running `accelerator help` shows all top-level subcommands.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0259-unify-help-style.md
+++ b/meta/work/0259-unify-help-style.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0259"
 title: "Unify Help Style"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: bug
-priority: medium
-tags: [cli, help]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "bug"
+priority: "medium"
+tags: ["cli", "help"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0259-unify-help-style.md
+++ b/meta/work/0259-unify-help-style.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0259"
+title: "Unify Help Style"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: bug
+priority: medium
+tags: [cli, help]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0259: Unify Help Style
+
+**Kind**: Bug
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Unify the help output style across the CLI so every command's help follows
+one consistent format.
+
+## Context
+
+Captured in the further-ideas backlog. Help text varies in layout and
+wording between commands.
+
+## Requirements
+
+- All CLI commands render help in a single consistent style.
+
+## Acceptance Criteria
+
+- [ ] Help output for every command follows the same format and conventions.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Kind is arguably a task; kept as bug per source tag.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0260-move-adr-to-own-subcommand.md
+++ b/meta/work/0260-move-adr-to-own-subcommand.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0260"
+title: "Move ADR Into Its Own Subcommand"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [cli, adr, corpus]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0260: Move ADR Into Its Own Subcommand
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move `adr` out of the `corpus` subcommand into its own top-level subcommand,
+mirroring how `work` is structured.
+
+## Context
+
+Captured in the further-ideas backlog. ADR operations currently nest under
+`corpus`; promoting them to a peer of `work` gives a cleaner command tree.
+
+## Requirements
+
+- ADR operations are reachable via a top-level `adr` subcommand.
+
+## Acceptance Criteria
+
+- [ ] `accelerator adr ...` exposes the ADR operations previously under
+  `corpus`.
+- [ ] Skills and docs referencing the old path are updated.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0260-move-adr-to-own-subcommand.md
+++ b/meta/work/0260-move-adr-to-own-subcommand.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0260"
 title: "Move ADR Into Its Own Subcommand"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [cli, adr, corpus]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["cli", "adr", "corpus"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0261-remove-todowrite-references.md
+++ b/meta/work/0261-remove-todowrite-references.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0261"
 title: "Remove TodoWrite References"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [skills, cleanup]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["skills", "cleanup"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0261-remove-todowrite-references.md
+++ b/meta/work/0261-remove-todowrite-references.md
@@ -1,0 +1,50 @@
+---
+type: work-item
+id: "0261"
+title: "Remove TodoWrite References"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [skills, cleanup]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0261: Remove TodoWrite References
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Remove references to `TodoWrite` (and similar) from skills and agents now
+that the tool has been disabled.
+
+## Context
+
+Captured in the further-ideas backlog. Skill and agent instructions still
+mention `TodoWrite`, which no longer exists in the harness.
+
+## Requirements
+
+- Remove `TodoWrite` references from all skills, agents, and docs.
+
+## Acceptance Criteria
+
+- [ ] No skill, agent, or doc references `TodoWrite`.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0262-render-design-inventory-screenshots.md
+++ b/meta/work/0262-render-design-inventory-screenshots.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0262"
 title: "Render Design-Inventory Screenshots"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: story
-priority: medium
-tags: [visualiser, design]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "story"
+priority: "medium"
+tags: ["visualiser", "design"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0262-render-design-inventory-screenshots.md
+++ b/meta/work/0262-render-design-inventory-screenshots.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0262"
+title: "Render Design-Inventory Screenshots"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: story
+priority: medium
+tags: [visualiser, design]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0262: Render Design-Inventory Screenshots
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Render the screenshots captured in design inventories within the
+visualiser, so a design inventory can be reviewed visually rather than as
+metadata alone.
+
+## Context
+
+Captured in the further-ideas backlog. Design inventories reference
+screenshots that the visualiser does not currently display.
+
+## Requirements
+
+- The visualiser displays screenshots associated with a design inventory.
+
+## Acceptance Criteria
+
+- [ ] A design inventory with screenshots renders those images in the
+  visualiser.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0263-rename-foreigndirt.md
+++ b/meta/work/0263-rename-foreigndirt.md
@@ -1,0 +1,54 @@
+---
+type: work-item
+id: "0263"
+title: "Rename ForeignDirt"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [naming, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0263: Rename ForeignDirt
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Rename the `ForeignDirt` type to a name without negative connotations,
+better expressing its domain role.
+
+## Context
+
+Captured in the further-ideas backlog. The current name carries an
+unhelpful negative framing.
+
+## Requirements
+
+- Choose a domain-appropriate replacement name and rename all usages.
+
+## Acceptance Criteria
+
+- [ ] `ForeignDirt` is renamed and no references to the old name remain.
+
+## Open Questions
+
+- What is the intended replacement name?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0263-rename-foreigndirt.md
+++ b/meta/work/0263-rename-foreigndirt.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0263"
 title: "Rename ForeignDirt"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [naming, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["naming", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
+++ b/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0264"
+title: "Remove Bash-Migration Negative-Assertion Tests"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [testing, cleanup]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0264: Remove Bash-Migration Negative-Assertion Tests
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Remove the negative-assertion tests left over from the Bash-to-Rust
+migration, which assert the absence of behaviour that is no longer relevant.
+
+## Context
+
+Captured in the further-ideas backlog. These tests were scaffolding during
+the migration and now add noise without value.
+
+## Requirements
+
+- Identify and remove negative-assertion tests that only existed to guard
+  the Bash-to-Rust transition.
+
+## Acceptance Criteria
+
+- [ ] Migration-era negative-assertion tests are removed.
+- [ ] The remaining suite still passes.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
+++ b/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0264"
 title: "Remove Bash-Migration Negative-Assertion Tests"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [testing, cleanup]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["testing", "cleanup"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
+++ b/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0265"
 title: "Collapse Discoverability-Hook And Format-Hook Switches"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [cli, hooks]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["cli", "hooks"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
+++ b/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
@@ -1,0 +1,56 @@
+---
+type: work-item
+id: "0265"
+title: "Collapse Discoverability-Hook And Format-Hook Switches"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [cli, hooks]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0265: Collapse Discoverability-Hook And Format-Hook Switches
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Collapse the `--discoverability-hook` and `--format=hook` switches into a
+single switch, removing the redundant way of requesting hook output.
+
+## Context
+
+Captured in the further-ideas backlog. Two flags currently express the same
+hook-output intent.
+
+## Requirements
+
+- Provide one switch for hook-formatted output and retire the redundant one.
+
+## Acceptance Criteria
+
+- [ ] A single switch controls hook output.
+- [ ] The removed switch is gone (or aliased with a deprecation, if
+  required).
+
+## Open Questions
+
+- Which switch name survives, and is a deprecation alias needed?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0266-remove-thiserror.md
+++ b/meta/work/0266-remove-thiserror.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0266"
 title: "Remove thiserror From The Codebase"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [cli, dependencies, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["cli", "dependencies", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0266-remove-thiserror.md
+++ b/meta/work/0266-remove-thiserror.md
@@ -1,0 +1,57 @@
+---
+type: work-item
+id: "0266"
+title: "Remove thiserror From The Codebase"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [cli, dependencies, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0266: Remove thiserror From The Codebase
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Remove the `thiserror` dependency from the codebase, replacing its derived
+error types with hand-written error definitions.
+
+## Context
+
+Captured in the further-ideas backlog. The intent is to drop the
+`thiserror` crate.
+
+## Requirements
+
+- Replace all `thiserror`-derived error types.
+- Remove `thiserror` from the dependency graph.
+
+## Acceptance Criteria
+
+- [ ] No crate depends on `thiserror`.
+- [ ] Error types are defined without it and the build passes.
+
+## Open Questions
+
+- What is the driver for removal — dependency reduction, control over error
+  shapes, or a policy?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
+++ b/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0267"
 title: "Move VCS Kind Detection Into The VCS Crates"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [vcs, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["vcs", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
+++ b/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
@@ -1,0 +1,51 @@
+---
+type: work-item
+id: "0267"
+title: "Move VCS Kind Detection Into The VCS Crates"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [vcs, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0267: Move VCS Kind Detection Into The VCS Crates
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move all VCS kind detection (git versus jj, and workspace classification)
+into the `vcs*` crates, so detection lives in one domain-owned place.
+
+## Context
+
+Captured in the further-ideas backlog. VCS kind detection is performed in
+more than one location; the `vcs*` crates should own it.
+
+## Requirements
+
+- All VCS kind detection is served by the `vcs*` crates.
+
+## Acceptance Criteria
+
+- [ ] No detection logic for VCS kind exists outside the `vcs*` crates.
+- [ ] Callers obtain the VCS kind via those crates.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0268-rename-remote-projection-crate.md
+++ b/meta/work/0268-rename-remote-projection-crate.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0268"
 title: "Rename The remote-projection Crate"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [naming, crates, work]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["naming", "crates", "work"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0268-rename-remote-projection-crate.md
+++ b/meta/work/0268-rename-remote-projection-crate.md
@@ -1,0 +1,55 @@
+---
+type: work-item
+id: "0268"
+title: "Rename The remote-projection Crate"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [naming, crates, work]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0268: Rename The remote-projection Crate
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Rename the `remote-projection` crate to a name more clearly focused on
+trackers or work items, better reflecting its domain role.
+
+## Context
+
+Captured in the further-ideas backlog. The current name does not convey the
+crate's purpose in tracker/work synchronisation.
+
+## Requirements
+
+- Choose a tracker- or work-focused name and rename the crate and its
+  references.
+
+## Acceptance Criteria
+
+- [ ] The crate is renamed and no references to `remote-projection` remain.
+
+## Open Questions
+
+- What is the intended replacement name?
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
+++ b/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
@@ -1,0 +1,53 @@
+---
+type: work-item
+id: "0269"
+title: "Remove Bash References From Jira And Linear Clients"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [jira, linear, cleanup]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0269: Remove Bash References From Jira And Linear Clients
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Remove all references to Bash and shell exit codes from the Jira and Linear
+client crates, left over from the shell-to-Rust migration.
+
+## Context
+
+Captured in the further-ideas backlog. The client crates still carry Bash-
+and exit-code-oriented vocabulary that no longer fits the Rust
+implementation.
+
+## Requirements
+
+- Remove Bash and exit-code references from the Jira and Linear client
+  crates, replacing them with idiomatic Rust error handling.
+
+## Acceptance Criteria
+
+- [ ] The Jira and Linear client crates contain no Bash or exit-code
+  references.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
+++ b/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0269"
 title: "Remove Bash References From Jira And Linear Clients"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [jira, linear, cleanup]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["jira", "linear", "cleanup"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0270-move-filesystem-into-shared-crate.md
+++ b/meta/work/0270-move-filesystem-into-shared-crate.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0270"
+title: "Move Filesystem Into A Shared Crate"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [crates, testing, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0270: Move Filesystem Into A Shared Crate
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move the `Filesystem` abstraction into a shared crate and use it everywhere
+filesystem access is required, along with a fake implementation for tests.
+
+## Context
+
+Captured in the further-ideas backlog. Filesystem access is done directly in
+places; a shared abstraction with a fake enables deterministic testing.
+
+## Requirements
+
+- A shared crate exposes the `Filesystem` abstraction and a fake.
+- All filesystem access goes through it.
+
+## Acceptance Criteria
+
+- [ ] Filesystem access across the workspace uses the shared abstraction.
+- [ ] A fake implementation is available for tests.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0270-move-filesystem-into-shared-crate.md
+++ b/meta/work/0270-move-filesystem-into-shared-crate.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0270"
 title: "Move Filesystem Into A Shared Crate"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [crates, testing, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["crates", "testing", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
+++ b/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
@@ -1,0 +1,55 @@
+---
+type: work-item
+id: "0271"
+title: "Unify Surface, RemoteTracker And Client Interfaces"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [work, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0271: Unify Surface, RemoteTracker And Client Interfaces
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Rationalise the `Surface`, `RemoteTracker`, and client-specific interfaces
+into a single unified interface for remote tracker interaction.
+
+## Context
+
+Captured in the further-ideas backlog. Three overlapping abstractions
+describe tracker interaction; consolidating reduces indirection and
+divergence.
+
+## Requirements
+
+- Design one unified interface subsuming `Surface`, `RemoteTracker`, and the
+  client-specific interfaces.
+- Migrate providers (Jira, Linear) onto it.
+
+## Acceptance Criteria
+
+- [ ] Tracker interaction is expressed through a single unified interface.
+- [ ] Provider implementations conform to it.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- Sizeable; may become an epic.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
+++ b/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0271"
 title: "Unify Surface, RemoteTracker And Client Interfaces"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [work, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["work", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0272-move-insecure-local-ok-under-accelerator.md
+++ b/meta/work/0272-move-insecure-local-ok-under-accelerator.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0272"
+title: "Move insecure-local-ok Marker Under .accelerator"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [config, cleanup]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0272: Move insecure-local-ok Marker Under .accelerator
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Move the `insecure-local-ok` marker file under the `.accelerator` directory,
+consolidating Accelerator-owned files in one place.
+
+## Context
+
+Captured in the further-ideas backlog. The marker currently sits outside
+`.accelerator`, unlike other plugin-owned files.
+
+## Requirements
+
+- Relocate the `insecure-local-ok` marker under `.accelerator`.
+- Update the code that reads/writes it, with migration for existing repos.
+
+## Acceptance Criteria
+
+- [ ] The marker is read from and written to `.accelerator`.
+- [ ] Existing repos are migrated so the marker keeps working.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0272-move-insecure-local-ok-under-accelerator.md
+++ b/meta/work/0272-move-insecure-local-ok-under-accelerator.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0272"
 title: "Move insecure-local-ok Marker Under .accelerator"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [config, cleanup]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["config", "cleanup"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
+++ b/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0273"
+title: "Domain Crate For Linear And Jira Subcommands"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [jira, linear, crates, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0273: Domain Crate For Linear And Jira Subcommands
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Introduce a domain crate for the `linear` and `jira` subcommands, moving
+their logic out of the command layer into a reusable, testable crate.
+
+## Context
+
+Captured in the further-ideas backlog. The tracker subcommands hold domain
+logic in the command surface rather than a dedicated crate.
+
+## Requirements
+
+- Extract `linear`/`jira` subcommand logic into a domain crate.
+- Have the subcommands delegate to it.
+
+## Acceptance Criteria
+
+- [ ] The `linear` and `jira` subcommands delegate to a domain crate.
+- [ ] The domain crate is independently tested.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
+++ b/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0273"
 title: "Domain Crate For Linear And Jira Subcommands"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [jira, linear, crates, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["jira", "linear", "crates", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 

--- a/meta/work/0274-isolate-gh-calls-into-shared-python-module.md
+++ b/meta/work/0274-isolate-gh-calls-into-shared-python-module.md
@@ -1,0 +1,52 @@
+---
+type: work-item
+id: "0274"
+title: "Isolate gh Calls Into A Shared Python Module"
+date: "2026-08-31T12:11:13+00:00"
+author: Toby Clemson
+producer: extract-work-items
+status: draft
+kind: task
+priority: medium
+tags: [build-system, github, refactor]
+last_updated: "2026-08-31T12:11:13+00:00"
+last_updated_by: Toby Clemson
+schema_version: 1
+---
+
+# 0274: Isolate gh Calls Into A Shared Python Module
+
+**Kind**: Task
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Isolate all calls to the `gh` CLI into a shared Python module, so GitHub
+interaction has one wrapper rather than scattered invocations.
+
+## Context
+
+Captured in the further-ideas backlog. `gh` is invoked from multiple places;
+a single module would centralise argument handling and error handling.
+
+## Requirements
+
+- Provide a shared Python module wrapping `gh`.
+- Route all `gh` invocations through it.
+
+## Acceptance Criteria
+
+- [ ] No code invokes `gh` directly; all use the shared module.
+
+## Drafting Notes
+
+- Extracted from source documents without interactive enrichment.
+  Acceptance criteria, dependencies, and kind may need refinement before
+  promoting from `draft` to `ready`.
+- "Python module" implies the build-system/`tasks/` layer as the home.
+
+## References
+
+- Source: `meta/notes/2026-06-23-further-ideas-backlog.md`

--- a/meta/work/0274-isolate-gh-calls-into-shared-python-module.md
+++ b/meta/work/0274-isolate-gh-calls-into-shared-python-module.md
@@ -1,16 +1,16 @@
 ---
-type: work-item
+type: "work-item"
 id: "0274"
 title: "Isolate gh Calls Into A Shared Python Module"
 date: "2026-08-31T12:11:13+00:00"
-author: Toby Clemson
-producer: extract-work-items
-status: draft
-kind: task
-priority: medium
-tags: [build-system, github, refactor]
+author: "Toby Clemson"
+producer: "extract-work-items"
+status: "draft"
+kind: "task"
+priority: "medium"
+tags: ["build-system", "github", "refactor"]
 last_updated: "2026-08-31T12:11:13+00:00"
-last_updated_by: Toby Clemson
+last_updated_by: "Toby Clemson"
 schema_version: 1
 ---
 


### PR DESCRIPTION

# Extract further-ideas backlog into work items 0231-0274

## Summary

Captures a running backlog of 44 feature, bug, and infrastructure ideas as a short-form note, then extracts each one into a structured work item so they enter the normal refinement and planning pipeline.

## Changes

- Adds `meta/notes/2026-06-23-further-ideas-backlog.md`, a running backlog of 44 ideas each tagged with an intended kind (`[Bug]`, `[Story]`, `[Task]`).
- Adds 44 work items, `0231`–`0274`, one per backlog line — each a source-faithful thin draft with Summary, Context, Requirements, seed acceptance criteria, and (where the source leaves a decision open) Open Questions.
- Marks every extracted item `status: draft`, `priority: medium`, and carries the verbatim non-enrichment Drafting Note so `/refine-work-item` and reviewers can identify them as needing individual expansion before promotion to `ready`.

## Context

Extracted from `meta/notes/2026-06-23-further-ideas-backlog.md` via `/extract-work-items`. No owning work item — these files are themselves the extracted backlog. Items span the visualiser, the CLI and its config/domain crates, the design skills, work-item sync, help output, and build-system cleanup.

## Testing

- [x] Slug-collision check against the existing 230 work items before allocation — no collisions.
- [x] IDs `0231`–`0274` allocated in one `accelerator work next-number --count 44` call, preserving presentation order.
- [ ] Frontmatter schema validation runs in CI's docs lane (not run locally in this session).

## Notes for Reviewers

- These are deliberately thin drafts, not fully-formed specs — intent captured, detail deferred to per-item refinement. Acceptance criteria and kinds may shift during refinement; several kinds are inherited from the source tag and flagged in Drafting Notes where the fit is loose (e.g. `0259` tagged bug but reads as a task).
- Open Questions carry real unmade decisions worth resolving during refinement: replacement names for `0263` (`ForeignDirt`) and `0268` (`remote-projection`), ban-vs-resolve for `0234`, config-vs-templates authority for `0238`, and precedence ordering for `0251`.
- A few tasks may grow into epics once refined — `0246`, `0249`, `0253`, `0271`.
