### PR TITLE
Reparent Rust CLI work items under 0136 and add successor epic 0276

### DIFF
--- a/meta/notes/2026-08-31-third-ideas-backlog.md
+++ b/meta/notes/2026-08-31-third-ideas-backlog.md
@@ -1,0 +1,27 @@
+---
+type: "note"
+id: "2026-08-31-third-ideas-backlog"
+title: "Third Ideas Backlog"
+date: "2026-08-31T22:58:31+00:00"
+author: "Toby Clemson"
+producer: "create-note"
+status: "captured"
+topic: "Third ideas backlog"
+tags: ["backlog", "ideas"]
+revision: "976279a0c0da91f3d7a63a1d602793193dbf462e"
+repository: "accelerator"
+last_updated: "2026-08-31T22:58:31+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Third Ideas Backlog
+
+Running backlog of feature, skill, and infrastructure ideas for the
+Accelerator plugin.
+
+* [Task] Move the Playwright scripts under the design crate under `cli/`
+* [Task] Extract constants for magic strings and numbers
+* [Task] Move playwright sources under cli/ instead of skill directory
+* [Task] Add switches to all skills
+* [Bug] Get PR descriptions to generate unwrapped by /describe-pr

--- a/meta/prs/100-description.md
+++ b/meta/prs/100-description.md
@@ -1,0 +1,76 @@
+---
+type: "pr-description"
+id: "100"
+title: "Reparent Rust CLI work items under 0136 and add successor epic 0276"
+date: "2026-09-05T22:38:10+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+relates_to: ["work-item:0136", "work-item:0276"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/100"
+pr_number: 100
+tags: ["work-items", "rust", "cli", "linear-sync"]
+revision: "e48e7ec5653f0ccc5f05741df48a8e41c13c3ca7"
+repository: "accelerator"
+last_updated: "2026-09-05T22:38:10+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Reparent Rust CLI work items under 0136 and add successor epic 0276
+
+## Summary
+
+Reorganises a parentless backlog of Rust-CLI work items into the right epics and
+records the Linear sync that followed. An audit of every work item numbered above
+0136 found 37 that belonged to the shell-to-Rust migration or the workspace it
+produced, none of them linked to an owning epic.
+
+## Changes
+
+- **Fold 13 migration remnants under epic 0136.** Bugs in the shipped
+  `config`/`corpus`/`migrate` crates, bash-cleanup tasks, the foundational
+  architecture spike, and the runtime-cache cluster are now children of 0136 and
+  appear in a dated "Post-migration remnants" subsection of its decomposition.
+- **Add successor epic 0276, Rust CLI Consolidation and Hardening.** Gathers the
+  24 post-migration evolution items — crate architecture, naming hygiene, CLI
+  ergonomics, and design-daemon lifecycle — that extend the workspace rather than
+  complete the migration. Renumbered from 0275 to avoid a cross-branch id clash.
+- **Reparent 24 items under 0276** with `parent` links and a dated provenance
+  note on each.
+- **Record the Linear sync.** 55 issues created on team PP (33 reorganised items
+  plus 22 pre-existing drafts), with their `external_id`s written back and the
+  sync baseline advanced.
+- **Capture the source note** `meta/notes/2026-08-31-third-ideas-backlog.md` from
+  which 0276's children were drawn.
+
+## Context
+
+Spans two epics rather than one work item: 0136 (Migrate Shell Scripts into a
+Rust CLI) and the new 0276. The Tier A/B split — remnants that belong to 0136
+versus evolution that belongs to 0276 — is documented in 0276's Drafting Notes
+and Open Questions. 0274 (isolate `gh` calls into a Python module) is deliberately
+left out and raised as an open question, as it runs counter to the Rust direction.
+
+## Testing
+
+- [x] Frontmatter validated across all 62 changed meta files (`accelerator corpus
+      frontmatter validate`) — zero violations.
+- [x] Push-only Linear sync completed with zero per-item failures; all 55 creates
+      wrote back an `external_id`.
+- [ ] No code changed, so no build or test suite applies to this PR.
+
+## Notes for Reviewers
+
+- **Two commits, deliberately split:** `9b4c99c` carries the reorganisation and
+  the source note; `f0a8f65` carries the Linear write-backs and baseline. The 33
+  items that were both reparented and created on Linear carry their new
+  `external_id` in the first commit — the parent edit and the id share a file and
+  cannot be separated at file granularity.
+- **28 Linear conflicts remain unresolved**, including 0182, 0201, and 0208 whose
+  parent updates did not reach Linear (remotely modified since the last sync).
+  Resolving them needs a bidirectional pass with `work.default_project_code: PP`
+  set — a deliberate follow-up, out of scope here.
+- **Open questions on 0276** (whether the crate-architecture cluster should be its
+  own sub-epic; whether 0274 belongs) are recorded on the epic for triage, not
+  settled by this PR.

--- a/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
+++ b/meta/work/0136-migrate-shell-scripts-to-rust-cli.md
@@ -55,7 +55,9 @@ dependency spine; each keeps the plugin functional at its step. Statuses vary
 and are tracked on the items themselves. Grandchildren are listed indented
 beneath the parent that owns them and are covered transitively by that parent's
 completion. This list was reconciled against the real parent-linked child set on
-2026-08-31 (see Drafting Notes).
+2026-08-31 (see Drafting Notes), and extended on 2026-09-05 with the
+post-migration remnants recovered from an audit of work items numbered above
+0136 (see the closing group).
 
 **Foundations (Phases 0–2):**
 - 0162 — Rust Toolchain Guard Rails in mise + CI
@@ -134,6 +136,34 @@ completion. This list was reconciled against the real parent-linked child set on
   on every dispatch)*
 - 0219 — Own the Recurring Absolute-Budget Check *(0189's primary gate is
   re-runnable in principle and re-run by nothing)*
+
+**Post-migration remnants (reconciled 2026-09-05):** recovered from an audit of
+work items numbered above 0136 that belonged to the migration or its shipped
+crates but had been left parentless. Post-migration *evolution* of the workspace
+(refactors, ergonomics, crate renames) is out of scope here and lives under the
+successor epic 0276.
+
+- 0158 — Modular Rust CLI Architecture and Hexagonal Workspace Layout *(the
+  foundational architecture spike, ported from luminosity, that feeds this epic)*
+- 0182 — bin/accelerator Requires CLAUDE_PLUGIN_ROOT in the Environment *(launcher
+  bug)*
+- 0184 — template_names Succeeds-With-Nothing on a Non-Installation Plugin Root
+  *(bug in the shipped config-adapters crate)*
+- 0201 — In-Process Section Diff *(removes work-adapters' shell-out to `diff -u`)*
+- 0240 — Corpus Update Frontmatter Quote Roundtrip *(bug in the shipped corpus
+  crate; pairs with 0221)*
+- 0241 — Migrate False Dirty-Tree Detection *(bug in the shipped migrate crate)*
+- 0245 — Invoke accelerator Directly in Skills *(completes the invocation-contract
+  cutover)*
+- 0264 — Remove Bash-Migration Negative-Assertion Tests *(retires migration
+  scaffolding)*
+- 0269 — Remove Bash References from the Jira and Linear Clients *(retires
+  shell-to-Rust residue)*
+- 0222 — Offline Populate Route for the Runtime Cache *(runtime-cache cluster)*
+- 0223 — Bounding the Default Runtime Cache Root *(sibling of 0218)*
+- 0225 — Advisory-Feed Monitoring for the Vendored Runtime Pins *(sibling of 0214)*
+- 0226 — Audit Repo-Settable Config Keys for Executable-Path Injection *(hardens
+  the shipped config crates)*
 
 The target architecture (git-style `accelerator` launcher dispatching to
 on-demand `accelerator-<sub>` static binaries, each a hexagonal crate; the

--- a/meta/work/0158-modular-rust-cli-architecture-and-hexagonal-workspace-layout.md
+++ b/meta/work/0158-modular-rust-cli-architecture-and-hexagonal-workspace-layout.md
@@ -7,10 +7,12 @@ author: "Toby Clemson"
 status: "done"
 kind: "spike"
 priority: "high"
+parent: "work-item:0136"
 external_id: "PP-181"
 tags: ["spike", "rust", "cli", "architecture", "hexagonal"]
-last_updated: "2026-06-27T12:23:42+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 ---
 

--- a/meta/work/0182-cli-derives-plugin-root-from-own-location.md
+++ b/meta/work/0182-cli-derives-plugin-root-from-own-location.md
@@ -8,13 +8,14 @@ producer: "create-work-item"
 status: "done"
 kind: "bug"
 priority: "high"
+parent: "work-item:0136"
 blocks: ["work-item:0186"]
 relates_to: ["work-item:0164", "work-item:0167", "work-item:0136", "work-item:0183", "work-item:0184", "work-item:0186", "work-item:0172", "codebase-research:2026-07-27-0182-plugin-root-self-location-implementation-surface"]
 source: "issue-research:2026-07-26-cli-requires-claude-plugin-root-env-var"
 tags: ["bug", "cli", "launcher", "bootstrap", "plugin-root", "skills"]
-last_updated: "2026-08-09T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
-last_updated_note: "Reciprocal relates_to edge to 0172, added while closing out 0172's Phase 10 (retirement cutover): 0172 removed the CLAUDE_PLUGIN_ROOT-allowlist entries this item's rename set covered for the retired bash migration engine, and repointed hooks/hooks.json's migrate SessionStart entry, which coordinates with this item's own launcher-link-refresh.sh entry ordering."
+last_updated_note: "Reciprocal relates_to edge to 0172, added while closing out 0172's Phase 10 (retirement cutover): 0172 removed the CLAUDE_PLUGIN_ROOT-allowlist entries this item's rename set covered for the retired bash migration engine, and repointed hooks/hooks.json's migrate SessionStart entry, which coordinates with this item's own launcher-link-refresh.sh entry ordering. Additionally: Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-712"
 ---

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -8,10 +8,12 @@ producer: "implement-plan"
 status: "draft"
 kind: "bug"
 priority: "low"
+parent: "work-item:0136"
 relates_to: ["work-item:0182"]
 tags: ["bug", "cli", "config", "templates", "plugin-root"]
-last_updated: "2026-07-29T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-714"
 ---

--- a/meta/work/0201-in-process-section-diff.md
+++ b/meta/work/0201-in-process-section-diff.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "done"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 relates_to: ["work-item:0170", "work-item:0174", "work-item:0188", "work-item:0198"]
 tags: ["rust", "work-items", "tech-debt"]
-last_updated: "2026-08-08T12:27:18+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-731"
 ---

--- a/meta/work/0208-runtime-test-lane-absent-from-every-build.md
+++ b/meta/work/0208-runtime-test-lane-absent-from-every-build.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 relates_to: ["work-item:0196"]
 tags: ["ci", "testing", "design", "playwright"]
-last_updated: "2026-08-20T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-738"
 ---

--- a/meta/work/0222-offline-populate-route-for-the-runtime-cache.md
+++ b/meta/work/0222-offline-populate-route-for-the-runtime-cache.md
@@ -8,11 +8,13 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "low"
+parent: "work-item:0136"
 blocked_by: ["work-item:0196"]
 relates_to: ["work-item:0196"]
 tags: ["distribution", "runtime", "cache", "offline", "security"]
-last_updated: "2026-08-20T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-752"
 ---

--- a/meta/work/0223-bounding-the-default-runtime-cache-root.md
+++ b/meta/work/0223-bounding-the-default-runtime-cache-root.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "low"
+parent: "work-item:0136"
 relates_to: ["work-item:0196"]
 tags: ["distribution", "runtime", "cache", "prune", "design"]
-last_updated: "2026-08-20T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-753"
 ---

--- a/meta/work/0224-consistent-platform-gating-of-unix-specific-code.md
+++ b/meta/work/0224-consistent-platform-gating-of-unix-specific-code.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "low"
+parent: "work-item:0276"
 relates_to: ["work-item:0196"]
 tags: ["rust", "cli", "portability", "consistency", "tech-debt"]
-last_updated: "2026-08-23T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-754"
 ---

--- a/meta/work/0225-advisory-feed-monitoring-for-the-vendored-runtime-pins.md
+++ b/meta/work/0225-advisory-feed-monitoring-for-the-vendored-runtime-pins.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 relates_to: ["work-item:0196"]
 tags: ["security", "distribution", "runtime", "playwright", "ci"]
-last_updated: "2026-08-20T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-755"
 ---

--- a/meta/work/0226-audit-repo-settable-config-keys-for-executable-path-injection.md
+++ b/meta/work/0226-audit-repo-settable-config-keys-for-executable-path-injection.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 relates_to: ["work-item:0196"]
 tags: ["security", "config", "visualiser", "design"]
-last_updated: "2026-08-20T00:00:00+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-756"
 ---

--- a/meta/work/0227-accelerator-config-validate-command.md
+++ b/meta/work/0227-accelerator-config-validate-command.md
@@ -8,10 +8,12 @@ producer: "create-work-item"
 status: "draft"
 kind: "story"
 priority: "medium"
+parent: "work-item:0276"
 relates_to: ["work-item:0221", "work-item:0226"]
 tags: ["config", "validation", "cli", "correctness"]
-last_updated: "2026-08-29T17:07:24+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-757"
 ---

--- a/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
+++ b/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "bug"
 priority: "medium"
+parent: "work-item:0136"
 tags: ["corpus", "frontmatter"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-770"
 ---

--- a/meta/work/0241-migrate-false-dirty-tree-detection.md
+++ b/meta/work/0241-migrate-false-dirty-tree-detection.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "bug"
 priority: "medium"
+parent: "work-item:0136"
 tags: ["migration", "vcs"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-771"
 ---

--- a/meta/work/0245-invoke-accelerator-directly-in-skills.md
+++ b/meta/work/0245-invoke-accelerator-directly-in-skills.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 tags: ["skills", "cli"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-775"
 ---

--- a/meta/work/0246-daemon-process-management-library.md
+++ b/meta/work/0246-daemon-process-management-library.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["visualiser", "infrastructure"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-776"
 ---

--- a/meta/work/0247-retire-server-pid-in-design-commands.md
+++ b/meta/work/0247-retire-server-pid-in-design-commands.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["design", "cleanup"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-777"
 ---

--- a/meta/work/0248-design-automation-integration-tests-in-ci.md
+++ b/meta/work/0248-design-automation-integration-tests-in-ci.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["design", "ci", "testing"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-778"
 ---

--- a/meta/work/0249-richer-document-model-crate.md
+++ b/meta/work/0249-richer-document-model-crate.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["corpus", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-779"
 ---

--- a/meta/work/0250-push-config-lookups-into-config-crates.md
+++ b/meta/work/0250-push-config-lookups-into-config-crates.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["config", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-780"
 ---

--- a/meta/work/0251-env-var-overrides-in-config-crates.md
+++ b/meta/work/0251-env-var-overrides-in-config-crates.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["config", "crates"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-781"
 ---

--- a/meta/work/0252-federate-config-into-domain-crates.md
+++ b/meta/work/0252-federate-config-into-domain-crates.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["config", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-782"
 ---

--- a/meta/work/0253-survey-clis-for-domain-crate-logic.md
+++ b/meta/work/0253-survey-clis-for-domain-crate-logic.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-783"
 ---

--- a/meta/work/0254-add-cli-logging.md
+++ b/meta/work/0254-add-cli-logging.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "observability"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-784"
 ---

--- a/meta/work/0256-push-work-list-logic-into-core-crate.md
+++ b/meta/work/0256-push-work-list-logic-into-core-crate.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["work", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-786"
 ---

--- a/meta/work/0258-help-show-subcommands.md
+++ b/meta/work/0258-help-show-subcommands.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "bug"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "help"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-788"
 ---

--- a/meta/work/0259-unify-help-style.md
+++ b/meta/work/0259-unify-help-style.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "bug"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "help"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-789"
 ---

--- a/meta/work/0260-move-adr-to-own-subcommand.md
+++ b/meta/work/0260-move-adr-to-own-subcommand.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "adr", "corpus"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-790"
 ---

--- a/meta/work/0263-rename-foreigndirt.md
+++ b/meta/work/0263-rename-foreigndirt.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["naming", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-793"
 ---

--- a/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
+++ b/meta/work/0264-remove-bash-migration-negative-assertion-tests.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 tags: ["testing", "cleanup"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-794"
 ---

--- a/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
+++ b/meta/work/0265-collapse-discoverability-hook-and-format-hook.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "hooks"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-795"
 ---

--- a/meta/work/0266-remove-thiserror.md
+++ b/meta/work/0266-remove-thiserror.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["cli", "dependencies", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-796"
 ---

--- a/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
+++ b/meta/work/0267-move-vcs-kind-detection-into-vcs-crates.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["vcs", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-797"
 ---

--- a/meta/work/0268-rename-remote-projection-crate.md
+++ b/meta/work/0268-rename-remote-projection-crate.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["naming", "crates", "work"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-798"
 ---

--- a/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
+++ b/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0136"
 tags: ["jira", "linear", "cleanup"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-799"
 ---

--- a/meta/work/0270-move-filesystem-into-shared-crate.md
+++ b/meta/work/0270-move-filesystem-into-shared-crate.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["crates", "testing", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-800"
 ---

--- a/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
+++ b/meta/work/0271-unify-surface-remotetracker-client-interfaces.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["work", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-801"
 ---

--- a/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
+++ b/meta/work/0273-domain-crate-for-linear-jira-subcommands.md
@@ -8,9 +8,11 @@ producer: "extract-work-items"
 status: "draft"
 kind: "task"
 priority: "medium"
+parent: "work-item:0276"
 tags: ["jira", "linear", "crates", "refactor"]
-last_updated: "2026-08-31T12:11:13+00:00"
+last_updated: "2026-09-05T00:00:00+00:00"
 last_updated_by: "Toby Clemson"
+last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
 external_id: "PP-803"
 ---

--- a/meta/work/0276-rust-cli-consolidation-and-hardening.md
+++ b/meta/work/0276-rust-cli-consolidation-and-hardening.md
@@ -1,0 +1,134 @@
+---
+type: "work-item"
+id: "0276"
+title: "Rust CLI Consolidation and Hardening"
+date: "2026-09-05T21:55:04+00:00"
+author: "Toby Clemson"
+producer: "create-work-item"
+status: "draft"
+kind: "epic"
+priority: "medium"
+relates_to: ["work-item:0136"]
+tags: ["rust", "cli", "consolidation", "hardening", "epic"]
+last_updated: "2026-09-05T21:55:04+00:00"
+last_updated_by: "Toby Clemson"
+last_updated_note: "Drafted as the successor epic to 0136 (renumbered 0275 to 0276 to avoid a cross-branch id conflict); gathering the post-migration Rust-CLI refactoring, ergonomics, and hardening backlog that accreted parentless after the shell-to-Rust migration completed."
+schema_version: 1
+external_id: "PP-860"
+---
+
+# 0276: Rust CLI Consolidation and Hardening
+
+**Kind**: Epic
+**Status**: Draft
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+Consolidate and harden the `cli/` Rust workspace now that the shell-to-Rust
+migration (0136) has landed. Push accreted domain logic down into crates,
+unify the command-layer surface, and close the ergonomics and diagnostics
+gaps that the migration deferred.
+
+## Context
+
+Epic 0136 migrated the bash library into the `cli/` Rust workspace and is
+effectively complete. In its wake a backlog of refactoring, naming,
+ergonomics, and hardening items accumulated parentless — extracted in bulk
+from the ideas-backlog notes (`meta/notes/2026-08-31-third-ideas-backlog.md`
+and predecessors) and never linked to an owning epic.
+
+These items are not the migration itself. They evolve the workspace the
+migration produced: command-layer logic that belongs in domain crates,
+overlapping abstractions, inconsistent help output, and missing structured
+logging. Housing them under a "Migrate Shell Scripts" epic would overstate
+that epic's scope, so they are gathered here as a distinct successor.
+
+Migration remnants proper — residual bash, shell-outs, and bugs in the
+shipped crates — remain under 0136.
+
+## Requirements
+
+High-level themes; each child work item carries its own acceptance criteria.
+
+- Push domain logic out of the command layer into reusable, independently
+  tested crates.
+- Rationalise overlapping abstractions and crate names into one coherent
+  domain vocabulary.
+- Deliver a consistent, discoverable CLI surface (help, logging, subcommand
+  structure).
+- Federate configuration into the domain crates that own it, with
+  environment-variable overrides.
+- Harden the design-daemon lifecycle and get its automation onto every build.
+
+## Decomposition
+
+Proposed child work items, grouped by theme. These are the Tier B candidates
+identified while auditing items numbered above 0136 and linked to this epic on
+2026-09-05.
+
+**Crate architecture — domain logic out of the command layer:**
+- 0249 — Richer Document Model Crate
+- 0250 — Push Config Lookups Into Config Crates
+- 0251 — Env Var Overrides In Config Crates
+- 0252 — Federate Config Into Domain Crates
+- 0253 — Survey CLIs For Domain-Crate Logic
+- 0256 — Push Work-List Logic Into Core Crate
+- 0267 — Move VCS Kind Detection Into The VCS Crates
+- 0270 — Move Filesystem Into A Shared Crate
+- 0271 — Unify Surface, RemoteTracker And Client Interfaces
+- 0273 — Domain Crate For Linear And Jira Subcommands
+
+**Naming and dependency hygiene:**
+- 0263 — Rename ForeignDirt
+- 0266 — Remove thiserror From The Codebase
+- 0268 — Rename The remote-projection Crate
+
+**CLI ergonomics and diagnostics:**
+- 0227 — accelerator config validate Command
+- 0254 — Add CLI Logging
+- 0258 — Help Should Show Subcommands
+- 0259 — Unify Help Style
+- 0260 — Move ADR Into Its Own Subcommand
+- 0265 — Collapse Discoverability-Hook And Format-Hook Switches
+
+**Design-daemon lifecycle and test coverage:**
+- 0208 — Runtime Test Lane Absent From Every Build
+- 0246 — Daemon Process Management Library
+- 0247 — Retire server.pid In Design Commands
+- 0248 — Design-Automation Integration Tests In CI
+
+**Cross-cutting:**
+- 0224 — Consistent Platform-Gating of Unix-Specific Code Across the CLI Crates
+
+## Open Questions
+
+- Should this epic subsume the whole Tier B set, or should the crate-architecture
+  cluster (0249–0273) be its own sub-epic given its size and internal ordering?
+- Does 0274 (isolate `gh` calls into a shared Python module) belong here, or does
+  it conflict with the Rust direction and warrant rescoping to a Rust wrapper first?
+
+## Dependencies
+
+- Blocked by: 0136 (the migration must be complete for consolidation to be
+  meaningful; it effectively is)
+- Blocks: none recorded yet
+
+## Drafting Notes
+
+- Scope was derived from an audit of every work item numbered above 0136,
+  judging each against 0136's boundary (the shell-to-Rust migration and its
+  shipped crates). Tier A items — migration remnants, launcher/config-crate
+  bugs, and the runtime-cache cluster — were reparented under 0136 directly and
+  are not listed here.
+- The child items above were linked to this epic (`parent: "work-item:0276"`) on
+  2026-09-05, following review of the >0136 audit.
+- 0274 is deliberately left out of the decomposition and raised as an open
+  question — as written it proposes a Python wrapper, which runs counter to the
+  Rust consolidation this epic pursues.
+
+## References
+
+- Related: 0136
+- Source: `meta/notes/2026-08-31-third-ideas-backlog.md`


### PR DESCRIPTION

# Reparent Rust CLI work items under 0136 and add successor epic 0276

## Summary

Reorganises a parentless backlog of Rust-CLI work items into the right epics and
records the Linear sync that followed. An audit of every work item numbered above
0136 found 37 that belonged to the shell-to-Rust migration or the workspace it
produced, none of them linked to an owning epic.

## Changes

- **Fold 13 migration remnants under epic 0136.** Bugs in the shipped
  `config`/`corpus`/`migrate` crates, bash-cleanup tasks, the foundational
  architecture spike, and the runtime-cache cluster are now children of 0136 and
  appear in a dated "Post-migration remnants" subsection of its decomposition.
- **Add successor epic 0276, Rust CLI Consolidation and Hardening.** Gathers the
  24 post-migration evolution items — crate architecture, naming hygiene, CLI
  ergonomics, and design-daemon lifecycle — that extend the workspace rather than
  complete the migration. Renumbered from 0275 to avoid a cross-branch id clash.
- **Reparent 24 items under 0276** with `parent` links and a dated provenance
  note on each.
- **Record the Linear sync.** 55 issues created on team PP (33 reorganised items
  plus 22 pre-existing drafts), with their `external_id`s written back and the
  sync baseline advanced.
- **Capture the source note** `meta/notes/2026-08-31-third-ideas-backlog.md` from
  which 0276's children were drawn.

## Context

Spans two epics rather than one work item: 0136 (Migrate Shell Scripts into a
Rust CLI) and the new 0276. The Tier A/B split — remnants that belong to 0136
versus evolution that belongs to 0276 — is documented in 0276's Drafting Notes
and Open Questions. 0274 (isolate `gh` calls into a Python module) is deliberately
left out and raised as an open question, as it runs counter to the Rust direction.

## Testing

- [x] Frontmatter validated across all 62 changed meta files (`accelerator corpus
      frontmatter validate`) — zero violations.
- [x] Push-only Linear sync completed with zero per-item failures; all 55 creates
      wrote back an `external_id`.
- [ ] No code changed, so no build or test suite applies to this PR.

## Notes for Reviewers

- **Two commits, deliberately split:** `9b4c99c` carries the reorganisation and
  the source note; `f0a8f65` carries the Linear write-backs and baseline. The 33
  items that were both reparented and created on Linear carry their new
  `external_id` in the first commit — the parent edit and the id share a file and
  cannot be separated at file granularity.
- **28 Linear conflicts remain unresolved**, including 0182, 0201, and 0208 whose
  parent updates did not reach Linear (remotely modified since the last sync).
  Resolving them needs a bidirectional pass with `work.default_project_code: PP`
  set — a deliberate follow-up, out of scope here.
- **Open questions on 0276** (whether the crate-architecture cluster should be its
  own sub-epic; whether 0274 belongs) are recorded on the epic for triage, not
  settled by this PR.
