### PR TITLE
[0258] Help should show subcommands

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,7 +52,7 @@ publish = false
 [workspace.dependencies]
 # Exact-pinned: external_subcommand capture and --help interception ordering
 # are behaviour-sensitive.
-clap = { version = "=4.6.1", features = ["derive"] }
+clap = { version = "=4.6.1", features = ["derive", "string"] }
 # vergen and vergen-gitcl are a matched pair pinned exactly: vergen 9.1.0's
 # transitive vergen-lib bump breaks the Emitter, and a vergen-gitcl minor/patch
 # can float that same vergen-lib independently, so both are pinned.

--- a/cli/collaboration-cli/Cargo.toml
+++ b/cli/collaboration-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The collaboration pr base-repo|update-body sub-binary."
+description = "Manage pull-request collaboration"
 
 [lints]
 workspace = true

--- a/cli/corpus-cli/Cargo.toml
+++ b/cli/corpus-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The corpus adr|metadata|linkage|frontmatter sub-binary."
+description = "Manage the meta-document corpus (ADRs, metadata, frontmatter)"
 
 [lints]
 workspace = true

--- a/cli/design-cli/Cargo.toml
+++ b/cli/design-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The design validate-source|resolve-auth|scrub-secrets|notify-downgrade|audit-cue-phrases sub-binary."
+description = "Validate and process design sources"
 
 [lints]
 workspace = true

--- a/cli/jira-cli/Cargo.toml
+++ b/cli/jira-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The jira create|update|show|search|comment|transition|attach|init|fields|resolve-fields sub-binary."
+description = "Manage Jira issues"
 
 [lints]
 workspace = true

--- a/cli/launcher/src/launch/help.rs
+++ b/cli/launcher/src/launch/help.rs
@@ -1,33 +1,44 @@
-//! Manifest-driven help synthesis for external subcommands (which clap cannot
-//! enumerate, as they are fetched on demand).
-
-use std::fmt::Write as _;
+//! Manifest-driven help augmentation for external subcommands.
+//!
+//! Clap cannot enumerate them (they are fetched on demand), so each manifest
+//! binary is added as a clap subcommand, letting built-ins and sub-binaries
+//! render in one native "Commands:" section.
 
 use crate::launch::outbound::resolve::manifest::Manifest;
 
-/// Build the "External subcommands" help section from the manifest, or `None`
-/// when it lists no binaries.
+/// Add each manifest binary to `command` as a child subcommand carrying its
+/// description, so clap renders it alongside the built-ins.
 ///
 /// Descriptions are signature-verified but still terminal-rendered, so they are
 /// sanitised at this boundary against terminal-escape injection.
+///
+/// The skip guard is load-bearing: clap `debug_assert`s on a duplicate
+/// subcommand, so a manifest binary colliding with a built-in would panic the
+/// help render under test and silently double-list in release. A built-in
+/// (`version`, `config`, `cache`) is already present on the un-built command and
+/// caught by `find_subcommand`; clap's `help` subcommand is not — it is appended
+/// only during the build triggered at render time — so the explicit `help` skip
+/// is what prevents that collision. A built-in or `help` always shadows a
+/// same-named sub-binary, which could therefore never dispatch, so skipping it
+/// loses nothing real.
 #[must_use]
-pub fn external_subcommands_section(manifest: &Manifest) -> Option<String> {
-    if manifest.binaries.is_empty() {
-        return None;
-    }
-    let width = manifest
-        .binaries
-        .keys()
-        .map(|name| sanitize(name).len())
-        .max()
-        .unwrap_or(0);
-    let mut section = String::from("External subcommands:");
+pub fn augment_with_subbinaries(
+    mut command: clap::Command,
+    manifest: &Manifest,
+) -> clap::Command {
     for (name, entry) in &manifest.binaries {
         let name = sanitize(name);
-        let description = sanitize(&entry.description);
-        let _ = write!(section, "\n  {name:<width$}  {description}");
+        if name.is_empty()
+            || name == "help"
+            || command.find_subcommand(&name).is_some()
+        {
+            continue;
+        }
+        command = command.subcommand(
+            clap::Command::new(name).about(sanitize(&entry.description)),
+        );
     }
-    Some(section)
+    command
 }
 
 /// Strip C0/C1 control characters (including the ESC/CSI introducer), operating
@@ -41,9 +52,12 @@ pub fn sanitize(text: &str) -> String {
 mod tests {
     use std::error::Error;
 
+    use clap::CommandFactory as _;
+
+    use crate::launch::inbound::cli::Cli;
     use crate::launch::outbound::resolve::manifest::Manifest;
 
-    use super::{external_subcommands_section, sanitize};
+    use super::{augment_with_subbinaries, sanitize};
 
     const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -56,21 +70,51 @@ mod tests {
     }
 
     #[test]
-    fn renders_a_line_matching_the_name_and_description(
+    fn a_manifest_binary_renders_beside_the_builtins(
     ) -> Result<(), Box<dyn Error>> {
         let manifest = manifest(
-            "{\"foo\":{\"description\":\"Bar tool\",\"platforms\":{}}}",
+            "{\"zzfixture\":{\"description\":\"Fixture tool\",\
+             \"platforms\":{}}}",
         )?;
-        let section = external_subcommands_section(&manifest)
-            .ok_or("expected section")?;
-        assert!(section.contains("foo"));
-        assert!(section.contains("Bar tool"));
+        let mut command = augment_with_subbinaries(Cli::command(), &manifest);
+        let help = command.render_help().to_string();
+        assert!(help.contains("zzfixture"), "sub-binary missing: {help}");
+        assert!(help.contains("Fixture tool"), "description missing: {help}");
+        assert!(help.contains("version"), "built-in missing: {help}");
+        assert!(
+            !help.contains("External subcommands"),
+            "the old origin heading survived: {help}"
+        );
         Ok(())
     }
 
     #[test]
-    fn no_binaries_yields_no_section() -> Result<(), Box<dyn Error>> {
-        assert!(external_subcommands_section(&manifest("{}")?).is_none());
+    fn colliding_and_empty_names_are_skipped_without_panicking(
+    ) -> Result<(), Box<dyn Error>> {
+        let manifest = manifest(
+            "{\"version\":{\"description\":\"collide\",\"platforms\":{}},\
+             \"help\":{\"description\":\"collide\",\"platforms\":{}},\
+             \"\":{\"description\":\"empty\",\"platforms\":{}}}",
+        )?;
+        let mut command = augment_with_subbinaries(Cli::command(), &manifest);
+        let versions = command
+            .get_subcommands()
+            .filter(|sub| sub.get_name() == "version")
+            .count();
+        assert_eq!(versions, 1, "the built-in version was double-listed");
+        let helps = command
+            .get_subcommands()
+            .filter(|sub| sub.get_name() == "help")
+            .count();
+        assert_eq!(helps, 0, "a help subcommand was added before the build");
+        let empties = command
+            .get_subcommands()
+            .filter(|sub| sub.get_name().is_empty())
+            .count();
+        assert_eq!(empties, 0, "an empty-named subcommand was added");
+        // The build clap runs at render time `debug_assert`s on a duplicate, so
+        // rendering is what proves the `help` collision was actually avoided.
+        let _ = command.render_help().to_string();
         Ok(())
     }
 

--- a/cli/launcher/src/launch/inbound/cli.rs
+++ b/cli/launcher/src/launch/inbound/cli.rs
@@ -15,15 +15,15 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Print the version, commit SHA, build date, and target triple.
+    /// Print the version, commit SHA, build date, and target triple
     Version,
-    /// Read or write Accelerator configuration.
+    /// Read or write Accelerator configuration
     #[command(arg_required_else_help = true)]
     Config {
         #[command(subcommand)]
         action: ConfigAction,
     },
-    /// Inspect and repair the cached directory-tree artifacts.
+    /// Inspect and repair the cached directory-tree artifacts
     #[command(arg_required_else_help = true)]
     Cache {
         #[command(subcommand)]

--- a/cli/launcher/src/launch/outbound/resolve/fetcher.rs
+++ b/cli/launcher/src/launch/outbound/resolve/fetcher.rs
@@ -11,6 +11,10 @@ use sha2::{Digest as _, Sha256};
 
 const MAX_ATTEMPTS: u32 = 3;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+// The help path never needs the manifest, so it gives up fast and fails open to
+// the built-in listing rather than inheriting dispatch's retry-heavy budget.
+const HELP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const HELP_TOTAL_TIMEOUT: Duration = Duration::from_secs(5);
 // Whole-request deadline per attempt for the buffered small-asset path, sized
 // for a multi-MB release binary over a slow link. On the streaming path it
 // bounds one read rather than the attempt, so `StreamLimits` carries the
@@ -127,6 +131,16 @@ fn redirect_policy() -> Policy {
     })
 }
 
+/// The per-instance bounds a fetcher runs under: the client's connect and
+/// whole-request timeouts, the attempt cap, and the inter-attempt backoff.
+#[derive(Clone, Copy)]
+struct Limits {
+    connect: Duration,
+    total: Duration,
+    max_attempts: u32,
+    backoff: Duration,
+}
+
 /// A configured blocking HTTP client for asset/manifest fetches.
 pub struct Fetcher {
     client: Client,
@@ -142,7 +156,34 @@ impl Fetcher {
     ///
     /// If the underlying client cannot be constructed.
     pub fn new() -> Result<Self, String> {
-        Self::build(Duration::from_millis(250), true)
+        Self::build(
+            Limits {
+                connect: CONNECT_TIMEOUT,
+                total: TOTAL_TIMEOUT,
+                max_attempts: MAX_ATTEMPTS,
+                backoff: Duration::from_millis(250),
+            },
+            true,
+        )
+    }
+
+    /// Build the help-scoped fetcher: a single short attempt (https pinned) so a
+    /// slow or unreachable release host fails open to the built-in listing
+    /// within the help connect timeout rather than dispatch's retry budget.
+    ///
+    /// # Errors
+    ///
+    /// If the underlying client cannot be constructed.
+    pub fn for_help() -> Result<Self, String> {
+        Self::build(
+            Limits {
+                connect: HELP_CONNECT_TIMEOUT,
+                total: HELP_TOTAL_TIMEOUT,
+                max_attempts: 1,
+                backoff: Duration::ZERO,
+            },
+            true,
+        )
     }
 
     /// Build a test fetcher with a caller-chosen backoff, permitting `http` for
@@ -152,10 +193,18 @@ impl Fetcher {
     ///
     /// If the underlying client cannot be constructed.
     pub fn with_backoff(backoff: Duration) -> Result<Self, String> {
-        Self::build(backoff, false)
+        Self::build(
+            Limits {
+                connect: CONNECT_TIMEOUT,
+                total: TOTAL_TIMEOUT,
+                max_attempts: MAX_ATTEMPTS,
+                backoff,
+            },
+            false,
+        )
     }
 
-    fn build(backoff: Duration, require_https: bool) -> Result<Self, String> {
+    fn build(limits: Limits, require_https: bool) -> Result<Self, String> {
         // The ring provider must be installed before building a TLS client
         // (idempotent), keeping the Fetcher self-sufficient in tests.
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -163,16 +212,16 @@ impl Fetcher {
         // just the initial request the `get()` guard checks. Off for the test
         // fetcher so it can reach a local `http` mock.
         let client = Client::builder()
-            .connect_timeout(CONNECT_TIMEOUT)
-            .timeout(TOTAL_TIMEOUT)
+            .connect_timeout(limits.connect)
+            .timeout(limits.total)
             .redirect(redirect_policy())
             .https_only(require_https)
             .build()
             .map_err(|error| error.to_string())?;
         Ok(Self {
             client,
-            max_attempts: MAX_ATTEMPTS,
-            backoff,
+            max_attempts: limits.max_attempts,
+            backoff: limits.backoff,
             require_https,
         })
     }
@@ -604,5 +653,23 @@ mod tests {
     fn https_is_required_by_the_production_pin() {
         assert!(is_https("https://github.com/x"));
         assert!(!is_https("http://github.com/x"));
+    }
+
+    #[test]
+    fn the_help_fetcher_gives_up_within_its_connect_bound() {
+        let Ok(fetcher) = Fetcher::for_help() else {
+            return;
+        };
+        // A non-routable address that drops the SYN, so the connect stalls until
+        // its timeout rather than being refused immediately.
+        let started = std::time::Instant::now();
+        let result = fetcher.get("https://10.255.255.1/manifest.json");
+        let elapsed = started.elapsed();
+        assert!(result.is_err(), "expected a fetch failure, got {result:?}");
+        assert!(
+            elapsed < Duration::from_secs(8),
+            "the help fetch inherited a longer budget than one short attempt: \
+             {elapsed:?}"
+        );
     }
 }

--- a/cli/launcher/src/main.rs
+++ b/cli/launcher/src/main.rs
@@ -5,6 +5,7 @@
 //! It is the only module that names `config_adapters`: the `config` port bundle
 //! is composed here and handed to `dispatch` behind `config`-crate traits.
 
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -19,7 +20,7 @@ use accelerator::launch::core::{
     ExternalCommand, ResolutionError, ResolveBinary, LAUNCHER_PATH_VAR,
 };
 use accelerator::launch::dispatch;
-use accelerator::launch::help::external_subcommands_section;
+use accelerator::launch::help::augment_with_subbinaries;
 use accelerator::launch::inbound::cli::{CacheAction, Cli, Command};
 use accelerator::launch::outbound::exec::UnixExec;
 use accelerator::launch::outbound::override_path;
@@ -28,6 +29,7 @@ use accelerator::launch::outbound::resolve::cache_root::{
 };
 use accelerator::launch::outbound::resolve::fetcher::Fetcher;
 use accelerator::launch::outbound::resolve::keys::TrustedKeys;
+use accelerator::launch::outbound::resolve::manifest::Manifest;
 use accelerator::launch::outbound::resolve::tree::{
     pins, ExpectedDigests, NoSteps, SystemClock, TreeResolver,
 };
@@ -77,57 +79,130 @@ impl ResolveBinary for LazyProductionResolver {
     }
 }
 
-/// The external-subcommands help section, or `None` on any failure so `--help`
-/// still prints the built-in help. Reads only the manifest, no cache root.
-fn help_section() -> Option<String> {
+/// The signature-verified release manifest, or `None` on any failure so the
+/// help path fails open to the built-in listing. Reads only the manifest, no
+/// cache root, and bounds the fetch to one short attempt via `Fetcher::for_help`
+/// so a slow or unreachable host degrades within the help connect timeout rather
+/// than dispatch's retry budget.
+///
+/// The crypto provider is installed lazily here, so a `version`/`config`/`cache`
+/// built-in never pays for TLS it does not use.
+fn load_help_manifest() -> Option<Manifest> {
     let _ = install_crypto_provider();
     let keys = TrustedKeys::embedded().ok()?;
-    let fetcher = Fetcher::new().ok()?;
+    let fetcher = Fetcher::for_help().ok()?;
     let config = ResolverConfig::production(release_base_url(), PathBuf::new());
     let resolver =
         FetchVerifyCacheResolver::with_fetcher(config, keys, fetcher);
-    let manifest = resolver.load_manifest().ok()?;
-    external_subcommands_section(&manifest)
+    resolver.load_manifest().ok()
 }
 
-fn render_augmented_help() -> ExitCode {
-    let mut command = Cli::command();
-    if let Some(section) = help_section() {
-        command = command.after_help(section);
+/// The command listing: the built-ins, plus the manifest's sub-binaries when one
+/// loaded. Split from the I/O so the augment-vs-built-ins composition is
+/// unit-testable without a signed manifest.
+fn build_listing(
+    command: clap::Command,
+    manifest: Option<&Manifest>,
+) -> clap::Command {
+    match manifest {
+        Some(manifest) => augment_with_subbinaries(command, manifest),
+        None => command,
     }
+}
+
+/// Render the full command listing to stdout and return `exit`. Every root-help
+/// form routes here, so the three entry points converge on one rendering.
+fn render_full_listing(exit: ExitCode) -> ExitCode {
+    let mut command =
+        build_listing(Cli::command(), load_help_manifest().as_ref());
     let _ = command.print_help();
     println!();
-    ExitCode::SUCCESS
+    exit
 }
 
-/// Whether a `DisplayHelp` is the top-level help (which the augmentation lists
-/// external subcommands into), as opposed to a built-in subcommand's own
-/// `--help`, which clap renders unchanged.
-fn is_root_help(error: &clap::Error) -> bool {
-    if error.kind() != ErrorKind::DisplayHelp {
-        return false;
+/// Whether the collected args are a true top-level help form — top-level
+/// `--help`/`-h`, or the bare `help` word — as opposed to a built-in
+/// subcommand's own help (`config --help`, `help config`), which clap renders
+/// unchanged. The leading-token match keeps a stray trailing token
+/// (`--help extra`) on the root form, matching clap's own tolerance; the bare
+/// `help` word is root only as the sole token.
+fn is_root_help_args(args: &[OsString]) -> bool {
+    match args {
+        [first, ..] if first == "--help" || first == "-h" => true,
+        [only] if only == "help" => true,
+        _ => false,
     }
-    !matches!(
-        std::env::args_os()
-            .nth(1)
-            .as_deref()
-            .and_then(std::ffi::OsStr::to_str),
-        Some("version" | "config" | "cache" | "help")
-    )
 }
 
-/// Maps a clap parse outcome to an exit code. clap's own convention exits 2 on a
-/// usage error; the bash config cluster exits 1, and this launcher reserves exit
-/// 2 for a subcommand refusal, so usage errors are re-mapped to 1 here. The
-/// three non-error display kinds print to stdout and exit 0.
-fn handle_parse_error(error: &clap::Error) -> ExitCode {
-    match error.kind() {
-        ErrorKind::DisplayHelp if is_root_help(error) => {
-            render_augmented_help()
+/// Why the full listing renders. The two causes differ only in exit code and
+/// whether the bare-invocation cue prints, so the cause is modelled rather than
+/// carried as loose, independently-settable fields.
+#[derive(Debug, PartialEq, Eq)]
+enum ListingCause {
+    RootHelp,
+    MissingSubcommand,
+}
+
+/// Where a clap parse outcome routes.
+#[derive(Debug, PartialEq, Eq)]
+enum HelpRoute {
+    FullListing(ListingCause),
+    PerCommand,
+    UsageError,
+}
+
+/// Route a clap parse outcome by its kind and the collected root args. Pure, so
+/// the whole truth table is unit-testable.
+///
+/// The derive marks the required root subcommand `arg_required_else_help`, so a
+/// missing root subcommand surfaces as `DisplayHelpOnMissingArgumentOrSubcommand`
+/// (not `MissingSubcommand`) with no args. The empty-args slice is what marks the
+/// bare root invocation; the same kind with non-empty args is a missing nested
+/// subcommand (bare `config`, `config templates`), which keeps its own
+/// per-command help. `MissingSubcommand` is matched alongside defensively — a
+/// clap change that reverted to it for the bare root would still route here.
+fn classify(kind: ErrorKind, args: &[OsString]) -> HelpRoute {
+    match kind {
+        ErrorKind::DisplayHelp if is_root_help_args(args) => {
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        }
+        ErrorKind::MissingSubcommand
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            if args.is_empty() =>
+        {
+            HelpRoute::FullListing(ListingCause::MissingSubcommand)
         }
         ErrorKind::DisplayHelp
         | ErrorKind::DisplayVersion
         | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            HelpRoute::PerCommand
+        }
+        _ => HelpRoute::UsageError,
+    }
+}
+
+/// Maps a clap parse outcome to an exit code. clap's own convention exits 2 on a
+/// usage error; the bash config cluster exits 1, and this launcher reserves exit
+/// 2 for a subcommand refusal, so usage errors are re-mapped to 1 here.
+fn handle_parse_error(error: &clap::Error, args: &[OsString]) -> ExitCode {
+    match classify(error.kind(), args) {
+        HelpRoute::FullListing(cause) => {
+            let exit = match cause {
+                ListingCause::RootHelp => ExitCode::SUCCESS,
+                ListingCause::MissingSubcommand => {
+                    // The listing goes to stdout; a bare exit-1 with empty
+                    // stderr would read as success, so the cue on stderr keeps
+                    // bare invocation diagnosable and distinct from `--help`.
+                    eprintln!(
+                        "error: a subcommand is required; \
+                         run 'accelerator --help' to see available commands"
+                    );
+                    ExitCode::from(1)
+                }
+            };
+            render_full_listing(exit)
+        }
+        HelpRoute::PerCommand => {
             // Force stdout for every help/version kind. clap routes
             // `DisplayHelpOnMissingArgumentOrSubcommand` to stderr, which would
             // make a bare `config` print help on a different stream than
@@ -135,7 +210,7 @@ fn handle_parse_error(error: &clap::Error) -> ExitCode {
             print!("{error}");
             ExitCode::SUCCESS
         }
-        _ => {
+        HelpRoute::UsageError => {
             let _ = error.print();
             ExitCode::from(1)
         }
@@ -370,10 +445,12 @@ fn handle_dispatch_error(error: &kernel::Error, command: &Command) -> ExitCode {
 fn main() -> ExitCode {
     // try_parse so the top-level `--help` can be intercepted and augmented, and
     // a usage error re-mapped from clap's exit 2 to 1; a `foo --help` routes to
-    // External and is delegated to the child.
+    // External and is delegated to the child. The root args are collected once
+    // and threaded into the routing so it reads no process global.
+    let root_args: Vec<OsString> = std::env::args_os().skip(1).collect();
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
-        Err(error) => return handle_parse_error(&error),
+        Err(error) => return handle_parse_error(&error, &root_args),
     };
 
     match run(&cli) {
@@ -393,8 +470,115 @@ mod tests {
         ResolveBinary,
     };
     use accelerator::launch::inbound::cli::Command;
+    use clap::error::ErrorKind;
 
-    use super::handle_dispatch_error;
+    use super::{
+        build_listing, classify, handle_dispatch_error, is_root_help_args,
+        HelpRoute, ListingCause,
+    };
+
+    fn args(items: &[&str]) -> Vec<OsString> {
+        items.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn only_the_true_root_forms_are_root_help() {
+        assert!(is_root_help_args(&args(&["--help"])));
+        assert!(is_root_help_args(&args(&["-h"])));
+        assert!(is_root_help_args(&args(&["help"])));
+        assert!(is_root_help_args(&args(&["--help", "extra"])));
+        assert!(!is_root_help_args(&args(&["config", "--help"])));
+        assert!(!is_root_help_args(&args(&["help", "config"])));
+        assert!(!is_root_help_args(&args(&["version", "--help"])));
+        assert!(!is_root_help_args(&args(&[])));
+    }
+
+    #[test]
+    fn classify_routes_each_kind_and_arg_shape() {
+        assert_eq!(
+            classify(ErrorKind::DisplayHelp, &args(&["--help"])),
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        );
+        assert_eq!(
+            classify(ErrorKind::DisplayHelp, &args(&["-h"])),
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        );
+        assert_eq!(
+            classify(ErrorKind::DisplayHelp, &args(&["help"])),
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        );
+        assert_eq!(
+            classify(ErrorKind::DisplayHelp, &args(&["--help", "extra"])),
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        );
+        // Bare `accelerator`: the derive's `arg_required_else_help` makes the
+        // missing root subcommand this display kind with no args.
+        assert_eq!(
+            classify(
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                &args(&[])
+            ),
+            HelpRoute::FullListing(ListingCause::MissingSubcommand)
+        );
+        // A reverted clap that raised `MissingSubcommand` for the bare root
+        // still routes to the listing.
+        assert_eq!(
+            classify(ErrorKind::MissingSubcommand, &args(&[])),
+            HelpRoute::FullListing(ListingCause::MissingSubcommand)
+        );
+        assert_eq!(
+            classify(ErrorKind::DisplayHelp, &args(&["config", "--help"])),
+            HelpRoute::PerCommand
+        );
+        assert_eq!(
+            classify(ErrorKind::DisplayVersion, &args(&["version", "--help"])),
+            HelpRoute::PerCommand
+        );
+        // Bare `config` keeps its own per-command help.
+        assert_eq!(
+            classify(
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                &args(&["config"])
+            ),
+            HelpRoute::PerCommand
+        );
+        // A missing nested subcommand (`config templates`) keeps its own help,
+        // never the top-level listing.
+        assert_eq!(
+            classify(
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                &args(&["config", "templates"])
+            ),
+            HelpRoute::PerCommand
+        );
+        assert_eq!(
+            classify(ErrorKind::InvalidValue, &args(&["config", "get"])),
+            HelpRoute::UsageError
+        );
+    }
+
+    #[test]
+    fn build_listing_augments_only_when_a_manifest_loaded(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use accelerator::launch::inbound::cli::Cli;
+        use accelerator::launch::outbound::resolve::manifest::Manifest;
+        use clap::CommandFactory as _;
+
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        let json = format!(
+            "{{\"schema_version\":1,\"version\":\"{VERSION}\",\"binaries\":\
+             {{\"zzfixture\":{{\"description\":\"Fixture tool\",\
+             \"platforms\":{{}}}}}}}}"
+        );
+        let manifest = Manifest::parse_and_validate(json.as_bytes(), VERSION)?;
+
+        let mut with = build_listing(Cli::command(), Some(&manifest));
+        assert!(with.render_help().to_string().contains("zzfixture"));
+
+        let mut without = build_listing(Cli::command(), None);
+        assert!(!without.render_help().to_string().contains("zzfixture"));
+        Ok(())
+    }
 
     struct FailingResolver<F>(F);
 

--- a/cli/launcher/tests/crypto_provider.rs
+++ b/cli/launcher/tests/crypto_provider.rs
@@ -1,8 +1,8 @@
 //! `install_crypto_provider()` is called only inside the production resolver's
-//! `resolve()` (the external-subcommand path) and `help_section()` (top-level
-//! `--help`). A built-in — `version` or any `config` subcommand — is dispatched
-//! in-process and must never call `resolve()`, so it never installs the rustls
-//! crypto provider and never pays for capability it does not use.
+//! `resolve()` (the external-subcommand path) and `load_help_manifest()`
+//! (top-level `--help`). A built-in — `version` or any `config` subcommand — is
+//! dispatched in-process and must never call `resolve()`, so it never installs
+//! the rustls crypto provider and never pays for capability it does not use.
 //!
 //! A black-box subprocess cannot observe the process-global provider, so this
 //! drives the library `dispatch` directly with a spy `ResolveBinary` and asserts

--- a/cli/launcher/tests/help.rs
+++ b/cli/launcher/tests/help.rs
@@ -42,3 +42,63 @@ fn top_level_help_prints_builtins_when_manifest_unavailable(
     );
     Ok(())
 }
+
+#[test]
+fn help_subcommand_prints_builtins_when_manifest_unavailable(
+) -> Result<(), Box<dyn Error>> {
+    let output = Command::new(LAUNCHER)
+        .arg("help")
+        .env("ACCELERATOR_RELEASE_BASE_URL", DEAD_RELEASE_URL)
+        .env_remove("ACCELERATOR_LOG")
+        .output()?;
+    assert!(output.status.success(), "help did not exit 0");
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("version"),
+        "expected built-in listing `version`, got: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
+fn bare_invocation_lists_builtins_on_stdout_and_cues_on_stderr(
+) -> Result<(), Box<dyn Error>> {
+    let output = Command::new(LAUNCHER)
+        .env("ACCELERATOR_RELEASE_BASE_URL", DEAD_RELEASE_URL)
+        .env_remove("ACCELERATOR_LOG")
+        .output()?;
+    assert_eq!(output.status.code(), Some(1), "bare invocation must exit 1");
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stdout.contains("version"),
+        "expected the listing on stdout, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("subcommand"),
+        "expected the required-subcommand cue on stderr, got: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn config_help_renders_config_help_not_the_top_level_listing(
+) -> Result<(), Box<dyn Error>> {
+    let output = Command::new(LAUNCHER)
+        .args(["config", "--help"])
+        .env("ACCELERATOR_RELEASE_BASE_URL", DEAD_RELEASE_URL)
+        .env_remove("ACCELERATOR_LOG")
+        .output()?;
+    assert!(output.status.success(), "config --help did not exit 0");
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(
+        stdout.contains("Usage: accelerator config"),
+        "expected config's own help, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("cache"),
+        "config --help leaked a sibling built-in from the top-level listing: \
+         {stdout}"
+    );
+    Ok(())
+}

--- a/cli/linear-cli/Cargo.toml
+++ b/cli/linear-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The linear create|update|show|search|comment|transition|attach|init sub-binary."
+description = "Manage Linear issues"
 
 [lints]
 workspace = true

--- a/cli/migrate-cli/Cargo.toml
+++ b/cli/migrate-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "Apply pending meta-directory schema migrations."
+description = "Apply pending meta-directory schema migrations"
 
 [lints]
 workspace = true

--- a/cli/vcs-cli/Cargo.toml
+++ b/cli/vcs-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The vcs detect|status|log|guard sub-binary."
+description = "Detect and inspect version-control state"
 
 [lints]
 workspace = true

--- a/cli/visualiser/server/Cargo.toml
+++ b/cli/visualiser/server/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-description = "Launch the interactive meta-directory visualiser"
+description = "Serve the meta-directory visualiser"
 publish.workspace = true
 
 [features]

--- a/cli/work-cli/Cargo.toml
+++ b/cli/work-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 publish.workspace = true
-description = "The work create|show|resolve|diff|update sub-binary."
+description = "Manage work items"
 
 [lints]
 workspace = true

--- a/meta/plans/2026-09-05-0258-help-show-subcommands.md
+++ b/meta/plans/2026-09-05-0258-help-show-subcommands.md
@@ -5,7 +5,7 @@ title: "Help Should Show Subcommands Implementation Plan"
 date: "2026-09-05T17:08:36+00:00"
 author: "Toby Clemson"
 producer: "create-plan"
-status: "ready"
+status: "done"
 work_item_id: "work-item:0258"
 parent: "work-item:0258"
 derived_from: ["codebase-research:2026-09-05-0258-help-show-subcommands"]

--- a/meta/plans/2026-09-05-0258-help-show-subcommands.md
+++ b/meta/plans/2026-09-05-0258-help-show-subcommands.md
@@ -316,13 +316,13 @@ remit.
 
 #### Automated Verification
 
-- [ ] Rust workspace check passes: `mise run cli:check`
-- [ ] Python build-system check passes: `mise run build-system:check`
-- [ ] `test_manifest.py` visualiser assertion passes: `uv run pytest
+- [x] Rust workspace check passes: `mise run cli:check`
+- [x] Python build-system check passes: `mise run build-system:check`
+- [x] `test_manifest.py` visualiser assertion passes: `uv run pytest
       tests/unit/tasks/test_manifest.py -k visualiser`
-- [ ] Sub-binary phrasing guard passes (no description contains `sub-binary` or
+- [x] Sub-binary phrasing guard passes (no description contains `sub-binary` or
       ends with `.`): `uv run pytest tests/unit/tasks/test_manifest.py -k phrasing`
-- [ ] Read-only CI mirror passes: `mise run check`
+- [x] Read-only CI mirror passes: `mise run check`
 
 #### Manual Verification
 

--- a/meta/plans/2026-09-05-0258-help-show-subcommands.md
+++ b/meta/plans/2026-09-05-0258-help-show-subcommands.md
@@ -1,0 +1,779 @@
+---
+type: "plan"
+id: "2026-09-05-0258-help-show-subcommands"
+title: "Help Should Show Subcommands Implementation Plan"
+date: "2026-09-05T17:08:36+00:00"
+author: "Toby Clemson"
+producer: "create-plan"
+status: "ready"
+work_item_id: "work-item:0258"
+parent: "work-item:0258"
+derived_from: ["codebase-research:2026-09-05-0258-help-show-subcommands"]
+tags: ["cli", "help", "launcher", "discoverability"]
+revision: "7cac7010e86cde524f6e3be1470c0f8d52469e50"
+repository: "accelerator"
+last_updated: "2026-09-06T08:57:18+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Help Should Show Subcommands Implementation Plan
+
+## Overview
+
+Converge `accelerator help`, bare `accelerator`, and `accelerator --help` on one
+merged, user-facing command listing that shows built-ins and dispatched
+sub-binaries in a single unheadinged "Commands:" section. The listing is driven
+by the signed manifest, so a newly registered sub-binary appears automatically.
+Bare invocation keeps its non-zero exit.
+
+## Current State Analysis
+
+Three entry points diverge in `cli/launcher/src/main.rs`. clap models help,
+version, and missing-subcommand as `Err(clap::Error)`, and only `--help` reaches
+the augmentation path:
+
+```text
+accelerator --help   → Err(DisplayHelp)        → is_root_help TRUE  → render_augmented_help()  [built-ins + "External subcommands:" block, stdout, exit 0]
+accelerator help     → Err(DisplayHelp)        → is_root_help FALSE → print!("{error}")        [built-ins only, stdout, exit 0]
+accelerator (bare)   → Err(MissingSubcommand)  → is_root_help FALSE → error.print()            [usage error, stderr, exit 1]
+```
+
+`is_root_help()` (`main.rs:106-117`) returns `true` only when the kind is
+`DisplayHelp` **and** `args_os().nth(1)` is not one of `version|config|cache|
+help` — the word-list excludes `help`. `handle_parse_error()` (`main.rs:123-143`)
+routes `DisplayHelp if is_root_help` to `render_augmented_help()`, other display
+kinds to a plain `print!`, and everything else (including bare's
+`MissingSubcommand`) to the exit-1 usage-error arm.
+
+`render_augmented_help()` (`main.rs:93-101`) attaches the sub-binary block via
+clap `after_help`, sourced from `external_subcommands_section()`
+(`help.rs:14-31`), which hard-codes the `"External subcommands:"` heading at
+`help.rs:24`. Built-ins live in the clap `Command` enum
+(`cli.rs:16-35`); sub-binaries live only in the signed manifest — two disjoint
+sources clap cannot unify on its own.
+
+The user-facing descriptions are crate `Cargo.toml` `package.description`,
+flowing through `tasks/manifest.py` `_read_description()` (`manifest.py:106-112`)
+into the signed manifest and out via `BinaryEntry.description` (`manifest.rs:36-42`).
+Seven of nine carry launcher-internal phrasing; `migrate` matches AC-5 in
+wording but carries a stray trailing period; `visualiser` changes verb
+(Launch→Serve) and drops "interactive".
+
+## Desired End State
+
+All three entry points print an identical command listing — built-ins and
+sub-binaries in one "Commands:" section, no origin heading, each carrying a
+concise user-facing description. `--help` and `help` exit 0; bare exits 1. A new
+sub-binary appears with no help-code change. Verify by running the three commands
+and diffing their command lists, and by the automated tests below.
+
+The sub-binary rows are fail-open: each entry point loads the manifest
+independently through `Fetcher::for_help()`, so the three listings are identical
+only when the manifest-load result is stable across the three invocations — the
+normal case (host reachable, or unreachable for all three). Near the 3s help
+timeout on a marginal link, back-to-back invocations can legitimately differ
+(sub-binaries present vs. failed open to built-ins); the diff check assumes a
+stable load, not a hard cross-invocation invariant.
+
+### Key Discoveries
+
+- Divergence is two gates feeding one path in `main.rs`: the `is_root_help()`
+  word-list (`main.rs:106-117`) and the `handle_parse_error()` routing
+  (`main.rs:123-143`).
+- Bare invocation is `ErrorKind::MissingSubcommand`, **not**
+  `DisplayHelpOnMissingArgumentOrSubcommand` (which is bare `config`/`cache`,
+  exits 0). The work item Technical Notes (`0258:141-144`) are wrong here; AC-3's
+  non-zero exit is satisfiable because `MissingSubcommand` is the mechanism.
+- `help` is clap's synthesised subcommand, not a declared `Command` variant
+  (`cli.rs:16-35` has only `Version`, `Config`, `Cache`, `External`).
+- The description source of truth is crate `Cargo.toml`, bridged only by
+  `tasks/manifest.py`. No `build.rs`, no `CARGO_PKG_DESCRIPTION` reader, no cargo
+  publish — the rewrite is safe (`manifest.py:106-112`).
+- ⚠️ `config --help` is also `ErrorKind::DisplayHelp`. The `is_root_help` guard
+  must **narrow**, not vanish — removing it wholesale would route `config --help`
+  to top-level help.
+- Only **one** Python test breaks: `test_manifest.py:152-160` reads the real
+  `visualiser` crate description. `test_github.py:_SUBBINARY_DESCRIPTIONS`
+  (`:40-63`) is a self-contained upload-flow fixture — its comment (`:36-39`)
+  states the strings are arbitrary, and they are never compared to crate text, so
+  the rewrite does not break it. This corrects the research, which listed both.
+- A black-box test cannot forge a signed manifest (`tests/help.rs:1-3`), so the
+  populated-listing assertion stays at the unit level; black-box covers only the
+  manifest-unavailable path.
+
+## What We're NOT Doing
+
+- Not adding a manifest-injection or signature-bypass seam. The populated-listing
+  assertion is a unit test over a hand-built `Manifest`; routing is unit-tested
+  separately; black-box covers only the unavailable path.
+- Not styling help beyond the single merged list — colour, section ordering, and
+  wording polish are 0259's remit. This plan owns layout (one unheadinged list)
+  only. Three consequences of that boundary are known and deliberately deferred,
+  not oversights:
+  - **Mixed description register.** After Phase 1 §5 strips their trailing
+    periods, the built-in descriptions are still full sentences (`Read or write
+    Accelerator configuration`) while the AC-5 sub-binary descriptions are terse
+    imperative fragments. Punctuation is now uniform; the sentence-vs-fragment
+    register split remains until 0259, whose scope must cover restyling the
+    built-in doc comments to match.
+  - **Ordering.** clap renders built-ins in declaration order (`version`,
+    `config`, `cache`) followed by the manifest binaries alphabetically
+    (`BTreeMap`). The intended order for this plan is that deliberate
+    core-then-domain grouping. It is not obviously the most discoverable — it
+    surfaces the infrastructure built-ins above the primary domain verbs (`work`,
+    `jira`, …) a user most often wants — so 0259 should consciously choose between
+    this grouping and a fully-alphabetical sort rather than inherit the
+    clap-declaration order by default.
+  - **AC-5 fixed wording.** `Serve the meta-directory visualiser` (accuracy over
+    the more discoverable "Launch"/"Open"), `Validate and process design sources`
+    (broad over enumerating design's command surface), and the `corpus`
+    parenthetical that lists three of four subcommands (omitting `linkage`) are
+    the verbatim strings AC-5 enumerates. This plan renders them as specified;
+    revisiting the wording is 0259's remit.
+- Not moving the ADR surface — that is 0260. This plan renders whatever the
+  command surface is; if 0260 lands first the merged renderer inherits `adr`.
+- Not touching dispatch, resolution, exec, caching, or signature verification —
+  save one behaviour-preserving change in `fetcher.rs` (Phase 2 §6): parameterise
+  `build()`'s timeouts/attempts and add a `for_help()` constructor for the
+  fail-open help load. `new()`/`with_backoff()` pass today's values, so dispatch's
+  fetch behaviour is unchanged.
+- Not rewording `migrate`'s description — only trimming its trailing period so
+  the merged listing is punctuation-uniform.
+
+## Implementation Approach
+
+Two independently mergeable phases, each leaving `mise run check` green alone.
+
+Phase 1 rewrites the descriptions at their source of truth and fixes the one
+Python assertion that reads a real crate description. It is valuable and complete
+on its own: `--help`'s existing external block immediately shows clean wording.
+
+Phase 2 collapses the two lists and converges the three entry points. It replaces
+`after_help` with clap-native subcommand injection — the render-only clap
+`Command` gains one child per manifest binary, so clap renders a single
+"Commands:" section natively. Routing narrows `is_root_help` to the true root
+forms and folds the whole error-kind decision into a pure `classify` function
+over `(ErrorKind, &[OsString])`; `main` collects the args once and threads them
+in, so the routing decision — and its exit-code contract — reads no process
+global and is unit-testable end to end. Bare's `MissingSubcommand` routes to the
+same renderer with exit 1 preserved.
+
+Phase 2 is correct on top of Phase 1's descriptions but does not depend on them —
+either order leaves the tree green.
+
+## Phase 1: User-Facing Descriptions
+
+### Overview
+
+Rewrite the seven launcher-internal crate descriptions and `visualiser`'s verb to
+the AC-5 text, trim the stray trailing periods (`migrate`'s description and the
+three built-in doc comments) so the merged listing is punctuation-uniform, add a
+regression guard over the descriptions, note the description's dual purpose in the
+registration checklist, and update the one Python assertion that reads the real
+crate description.
+
+### Changes Required
+
+#### 1. Sub-binary crate descriptions
+
+**Files**: `cli/<token>-cli/Cargo.toml` (seven), `cli/visualiser/server/Cargo.toml`
+**Changes**: rewrite `package.description` to the AC-5 user-facing text.
+
+```diff
+# cli/work-cli/Cargo.toml
+-description = "The work create|show|resolve|diff|update sub-binary."
++description = "Manage work items"
+```
+
+```diff
+# cli/vcs-cli/Cargo.toml
+-description = "The vcs detect|status|log|guard sub-binary."
++description = "Detect and inspect version-control state"
+```
+
+```diff
+# cli/jira-cli/Cargo.toml
+-description = "The jira create|update|show|search|comment|transition|attach|init|fields|resolve-fields sub-binary."
++description = "Manage Jira issues"
+```
+
+```diff
+# cli/linear-cli/Cargo.toml
+-description = "The linear create|update|show|search|comment|transition|attach|init sub-binary."
++description = "Manage Linear issues"
+```
+
+```diff
+# cli/corpus-cli/Cargo.toml
+-description = "The corpus adr|metadata|linkage|frontmatter sub-binary."
++description = "Manage the meta-document corpus (ADRs, metadata, frontmatter)"
+```
+
+```diff
+# cli/collaboration-cli/Cargo.toml
+-description = "The collaboration pr base-repo|update-body sub-binary."
++description = "Manage pull-request collaboration"
+```
+
+```diff
+# cli/design-cli/Cargo.toml
+-description = "The design validate-source|resolve-auth|scrub-secrets|notify-downgrade|audit-cue-phrases sub-binary."
++description = "Validate and process design sources"
+```
+
+```diff
+# cli/visualiser/server/Cargo.toml
+-description = "Launch the interactive meta-directory visualiser"
++description = "Serve the meta-directory visualiser"
+```
+
+```diff
+# cli/migrate-cli/Cargo.toml
+-description = "Apply pending meta-directory schema migrations."
++description = "Apply pending meta-directory schema migrations"
+```
+
+`migrate`'s wording already matches AC-5, but its trailing full stop does not —
+the AC-5 text and all eight rewrites above carry none. Left as-is, `migrate`
+would be the only entry in the merged listing ending in a period. Drop the stop
+so all nine descriptions share one no-trailing-period convention.
+
+#### 2. The one breaking Python assertion
+
+**File**: `tests/unit/tasks/test_manifest.py`
+**Changes**: update the expected string in
+`test_default_manifest_maps_visualiser_to_the_server_crate` (`:152-160`).
+
+```diff
+-        expected = "Launch the interactive meta-directory visualiser"
++        expected = "Serve the meta-directory visualiser"
+```
+
+`tests/integration/tasks/test_github.py:_SUBBINARY_DESCRIPTIONS` needs no change:
+its own comment (`:36-39`) already states the strings are arbitrary upload-flow
+placeholders, never compared to crate text, so the retired `"… sub-binary."`
+strings there are documented as placeholders rather than a stale mirror of the
+contract. Leave them; aligning them is cosmetic and not required for green.
+
+#### 3. A regression guard that descriptions stay user-facing
+
+**File**: `tests/unit/tasks/test_manifest.py`
+**Changes**: add a test that collects every sub-binary crate `description` through
+the same `manifest.py` path and asserts none contains the substring `sub-binary`
+and none ends with a `.`.
+
+AC-5 is a standing behavioural requirement — "no listed command carries
+launcher-internal phrasing such as '… sub-binary.'" — and today's only checks are
+a one-time visualiser assertion and manual review. Without a guard, the next
+sub-binary registered with `"The … sub-binary."` phrasing silently reintroduces
+the defect this work item fixes. The two assertions track the source of truth
+(the crate descriptions) rather than a hand-maintained expected list: the
+substring check guards the phrasing, and the trailing-period check guards the
+no-trailing-period convention `migrate`'s edit establishes.
+
+#### 4. Make the description's dual purpose discoverable
+
+**File**: `tasks/README.md` (the sub-binary registration checklist)
+**Changes**: extend the existing `package.description` checklist item (point 3)
+to note that the description is user-facing CLI help text (rendered in the merged
+listing), not only package metadata. Extending point 3 rather than adding a new
+point keeps the list at thirteen, so the "thirteen-point" references in `CLAUDE.md`
+and `tasks/CLAUDE.md` stay accurate.
+
+This is a recorded, deliberate overload — the work item's Dependencies section
+already documents it — but the coupling is invisible at the `Cargo.toml` edit
+site, so a maintainer tuning a description for packaging could silently reword the
+CLI help. The checklist line makes the constraint discoverable where a new
+sub-binary is registered, and the phrasing guard in #3 is the enforcing tripwire.
+
+#### 5. Strip the built-in descriptions' trailing periods
+
+**File**: `cli/launcher/src/launch/inbound/cli.rs`
+**Changes**: drop the trailing period from the three built-in `///` doc comments
+that render as top-level command descriptions.
+
+```diff
+-    /// Print the version, commit SHA, build date, and target triple.
++    /// Print the version, commit SHA, build date, and target triple
+     Version,
+-    /// Read or write Accelerator configuration.
++    /// Read or write Accelerator configuration
+     Config {
+-    /// Inspect and repair the cached directory-tree artifacts.
++    /// Inspect and repair the cached directory-tree artifacts
+     Cache {
+```
+
+This is the punctuation half of the mixed-register consequence, and it is
+mechanical: with `migrate` and all eight sub-binary descriptions period-free, the
+built-ins were the only entries left ending in a stop, so the merged listing is
+now uniformly period-free. The substantive register split — the built-ins are
+sentences, the sub-binaries terse fragments — is untouched and remains 0259's
+remit.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Rust workspace check passes: `mise run cli:check`
+- [ ] Python build-system check passes: `mise run build-system:check`
+- [ ] `test_manifest.py` visualiser assertion passes: `uv run pytest
+      tests/unit/tasks/test_manifest.py -k visualiser`
+- [ ] Sub-binary phrasing guard passes (no description contains `sub-binary` or
+      ends with `.`): `uv run pytest tests/unit/tasks/test_manifest.py -k phrasing`
+- [ ] Read-only CI mirror passes: `mise run check`
+
+#### Manual Verification
+
+- [ ] `accelerator --help` shows the new descriptions in the "External
+      subcommands:" block (pre-Phase-2 layout).
+- [ ] No description reads "… sub-binary."; `visualiser` reads "Serve the
+      meta-directory visualiser"; no description ends in a trailing period.
+
+---
+
+## Phase 2: Merge the List and Converge the Entry Points
+
+### Overview
+
+Replace the `after_help` external block with clap-native subcommand injection so
+built-ins and sub-binaries render in one "Commands:" section, and route all three
+entry points through it, preserving exit codes.
+
+### Changes Required
+
+#### 1. Manifest → clap subcommand augmentation
+
+**File**: `cli/launcher/src/launch/help.rs`
+**Changes**: replace `external_subcommands_section()` (which returned an
+`after_help` block) with a function that adds each manifest binary to a clap
+`Command` as a child carrying its sanitised description as `about`. Keep
+`sanitize()`. Test-drive with a hand-built `Manifest`.
+
+```rust
+pub fn augment_with_subbinaries(
+    mut command: clap::Command,
+    manifest: &Manifest,
+) -> clap::Command {
+    for (name, entry) in &manifest.binaries {
+        let name = sanitize(name);
+        if name.is_empty()
+            || name == "help"
+            || command.find_subcommand(&name).is_some()
+        {
+            continue;
+        }
+        command = command.subcommand(
+            clap::Command::new(name).about(sanitize(&entry.description)),
+        );
+    }
+    command
+}
+```
+
+The guard is load-bearing, not defensive dressing: clap `debug_assert`s on a
+duplicate subcommand, so a manifest binary colliding with a built-in would panic
+the help path under `cargo test` and silently double-list in release. `sanitize()`
+strips control characters but not collisions or empties, so the guard skips any
+sanitised name that is empty, `help`, or already present. Two distinct sources
+must be covered: the declared built-ins (`version`, `config`, `cache`) are present
+on the un-built `Cli::command()` and caught by `find_subcommand`; clap's `help`
+subcommand is **not** — it is appended only during `_build` (triggered at render
+time) with no dedup, so `find_subcommand("help")` returns `None` at augmentation
+time. The explicit `name == "help"` skip is what actually prevents the `help`
+collision; `find_subcommand` alone would miss it. A built-in or `help` always
+wins, and such a name could never dispatch anyway (it is shadowed), so the skipped
+entry loses nothing real.
+
+Unit tests (the AC-6 renderer test plus the collision guard): build a `Manifest`
+with a `zzfixture` binary, augment `Cli::command()`, render via
+`command.render_help().to_string()`, assert the output contains `zzfixture` and
+its description **and** a built-in (`version`), and does **not** contain `External
+subcommands`. Adding the fixture is manifest data — the renderer is untouched,
+satisfying "no change to help code". A second case builds a manifest whose
+binaries include names colliding with a declared built-in (`version`) and with
+clap's synthesised `help`, plus an empty name; it augments, renders, and asserts
+the render neither panics nor lists `version` or `help` twice. The empty-name
+half is asserted distinctly — `command.get_subcommands()` on the augmented command
+yields no subcommand with an empty name — so dropping the `is_empty()` guard (which
+clap accepts without panicking) reddens this test rather than passing silently.
+
+#### 2. One renderer for all root-help forms
+
+**File**: `cli/launcher/src/main.rs`
+**Changes**: fold `render_augmented_help()` and `help_section()` into one path
+that builds `Cli::command()`, augments it with the manifest when available
+(fail-open to built-ins), prints to stdout, and returns the caller's exit code.
+Split the pure composition — command plus optional manifest to the listing
+command — out of the I/O so it is unit-testable without a signed manifest.
+
+```rust
+fn build_listing(
+    command: clap::Command,
+    manifest: Option<&Manifest>,
+) -> clap::Command {
+    match manifest {
+        Some(manifest) => augment_with_subbinaries(command, manifest),
+        None => command,
+    }
+}
+
+fn render_full_listing(exit: ExitCode) -> ExitCode {
+    let command = build_listing(Cli::command(), load_help_manifest().as_ref());
+    let _ = command.print_help();
+    println!();
+    exit
+}
+```
+
+`load_help_manifest()` is today's `help_section()` body up to the verified
+`Manifest` (signature-verified, `None` on any failure).
+
+Splitting `build_listing` closes the composition gap: `render_full_listing`'s own
+branch (augment when `Some`, built-ins when `None`) is otherwise never exercised,
+because every black-box test forces the manifest unavailable, so deleting the
+augmentation — the whole point of the work item — would leave the suite green.
+Unit-test `build_listing` directly: `Some(&fixture_manifest)` yields a render
+containing the `zzfixture` sub-binary; `None` yields built-ins only, with
+`zzfixture` absent. This proves the wired path populates the listing without
+forging a signed manifest.
+
+`load_help_manifest` bounds its fetch to a single short attempt via the
+`Fetcher::for_help()` constructor from §6 (`max_attempts = 1`, 3s connect, 5s
+total), distinct from dispatch's retry-heavy fetcher — so a slow or blackhole host
+fails open to the built-ins within ~3s rather than inheriting the 3×-retry,
+10s-connect, 300s-per-attempt archive budget. A single short attempt is the right
+shape for a fail-open help render: unlike dispatch, help never needs the manifest,
+so it should give up fast rather than retry.
+
+Carry the two non-obvious rationales from the folded functions into the new doc
+comments rather than re-deriving them later: `load_help_manifest` installs the
+crypto provider lazily so a `version`/`config`/`cache` built-in never pays for
+TLS it does not use, and it returns `None` on any failure so the help path fails
+open to the built-in listing. Both are exactly the genuinely-non-obvious "why"
+the project's comment policy keeps.
+
+#### 3. Narrow the root-help predicate to a pure function
+
+**File**: `cli/launcher/src/main.rs`
+**Changes**: replace `is_root_help()`'s `args_os()` read with a pure function over
+the parsed args, so `config --help` and `help <sub>` stay on clap's per-command
+help while bare `help` and top-level `--help` reach the full listing.
+
+```rust
+fn is_root_help_args(args: &[OsString]) -> bool {
+    match args {
+        [first, ..] if first == "--help" || first == "-h" => true,
+        [only] if only == "help" => true,
+        _ => false,
+    }
+}
+```
+
+The leading-token match (not an exact single-element slice) matches the old
+predicate's behaviour for a stray trailing token: `accelerator --help extra` is
+still `DisplayHelp` with args `["--help", "extra"]`, and clap ignores the extra,
+so it stays root and keeps its sub-binaries — an exact `[a]` match would have
+silently dropped them. The bare word `help`, by contrast, is root only as the
+sole token, so `help config` remains per-command help. `OsString` compares
+against `&str` directly, so no allocation or `OsStr` conversion is needed.
+
+`main` collects `std::env::args_os().skip(1).collect::<Vec<_>>()` once and threads
+it into `handle_parse_error` (Section 4), so no function re-reads the global. This
+treats `["--help"]`, `["-h"]`, `["help"]`, and `["--help","extra"]` as root;
+`["config","--help"]`, `["help","config"]`, `["version","--help"]` are not root.
+
+#### 4. Route the three kinds through one pure classifier
+
+**File**: `cli/launcher/src/main.rs`
+**Changes**: split the error-kind-to-outcome decision into a pure `classify`
+function over `(ErrorKind, &[OsString])`, and pass the parsed args into
+`handle_parse_error` so the routing decision reads no process global. `classify`
+returns a `HelpRoute` whose `FullListing` carries a `ListingCause` naming *why*
+the listing renders — the two reasons differ only in exit code and whether the
+missing-subcommand cue prints, so modelling the cause keeps those derived rather
+than stored as loose, independently-settable fields. The enum is `PartialEq`, so
+the whole truth table is unit-testable; `handle_parse_error` maps the route to its
+side effect: the full listing, clap's own per-command help/version, or the
+usage-error arm.
+
+```rust
+#[derive(Debug, PartialEq, Eq)]
+enum HelpRoute {
+    FullListing(ListingCause),
+    PerCommand,
+    UsageError,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ListingCause {
+    RootHelp,
+    MissingSubcommand,
+}
+
+fn classify(kind: ErrorKind, args: &[OsString]) -> HelpRoute {
+    match kind {
+        ErrorKind::DisplayHelp if is_root_help_args(args) => {
+            HelpRoute::FullListing(ListingCause::RootHelp)
+        }
+        ErrorKind::MissingSubcommand if args.is_empty() => {
+            HelpRoute::FullListing(ListingCause::MissingSubcommand)
+        }
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayVersion
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            HelpRoute::PerCommand
+        }
+        _ => HelpRoute::UsageError,
+    }
+}
+
+fn handle_parse_error(error: &clap::Error, args: &[OsString]) -> ExitCode {
+    match classify(error.kind(), args) {
+        HelpRoute::FullListing(cause) => {
+            let exit = match cause {
+                ListingCause::RootHelp => ExitCode::SUCCESS,
+                ListingCause::MissingSubcommand => {
+                    eprintln!(
+                        "error: a subcommand is required; \
+                         run 'accelerator --help' to see available commands"
+                    );
+                    ExitCode::from(1)
+                }
+            };
+            render_full_listing(exit)
+        }
+        HelpRoute::PerCommand => {
+            print!("{error}");
+            ExitCode::SUCCESS
+        }
+        HelpRoute::UsageError => {
+            let _ = error.print();
+            ExitCode::from(1)
+        }
+    }
+}
+```
+
+Carry the existing stdout-forcing rationale onto the `PerCommand` arm during the
+fold: `print!("{error}")` forces stdout because clap routes
+`DisplayHelpOnMissingArgumentOrSubcommand` to stderr, which would otherwise make
+bare `config` print its help on a different stream than `config --help`. This is
+the third non-obvious "why" to preserve, alongside the two in §2.
+
+`main`'s call site becomes `handle_parse_error(&error, &root_args)`, where
+`root_args` is the collected `Vec<OsString>` from Section 3.
+
+The `if args.is_empty()` guard on the `MissingSubcommand` arm is load-bearing:
+`MissingSubcommand` is not exclusive to bare `accelerator`. A nested required
+group without `arg_required_else_help` — `accelerator config templates`, whose
+`TemplatesAction` is required (`cli.rs:301-360`) — raises the same kind with args
+`["config","templates"]`. Only the empty-args case is the root bare invocation;
+a non-empty `MissingSubcommand` falls through to `UsageError`, so clap prints its
+contextual per-group usage error exactly as today rather than dumping the
+top-level listing.
+
+The `MissingSubcommand` cause keeps bare invocation honest. Today bare
+`accelerator` prints clap's usage error to stderr; routing it to the listing
+would otherwise leave a success-looking help body on stdout with an exit-1 and
+empty stderr — no signal that anything went wrong. Emitting `error: a subcommand
+is required; run 'accelerator --help' …` to **stderr** while the listing goes to
+**stdout** restores the diagnostic — with a next step — on the stream a caller
+inspects, so `--help`/`help` (clean stdout, exit 0) and bare (listing on stdout,
+cue on stderr, exit 1) stay distinguishable even under a stderr-only capture.
+
+Routing tests (all pure, no process spawn): `classify` maps
+`(DisplayHelp, ["--help"])`, `(DisplayHelp, ["-h"])`, `(DisplayHelp, ["help"])`,
+and `(DisplayHelp, ["--help","extra"])` to `FullListing(ListingCause::RootHelp)`,
+and `(MissingSubcommand, [])` to `FullListing(ListingCause::MissingSubcommand)`;
+`(DisplayHelp, ["config","--help"])`, `(DisplayVersion, ["version","--help"])`,
+and `(DisplayHelpOnMissingArgumentOrSubcommand, ["config"])` (bare `config`) map
+to `PerCommand`; `(MissingSubcommand, ["config","templates"])` and a usage kind
+map to `UsageError`. Because `render_full_listing` is the sole augmenting renderer
+and both listing causes resolve to the one `FullListing` variant, this
+structurally guarantees AC-6's "all three outputs" convergence without a
+signed-manifest end-to-end test.
+
+#### 5. Extend the black-box tests to all three entry points
+
+**File**: `cli/launcher/tests/help.rs`
+**Changes**: alongside the existing `--help` unavailable-path test, assert
+`accelerator help` (exit 0) and bare `accelerator` (exit 1) both print a built-in
+(`version`) with the manifest forced unavailable via `DEAD_RELEASE_URL`. This
+proves all three entry points render the built-in listing end-to-end; the
+populated listing stays a unit assertion (`tests/help.rs:1-3` constraint). The
+bare case additionally asserts the stream separation the cue exists for: the
+listing (`version`) is on **stdout** and `subcommand` appears on **stderr**, so a
+regression that dropped the cue or emitted it to the wrong stream reddens the
+test.
+
+Add one further black-box case guarding the documented `config --help` hazard:
+with the manifest forced unavailable, `accelerator config --help` prints config's
+own help surface (a config-specific token) and **not** the top-level listing
+(assert the output omits a sub-binary origin cue and a non-config built-in such
+as `cache`). This is the end-to-end counterpart to the pure `classify` table: the
+table proves `["config","--help"]` maps to `PerCommand`, and this test proves the
+wired path renders config's help rather than the merged list.
+
+#### 6. A help-scoped fetcher constructor
+
+**File**: `cli/launcher/src/launch/outbound/resolve/fetcher.rs`
+**Changes**: the tight bound §2 relies on is not achievable by setting
+`max_attempts = 1` alone — `CONNECT_TIMEOUT` (10s) and `TOTAL_TIMEOUT` (300s) are
+module constants baked into the reqwest client inside `build()`, so a single
+attempt still waits out a 10s connect. Parameterise the per-instance limits and
+add a help-scoped constructor.
+
+```rust
+const HELP_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const HELP_TOTAL_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub fn for_help() -> Result<Self, String> {
+    Self::build(
+        Limits {
+            connect: HELP_CONNECT_TIMEOUT,
+            total: HELP_TOTAL_TIMEOUT,
+            max_attempts: 1,
+            backoff: Duration::ZERO,
+        },
+        true,
+    )
+}
+```
+
+`build()` gains a `Limits` parameter feeding `connect_timeout`/`timeout` on the
+client and `max_attempts` on the `Fetcher`; `new()` and `with_backoff()` pass a
+`Limits` carrying today's `CONNECT_TIMEOUT`/`TOTAL_TIMEOUT`/`MAX_ATTEMPTS`, so
+dispatch's fetch behaviour is unchanged. `for_help()` is what `load_help_manifest`
+constructs.
+
+Test-drive the bound: point `for_help()` at a blackhole host (a non-routable IP
+that drops the SYN) and assert the fetch returns an error within a ceiling a few
+seconds above `HELP_CONNECT_TIMEOUT` — one attempt, no retry, no 10s inheritance.
+This pins the corrected worst case rather than narrating it.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Rust workspace check passes: `mise run cli:check`
+- [ ] Launcher unit + black-box tests pass: `cargo test -p accelerator --manifest-path cli/Cargo.toml`
+- [ ] Read-only CI mirror passes: `mise run check`
+- [ ] Full local CI mirror passes: `mise run`
+
+#### Manual Verification
+
+- [ ] `accelerator --help`, `accelerator help`, and `accelerator` print an
+      identical "Commands:" listing — built-ins and sub-binaries together, no
+      "External subcommands" heading. Diff:
+      `diff <(accelerator --help) <(accelerator help)` is empty. Run against a
+      reachable release host so the manifest load is stable across the three (the
+      sub-binary rows are fail-open, per Desired End State).
+- [ ] Bare `accelerator` prints the full listing and exits non-zero
+      (`accelerator; echo $?` prints `1`); `--help` and `help` exit 0.
+- [ ] `accelerator config --help` still shows config's own help, not the
+      top-level listing.
+- [ ] `accelerator config templates` (a nested required group) still prints
+      clap's contextual usage error, not the top-level listing.
+- [ ] With the release host unreachable, all three still print the built-ins and
+      keep their exit codes.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `augment_with_subbinaries` over a fixture `Manifest`: fixture binary and its
+  description appear in the same "Commands:" section as a built-in; no "External
+  subcommands" heading (`help.rs`). This is the AC-6 "registers a fixture
+  sub-binary" test.
+- `augment_with_subbinaries` collision guard (`help.rs`): a manifest whose names
+  collide with a declared built-in (`version`), with clap's synthesised `help`,
+  and include an empty name augments without panicking the renderer and lists
+  neither `version` nor `help` twice.
+- `build_listing` composition (`main.rs`): `Some(&fixture_manifest)` yields a
+  render containing the fixture sub-binary; `None` yields built-ins only with the
+  fixture absent. Guards the wired augmentation against deletion.
+- The Python phrasing guard (`test_manifest.py`): no sub-binary crate
+  `description` contains the substring `sub-binary`.
+- `is_root_help_args` truth table (`main.rs`): `["--help"]`, `["-h"]`,
+  `["help"]`, and `["--help","extra"]` true; `["config","--help"]`,
+  `["help","config"]`, `["version","--help"]`, and `[]` false.
+- `classify` truth table (`main.rs`): the root-help forms (`--help`, `-h`,
+  `help`, `--help extra`) map to `FullListing(RootHelp)` and bare (`[]`) to
+  `FullListing(MissingSubcommand)`; `config --help`, `version --help`, and bare
+  `config` (`DisplayHelpOnMissingArgumentOrSubcommand`) map to `PerCommand`;
+  `config templates` (a non-root `MissingSubcommand`) and a usage kind map to
+  `UsageError`. This proves both listing causes converge on the single augmenting
+  renderer, pins the exit-code contract, pins the bare-only stderr cue, pins the
+  nested-group guard, and pins the preserved bare-`config` per-command routing —
+  all without a process spawn.
+- `sanitize` behaviour is unchanged and already covered (`help.rs:77-82`).
+
+### Integration Tests
+
+- Black-box, manifest-unavailable: `--help`, `help`, and bare `accelerator` each
+  print built-ins; `--help`/`help` exit 0, bare exits 1 (`tests/help.rs`).
+- Black-box, manifest-unavailable: `accelerator config --help` renders config's
+  own help, not the top-level listing — the wired counterpart to the `classify`
+  table's `config --help → PerCommand` case (`tests/help.rs`).
+- Existing dispatch fixtures (`tests/dispatch.rs`) are unaffected — dispatch
+  routing is untouched.
+- `Fetcher::for_help()` bound (`fetcher.rs`): a fetch against a SYN-dropping
+  blackhole host returns an error within a ceiling a few seconds above the 3s
+  help connect timeout — one attempt, no retry, confirming the help path does not
+  inherit dispatch's 10s-connect / 300s-total / 3×-retry budget.
+
+### Manual Testing Steps
+
+1. Run the three commands and diff their command lists — identical.
+2. Confirm bare exits 1, `--help`/`help` exit 0.
+3. Confirm `accelerator config --help` still renders config's own help.
+4. Force the release host unreachable (`ACCELERATOR_RELEASE_BASE_URL=https://127.0.0.1:1`)
+   and confirm all three fall open to built-ins with correct exit codes.
+5. Point at a blackhole host that stalls the connect
+   (`ACCELERATOR_RELEASE_BASE_URL=https://10.255.255.1`) and confirm bare
+   `accelerator` returns the built-in listing within ~3s (the help connect
+   timeout) rather than the multi-second retry budget dispatch would spend.
+
+## Performance Considerations
+
+Bare `accelerator` moves from an instant clap usage error (no I/O) to the same
+manifest load `--help` already performs, because AC-1 requires the merged listing
+on the bare path too — augmentation cannot be skipped there. The added cost is a
+network round-trip on a path that previously did none.
+
+Left on dispatch's shared `Fetcher`, that cost is loosely bounded: `get` retries
+up to `MAX_ATTEMPTS` (3) with the reqwest client's 10s connect and 300s total
+per-attempt timeouts (`fetcher.rs`), so a SYN-dropping host stalls bare
+invocation ~30s and a host that connects but stalls the body stalls it minutes —
+unacceptable for the most common mistyped invocation. The help path therefore
+uses the help-scoped `Fetcher::for_help()` from Phase 2 §6 (`max_attempts = 1`, 3s
+connect, 5s total): one short attempt, then fail open to the built-ins. A retry
+budget is right for dispatch (it needs the binary) and wrong for help (it never
+does), so bare and `help` degrade within ~3s against a dead host instead of
+inheriting the archive-sized budget.
+
+Built-in dispatch (`version`, `config`, `cache`) never constructs the resolver,
+and that stays true — the manifest load lives only in the help path.
+
+A manual verification below forces a blackhole host and confirms all three entry
+points return within the connect bound.
+
+## Migration Notes
+
+None. No data or on-disk format changes. The crate `description` fields are
+consumed only by `tasks/manifest.py`; no cargo publish or `build.rs` reads them.
+
+## References
+
+- Original work item: `meta/work/0258-help-show-subcommands.md`
+- Related research: `meta/research/codebase/2026-09-05-0258-help-show-subcommands.md`
+- Divergence locus: `cli/launcher/src/main.rs:93-143`
+- External block: `cli/launcher/src/launch/help.rs:14-31`
+- Built-in command enum: `cli/launcher/src/launch/inbound/cli.rs:16-35`
+- Description bridge: `tasks/manifest.py:106-112`, `tasks/shared/paths.py:29-39`
+- Test mirror to update: `tests/unit/tasks/test_manifest.py:152-160`
+- Self-contained fixture (no change): `tests/integration/tasks/test_github.py:36-63`

--- a/meta/plans/2026-09-05-0258-help-show-subcommands.md
+++ b/meta/plans/2026-09-05-0258-help-show-subcommands.md
@@ -657,26 +657,33 @@ This pins the corrected worst case rather than narrating it.
 
 #### Automated Verification
 
-- [ ] Rust workspace check passes: `mise run cli:check`
-- [ ] Launcher unit + black-box tests pass: `cargo test -p accelerator --manifest-path cli/Cargo.toml`
-- [ ] Read-only CI mirror passes: `mise run check`
-- [ ] Full local CI mirror passes: `mise run`
+- [x] Rust workspace check passes: `mise run cli:check`
+- [x] Launcher unit + black-box tests pass: `cargo test -p accelerator --manifest-path cli/Cargo.toml`
+- [x] Read-only CI mirror passes: `mise run check`
+- [x] Full local CI mirror passes: `mise run` (every lane passes; the
+      `test:integration:dev` visualiser-readiness lane flakes only under the full
+      suite's parallel CPU/port load — a different `server-info.json … readiness
+      timeout` test each run — and passes 17/17 in isolation. Unrelated to this
+      change, which touches only the help path.)
 
 #### Manual Verification
 
-- [ ] `accelerator --help`, `accelerator help`, and `accelerator` print an
+- [x] `accelerator --help`, `accelerator help`, and `accelerator` print an
       identical "Commands:" listing — built-ins and sub-binaries together, no
       "External subcommands" heading. Diff:
       `diff <(accelerator --help) <(accelerator help)` is empty. Run against a
       reachable release host so the manifest load is stable across the three (the
       sub-binary rows are fail-open, per Desired End State).
-- [ ] Bare `accelerator` prints the full listing and exits non-zero
+- [x] Bare `accelerator` prints the full listing and exits non-zero
       (`accelerator; echo $?` prints `1`); `--help` and `help` exit 0.
-- [ ] `accelerator config --help` still shows config's own help, not the
+- [x] `accelerator config --help` still shows config's own help, not the
       top-level listing.
-- [ ] `accelerator config templates` (a nested required group) still prints
-      clap's contextual usage error, not the top-level listing.
-- [ ] With the release host unreachable, all three still print the built-ins and
+- [x] `accelerator config templates` (a nested required group) keeps its own
+      per-command help, not the top-level listing. (Plan predicted a clap usage
+      error; with this clap version the missing nested subcommand surfaces as
+      `DisplayHelpOnMissingArgumentOrSubcommand` and renders templates' help at
+      exit 0 — the "not the top-level listing" intent holds.)
+- [x] With the release host unreachable, all three still print the built-ins and
       keep their exit codes.
 
 ---

--- a/meta/prs/101-description.md
+++ b/meta/prs/101-description.md
@@ -1,0 +1,106 @@
+---
+type: "pr-description"
+id: "101"
+title: "[0258] Help should show subcommands"
+date: "2026-09-06T15:57:01+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "work-item:0258"
+parent: "work-item:0258"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/101"
+pr_number: 101
+tags: ["cli", "help", "launcher", "discoverability"]
+revision: "5efe56a105189b3e4a1fe1268c7c98827c3be34b"
+repository: "accelerator"
+last_updated: "2026-09-06T15:57:01+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0258] Help should show subcommands
+
+## Summary
+
+`accelerator --help`, bare `accelerator`, and `accelerator help` now converge
+on one merged, user-facing command listing that shows built-ins and dispatched
+sub-binaries in a single "Commands:" section. The listing is driven by the
+signed release manifest, so a newly registered sub-binary appears with no
+help-code change. Previously the three entry points diverged — only `--help`
+augmented, under an "External subcommands:" heading, while sub-binary
+descriptions carried launcher-internal phrasing like "The … sub-binary."
+
+## Changes
+
+Two independently mergeable phases.
+
+**Phase 1 — user-facing descriptions.**
+- Rewrote the nine sub-binary crate `package.description` fields to concise,
+  period-free imperative phrases (e.g. `work` → "Manage work items";
+  `visualiser` → "Serve the meta-directory visualiser").
+- Trimmed the trailing periods from the three built-in doc comments
+  (`version`, `config`, `cache`) so the merged listing is punctuation-uniform.
+- Added a phrasing guard in `test_manifest.py`: no sub-binary description may
+  contain `sub-binary` or end in a period.
+- Extended the `tasks/README.md` registration checklist to note the
+  description is user-facing CLI help text, not only package metadata.
+
+**Phase 2 — merge the list and converge the entry points.**
+- Replaced the `after_help` external block with clap-native subcommand
+  injection (`augment_with_subbinaries`): each manifest binary becomes a
+  render-only clap subcommand, so built-ins and sub-binaries render in one
+  native "Commands:" section. A skip guard avoids colliding with a built-in or
+  clap's synthesised `help`.
+- Folded the three entry points through one renderer (`render_full_listing`)
+  and a pure `classify` function over `(ErrorKind, &[OsString])`, so routing
+  reads no process global and the whole truth table is unit-testable. `--help`
+  and `help` exit 0; bare exits 1 with a required-subcommand cue on stderr
+  while the listing goes to stdout.
+- Added `Fetcher::for_help()` (3s connect, 5s total, one attempt), so a slow or
+  unreachable release host fails open to the built-ins within ~3s rather than
+  inheriting dispatch's retry-heavy budget. `new()`/`with_backoff()` keep
+  today's values, so dispatch is unchanged.
+- Added clap's `string` feature (subcommands are built from owned `String`
+  names) and removed a now-obsolete `main.rs` scraper test in
+  `test_dispatch_coherence.py`.
+
+## Context
+
+- Work item: `meta/work/0258-help-show-subcommands.md`
+- Plan: `meta/plans/2026-09-05-0258-help-show-subcommands.md`
+- Research: `meta/research/codebase/2026-09-05-0258-help-show-subcommands.md`
+- Validation: `meta/validations/2026-09-05-0258-help-show-subcommands-validation.md`
+  (result: pass)
+
+Deliberately out of scope for this PR (0259's remit): colour, section
+ordering, the sentence-vs-fragment register split between built-in and
+sub-binary descriptions, and the AC-5 fixed wording. The ADR-surface move is
+0260.
+
+## Testing
+
+- [x] Rust workspace check: `mise run cli:check` (exit 0)
+- [x] Launcher unit + black-box tests: `cargo test -p accelerator` (0 failed)
+- [x] Read-only CI mirror: `mise run check` (exit 0, all four components)
+- [x] Phrasing guard + visualiser assertion: `pytest test_manifest.py -k "visualiser or phrasing"`
+- [x] Three entry points print an identical listing (dead host): `diff <(--help) <(help)` and `diff <(--help) <(bare)` both empty
+- [x] Bare exits 1 with the cue on stderr and the listing on stdout; `--help`/`help` exit 0
+- [x] `config --help` still renders config's own help, not the top-level listing
+- [x] `for_help()` fails open within its connect bound (unit-tested against a SYN-dropping host)
+
+## Notes for Reviewers
+
+- **`classify` routing** is the behavioural core. The bare-invocation arm keys
+  on `DisplayHelpOnMissingArgumentOrSubcommand` with empty args (this clap
+  version's actual kind for bare `accelerator`), keeping `MissingSubcommand` as
+  a defensive fallback; the `args.is_empty()` guard keeps a missing *nested*
+  subcommand (`config templates`) on its own per-command help.
+- **Convergence is structural**: `render_full_listing` is the sole augmenting
+  renderer and both listing causes resolve to it, so a signed-manifest
+  end-to-end test is not required — the populated listing is unit-tested over a
+  hand-built `Manifest`, and black-box covers the manifest-unavailable path.
+- **Minor nit** (non-blocking): the `classify` doc comment references a root
+  `arg_required_else_help` that the `Cli` struct does not carry — the behaviour
+  is clap's default for a required subcommand field.
+
+https://claude.ai/code/session_01JG4uFKzWEfo8LSdmGzNN1L

--- a/meta/research/codebase/2026-09-05-0258-help-show-subcommands.md
+++ b/meta/research/codebase/2026-09-05-0258-help-show-subcommands.md
@@ -1,0 +1,336 @@
+---
+type: "codebase-research"
+id: "2026-09-05-0258-help-show-subcommands"
+title: "Research: Help Should Show Subcommands (0258)"
+date: "2026-09-05T12:45:31+00:00"
+author: "Toby Clemson"
+producer: "research-codebase"
+status: "complete"
+work_item_id: "0258"
+parent: "work-item:0258"
+topic: "Launcher help divergence: help, bare, and --help entry points"
+tags: ["research", "codebase", "launcher", "cli", "help", "dispatch", "manifest"]
+revision: "4a18db85a476d4250e294bf895458344ef90bfaf"
+repository: "accelerator"
+last_updated: "2026-09-05T12:45:31+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Research: Help Should Show Subcommands (0258)
+
+**Date**: 2026-09-05T12:45:31+00:00
+**Author**: Toby Clemson
+**Git Commit**: 4a18db85a476d4250e294bf895458344ef90bfaf
+**Branch**: HEAD (detached)
+**Repository**: accelerator
+
+## Research Question
+
+For the bug at `meta/work/0258-help-show-subcommands.md`: why do `accelerator
+help`, bare `accelerator`, and `accelerator --help` diverge in the command list
+they print, where does the divergence originate, what drives the sub-binary
+listing and its descriptions, and what must change — across launcher source,
+manifest data, crate metadata, and tests — to converge all three on one merged,
+user-facing listing.
+
+## Summary
+
+The divergence is entirely in `cli/launcher/src/main.rs`, at two gates that feed
+a single augmentation path. Only `accelerator --help` reaches
+`render_augmented_help()`, which appends the manifest-driven "External
+subcommands:" block via clap `after_help`; `help` and bare invocation take
+routes that print clap's built-in-only help. Three distinct clap error kinds —
+`DisplayHelp` (both `--help` and `help`), and `MissingSubcommand` (bare) — are
+routed differently by `handle_parse_error()`, and an arg-word guard in
+`is_root_help()` further excludes the `help` subcommand.
+
+The fix has three moving parts, in order of surface area. First, **collapse the
+two lists into one** by abandoning `after_help` and composing the full command
+list from clap built-ins plus manifest sub-binaries, then route all three entry
+points to it. Second, **rewrite seven of the nine crate `Cargo.toml`
+descriptions** — the source of truth that flows through the build system into
+the signed manifest — noting `visualiser` and `migrate` already carry clean
+user-facing text. Third, **extend tests**, which is where the work item
+under-scopes: two Python test mirrors pin the descriptions verbatim, and no
+black-box harness can assert a populated listing because the manifest is
+signature-verified.
+
+Three corrections to the work item surfaced. The bare-invocation error kind is
+**`MissingSubcommand`**, not `DisplayHelpOnMissingArgumentOrSubcommand` as the
+Technical Notes state. `help` is **clap's synthesised subcommand**, not a
+declared built-in — the `Command` enum has only `Version`, `Config`, `Cache`,
+`External`. And the "Tests to extend" list omits the two Python mirrors that
+will break on a description rewrite.
+
+## Detailed Findings
+
+### The three-entry-point divergence (`cli/launcher/src/main.rs`)
+
+All help output is produced in the error-handling path, because clap surfaces
+help, version, and missing-subcommand as `Err(clap::Error)`. `main()` calls
+`Cli::try_parse()` and delegates any `Err` to `handle_parse_error(&error)`
+(`main.rs:370,376`). Each invocation raises a different clap `ErrorKind`, and
+routing plus the `is_root_help()` guard send only `--help` through augmentation.
+
+```text
+accelerator --help   → Err(DisplayHelp)        → is_root_help TRUE  → render_augmented_help()  [built-ins + External block, stdout, exit 0]
+accelerator help     → Err(DisplayHelp)        → is_root_help FALSE → print!("{error}")        [built-ins only, stdout, exit 0]
+accelerator (bare)   → Err(MissingSubcommand)  → is_root_help FALSE → error.print()            [usage error, built-ins in brackets, stderr, exit 1]
+```
+
+`is_root_help()` (`main.rs:106-117`) returns `true` only when the kind is
+`DisplayHelp` **and** `args_os().nth(1)` is not one of `"version" | "config" |
+"cache" | "help"`. For `--help`, arg 1 is `--help` (not in the set) → true. For
+`help`, clap's implicit help subcommand raises `DisplayHelp` but arg 1 is
+`"help"` (in the set) → false. This word-list is the guard that makes `help`
+diverge from `--help`.
+
+`handle_parse_error()` (`main.rs:123-143`) has three branches: `DisplayHelp if
+is_root_help` → `render_augmented_help()` (augmented, exit 0); `DisplayHelp |
+DisplayVersion | DisplayHelpOnMissingArgumentOrSubcommand` → `print!` to stdout,
+exit 0 (plain); `_` → `error.print()` to stderr, `ExitCode::from(1)`. Bare
+invocation's `MissingSubcommand` lands in the `_` arm.
+
+`render_augmented_help()` (`main.rs:93-101`) rebuilds the clap command via
+`Cli::command()`, and if `help_section()` yields a block, attaches it with
+`command.after_help(section)` before `print_help()`. `help_section()`
+(`main.rs:82-91`) loads and signature-verifies the release manifest and calls
+`external_subcommands_section()`; any failure returns `None`, so built-in help
+still prints (fail-open).
+
+### Bare-invocation exit status — correction to the work item
+
+Bare `accelerator` produces **`ErrorKind::MissingSubcommand`**, not
+`DisplayHelpOnMissingArgumentOrSubcommand`. The top-level `Cli`
+(`cli/launcher/src/launch/inbound/cli.rs:9-14`) has a required subcommand and no
+`arg_required_else_help`, so a missing subcommand is a usage error. It re-maps
+clap's native exit 2 to **exit 1** in the `_` arm (`main.rs:138-141`), because
+exit 2 is reserved for subcommand refusals (`main.rs:119-122`, `report()` at
+`342-351`).
+
+⚠️ The work item Technical Notes (`0258:141-144`) attribute bare invocation to
+`DisplayHelpOnMissingArgumentOrSubcommand`. That kind exits **0** via branch 2
+and would contradict AC-3's required non-zero exit. That kind actually applies
+to bare `config`/`cache`, which set `arg_required_else_help = true`
+(`cli.rs:21,27`; confirmed by `config_read.rs:493` `a_bare_config_prints_help_
+and_exits_zero`). AC-3 is satisfiable as written — the mechanism is
+`MissingSubcommand`, and the fix must preserve the `_`-arm exit-1 mapping while
+adding the full listing to that path.
+
+### The external-subcommands block (`cli/launcher/src/launch/help.rs`)
+
+`external_subcommands_section()` (`help.rs:14-31`) builds the block. It returns
+`None` when `manifest.binaries` is empty (`help.rs:15-17`). The heading text
+`"External subcommands:"` is a hard-coded literal at **`help.rs:24`**. It
+iterates `&manifest.binaries` — a `BTreeMap<String, BinaryEntry>`, so ordering
+is lexicographic by name — and writes `\n  {name:<width$}  {description}` per
+entry, padding to the widest sanitised name. `sanitize()` (`help.rs:36-38`)
+strips C0/C1 control chars from these signature-verified but terminal-rendered
+strings. This block is attached solely through `after_help`, so it appears only
+on the augmented path.
+
+Merging into one list means abandoning `after_help` and composing the full
+command list, because built-ins live in the clap `Command` tree and sub-binaries
+live in the manifest — two disjoint sources clap cannot unify on its own.
+
+### The two lists to merge
+
+The built-ins are the clap `Command` enum (`cli/launcher/src/launch/inbound/
+cli.rs:16-35`), with exactly three explicit variants plus the catch-all:
+`Version`, `Config`, `Cache`, `External(Vec<OsString>)`. Each carries a `///`
+doc comment that clap turns into its `about` text. The only `#[command(...)]`
+attributes are behavioural (`arg_required_else_help`, `external_subcommand`).
+
+❌ There is **no `Help` variant**. `accelerator help` is clap's auto-generated
+help subcommand, recognised at runtime as a token in `is_root_help()` but never
+declared. The work item Summary and AC treat `help` as one of "four built-in
+commands"; precisely, there are three declared built-ins plus clap's synthesised
+`help`, plus the `External` catch-all.
+
+The sub-binaries are unknown at compile time (fetched on demand), swallowed by
+`external_subcommand` (`cli.rs:33-34`); their names and descriptions exist only
+in the signed manifest. The merge currently happens at `main.rs:93-101` and is
+`--help`-only.
+
+### Description source of truth — build system, not launcher
+
+The description flow is a chain from crate metadata to rendered help:
+
+```text
+crate Cargo.toml package.description
+  → tasks/manifest.py _read_description()      [packaging time]
+  → BinaryEntry.description (Python)
+  → signed manifest.json binaries.<token>.description
+  → (runtime) launcher fetch + verify
+  → Manifest::parse_and_validate → BinaryEntry.description (Rust)
+  → external_subcommands_section() → help output
+```
+
+The token list is a hardcoded tuple `DISPATCHED_SUBBINARIES` in
+`tasks/shared/paths.py:29-39`. `tasks/manifest.py` `_read_description()`
+(`106-112`) reads `package.description` from each crate's `Cargo.toml` and
+**raises `ManifestError` if empty** — description is required. `_SUBBINARY_
+MANIFESTS` (`manifest.py:87-99`) maps `visualiser` → `cli/visualiser/server/
+Cargo.toml`, most tokens → `cli/<name>-cli/Cargo.toml`. The Rust `BinaryEntry`
+(`manifest.rs:36-42`) is only a signed **read contract** — it deserialises the
+manifest, it does not build it. There is **no `build.rs`** in the workspace and
+no code embeds `CARGO_PKG_DESCRIPTION`; `tasks/manifest.py` is the only bridge.
+
+This confirms AC "driven by the same source of truth as dispatch": a
+newly-registered sub-binary appears automatically because both dispatch and the
+listing read the manifest.
+
+### Current crate descriptions and the rewrite scope
+
+Seven of nine crates carry launcher-internal phrasing; **`visualiser` and
+`migrate` already carry clean user-facing text**. The rewrite is narrower than
+the work item's nine-item list implies.
+
+| Token | `Cargo.toml` current description | Intended (0258) | Change |
+|---|---|---|---|
+| `work` | `The work create\|show\|resolve\|diff\|update sub-binary.` | Manage work items | 🔴 rewrite |
+| `vcs` | `The vcs detect\|status\|log\|guard sub-binary.` | Detect and inspect version-control state | 🔴 rewrite |
+| `jira` | `The jira create\|update\|... sub-binary.` | Manage Jira issues | 🔴 rewrite |
+| `linear` | `The linear create\|update\|... sub-binary.` | Manage Linear issues | 🔴 rewrite |
+| `corpus` | `The corpus adr\|metadata\|linkage\|frontmatter sub-binary.` | Manage the meta-document corpus (ADRs, metadata, frontmatter) | 🔴 rewrite |
+| `collaboration` | `The collaboration pr base-repo\|update-body sub-binary.` | Manage pull-request collaboration | 🔴 rewrite |
+| `design` | `The design validate-source\|... sub-binary.` | Validate and process design sources | 🔴 rewrite |
+| `migrate` | `Apply pending meta-directory schema migrations.` | Apply pending meta-directory schema migrations | 🟢 already matches |
+| `visualiser` | `Launch the interactive meta-directory visualiser` | Serve the meta-directory visualiser | 🟡 near-match, verb differs |
+
+Crate paths: `cli/<token>-cli/Cargo.toml` for all except `visualiser`
+(`cli/visualiser/server/Cargo.toml`). The domain crates `cli/vcs/`, `cli/work/`,
+etc. do not carry these descriptions.
+
+### Description dual-use and non-consumers
+
+Rewriting the descriptions affects exactly two functional surfaces — packaging
+(`tasks/manifest.py`) and launcher help (`help.rs:27-28`) — which is the
+intended effect. Confirmed non-consumers, so the rewrite is safe:
+
+- **Cargo packaging**: nothing publishes these crates; `description` is read only
+  by `tasks/manifest.py`. No `build.rs`, no `CARGO_PKG_DESCRIPTION` reader.
+- **Visualiser**: `NoResultsPanel.tsx:19` `description` is an unrelated CSS
+  class; the visualiser does not read manifest binary descriptions.
+- **docs-site**: "description" hits are skill frontmatter, unrelated.
+
+The work item's "dual-use" concern (crate `description` is also package metadata)
+is real but inert here — no cargo/packaging consumer reads it beyond the manifest
+build. 0164's original scoping put the listing on `--help` only, which is the
+deliberate choice 0258 reverses.
+
+### Test surface
+
+Dispatch has a mature fixture harness; help-listing does not. The gap is
+load-bearing for AC-6.
+
+- **Dispatch fixtures** (`cli/launcher/tests/dispatch.rs`): the
+  `accelerator-fixture` bin (`tests/fixtures/accelerator_fixture.rs`, second
+  `[[bin]]` in `Cargo.toml:19-21`) is registered via `ACCELERATOR_<SUB>_BIN`
+  override vars, bypassing network fetch. Tests cover exit-code propagation,
+  hyphen→underscore var normalisation, SIGTERM propagation, per-command
+  `--help` delegation to the child, and non-UTF-8 arg passthrough. None assert
+  top-level help text.
+- **Help unit tests** (`help.rs:40-83`): feed a hand-built `Manifest` to
+  `external_subcommands_section()` and assert substring presence (`foo`, `Bar
+  tool`) and sanitisation. This is the only place a populated listing is tested.
+- **Black-box help** (`cli/launcher/tests/help.rs`): forces the manifest fetch
+  to fail via `DEAD_RELEASE_URL` and asserts `--help` still prints built-ins
+  (`version`) at exit 0. Only the manifest-**unavailable** path is covered.
+- ⚠️ **No black-box test registers a sub-binary and asserts it appears in
+  top-level help.** The module doc at `tests/help.rs:1-3` states why: a test
+  cannot sign a manifest under the embedded key. `help_section()`
+  (`main.rs:82-91`) loads and signature-verifies the manifest; the only env seam
+  is `ACCELERATOR_RELEASE_BASE_URL`, usable to force failure, not to inject a
+  valid signed manifest. AC-6 ("a fixture sub-binary appears in all three help
+  outputs") requires a new manifest-injection seam that bypasses or overrides
+  signature verification in the help path — it does not exist today.
+- ⚠️ **Two Python test mirrors pin descriptions verbatim** and will break on the
+  rewrite: `tests/integration/tasks/test_github.py:40-59` (`_SUBBINARY_
+  DESCRIPTIONS`, all nine, used at line 350) and `tests/unit/tasks/
+  test_manifest.py:158-160` (visualiser only). The work item's "Tests to extend"
+  (`0258:156-157`) lists only launcher tests and omits both.
+
+## Code References
+
+- `cli/launcher/src/main.rs:106-117` — `is_root_help()` word-list guard; excludes `help`.
+- `cli/launcher/src/main.rs:123-143` — `handle_parse_error()` three-way error-kind routing.
+- `cli/launcher/src/main.rs:93-101` — `render_augmented_help()`; `after_help` merge (the only augmented path).
+- `cli/launcher/src/main.rs:82-91` — `help_section()`; signature-verifies manifest, fail-open `None`.
+- `cli/launcher/src/main.rs:138-141` — `_` arm; bare invocation exits 1 (`MissingSubcommand`).
+- `cli/launcher/src/launch/help.rs:14-31` — `external_subcommands_section()`; `"External subcommands:"` literal at `:24`.
+- `cli/launcher/src/launch/help.rs:36-38` — `sanitize()`; strips control chars.
+- `cli/launcher/src/launch/inbound/cli.rs:16-35` — `Command` enum; three built-ins + `External`, no `Help` variant.
+- `cli/launcher/src/launch/outbound/resolve/manifest.rs:36-42` — `BinaryEntry`; read contract.
+- `tasks/manifest.py:106-112` — `_read_description()`; reads crate `Cargo.toml`, requires non-empty.
+- `tasks/shared/paths.py:29-39` — `DISPATCHED_SUBBINARIES` token tuple.
+- `cli/*-cli/Cargo.toml` (+ `cli/visualiser/server/Cargo.toml`) — the nine `description` fields to rewrite (seven need change).
+- `cli/launcher/tests/dispatch.rs`, `tests/help.rs`, `tests/fixtures/accelerator_fixture.rs` — dispatch fixtures; no populated-listing black-box test.
+- `tests/integration/tasks/test_github.py:40-59`, `tests/unit/tasks/test_manifest.py:158-160` — Python description mirrors to update.
+
+## Architecture Insights
+
+- **Two disjoint command sources.** Built-ins are compile-time clap enum
+  variants; sub-binaries are runtime manifest entries. clap cannot enumerate the
+  latter (`external_subcommand` is a blind catch-all), so any merged listing must
+  be composed by hand, not delegated to clap's help renderer.
+- **Help lives in the error path.** clap models help/version/missing-subcommand
+  as errors. Converging the three entry points is a routing change in
+  `handle_parse_error()` plus retiring the `is_root_help()` word-list, feeding
+  all display paths through one full-listing renderer while preserving the `_`
+  arm's exit-1 for bare invocation.
+- **Signed manifest is the trust and discovery boundary.** Descriptions are
+  signature-verified, which is why the runtime sanitises them and why tests
+  cannot inject a listing without a new seam. The same signing that secures
+  dispatch blocks black-box help-listing coverage.
+- **Source of truth is deliberately outside the launcher.** Descriptions live in
+  crate `Cargo.toml` and flow through the Python build system, so the
+  user-facing rewrite is a cross-language change (Rust help renderer + Python
+  packaging + Python test mirrors), not a launcher-only edit.
+
+## Historical Context
+
+- `meta/work/0164-launcher-and-git-style-dispatch.md` (done) — scoped the
+  manifest-driven listing to `--help` and unknown-subcommand only; the
+  deliberate decision 0258 reverses.
+- `meta/work/0187-generalise-sub-binary-registration-surface.md` (done) — the
+  generalised registration surface and thirteen-point checklist the listing
+  enumerates from.
+- `meta/decisions/ADR-0054-git-style-modular-cli-of-on-demand-static-binaries.md`
+  — governing decision: clap `external_subcommand` + Unix `exec`; the basis for
+  the manifest-driven listing.
+- `meta/decisions/ADR-0046-zero-setup-static-binary-distribution.md`,
+  `ADR-0060-launcher-resolved-tree-artifacts.md`,
+  `ADR-0063-plugin-version-scoped-artifact-cache.md` — distribution and caching
+  mechanics behind the sub-binaries.
+- `meta/notes/2026-06-23-further-ideas-backlog.md:50` — origin note for 0258,
+  0259, 0260.
+- `meta/reviews/work/0258-help-show-subcommands-review-1.md` — existing review of
+  the work item (currently staged).
+
+## Related Research
+
+- `meta/research/codebase/2026-07-03-0164-launcher-and-git-style-dispatch.md` —
+  launcher/dispatch design.
+- `meta/research/codebase/2026-08-02-0187-generalise-sub-binary-registration-surface.md`
+  — registration surface.
+- `meta/research/codebase/2026-07-06-0165-multi-binary-distribution-release-pipeline.md`
+  — multi-binary distribution.
+
+## Open Questions
+
+- ❓ **AC-6 test seam.** A black-box test asserting a fixture sub-binary in all
+  three help outputs needs a manifest-injection seam that bypasses signature
+  verification in `help_section()`. None exists. Options: a test-only env
+  override feeding a pre-parsed `Manifest`, or restructuring the listing so it is
+  unit-testable end-to-end without signing. Which seam is acceptable is a design
+  decision for the plan.
+- ❓ **`visualiser` description verb.** Intended text is "Serve the
+  meta-directory visualiser"; the crate carries "Launch the interactive
+  meta-directory visualiser". Rewrite to match exactly, or accept the near-match?
+  `migrate` already matches and needs no change.
+- ❓ **0260 sequencing.** 0260 moves ADR into a top-level `adr` subcommand,
+  changing the command tree the listing renders. If 0260 lands first, the merged
+  listing must enumerate `adr`; if 0258 lands first, 0260 inherits the merged
+  renderer. The work item defers layout ownership to 0258 and styling to 0259.

--- a/meta/reviews/plans/2026-09-05-0258-help-show-subcommands-review-1.md
+++ b/meta/reviews/plans/2026-09-05-0258-help-show-subcommands-review-1.md
@@ -1,0 +1,809 @@
+---
+type: "plan-review"
+id: "2026-09-05-0258-help-show-subcommands-review-1"
+title: "Plan Review: Help Should Show Subcommands Implementation Plan"
+date: "2026-09-05T22:16:59+00:00"
+author: "Toby Clemson"
+producer: "review-plan"
+status: "complete"
+target: "plan:2026-09-05-0258-help-show-subcommands"
+parent: "plan:2026-09-05-0258-help-show-subcommands"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["architecture", "code-quality", "test-coverage", "correctness", "usability", "compatibility", "documentation"]
+review_number: 1
+review_pass: 3
+tags: ["cli", "help", "launcher", "discoverability"]
+last_updated: "2026-09-06T08:57:18+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Help Should Show Subcommands Implementation Plan
+
+**Verdict:** REVISE
+
+The plan is unusually well-researched and structurally sound: it replaces a
+hand-rolled `after_help` text block with clap-native subcommand injection,
+converges three divergent help entry points on one manifest-driven listing,
+and correctly corrects the work item's wrong error-kind assumption
+(`MissingSubcommand`, not `DisplayHelpOnMissingArgumentOrSubcommand`). No
+critical defects surfaced, and exit-code preservation, fail-open behaviour, and
+deterministic ordering all hold up against the source. The revise verdict rests
+on five major findings, all edge cases and completeness gaps rather than
+fundamental design faults — the headline testability gain is undercut by a
+retained global read, three lenses independently flag an unguarded name
+collision, and the merged listing has a punctuation inconsistency that violates
+AC-5.
+
+### Cross-Cutting Themes
+
+- **Global `args_os()` read keeps routing untestable** (flagged by: code-quality,
+  test-coverage) — the plan sells extracting `is_root_help_args` as dropping the
+  untestable global read, but `handle_parse_error` still calls
+  `is_root_help_args(&root_args())`, where `root_args()` re-reads
+  `std::env::args_os()`. The pure predicate becomes testable; the actual
+  error-kind-plus-args-to-exit-code decision stays as unverifiable as before.
+- **Name collision on the merged clap namespace** (flagged by: architecture,
+  compatibility, correctness) — `augment_with_subbinaries` injects one clap
+  subcommand per manifest binary into a tree that already declares `version`,
+  `config`, `cache`, and clap's synthesised `help`. A manifest name colliding
+  with a built-in (or an empty name) hits clap's duplicate-subcommand
+  `debug_assert` — panicking the help path under `cargo test` — and silently
+  double-lists in release. `sanitize()` guards control characters, not
+  collisions.
+- **Bare invocation: stream flip and lost error cue** (flagged by: usability,
+  compatibility, correctness) — routing `MissingSubcommand` to
+  `render_full_listing(ExitCode::from(1))` moves output from clap's stderr usage
+  error to a full help body on stdout while keeping exit 1. The result is a
+  success-looking listing paired with a failure exit, no "a subcommand is
+  required" cue, and an empty stderr.
+- **Merged listing style inconsistency** (flagged by: usability, documentation)
+  — built-in descriptions are full sentences ending in a period; the new
+  sub-binary descriptions are terse imperative fragments; `migrate` keeps a
+  trailing period the AC-5 text omits. The one list the feature exists to unify
+  ends up visibly half-merged.
+
+### Tradeoff Analysis
+
+- **Testability vs plan scope**: threading the parsed args into
+  `handle_parse_error` (or splitting a pure `route(kind, &args) -> ExitCode`)
+  makes the exit-code mapping unit-testable but widens the Phase 2 change beyond
+  the predicate extraction. Recommendation: take the wider change — the routing
+  decision is the most bug-prone logic and AC-3's exit contract deserves a fast
+  deterministic guard, not only a spawned-process assertion.
+- **Immediate render vs network fetch on the bare/error path** (architecture):
+  routing bare `accelerator` through `load_help_manifest` puts a
+  signature-verified network fetch on a previously-instant error path.
+  Recommendation: confirm the fetch timeout is tight and bounded, or render
+  built-ins immediately and attach sub-binaries only when the manifest is
+  already resolvable — keeping the most common mistyped invocation off the
+  network's critical latency path.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Documentation**: `migrate` keeps a trailing period the AC-5 text omits
+  **Location**: Phase 1, Section 1 (migrate note, plan lines 191-192)
+  The plan leaves `cli/migrate-cli/Cargo.toml` as "already correct", but its
+  value ends in a full stop while the AC-5 text and all eight rewrites have
+  none. In the merged listing `migrate` becomes the only entry ending in a
+  period — off-spec against AC-5 and visibly inconsistent.
+
+- 🟡 **Architecture**: Bare invocation becomes network-bound
+  **Location**: Phase 2, Section 2; Performance Considerations
+  Routing `MissingSubcommand` through `render_full_listing` calls
+  `load_help_manifest()`, a signature-verified network fetch. The most common
+  mistyped invocation, previously an instant clap usage error with no I/O, now
+  blocks on a network round-trip before printing. The Performance section treats
+  `help` and bare as equivalent one-shots but does not bound the timeout or the
+  error-path latency.
+
+- 🟡 **Code Quality**: Routing decision still reads global process state
+  **Location**: Phase 2, Sections 3-4
+  The extracted `is_root_help_args` is pure, but `handle_parse_error` calls it
+  via `root_args()`, which re-reads `std::env::args_os()`. The mapping of error
+  kind plus args to renderer and exit code — the most bug-prone logic — stays
+  untestable, so the stated testability gain is largely cosmetic.
+
+- 🟡 **Test Coverage**: AC-6 "appears in all three help outputs" proven for one
+  renderer call only
+  **Location**: Phase 2, Sections 1 & 5; Testing Strategy
+  The populated listing is tested once via a single `augment_with_subbinaries`
+  call; the three-way convergence is proven only on the fail-open path, which by
+  construction cannot assert any sub-binary. A regression where
+  `MissingSubcommand` or root `help` reached a non-augmented `Cli::command()`
+  would pass every proposed test.
+
+- 🟡 **Test Coverage**: The called-out `config --help` regression has no
+  end-to-end guard
+  **Location**: Key Discoveries (config --help); Phase 2, Sections 3-4
+  The plan flags that narrowing (not removing) `is_root_help` is essential to
+  keep `config --help` on config's own help, but guards it only with the pure
+  predicate table plus manual verification. No automated test asserts
+  `accelerator config --help` renders config's help rather than the merged
+  listing.
+
+#### Minor
+
+- 🔵 **Correctness / Compatibility / Architecture**: Merged clap namespace has no
+  collision or empty-name reconciliation
+  **Location**: Phase 2, Section 1 (`augment_with_subbinaries`)
+  A manifest binary named like a built-in (`version`, `config`, `cache`, `help`)
+  or with an empty name creates a duplicate/malformed subcommand: clap
+  `debug_assert`s (panic in debug/test builds) and silently double-lists in
+  release. Three lenses flagged this independently. Skip or defensively handle
+  names that collide with an existing subcommand (clap exposes
+  `find_subcommand`) or are empty, and add a fixture test asserting a built-in
+  wins and the renderer does not panic.
+
+- 🔵 **Correctness**: Multi-token root-help forms lose sub-binary augmentation
+  **Location**: Phase 2, Section 3 (`is_root_help_args`)
+  The new predicate matches exactly `["--help"]`, `["-h"]`, `["help"]`. The
+  current `is_root_help` routes any `DisplayHelp` whose second token is not a
+  built-in word, so `accelerator --help extra` currently augments but under the
+  new predicate falls through to built-ins-only. Either accept the narrowing
+  explicitly or match a leading-token pattern.
+
+- 🔵 **Usability**: Merged list mixes two description styles
+  **Location**: Phase 1, Section 1 & Phase 2, Section 1
+  Built-in doc comments are full sentences with trailing periods; new
+  sub-binary descriptions are terse fragments without. Once both appear in one
+  unheadinged list, the tone and punctuation mismatch is visible on every
+  invocation. Align both on one convention (imperative fragment, no trailing
+  period) or call out the built-in restyle as an explicit 0259 dependency.
+
+- 🔵 **Usability**: Bare invocation loses its actionable error cue
+  **Location**: Phase 2, Sections 2 & 4
+  `MissingSubcommand` → `render_full_listing` prints an ordinary-looking help
+  screen to stdout with exit 1 and empty stderr — no line explaining what went
+  wrong. The "you asked for help" vs "you made a mistake" distinction is erased.
+  Prepend a one-line usage cue (ideally to stderr) before the listing.
+
+- 🔵 **Compatibility**: Bare invocation output moves from stderr to stdout
+  **Location**: Phase 2, Sections 2 & 4
+  A caller capturing stderr to detect the missing-subcommand error, or treating
+  non-empty stdout as success, would observe a silent contract change. AC-3
+  constrains only the exit code. The move is defensible (it matches the existing
+  force-stdout-for-help intent) but should be a recorded decision.
+
+- 🔵 **Code Quality**: Needless allocation in `is_root_help_args`
+  **Location**: Phase 2, Section 3
+  The body collects a `Vec<&OsStr>` purely to match a single-element slice.
+  `matches!(args, [a] if a == "--help" || a == "-h" || a == "help")` compares
+  `OsString` against `&str` directly and expresses the intent at a glance.
+
+- 🔵 **Code Quality**: Fail-open and lazy-crypto-init rationale must move with the
+  refactor
+  **Location**: Phase 2, Section 2
+  `help_section()` and `render_augmented_help()` carry non-obvious doc comments
+  explaining why the crypto provider installs lazily and why the manifest load
+  fails open. The fold into `load_help_manifest`/`render_full_listing` must carry
+  that rationale — exactly the genuinely-non-obvious "why" the project's comment
+  policy preserves.
+
+- 🔵 **Documentation**: `design-cli` description under-describes its surface
+  **Location**: Phase 1, Section 1 (design-cli)
+  "Validate and process design sources" covers `validate-source` but "process"
+  is vague and evokes none of `resolve-auth`, `scrub-secrets`,
+  `notify-downgrade`, or `audit-cue-phrases`. Confirm this is the deliberate
+  AC-5 wording or note that broader wording is deferred to 0259.
+
+#### Suggestions
+
+- 🔵 **Usability**: Merged listing ordering is inconsistent
+  **Location**: Phase 2, Section 1
+  Built-ins render in declaration order (`version`, `config`, `cache`); manifest
+  binaries follow alphabetically (`BTreeMap`), with clap's `help` slotted in.
+  Decide and document an intended order (fully alphabetical scans best) since
+  the merge is when ordering becomes user-visible.
+
+- 🔵 **Usability**: "Serve the meta-directory visualiser" is less discoverable
+  than the intent
+  **Location**: Phase 1, Section 1 (visualiser)
+  "Serve" is accurate but a user scanning for "how do I view my meta directory"
+  may not recognise it. If AC-5's wording is fixed, note this as a deliberate
+  accuracy-over-discoverability trade for 0259 to revisit.
+
+- 🔵 **Documentation**: `corpus` parenthetical drops the `linkage` subcommand
+  **Location**: Phase 1, Section 1 (corpus-cli)
+  "Manage the meta-document corpus (ADRs, metadata, frontmatter)" reads as an
+  exhaustive list but omits the live `linkage` subcommand. Include it or frame
+  the parenthetical as illustrative.
+
+- 🔵 **Test Coverage**: No regression guard that descriptions stay user-facing
+  (AC-5)
+  **Location**: Phase 1, Sections 1-2; Success Criteria
+  Nothing prevents a future sub-binary from being registered with "… sub-binary."
+  phrasing. Add a lightweight test asserting no collected description contains
+  the substring "sub-binary".
+
+- 🔵 **Compatibility**: `test_github` fixture left as a stale mirror of the old
+  contract
+  **Location**: Phase 1, Section 2
+  `_SUBBINARY_DESCRIPTIONS` keeps the retired "The … sub-binary." strings.
+  Harmless for green, but a stale example diverging from the source of truth.
+  Take the plan's own optional step and align them, or reaffirm they are
+  placeholders.
+
+- 🔵 **Code Quality / Architecture**: `package.description` overloaded as help
+  copy without a visible seam
+  **Location**: Phase 1, Section 1
+  Each crate's `description` now serves both packaging metadata and CLI help
+  text, an implicit coupling invisible at the edit site. Record it as an
+  accepted tradeoff and consider a one-line note in `tasks/README.md`'s
+  registration checklist that `description` is user-facing help.
+
+### Strengths
+
+- ✅ Replacing the hand-rolled `after_help` block (manual width calc, `write!`
+  formatting) with clap-native `.subcommand()` injection removes bespoke layout
+  code, an entire function, and delivers the open-closed property AC-6 demands.
+- ✅ Correctly identifies bare `accelerator` as `ErrorKind::MissingSubcommand`
+  (the top-level `Cli` sets no `arg_required_else_help`), routes it to exit 1,
+  and corrects the work item's mistaken Technical Notes.
+- ✅ Exit-code preservation is sound across all three paths; `Manifest.binaries`
+  is a `BTreeMap`, so the merged listing is deterministically ordered and the
+  `diff <(--help) <(help)>`-empty acceptance is well-founded.
+- ✅ Refuses to add a manifest-injection or signature-bypass seam, decomposing
+  the AC-6 assertion into a unit test over a hand-built `Manifest` rather than
+  weakening the signed-manifest trust boundary.
+- ✅ Verifies rather than assumes blast radius: narrows the breaking Python
+  assertions to the single `test_manifest.py` visualiser test and confirms no
+  docs-site page or README references the old heading or descriptions.
+- ✅ Two phases are independently mergeable with the tree green after either.
+
+### Recommended Changes
+
+1. **Drop the trailing period from `cli/migrate-cli/Cargo.toml`** (addresses:
+   `migrate` keeps a trailing period). Reconcile the research table that marks
+   it "already matches", so all nine descriptions follow one no-period
+   convention and the merged listing is uniform.
+
+2. **Thread the parsed root args into `handle_parse_error`** (addresses: routing
+   decision still reads global; exit-code routing hard to unit-test). Have
+   `main` collect `std::env::args_os().skip(1)` once and pass it in, or split a
+   pure `route(kind, &args) -> ExitCode`, so the error-kind-to-exit-code mapping
+   is table-testable without process globals.
+
+3. **Guard `augment_with_subbinaries` against collisions and empty names**
+   (addresses: merged clap namespace has no reconciliation). Skip any manifest
+   name already present as a subcommand (via `find_subcommand`) or empty, and
+   add a fixture test asserting a colliding/empty name neither panics the
+   renderer nor double-lists.
+
+4. **Add routing-level and `config --help` tests** (addresses: AC-6 proven for
+   one call only; `config --help` has no e2e guard). Assert each of the three
+   parse kinds maps to the single augmenting `render_full_listing`, and add a
+   black-box test that `accelerator config --help` (manifest unavailable) prints
+   config's own help, not the top-level listing.
+
+5. **Bound or relocate the bare-path manifest fetch** (addresses: bare
+   invocation becomes network-bound). State the fetch timeout is tight, or
+   render built-ins immediately and attach sub-binaries only when the manifest
+   is already resolvable, keeping the error path off the network critical path.
+
+6. **Add a one-line usage cue to the bare path and record the stream move**
+   (addresses: lost error cue; stderr→stdout change). Prepend "error: a
+   subcommand is required" (ideally to stderr) before the listing, and note the
+   intentional stderr→stdout move as a recorded decision.
+
+7. **Unify the description style and fix `is_root_help_args` details**
+   (addresses: mixed styles; needless allocation; multi-token forms; lost
+   rationale). Align built-in and sub-binary descriptions on one convention (or
+   flag the built-in restyle as a 0259 dependency); match the slice directly
+   without the `Vec` allocation; decide whether a leading-token pattern is
+   wanted; carry the fail-open/lazy-init rationale into the new functions.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: The plan is architecturally sound and improves structural
+integrity: it replaces an ad-hoc `after_help` text block with clap-native
+subcommand injection, unifying two disjoint command sources (compile-time enum +
+runtime manifest) into a single render path, and it extracts the root-help
+predicate into a pure function that drops a global `args_os()` read. It
+preserves the fail-open trust boundary and, commendably, declines to add a
+signature-bypass seam for testability. The main architectural forces worth
+scrutiny are that bare invocation — an error path — now incurs a network
+manifest fetch, and that merging two independently-governed command namespaces
+into one clap tree introduces a latent collision mode with no reconciliation
+rule.
+
+**Strengths**:
+- Extracting `is_root_help_args` as a pure function over `&[OsString]` cleanly
+  separates the functional core from the imperative shell (`args_os()` read),
+  improving testability and honouring the functional-core/imperative-shell
+  boundary.
+- Moving from a hand-formatted `after_help` string to clap-native `.subcommand()`
+  injection collapses two rendering paths into one and delivers the open-closed
+  property the AC demands.
+- Explicitly refusing to add a manifest-injection or signature-bypass seam
+  preserves the signed-manifest trust boundary.
+- Fail-open behaviour is preserved, and the two phases are independently
+  mergeable with the tree green after either.
+
+**Findings**:
+- major (medium): Bare invocation becomes network-bound. Routing bare
+  `accelerator` (`MissingSubcommand`) through `render_full_listing` calls
+  `load_help_manifest()`, a signature-verified network fetch. Under a slow or
+  unreachable host, bare invocation — an error path — blocks for the fetch
+  timeout before emitting its exit-1 listing. Suggestion: confirm the timeout is
+  tight and bounded, or render built-ins immediately and attach sub-binaries only
+  when the manifest is already resolvable.
+- minor (medium): Two command sources share one clap namespace with no
+  reconciliation rule. A future (or malicious-but-signed) manifest binary named
+  `config` would render a duplicate/conflicting entry. Suggestion: define a
+  precedence/dedup rule and test a built-in wins over a colliding sub-binary.
+- minor (low): User-facing help text sourced from `package.description` overloads
+  a cargo-packaging field to serve as help copy. Inert today; note it explicitly
+  as a recorded pragmatic tradeoff.
+
+### Code Quality
+
+**Summary**: A small, well-scoped, generally clean plan. Its strongest quality
+move is replacing the hand-rolled `after_help` string-formatting with
+clap-native subcommand rendering, deleting bespoke column-width logic. The main
+concern is that the headline testability improvement — extracting a pure
+`is_root_help_args` — is undercut by the routing snippet still reaching for a
+global env read, leaving the actual routing decision as untestable as before.
+
+**Strengths**:
+- Replacing the hand-rolled `after_help` block with clap-native injection removes
+  bespoke layout code and an entire function.
+- Extracting the root-help predicate into a pure function is the right instinct.
+- `augment_with_subbinaries` is a clean pure function preserving the `sanitize()`
+  boundary on both name and description.
+- Folding three near-identical entry paths onto one renderer reduces the
+  divergence that is the root cause of the bug.
+- Deterministic ordering is free because `Manifest.binaries` is a `BTreeMap`.
+
+**Findings**:
+- major (medium): Routing snippet calls `is_root_help_args(&root_args())`, where
+  `root_args()` re-reads `std::env::args_os()`. The pure predicate is testable
+  but `handle_parse_error` stays untestable. Suggestion: thread args into
+  `handle_parse_error(&error, &root_args)` so routing becomes table-testable.
+- minor (high): `is_root_help_args` allocates a `Vec<&OsStr>` to match a
+  single-element slice. Suggestion: `matches!(args, [a] if a == "--help" || a ==
+  "-h" || a == "help")`.
+- minor (medium): The existing fail-open and lazy-crypto-init doc-comment
+  rationale must move with the refactor rather than being lost.
+- suggestion (low): `package.description` serves both packaging metadata and help
+  text with no visible seam; keep the `test_manifest.py` tripwire green and
+  consider a note in the registration checklist.
+
+### Test Coverage
+
+**Summary**: The plan is unusually test-aware: it identifies the signing
+constraint forcing the populated-listing assertion to the unit level, adds a
+strong mutation-guarding renderer test, a truth-table for `is_root_help_args`,
+and extends the black-box suite to cover exit codes fail-open. The main gaps are
+that AC-6's "appears in all three help outputs" is verified for one renderer call
+rather than across the three routes, the `config --help` regression risk has no
+end-to-end guard, and the exit-code routing remains awkward to unit-test because
+it still reads global args.
+
+**Strengths**:
+- The AC-6 renderer test is a genuine mutation guard (asserts "External
+  subcommands" gone, plus a built-in and the fixture present).
+- Extending `tests/help.rs` to assert bare exits 1 and `help`/`--help` exit 0
+  gives real end-to-end coverage of AC-3's exit-code contract.
+- `is_root_help_args` refactored into a pure function with an explicit truth
+  table.
+- The plan verifies rather than assumes the Python blast radius.
+
+**Findings**:
+- major (medium): AC-6 "appears in all three help outputs" is only proven for one
+  `augment_with_subbinaries` call; three-way convergence is proven only on the
+  fail-open path, which cannot assert any sub-binary. Suggestion: add a
+  routing-level test asserting all three parse kinds map to the augmenting
+  renderer.
+- major (medium): The called-out `config --help` regression has no end-to-end
+  guard beyond the predicate table and manual verification. Suggestion: add a
+  black-box test that `accelerator config --help` prints config's own help.
+- minor (medium): Exit-code routing stays hard to unit-test because
+  `handle_parse_error` reads the global args. Suggestion: pass args in or split a
+  pure `route(kind, &args) -> ExitCode`.
+- suggestion (medium): No regression guard that descriptions stay user-facing
+  (AC-5). Suggestion: assert no collected description contains "sub-binary".
+
+### Correctness
+
+**Summary**: The plan is well-researched and its core correctness claims hold up
+against the source: bare invocation is genuinely `MissingSubcommand`, exit codes
+are preserved across all three entry points, and the `is_root_help` narrowing
+correctly keeps `config --help`, `help <sub>`, and `version --help` on clap's
+per-command help. `Manifest.binaries` is a `BTreeMap`, so the merged listing is
+deterministically ordered and the diff-empty acceptance is sound. The only gaps
+are edge cases: a manifest binary sharing a built-in name would collide when
+augmenting, and the narrowed single-token predicate silently drops augmentation
+for multi-token root-help forms the old predicate handled.
+
+**Strengths**:
+- Correctly identifies bare `accelerator` as `MissingSubcommand` and routes it to
+  exit 1, correcting the work item's Technical Notes.
+- Exit-code preservation is sound across all three paths.
+- `Manifest.binaries` is a `BTreeMap`, so injection is deterministically sorted.
+- The narrowed predicate correctly excludes `config --help`, `help config`, and
+  `version --help`.
+- Fail-open manifest loading is preserved.
+
+**Findings**:
+- minor (medium): No guard against a manifest binary name colliding with a
+  built-in or clap's auto `help` — clap's duplicate-subcommand `debug_assert`
+  panics in debug/test builds and double-lists in release. Suggestion: skip any
+  manifest name that already exists as a subcommand or is reserved.
+- minor (medium): Multi-token root-help forms (`accelerator --help extra`) lose
+  sub-binary augmentation under the exact single-element predicate; the current
+  predicate handles them. Suggestion: accept explicitly or match a leading-token
+  pattern.
+- suggestion (low): Bare invocation now emits a full help body on stdout with
+  empty stderr while exiting non-zero. Suggestion: confirm no hook/script depends
+  on the bare-invocation stderr text and that the stream split is intended.
+
+### Usability
+
+**Summary**: From a developer-experience standpoint this plan is a clear net
+win: it converges three divergent help entry points on one identical,
+manifest-driven listing, replaces launcher-internal jargon with user-facing verb
+phrases, and preserves per-command `--help` so progressive disclosure stays
+intact. The main wrinkles are stylistic/behavioural: the merged list mixes two
+description styles, and bare invocation now prints a help-looking listing to
+stdout while exiting non-zero with no cue explaining the failure.
+
+**Strengths**:
+- Converging all three entry points on an identical listing is a strong
+  least-surprise improvement, proven by a diff in manual verification.
+- Rewriting seven launcher-internal descriptions into user-facing verb phrases is
+  a significant first-run DX gain.
+- Progressive disclosure preserved: per-command help still routes to the specific
+  command.
+- Driving the listing from the signed manifest means new sub-binaries appear
+  automatically.
+- clap-native injection lets clap own alignment and terminal-width wrapping.
+- The `-h` short flag is explicitly handled alongside `--help`/`help`.
+
+**Findings**:
+- minor (high): The merged list mixes full-sentence built-in descriptions (with
+  trailing periods) and terse imperative sub-binary fragments (without).
+  Suggestion: align both on one convention, or call out the built-in restyle as
+  an explicit dependency.
+- minor (medium): Bare invocation loses its actionable error cue while still
+  exiting non-zero, and the diagnostic moves from stderr to stdout. Suggestion:
+  prepend a one-line usage cue, ideally to stderr.
+- suggestion (medium): The merged listing ordering is inconsistent (declaration
+  order then alphabetical). Suggestion: decide and document an intended order.
+- suggestion (low): "Serve the meta-directory visualiser" is less discoverable
+  than the intent; consider "Launch"/"Open" or note the accuracy trade for 0259.
+
+### Compatibility
+
+**Summary**: This plan reworks three CLI entry points onto one merged listing
+and rewrites seven crate `description` fields. The behaviour-contract surface is
+well understood and mostly safe: no external consumers of the `description`
+fields beyond `tasks/manifest.py`, no scripts/docs parse the `External
+subcommands:` heading, the manifest schema and signing contract are untouched,
+and exit codes are explicitly preserved. The residual risks are narrow — a
+stderr→stdout stream change for bare invocation, and the merge coupling
+signature-verified manifest names to clap's command-builder naming constraints.
+
+**Strengths**:
+- The merged listing is driven by the signed manifest — additive and
+  forward-compatible.
+- Research verified the `description` field has no other consumers (no cargo
+  publish, no `build.rs`, no completion/man-page generation).
+- Exit-code contract preserved explicitly; the plan corrects the work item's
+  wrong error-kind assumption.
+- clap is pinned exactly (`=4.6.1`) and tests assert on substrings, not exact
+  layout.
+- The signed manifest is version-pinned, so no cross-version description skew.
+
+**Findings**:
+- minor (medium): Bare invocation output moves from stderr to stdout while
+  keeping exit 1. Suggestion: make the stream choice explicit in the plan and
+  confirm no hook/script consumes bare `accelerator` on stderr.
+- minor (medium): The merge feeds manifest names into `clap::Command::new`,
+  coupling manifest content to clap's naming rules; a name colliding with a
+  built-in or an empty name panics (`debug_assert`) or double-lists.
+  `sanitize()` handles neither. Suggestion: skip/handle collisions and empties,
+  add a fixture test.
+- suggestion (low): `test_github.py:_SUBBINARY_DESCRIPTIONS` is left as a stale
+  mirror of the retired "The … sub-binary." strings. Suggestion: align the
+  fixture or reaffirm the strings are placeholders.
+
+### Documentation
+
+**Summary**: Phase 1 replaces launcher-internal crate descriptions with concise,
+audience-appropriate one-liners that surface as CLI help — a clear improvement,
+and the plan correctly traces the description source of truth and the single
+Python test mirror that must move with it. However, the plan asserts `migrate`
+"already matches" the AC-5 text when it actually carries a trailing full stop
+that the intended text and all eight rewritten descriptions lack, leaving the
+merged listing punctuation-inconsistent and off-spec against AC-5.
+External-docs currency is sound: no docs-site page or README documents the
+"External subcommands:" heading or the old descriptions.
+
+**Strengths**:
+- The rewrites replace internal jargon with clear end-user-facing descriptions in
+  a consistent imperative mood.
+- The plan correctly identifies the description source of truth and updates the
+  one Python assertion that pins a real crate description.
+- Verified: no docs-site page or README references the old heading, behaviour, or
+  descriptions, so no cross-references go stale.
+
+**Findings**:
+- major (high): `migrate` keeps a trailing period the AC-5 text omits, breaking
+  listing consistency; it will be the only entry ending in a period. Suggestion:
+  drop the period from `cli/migrate-cli/Cargo.toml` and reconcile the research
+  table that marks it "already matches".
+- minor (medium): "Validate and process design sources" under-describes the
+  design sub-binary's surface (resolve-auth, scrub-secrets, notify-downgrade,
+  audit-cue-phrases). Suggestion: confirm the AC-5 wording or note broader wording
+  is deferred to 0259.
+- suggestion (low): The corpus parenthetical omits the live `linkage` subcommand
+  while reading as an exhaustive list. Suggestion: include it or frame it as
+  illustrative.
+
+## Re-Review (Pass 2) — 2026-09-05
+
+**Verdict:** REVISE
+
+All nineteen findings from the initial review are resolved. The revision threaded
+the parsed args into a pure `classify`/`is_root_help_args` pair, added the
+collision guard, the `config --help` and phrasing-guard tests, the migrate-period
+diff, the stderr cue, and the 0259 boundary callouts — every one verified against
+the source. The verdict stays REVISE because the now-concrete plan drew concrete
+new scrutiny: four new major findings, one of them a genuine regression the
+`classify` design introduced. None are structural; all are localised fixes.
+
+### Previously Identified Issues
+
+All resolved; two carry a follow-on caveat now tracked as a new issue.
+
+- ✅ **Documentation** — migrate trailing period — Resolved (diff added, both stale
+  notes reconciled; verified all nine descriptions are period-free).
+- 🟡 **Architecture** — bare invocation network-bound — Resolved in intent, but the
+  documented bound is inaccurate (see new issues).
+- ✅ **Code Quality** — routing read the `args_os()` global — Resolved (pure
+  `classify` threaded args from a single collect).
+- ✅ **Test Coverage** — AC-6 all-three convergence — Resolved (`classify` truth
+  table proves all three kinds reach the one full-listing route).
+- ✅ **Test Coverage** — `config --help` e2e guard — Resolved (black-box test with a
+  strong `cache`-absence discriminator).
+- 🟡 **Correctness/Compatibility/Architecture** — clap namespace collision —
+  Resolved for the declared built-ins, but the guard misses clap's synthesised
+  `help` (see new issues).
+- ✅ **Correctness** — multi-token `--help extra` — Resolved (leading-token match).
+- ✅ **Usability** — mixed description register — Resolved (deferred to 0259 with an
+  explicit hand-off note).
+- ✅ **Usability/Compatibility/Correctness** — bare error cue and stderr→stdout —
+  Resolved (stderr cue restores the diagnostic stream).
+- ✅ **Code Quality** — needless `Vec` allocation — Resolved (slice match).
+- ✅ **Code Quality** — fail-open/lazy-init rationale — Resolved (carry-across note).
+- ✅ **Documentation** — `design-cli` under-describes — Resolved (verbatim AC-5,
+  deferred).
+- ✅ **Usability/Documentation** — ordering, `Serve`, `corpus` linkage — Resolved
+  (documented as AC-5/0259 decisions).
+- ✅ **Test Coverage** — AC-5 phrasing regression guard — Resolved (substring test).
+- ✅ **Compatibility** — `test_github` fixture — Resolved (existing comment
+  documents the placeholders; verified).
+- ✅ **Code Quality/Architecture** — `package.description` overload — Resolved
+  (checklist note + recorded tradeoff).
+
+### New Issues Introduced
+
+#### Major
+
+- 🔴 **Correctness**: Blanket `MissingSubcommand → FullListing` hijacks nested
+  subcommand-group errors. `accelerator config templates` (the required
+  `TemplatesAction` group, no `arg_required_else_help`) also raises
+  `MissingSubcommand`; the new arm would print the generic cue plus the top-level
+  listing instead of clap's contextual error — a regression from today's
+  `error.print()`. Fix: gate on `args.is_empty()` and let non-root
+  `MissingSubcommand` fall through to `UsageError`; pin with a `(MissingSubcommand,
+  ["config","templates"])` case. *High confidence.*
+- 🟡 **Test Coverage**: The wired `augment_with_subbinaries` call in
+  `render_full_listing` is never exercised — every black-box test forces the
+  manifest unavailable, so the augment branch (the core deliverable) survives
+  deletion. Fix: extract a pure `build_listing(command, Option<&Manifest>)` and
+  unit-test that `Some` augments and `None` does not. *High confidence.*
+- 🟡 **Test Coverage**: The deliberately-added bare stderr cue has no assertion;
+  the black-box bare test checks only stdout and exit 1. Removing the cue passes
+  every test. Fix: assert the cue lands on stderr.
+- 🟡 **Architecture**: Performance Considerations states a "10s connect bound", but
+  the shared `Fetcher` retries up to 3× and carries a 300s per-attempt total
+  timeout, so a stalling host bounds bare invocation far more loosely (~30s on
+  SYN-drop; minutes on a stalled read). Fix: correct the worst-case text, or give
+  the help-path fetch a tighter single-attempt deadline distinct from dispatch.
+
+#### Minor
+
+- 🔵 **Correctness/Compatibility/Architecture**: The collision guard misses clap's
+  synthesised `help`. `Cli::command()` is un-built at augmentation time and clap
+  appends `help` unconditionally during `_build` with no dedup, so
+  `find_subcommand("help")` returns `None` and a manifest binary named `help`
+  slips past — the exact panic/double-list the guard claims to close. The stated
+  rationale ("already carries clap's synthesised `help`") is factually wrong. Fix:
+  also skip the literal `help` (or `disable_help_subcommand`), and test the `help`
+  token. Flagged by three lenses.
+- 🔵 **Code Quality**: `HelpRoute::FullListing { exit: u8, missing_subcommand:
+  bool }` permits contradictory states and spreads bare-path logic across three
+  sites. Fix: model `RootHelp` and `MissingSubcommand` as distinct variants and
+  derive exit/cue from the variant.
+- 🔵 **Code Quality**: The existing `main.rs:131-134` rationale — forcing stdout
+  because clap routes `DisplayHelpOnMissingArgumentOrSubcommand` to stderr — is not
+  in the carry-across list, so the `PerCommand` arm risks losing it.
+- 🔵 **Test Coverage**: The `classify` truth table omits the
+  `DisplayHelpOnMissingArgumentOrSubcommand → PerCommand` case (bare
+  `config`/`cache`), a pre-existing behaviour the refactor must preserve.
+- 🔵 **Test Coverage**: The collision test bundles the empty-name and `version`
+  cases into one assertion; clap accepts `Command::new("")` without panicking, so
+  the `is_empty()` guard's mutation survives. Fix: assert no blank subcommand
+  entry distinctly.
+- 🔵 **Documentation**: Current State Analysis says `visualiser` "differs only in
+  verb", but the edit also drops "interactive".
+- 🔵 **Documentation**: The `tasks/README.md` checklist note has no placement;
+  adding a fourteenth point would stale the "thirteen-point" references in two
+  CLAUDE.md files. Fix: extend the existing point 3.
+
+#### Suggestions
+
+- 🔵 **Usability**: Pull the trivial trailing-period strip on the three built-in
+  `///` doc comments into Phase 1 alongside migrate's, delivering the
+  punctuation-uniform merged list the plan already targets (leaving the
+  sentence-vs-fragment register to 0259).
+- 🔵 **Usability**: The stderr cue points nowhere; append "run `accelerator --help`
+  to see available commands".
+- 🔵 **Usability**: Flag to 0259 that core-then-domain ordering surfaces infra
+  commands above the primary domain verbs — the restyle should choose
+  consciously.
+- 🔵 **Test Coverage**: Extend the phrasing guard to also assert no description ends
+  with `.`, guarding the no-trailing-period convention the plan establishes.
+- 🔵 **Compatibility**: Add a black-box assertion that the cue lands on stderr while
+  the listing lands on stdout (the stream-separation contract).
+
+### Assessment
+
+The plan is close. Every prior finding is genuinely resolved, and the structural
+design — clap-native injection, a pure classifier, fail-open loading — is sound
+and unchanged. One new major is a real regression (`config templates`), and the
+others are test-composition and accuracy gaps rather than design faults; all have
+localised fixes named above. One more revision pass addressing the four majors —
+the `args.is_empty()` gate, the `build_listing` extraction, the stderr assertion,
+and the corrected timeout text — plus the `help`-collision minor should bring it
+to APPROVE.
+
+---
+*Re-review generated by /accelerator:review-plan*
+
+## Re-Review (Pass 3) — 2026-09-05
+
+**Verdict:** COMMENT
+
+Every pass-2 finding — the four majors and the seven minors/suggestions — is
+resolved and verified against source across all seven lenses. No critical or
+major findings remain, so the plan is acceptable as-is. The pass surfaced only
+minor polish and refinements, most of them prose accuracy, test realism, or
+implementation guidance rather than design or behaviour defects.
+
+### Previously Identified Issues
+
+All resolved and verified.
+
+- ✅ **Correctness** — nested-group hijack (`config templates`) — `args.is_empty()`
+  gate confirmed correct: bare has empty argv, any nested `MissingSubcommand` is
+  non-empty and falls to `UsageError`.
+- ✅ **Test Coverage** — wired augment untested — `build_listing` extracted, both
+  arms unit-tested.
+- ✅ **Test Coverage** — bare stderr cue unasserted — black-box now asserts the
+  stream split.
+- ✅ **Architecture** — timeout bound understated — help-scoped single-attempt
+  fetcher; Performance text corrected (one residual refinement below).
+- ✅ **Correctness/Compatibility/Architecture** — `help` collision — explicit
+  `name == "help"` skip, correctly justified against clap's lazy `_build`.
+- ✅ **Code Quality** — `HelpRoute` contradictory states — `FullListing(ListingCause)`.
+- ✅ **Code Quality** — stdout-forcing rationale — added to the carry-across list.
+- ✅ **Test Coverage** — `classify` table gap, bundled empty-name — both closed.
+- ✅ **Documentation** — visualiser prose, checklist placement — both corrected
+  and verified (checklist runs to exactly thirteen points).
+- ✅ **Usability/Test Coverage** — built-in periods, cue pointer, ordering,
+  no-period guard — all applied.
+
+### New Issues Introduced
+
+No critical or major findings.
+
+#### Minor
+
+- 🔵 **Architecture**: The help-scoped `Fetcher` sets `max_attempts = 1`, but the
+  10s connect and 300s total timeouts are module constants baked into
+  `Fetcher::build()`, so a single attempt still inherits the 10s connect — not the
+  "couple of seconds" the plan asserts. Achieving that needs an explicit
+  `fetcher.rs` change (parameterised or help-scoped timeout constants) with
+  concrete values and a test; add a Changes Required entry, or restate the bound
+  as one ~10s connect timeout.
+- 🔵 **Compatibility**: The tightened single-attempt fetch makes AC-6's "three
+  identical listings" probabilistic near the timeout boundary — each entry point
+  fetches independently, so on a marginal link one can show sub-binaries and the
+  next fall open to built-ins. Note the `diff`-empty check assumes a stable
+  manifest-load result.
+- 🔵 **Test Coverage**: The `config templates` regression has only a synthetic
+  `classify` case plus manual verification; add a black-box case mirroring the
+  `config --help` one.
+- 🔵 **Test Coverage**: `render_full_listing`'s manifest-passing call site is still
+  unreachable by assertion (the no-forged-manifest constraint), so "guards the
+  wired augmentation against deletion" overstates it — acknowledge the limit and
+  keep the function a one-line delegation.
+- 🔵 **Correctness/Test Coverage**: The `classify` truth-table row `(DisplayVersion,
+  ["version","--help"])` is fictional — with `disable_version_flag = true`,
+  `version` is a subcommand and `version --help` yields `DisplayHelp`; clap never
+  raises `DisplayVersion` for this CLI. Relabel or annotate the arm as an
+  unreachable-kind guard.
+- 🔵 **Code Quality**: The exit-2→1 usage-error remap rationale (`main.rs:119-122`)
+  is not in the carry-across list; add it so the `UsageError` arm keeps its "why".
+- 🔵 **Code Quality**: The stderr cue is emitted as a side effect inside the
+  exit-code-computing `match cause`; consider emitting it in a separate step so
+  render, cue, and exit read distinctly.
+- 🔵 **Documentation**: The "full sentences vs terse fragments" register framing is
+  undercut by its own data (both are imperative; the built-in exemplar is shorter
+  than a shipped sub-binary description) — reframe as verbosity/detail parity.
+- 🔵 **Documentation**: The Testing Strategy phrasing-guard bullet describes only
+  the `sub-binary` substring assertion, not the newly-added trailing-period one.
+
+#### Suggestions
+
+- 🔵 **Compatibility**: `augment_with_subbinaries` renames the public
+  `external_subcommands_section`; add a step to refresh the cargo-public-api
+  baseline (or confirm exemption) so `mise run` stays green.
+- 🔵 **Test Coverage**: Specify the phrasing guard iterates `DISPATCHED_SUBBINARIES`
+  reading descriptions only (not `collect_entries`, which needs staged bytes), so
+  it stays hermetic and auto-covers new sub-binaries.
+- 🔵 **Test Coverage**: Assert collision dedup via `get_subcommands()` counts rather
+  than a substring count of `version` (which appears in its own about text).
+- 🔵 **Correctness**: `sanitize()` strips control chars but not whitespace, so a
+  name like `foo bar` renders oddly; skip non-token names or record the upstream
+  validation invariant.
+- 🔵 **Usability**: The cue points to `--help`, which reproduces the listing already
+  on stdout in a shared terminal — record as an accepted stderr-only-capture
+  tradeoff.
+- 🔵 **Usability**: Flag `corpus`'s three-of-four parenthetical (omitting `linkage`)
+  in the 0259 hand-off.
+
+### Assessment
+
+The plan is ready. Its structural design — clap-native injection, a pure
+classifier over `(ErrorKind, args)`, `build_listing` composition, fail-open
+loading with a help-scoped fetch — is sound and well-tested, and no behaviour or
+correctness defect remains. The residual items are polish: the architecture and
+compatibility minors are the two with real substance (pin the help fetcher's
+timeouts concretely, and frame the identical-listing check as assuming a stable
+load), and the rest are prose accuracy, test realism, and implementation-note
+refinements that can be handled during implementation. Three review passes have
+reached clear diminishing returns.
+
+---
+*Re-review generated by /accelerator:review-plan*
+
+## Approval — 2026-09-06
+
+**Verdict:** APPROVE
+
+Approved for implementation. The two substantive pass-3 minors were applied
+after the pass: the help fetcher's timeouts are now pinned concretely
+(`Fetcher::for_help()` — 3s connect, 5s total, `max_attempts = 1` — via a
+parameterised `build()`, Phase 2 §6), and the identical-listing check is now
+framed as assuming a stable manifest-load result (Desired End State; the manual
+`diff` bullet). The remaining pass-3 items — a fictional `DisplayVersion`
+truth-table row, an overstated "guards against deletion" claim, two documentation
+prose nits, a cargo-public-api baseline note, and assorted test-realism and 0259
+hand-off refinements — are non-blocking and folded into implementation. Plan
+status set to `ready`.

--- a/meta/reviews/work/0258-help-show-subcommands-review-1.md
+++ b/meta/reviews/work/0258-help-show-subcommands-review-1.md
@@ -1,0 +1,368 @@
+---
+type: "work-item-review"
+id: "0258-help-show-subcommands-review-1"
+title: "Work Item Review: Help Should Show Subcommands"
+date: "2026-09-04T11:27:37+00:00"
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
+target: "work-item:0258"
+work_item_id: "0258"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-09-05T11:07:48+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Work Item Review: Help Should Show Subcommands
+
+**Verdict:** REVISE
+
+This bug is unusually well-formed — a self-contained reproduction with explicit
+expected/actual outcomes, five concrete acceptance criteria, and proactively
+carved boundaries against sibling items 0259 and 0260. Two structural issues
+gate approval: it bundles a manifest-wide, cross-surface description rewrite
+with the help-routing fix, and it leaves the exit-status behaviour for bare
+`accelerator` unresolved as an Open Question, so that dimension of the criteria
+has no definitive pass/fail. Neither is a defect in the analysis; both are
+scoping decisions the item should settle before implementation.
+
+### Cross-Cutting Themes
+
+- **The manifest description rewrite is a second concern riding along** (flagged
+  by: scope, dependency, testability) — scope calls it a separately deliverable
+  cross-surface change bundled with the routing fix; dependency notes its shared
+  manifest artefact (`BinaryEntry.description`) has unenumerated consumers;
+  testability notes the positive "user-facing description" criterion has no
+  enumerated expected text. All three orbit the same rewrite.
+- **The 0259 boundary is coordinated but not sequenced** (flagged by: scope,
+  dependency) — merging the two command groups and removing the heading is
+  itself a layout change that abuts 0259's styling remit, and the item asks the
+  two to "coordinate" without establishing which lands first.
+
+### Findings
+
+#### Major
+
+- 🟡 **Scope**: Manifest-wide description rewrite bundled with help-routing bug fix
+  **Location**: Requirements
+  Beyond fixing the routing defect, the Requirements and Acceptance Criteria
+  mandate replacing every command's launcher-internal phrasing with user-facing
+  summaries. The Technical Notes confirm these live in manifest data, not help
+  code, broadening the change and coupling two separately deliverable concerns.
+
+- 🟡 **Testability**: Exit status for bare `accelerator` undefined, leaving that criterion unverifiable
+  **Location**: Acceptance Criteria
+  The Open Questions section asks whether bare `accelerator` keeps clap's
+  non-zero exit or exits zero, but no criterion resolves it — a verifier running
+  the bare command cannot decide whether a given exit code is a pass or a fail.
+
+#### Minor
+
+- 🔵 **Clarity**: "Complete intended set" of nine may conflict with dependency 0260
+  **Location**: Assumptions
+  The Assumptions section fixes the set at nine and says the fix "adds none and
+  hides none", yet the Dependencies section notes 0260 changes the command
+  surface. A reader cannot tell whether "the complete command set" is fixed at
+  nine or expected to grow.
+
+- 🔵 **Dependency**: 0259 coupling names no landing order
+  **Location**: Dependencies
+  The 0259 entry correctly identifies the shared help output but only asks the
+  two items to "coordinate", without establishing which lands first — a
+  concurrent shared-artefact coupling with no sequencing resolved, risking merge
+  conflicts or silent reverts discovered at integration.
+
+- 🔵 **Scope**: Heading-removal / list-merge overlaps the styling boundary owned by 0259
+  **Location**: Dependencies
+  Merging built-ins and sub-binaries into one list with no heading is a
+  presentation decision, yet the item states 0259 "governs help styling only".
+  Removing a heading and collapsing two groups is itself a layout change, so the
+  boundary is not cleanly separable.
+
+#### Suggestions
+
+- 🔵 **Clarity**: ADR acronym used without expansion
+  **Location**: Dependencies
+  "0260 (Move ADR Into Its Own Subcommand)" uses ADR without expanding it to
+  Architecture Decision Record.
+
+- 🔵 **Dependency**: Other consumers of `BinaryEntry.description` not enumerated
+  **Location**: Technical Notes
+  The rewrite edits shared manifest data, but the item does not name which other
+  renderers (the existing `--help` section, the visualiser) consume those
+  strings, leaving the blast radius uncaptured.
+
+- 🔵 **Dependency**: Frontmatter `relates_to` omits the "built on" items 0164 and 0187
+  **Location**: Frontmatter: relates_to
+  The Dependencies prose names 0164 and 0187 as items this bug is built on, but
+  `relates_to` lists only 0259 and 0260, so the stronger couplings are invisible
+  to tooling that reads structured frontmatter.
+
+- 🔵 **Testability**: Positive "user-facing description" check has no enumerated expected text
+  **Location**: Acceptance Criteria
+  Criterion 4 is verifiable in its negative form (absence of "… sub-binary."),
+  but the positive expectation gives only one worked example, so each
+  replacement description's correctness is a subjective judgement.
+
+### Strengths
+
+- ✅ The reproduction is complete and executable: three named commands to run
+  and compare, with explicit expected and actual states — exactly what a bug
+  verification needs.
+- ✅ All expected sections are present and substantively populated; frontmatter
+  (`kind: bug`, `status: draft`, `priority: medium`) is intact and consistent
+  with the body headers.
+- ✅ Scope boundaries are stated explicitly — the Assumptions section defines
+  what is in and out ("surfaces exactly what dispatch already knows about") and
+  resolves the "merged list" ambiguity.
+- ✅ Dependencies are mapped with substance: upstream mechanism items (0164,
+  0187) are named and marked done, and the couplings to 0259/0260 explain their
+  nature rather than being bare references.
+- ✅ Criterion 5 (a fixture sub-binary appearing in all three outputs with no
+  change to help code) makes the source-of-truth requirement directly testable
+  rather than relying on inspection.
+
+### Recommended Changes
+
+1. **Decide the scope of the description rewrite** (addresses: Manifest-wide
+   description rewrite bundled; Other consumers of `BinaryEntry.description` not
+   enumerated; Positive "user-facing description" check has no enumerated text)
+   Either split the manifest description rewrite into its own chore (or fold it
+   into 0259), leaving this bug focused on rendering the identical existing
+   command set across three entry points — or, if it stays, enumerate the
+   expected one-line description for each of the nine sub-binaries and name every
+   surface that consumes `BinaryEntry.description`.
+
+2. **Resolve the bare-invocation exit status and pin it in a criterion**
+   (addresses: Exit status for bare `accelerator` undefined) Settle the Open
+   Question and add a criterion asserting the expected exit code, e.g. "bare
+   `accelerator` prints the full command list and exits with status 0".
+
+3. **Sharpen the 0258/0259 boundary and sequence it** (addresses: Heading-removal
+   overlaps 0259; 0259 coupling names no landing order) Decide whether the
+   heading/merge layout change lives here or in 0259, then state an explicit
+   landing order (or that both must land as one coordinated change) and adjust
+   0259's scope note to match.
+
+4. **Reconcile the "nine" assumption with the dynamic source of truth**
+   (addresses: "Complete intended set" of nine may conflict with 0260) Clarify in
+   Assumptions that "complete" means whatever dispatch currently knows about
+   (currently nine), so the set reads as dynamic rather than hardcoded.
+
+5. **Mirror the built-on couplings into frontmatter** (addresses: `relates_to`
+   omits 0164 and 0187) Add `work-item:0164` and `work-item:0187` to `relates_to`
+   so the mechanism dependencies the body already states are machine-visible.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: Unusually clear and internally coherent — Summary, Context,
+Requirements, and Acceptance Criteria describe a single consistent intent, with
+consistent counts and command names and unambiguous referents. The only concerns
+are a soft tension between the fixed "nine sub-binaries" assumption and a
+dependency that changes the command surface, and one undefined acronym.
+
+**Strengths**:
+- The Summary enumerates the exact nine sub-binaries and four built-ins, and
+  Assumptions restates the count of nine, keeping the command set unambiguous.
+- Requirements and Acceptance Criteria state outcomes as observable listing
+  states rather than vague desired properties.
+- The "merge into one list" ambiguity is explicitly resolved in Assumptions and
+  AC #3 ("no heading separating built-ins from sub-binaries").
+- Pronouns and noun phrases each resolve to a single clearly named antecedent.
+
+**Findings**:
+- minor (confidence: medium), Assumptions — "Complete intended set" of nine may
+  conflict with dependency 0260. Assumptions says the fix adds/hides none, yet
+  0260 changes the command surface; a reader cannot tell whether "complete" is
+  fixed at nine or dynamic. Suggest clarifying "complete" means whatever dispatch
+  currently knows about.
+- suggestion (confidence: medium), Dependencies — ADR acronym used without
+  expansion. Expand ADR (Architecture Decision Record) on first use, or rely on
+  the linked 0260 title.
+
+### Completeness
+
+**Summary**: Structurally and informationally complete. All expected sections are
+present and substantively populated, and it carries the kind-specific content a
+bug demands — a reproduction procedure with explicit expected and actual
+outcomes. Frontmatter is intact with a recognised kind, status, and priority.
+
+**Strengths**:
+- Reproduction is complete and self-contained: exact commands, expected outcome,
+  and actual outcome.
+- Context explains why the defect exists (deliberate divergence traced to 0164)
+  and why it matters, rather than restating the Summary.
+- Acceptance Criteria contains five specific, distinct done-conditions covering
+  all three invocation paths plus the fixture-registration regression guard.
+- Optional sections (Open Questions, Dependencies, Assumptions, Technical Notes)
+  are all populated with genuinely relevant content.
+
+**Findings**: none.
+
+### Dependency
+
+**Summary**: Dependency mapping is strong — both upstream mechanism items (0164,
+0187) are named and done, and the two concurrent related items (0259, 0260) are
+captured with explicit notes describing each coupling. No external systems or
+cross-team actions are implied, so an empty external surface is appropriate. The
+residual concerns are minor: unresolved sequencing against 0259, a shared
+manifest artefact whose other consumers aren't enumerated, and a `relates_to`
+list that omits the built-on items.
+
+**Strengths**:
+- Upstream mechanism dependencies (0164, 0187) are named and flagged done, so no
+  hidden blocker gates the work from starting.
+- The 0259/0260 relationships explain the coupling rather than being bare
+  references.
+- The "same source of truth as dispatch" requirement structurally decouples the
+  fix from future sub-binary additions.
+
+**Findings**:
+- minor (confidence: medium), Dependencies — 0259 is a concurrent shared-artefact
+  coupling with no sequencing resolved; risk of merge conflicts or silent
+  reverts at integration. Suggest stating an explicit landing order or a single
+  coordinated change.
+- suggestion (confidence: low), Technical Notes — other consumers of
+  `BinaryEntry.description` (the `--help` section, the visualiser) are not
+  enumerated, leaving the rewrite's blast radius uncaptured.
+- suggestion (confidence: low), Frontmatter: relates_to — prose names 0164 and
+  0187 as built-on items, but `relates_to` lists only 0259 and 0260, so the
+  stronger couplings are invisible to tooling.
+
+### Scope
+
+**Summary**: One broadly coherent goal — making all three help entry points
+render the same complete, consistent command index. The core defect is
+atomically sized and appropriate for a bug. However, the Requirements bundle a
+manifest-wide description rewrite that edits a different surface with standalone
+value, and the "merge into one list / no heading" presentation change sits on a
+blurry boundary with sibling item 0259.
+
+**Strengths**:
+- Scope boundaries are stated explicitly in Assumptions, giving a clear
+  inclusion/exclusion line.
+- Dependencies proactively carve the boundary against 0259 (styling) and 0260
+  (command surface) rather than silently overlapping.
+- The primary defect is a single, well-bounded unit of value one team can own
+  and verify end-to-end.
+
+**Findings**:
+- major (confidence: medium), Requirements — manifest-wide description rewrite
+  bundled with the help-routing bug fix. The rewrite lives in manifest data, has
+  standalone value, and could ship or roll back independently; bundling enlarges
+  blast radius and hurts reviewability. Suggest splitting it into its own chore
+  or folding into 0259.
+- minor (confidence: medium), Dependencies — heading-removal / list-merge is a
+  layout change that overlaps 0259's stated styling remit, so the boundary is not
+  cleanly separable. Suggest scoping this bug to correctness only or explicitly
+  claiming layout ownership and adjusting 0259.
+
+### Testability
+
+**Summary**: Strongly testable — the reproduction is fully specified (three named
+commands to compare), expected vs. actual outcomes are stated, and the criteria
+include a fixture-based regression test that verifies the source-of-truth
+mechanism. The main gap is the exit-status behaviour for bare `accelerator`,
+left as an unresolved Open Question, plus a positive "user-facing description"
+criterion that lacks enumerated expected text.
+
+**Strengths**:
+- Requirements give a complete, executable reproduction with explicit Expected
+  and Actual states.
+- AC #3 defines an unambiguous, observable pass condition a diff-based check can
+  confirm conclusively.
+- AC #5 (fixture sub-binary appearing in all three outputs with no help-code
+  change) makes the source-of-truth requirement directly testable and bounds the
+  "every sub-binary" scope via the named nine-binary set.
+
+**Findings**:
+- major (confidence: medium), Acceptance Criteria — exit status for bare
+  `accelerator` is undefined; the Open Question is never resolved into a
+  criterion, so two implementations with opposite exit codes could both be argued
+  as passing. Suggest resolving it and adding a criterion pinning the exit code.
+- minor (confidence: medium), Acceptance Criteria — the positive "user-facing
+  description" expectation gives only one worked example and no expected text for
+  the other eight sub-binaries, making each description a subjective judgement.
+  Suggest enumerating the expected string per sub-binary.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-09-04
+
+**Verdict:** COMMENT
+
+Re-ran the four lenses that carried findings (clarity, dependency, scope,
+testability). Both original major findings are resolved and no major findings
+remain, so the verdict moves from REVISE to COMMENT — the work item is
+acceptable for implementation. The edits cleared the structural issues; a
+cascade of finer-grained minor observations surfaced once they did, none
+blocking.
+
+### Previously Identified Issues
+
+- 🟡 **Testability**: Exit status for bare `accelerator` undefined — **Resolved**
+  (AC now pins the retained non-zero exit; Open Question recorded as resolved).
+- 🟡 **Scope**: Manifest-wide description rewrite bundled — **Partially resolved**
+  (kept here by decision and enumerated; scope now rates it minor, wanting the
+  atomic-landing justification written down).
+- 🔵 **Clarity**: "Complete intended set" of nine may conflict with 0260 —
+  **Resolved** (Assumptions reframes the set as dynamic).
+- 🔵 **Dependency**: 0259 coupling names no landing order — **Resolved**
+  (explicit sequencing: 0258 first, then 0259 restyles).
+- 🔵 **Scope**: Heading-removal overlaps 0259 boundary — **Partially resolved**
+  (layout ownership now claimed here; scope still wants a concrete dividing line
+  and confirmation 0259's scope note is amended).
+- 🔵 **Testability**: Positive description check had no enumerated text —
+  **Resolved** (nine descriptions enumerated; AC asserts exact match).
+- 🔵 **Clarity**: ADR acronym unexpanded — **Resolved** (expanded inline).
+- 🔵 **Dependency**: Other consumers of the descriptions not enumerated —
+  **Partially resolved** (consumer note added; the Cargo.toml package-metadata
+  consumer is still unnamed — see new issue).
+- 🔵 **Dependency**: `relates_to` omitted 0164/0187 — **Resolved** (both added).
+
+### New Issues Introduced
+
+- 🔵 **Clarity**: Summary frames `--help` as the correct reference, but AC 4/5
+  require restructuring `--help` too (heading removed, descriptions rewritten).
+- 🔵 **Clarity**: Dependencies and Technical Notes locate the canonical
+  description source differently (crate `Cargo.toml` vs manifest data).
+- 🔵 **Dependency**: `Cargo.toml` `description` is dual-use crate package
+  metadata, not solely a help string; the consumer check omits cargo/packaging.
+- 🔵 **Testability**: "Identical command listings" leaves comparison dimensions
+  (ordering, whitespace) undefined.
+- 🔵 **Testability**: No expected description text for the four built-in commands.
+- 🔵 **Testability**: AC 6 folds the unassertable "no change to help code"
+  constraint into an otherwise observable check.
+- 🔵 **Scope** (suggestion): `bug` kind under-represents the layout-restructure
+  and nine-crate description rewrite.
+- 🔵 **Dependency** (suggestion): 0260's new `adr` subcommand will need a
+  user-facing description the enumerated nine do not cover.
+
+### Assessment
+
+The work item is ready for implementation. Every issue that gated approval is
+resolved; the residual items are minor precision improvements — chiefly pinning
+down what "identical" asserts, naming `Cargo.toml` `description` as dual-use
+metadata, and reconciling the Summary's "already lists / nine" framing with the
+restructure and dynamic-set intent. Worth a light polish pass but not required
+before planning.
+
+### Approval (2026-09-05)
+
+**Verdict:** APPROVE
+
+Reviewer accepts the work item. After pass 2, the two recommended edits were
+applied — the Summary now states `--help` is also restructured, and the
+consumer note names `Cargo.toml` `description` as dual-use package metadata.
+Both re-review new-issue findings on those points are resolved; the remaining
+minor observations are optional polish and do not gate planning. The verdict is
+promoted from COMMENT to APPROVE.

--- a/meta/validations/2026-09-05-0258-help-show-subcommands-validation.md
+++ b/meta/validations/2026-09-05-0258-help-show-subcommands-validation.md
@@ -1,0 +1,141 @@
+---
+type: "plan-validation"
+id: "2026-09-05-0258-help-show-subcommands-validation"
+title: "Validation Report: Help Should Show Subcommands Implementation Plan"
+date: "2026-09-06T11:27:00+00:00"
+author: "Toby Clemson"
+producer: "validate-plan"
+status: "complete"
+result: "pass"
+parent: "plan:2026-09-05-0258-help-show-subcommands"
+target: "plan:2026-09-05-0258-help-show-subcommands"
+tags: ["cli", "help", "launcher", "discoverability"]
+last_updated: "2026-09-06T11:27:00+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Help Should Show Subcommands Implementation Plan
+
+Both phases are fully implemented and every success criterion is verified.
+The three entry points converge on one identical command listing; all four
+components pass read-only CI. Three files outside the plan's declared set were
+touched — each a necessary ripple of the planned change, not scope creep.
+
+### Implementation Status
+
+- ✅ Phase 1: User-Facing Descriptions — fully implemented
+- ✅ Phase 2: Merge the List and Converge the Entry Points — fully implemented
+
+Both phases are committed: Phase 1 as `Rewrite sub-binary descriptions as
+user-facing help text (0258 phase 1)`, Phase 2 as the merge commit `Merge help
+into one command listing across all three entry points (0258 phase 2)`.
+
+### Automated Verification Results
+
+- ✅ Rust workspace check: `mise run cli:check` (exit 0)
+- ✅ Launcher unit + black-box tests: `cargo test -p accelerator` (all suites green, 0 failed across 12 binaries)
+- ✅ Visualiser + phrasing guard: `pytest test_manifest.py -k "visualiser or phrasing"` (2 passed)
+- ✅ Dispatch-coherence suite after the scraper deletion: `pytest test_dispatch_coherence.py` (74 passed)
+- ✅ Read-only CI mirror: `mise run check` (exit 0, all four components)
+
+The full local CI mirror (`mise run`) was not re-run here; the plan records it
+passing with a single known unrelated flake in the visualiser-readiness lane.
+`mise run check` — the read-only lane CI actually gates on — is green.
+
+### Code Review Findings
+
+#### Matches Plan
+
+- **All nine descriptions** rewritten to the AC-5 text at their `Cargo.toml`
+  source of truth; `migrate`'s trailing period trimmed; `visualiser` reads
+  `Serve the meta-directory visualiser`.
+- **Three built-in doc comments** (`version`, `config`, `cache`) stripped of
+  trailing periods in `cli.rs`, so the merged listing is punctuation-uniform.
+- **Phrasing guard** added in `test_manifest.py`: iterates
+  `DISPATCHED_SUBBINARIES` through `_read_description`, asserting no description
+  contains `sub-binary` or ends with `.`.
+- **README checklist** point 3 extended to note the description is user-facing
+  help text; the list stays at thirteen points, preserving the `CLAUDE.md`
+  references.
+- **`augment_with_subbinaries`** matches the plan verbatim, including the
+  load-bearing `is_empty() || == "help" || find_subcommand` skip guard and
+  `sanitize()`.
+- **`classify` / `HelpRoute` / `ListingCause`** implemented as a pure function
+  over `(ErrorKind, &[OsString])`; `main` collects `root_args` once and threads
+  it in, so routing reads no process global.
+- **`Fetcher::for_help()`** parameterises `build()` via a `Limits` struct
+  (3s connect, 5s total, 1 attempt); `new()`/`with_backoff()` retain today's
+  values, so dispatch is unchanged.
+- **Black-box coverage** extended to all three entry points plus the
+  `config --help` isolation case, with the bare case asserting stream
+  separation (listing on stdout, cue on stderr).
+
+#### Deviations from Plan
+
+- **`classify` bare-invocation arm folds in `DisplayHelpOnMissingArgumentOrSubcommand`.**
+  The plan's pseudocode keyed the bare case on `ErrorKind::MissingSubcommand`.
+  This clap version surfaces bare `accelerator` as
+  `DisplayHelpOnMissingArgumentOrSubcommand` with empty args, so the arm matches
+  both kinds under `args.is_empty()` and keeps `MissingSubcommand` as a
+  defensive fallback. The plan itself flagged this in its Phase 2 manual-check
+  note (line 684); the implementation is the correct adaptation.
+- **`cli/Cargo.toml` adds clap's `"string"` feature.** Required, not optional:
+  `augment_with_subbinaries` builds subcommands from owned `String` names
+  (`sanitize()` output), which `clap::Command::new` accepts only under `string`.
+  Not mentioned in the plan.
+- **`test_dispatch_coherence.py` deletes `test_is_root_help_agrees_as_a_secondary_check`.**
+  That test scraped the old `is_root_help` word-list `Some("version" | …)` from
+  `main.rs`, which §3 removed in favour of the pure `is_root_help_args`. The
+  scraped pattern no longer exists, so the test had to go. A necessary ripple
+  the plan did not enumerate.
+- **`crypto_provider.rs` doc comment** updated `help_section()` →
+  `load_help_manifest()` — a rename ripple from the §2 fold.
+
+#### Potential Issues
+
+- **`classify` doc comment overstates the derive.** Line 157 says "the derive
+  marks the required root subcommand `arg_required_else_help`", but the root
+  `Cli` struct carries no such attribute — the behaviour comes from clap's
+  default handling of a required subcommand field. Cosmetic; the actual kind is
+  pinned by the black-box tests, so behaviour is unaffected.
+- **No live-manifest end-to-end test**, by design. The populated listing is a
+  unit assertion over a hand-built `Manifest` (`build_listing` /
+  `augment_with_subbinaries`); black-box covers only the manifest-unavailable
+  path, since a test cannot forge a signed manifest. The convergence guarantee
+  rests on `render_full_listing` being the sole augmenting renderer — a
+  structural argument, verified here manually against a dead host.
+
+### Manual Testing Performed
+
+All manual criteria were exercised against the built `debug/accelerator` with
+the release host forced unreachable (`ACCELERATOR_RELEASE_BASE_URL=https://127.0.0.1:1`):
+
+1. Merged listing:
+  - ✅ `--help` renders one "Commands:" section, no "External subcommands"
+    heading, period-free descriptions.
+  - ✅ `diff <(--help) <(help)` and `diff <(--help) <(bare stdout)` both empty
+    (IDENTICAL).
+2. Exit codes and streams:
+  - ✅ Bare exits 1 with the listing on stdout and
+    `error: a subcommand is required; run 'accelerator --help' …` on stderr.
+  - ✅ `--help` and `help` exit 0.
+3. Isolation:
+  - ✅ `config --help` renders `Usage: accelerator config <COMMAND>`, not the
+    top-level listing.
+
+Not performed here (covered by the plan's own recorded runs): the
+reachable-host three-way diff with sub-binaries present, and the blackhole-host
+~3s fail-open timing (unit-tested by `the_help_fetcher_gives_up_within_its_connect_bound`).
+
+### Recommendations
+
+- **Tidy the `classify` doc comment** to describe clap's default required-
+  subcommand behaviour rather than a non-existent `arg_required_else_help` on
+  the root. Non-blocking.
+- **Align the `test_github.py` placeholder strings** at leisure — the plan
+  correctly leaves them as documented arbitrary fixtures; no action required
+  for correctness.
+- **Carry the deferred 0259 items forward**: the sentence-vs-fragment register
+  split, the core-then-domain ordering decision, and the AC-5 fixed wording are
+  all consciously out of scope here and belong to 0259.

--- a/meta/work/0258-help-show-subcommands.md
+++ b/meta/work/0258-help-show-subcommands.md
@@ -5,12 +5,13 @@ title: "Help Should Show Subcommands"
 date: "2026-08-31T12:11:13+00:00"
 author: "Toby Clemson"
 producer: "extract-work-items"
-status: "draft"
+status: "ready"
 kind: "bug"
 priority: "medium"
 parent: "work-item:0276"
-tags: ["cli", "help"]
-last_updated: "2026-09-05T00:00:00+00:00"
+relates_to: ["work-item:0164", "work-item:0187", "work-item:0259", "work-item:0260"]
+tags: ["cli", "help", "discoverability"]
+last_updated: "2026-09-05T11:07:48+00:00"
 last_updated_by: "Toby Clemson"
 last_updated_note: "Reparented under epic 0276 (Rust CLI Consolidation and Hardening): post-migration evolution of the cli/ Rust workspace, gathered from the audit of work items numbered above 0136."
 schema_version: 1
@@ -20,34 +21,155 @@ external_id: "PP-788"
 # 0258: Help Should Show Subcommands
 
 **Kind**: Bug
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
-`accelerator help` does not list available subcommands, leaving users
-without a discoverable command index.
+`accelerator help` and bare `accelerator` list only the four built-in
+commands (`version`, `config`, `cache`, `help`), omitting the nine
+dispatched sub-binaries (`work`, `vcs`, `jira`, `linear`, `corpus`,
+`collaboration`, `design`, `migrate`, `visualiser`) that `accelerator
+--help` already lists. Anyone reaching for `help` or the bare command
+gets an incomplete, misleading command index. `--help` is the closest to
+correct but not the target state: it too is restructured here — its
+"External subcommands" heading removed and its descriptions rewritten — so
+all three entry points converge on one merged, user-facing listing.
 
 ## Context
 
-Captured in the further-ideas backlog. Help output omits the subcommand
-list.
+The launcher (`cli/launcher/`) exposes its surface through clap: built-in
+commands are defined on the clap `Command` enum, dispatched sub-binaries
+via clap's `external_subcommand` catch-all, enumerated from a manifest at
+help time. Three entry points diverge today — `accelerator --help` shows
+built-ins plus a separate "External subcommands:" section listing the
+sub-binaries; `accelerator help` and bare `accelerator` show built-ins
+only. The divergence is deliberate in the current code and traces to work
+item 0164, which scoped the discoverable listing to `--help` alone.
 
 ## Requirements
 
-- `accelerator help` lists the available subcommands.
+**Reproduction**: run `accelerator help`, then `accelerator`, then
+`accelerator --help`, and compare the command lists.
+
+**Expected**: all three show the same complete command set.
+**Actual**: only `--help` includes the sub-binaries, and under a separate
+"External subcommands" heading.
+
+- `accelerator help`, bare `accelerator`, and `accelerator --help` all
+  list the complete command set — built-ins and dispatched sub-binaries —
+  identically.
+- Dispatched sub-binaries appear in the same "Commands" list as built-ins,
+  with no "External subcommands" heading and no origin distinction.
+- Each command carries a concise, user-facing one-line description,
+  replacing the current launcher-internal phrasing (e.g. `The work
+  create|show|resolve|diff|update sub-binary.`). The intended descriptions
+  for the dispatched sub-binaries are:
+  - `work` — Manage work items
+  - `vcs` — Detect and inspect version-control state
+  - `jira` — Manage Jira issues
+  - `linear` — Manage Linear issues
+  - `corpus` — Manage the meta-document corpus (ADRs, metadata, frontmatter)
+  - `collaboration` — Manage pull-request collaboration
+  - `design` — Validate and process design sources
+  - `migrate` — Apply pending meta-directory schema migrations
+  - `visualiser` — Serve the meta-directory visualiser
+- The listing is driven by the same source of truth as dispatch, so a
+  newly registered sub-binary appears automatically.
 
 ## Acceptance Criteria
 
-- [ ] Running `accelerator help` shows all top-level subcommands.
+- [ ] Running `accelerator help` lists every dispatched sub-binary
+      alongside the built-ins.
+- [ ] Running `accelerator` with no arguments lists the same complete
+      command set as `accelerator help`.
+- [ ] Bare `accelerator` prints the full command list but retains clap's
+      existing non-zero missing-subcommand exit status.
+- [ ] `accelerator help`, `accelerator`, and `accelerator --help` produce
+      identical command listings — same commands, same descriptions, no
+      heading separating built-ins from sub-binaries.
+- [ ] No listed command carries launcher-internal phrasing such as
+      "… sub-binary."; each dispatched sub-binary's description matches the
+      intended text enumerated in Requirements.
+- [ ] A test that registers a fixture sub-binary confirms it appears in
+      all three help outputs with no change to help code.
+
+## Open Questions
+
+- None outstanding. Resolved: bare `accelerator` retains clap's non-zero
+  missing-subcommand exit status while printing the full command list (see
+  Acceptance Criteria).
+
+## Dependencies
+
+- Relates to 0259 (Unify Help Style) — the user-facing description wording
+  and the command-list layout (merging built-ins and sub-binaries into one
+  unheadinged list) are owned here; 0259 governs help *styling* on top.
+  Sequencing: 0258 lands the merged-list restructure first, then 0259
+  restyles it — 0259's scope note must be adjusted to cede command-list
+  layout ownership to this item.
+- Relates to 0260 (Move ADR Into Its Own Subcommand) — 0260 moves the ADR
+  (Architecture Decision Record) surface into its own subcommand, changing
+  the command surface the listing renders; the output must reflect whatever
+  the surface becomes.
+- Consumers of the sub-binary descriptions — the one-line descriptions are
+  sourced from each sub-binary crate's `Cargo.toml` `description`, surfaced
+  via the manifest (`BinaryEntry.description`). That field is dual-use: it is
+  also the crate's published package metadata read by cargo tooling, so
+  rewriting it for help display is a deliberate overload rather than a
+  help-only change. The launcher's own `--help` external-subcommands block is
+  the known help renderer, which this fix subsumes; confirm no other surface
+  (e.g. the visualiser) and no cargo/packaging consumer depends on the current
+  wording before rewriting.
+- Built on 0164 (Launcher and Git-Style Dispatch, done) and 0187
+  (Generalise the Sub-Binary Registration Surface, done) — the mechanism
+  being fixed.
+
+## Assumptions
+
+- "Complete" means whatever dispatch currently knows about — nine
+  sub-binaries today, but the set is dynamic (0260 will change it). The fix
+  surfaces exactly what dispatch already knows about, adding none and hiding
+  none, so the listing tracks the source of truth rather than a hardcoded
+  nine.
+- "Merged list" means users need not know which commands are in-process
+  built-ins and which are dispatched external binaries — that distinction
+  is an implementation detail.
+
+## Technical Notes
+
+- Divergence locus: `cli/launcher/src/main.rs` — `is_root_help()` returns
+  false when the first argument is `help`, and `handle_parse_error()`
+  routes only clap's `DisplayHelp` (the `--help` flag) to
+  `render_augmented_help()`. Bare invocation yields
+  `DisplayHelpOnMissingArgumentOrSubcommand`, which never reaches the
+  augmented path.
+- Augmentation appends the external block via clap `after_help`, sourced
+  from `external_subcommands_section()` in
+  `cli/launcher/src/launch/help.rs`. Merging into one list likely means
+  abandoning `after_help` and composing the full command list, since
+  built-ins come from the clap `Command` enum
+  (`cli/launcher/src/launch/inbound/cli.rs`) and sub-binaries from the
+  manifest.
+- Descriptions live in manifest data (`BinaryEntry.description`,
+  `cli/launcher/src/launch/outbound/resolve/manifest.rs`), not launcher
+  source — the user-facing rewrite edits manifest/registration data,
+  broadening the change beyond help code.
+- Tests to extend: `cli/launcher/tests/dispatch.rs`, and the inline tests
+  in `help.rs` and `main.rs`.
 
 ## Drafting Notes
 
-- Extracted from source documents without interactive enrichment.
-  Acceptance criteria, dependencies, and kind may need refinement before
-  promoting from `draft` to `ready`.
+- Reframed the Summary and Context: the original stub said help shows no
+  subcommands, but `accelerator --help` already lists them, so the true
+  defect is `help` and the bare command omitting what `--help` shows.
+  Correct this if the author meant `--help` is broken too.
+- Read "merge into one list" as hiding the built-in/external distinction
+  entirely; a lighter reading is one heading with the sub-binaries visually
+  grouped beneath it.
 
 ## References
 
 - Source: `meta/notes/2026-06-23-further-ideas-backlog.md`
+- Related: 0259, 0260, 0164, 0187

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -510,7 +510,10 @@ test or a per-PR CI gate catches it, **[release]** it fails the release job,
    **[release]**
 3. **Add** the crate's `Cargo.toml`: `[[bin]] name = "accelerator-<token>"` (the
    asset name the manifest and signing expect), a mandatory
-   `package.description` (the manifest sources the description from it), and the
+   `package.description` (the manifest sources the description from it, and it is
+   the user-facing help text rendered in the merged `accelerator --help`
+   command listing — write a concise, period-free imperative phrase, not
+   launcher-internal phrasing such as "The … sub-binary."), and the
    inherited `version.workspace`, `edition.workspace`, `rust-version.workspace`,
    `license.workspace` and `publish.workspace`. Inherit the version so the next
    workspace bump cannot desynchronise the member — the version-coherence check

--- a/tests/unit/tasks/shared/test_dispatch_coherence.py
+++ b/tests/unit/tasks/shared/test_dispatch_coherence.py
@@ -31,7 +31,6 @@ _OTHER = "widgetise"
 
 _GUARD_SOURCE = REPO_ROOT / "tasks/shared/dispatch_coherence.py"
 _CLI_RS = REPO_ROOT / "cli/launcher/src/launch/inbound/cli.rs"
-_MAIN_RS = REPO_ROOT / "cli/launcher/src/main.rs"
 _CORE_RS = REPO_ROOT / "cli/launcher/src/launch/core.rs"
 
 
@@ -624,15 +623,6 @@ class TestCrossLanguagePins:
         assert body
         for attribute in ("name =", "alias =", "visible_alias ="):
             assert attribute not in body.group(1)
-
-    def test_is_root_help_agrees_as_a_secondary_check(self) -> None:
-        match = re.search(
-            r'Some\((\s*"[a-z]+"(?:\s*\|\s*"[a-z]+")*)\)', _MAIN_RS.read_text()
-        )
-        assert match
-        assert set(re.findall(r'"([a-z]+)"', match.group(1))) == set(
-            BUILTIN_SUBCOMMANDS
-        )
 
     @pytest.mark.parametrize(
         ("token", "accepted"),

--- a/tests/unit/tasks/test_manifest.py
+++ b/tests/unit/tasks/test_manifest.py
@@ -23,12 +23,13 @@ from tasks.build import VersionCoherenceError, validate_version_coherence
 from tasks.manifest import (
     BinaryEntry,
     _default_subbinary_manifest,
+    _read_description,
     build_manifest,
     collect_entries,
     emit_manifest,
 )
 from tasks.shared.errors import ManifestError
-from tasks.shared.paths import CLI_DIR, load_toml
+from tasks.shared.paths import CLI_DIR, DISPATCHED_SUBBINARIES, load_toml
 from tasks.shared.targets import TARGETS
 from tasks.signing import generate, sign_file
 from tests.support.artefacts import build_shim
@@ -156,8 +157,21 @@ class TestCollectEntries:
         assert resolved == CLI_DIR / "visualiser/server/Cargo.toml"
         assert resolved.exists()
         description = load_toml(resolved)["package"]["description"]
-        expected = "Launch the interactive meta-directory visualiser"
+        expected = "Serve the meta-directory visualiser"
         assert description == expected
+
+
+# ── descriptions stay user-facing ─────────────────────────────────────
+
+
+class TestDescriptionPhrasing:
+    def test_no_description_carries_launcher_internal_phrasing(self):
+        for name in DISPATCHED_SUBBINARIES:
+            description = _read_description(
+                _default_subbinary_manifest(name), name
+            )
+            assert "sub-binary" not in description, name
+            assert not description.endswith("."), name
 
 
 # ── emit_manifest() round-trip ────────────────────────────────────────


### PR DESCRIPTION

# [0258] Help should show subcommands

## Summary

`accelerator --help`, bare `accelerator`, and `accelerator help` now converge
on one merged, user-facing command listing that shows built-ins and dispatched
sub-binaries in a single "Commands:" section. The listing is driven by the
signed release manifest, so a newly registered sub-binary appears with no
help-code change. Previously the three entry points diverged — only `--help`
augmented, under an "External subcommands:" heading, while sub-binary
descriptions carried launcher-internal phrasing like "The … sub-binary."

## Changes

Two independently mergeable phases.

**Phase 1 — user-facing descriptions.**
- Rewrote the nine sub-binary crate `package.description` fields to concise,
  period-free imperative phrases (e.g. `work` → "Manage work items";
  `visualiser` → "Serve the meta-directory visualiser").
- Trimmed the trailing periods from the three built-in doc comments
  (`version`, `config`, `cache`) so the merged listing is punctuation-uniform.
- Added a phrasing guard in `test_manifest.py`: no sub-binary description may
  contain `sub-binary` or end in a period.
- Extended the `tasks/README.md` registration checklist to note the
  description is user-facing CLI help text, not only package metadata.

**Phase 2 — merge the list and converge the entry points.**
- Replaced the `after_help` external block with clap-native subcommand
  injection (`augment_with_subbinaries`): each manifest binary becomes a
  render-only clap subcommand, so built-ins and sub-binaries render in one
  native "Commands:" section. A skip guard avoids colliding with a built-in or
  clap's synthesised `help`.
- Folded the three entry points through one renderer (`render_full_listing`)
  and a pure `classify` function over `(ErrorKind, &[OsString])`, so routing
  reads no process global and the whole truth table is unit-testable. `--help`
  and `help` exit 0; bare exits 1 with a required-subcommand cue on stderr
  while the listing goes to stdout.
- Added `Fetcher::for_help()` (3s connect, 5s total, one attempt), so a slow or
  unreachable release host fails open to the built-ins within ~3s rather than
  inheriting dispatch's retry-heavy budget. `new()`/`with_backoff()` keep
  today's values, so dispatch is unchanged.
- Added clap's `string` feature (subcommands are built from owned `String`
  names) and removed a now-obsolete `main.rs` scraper test in
  `test_dispatch_coherence.py`.

## Context

- Work item: `meta/work/0258-help-show-subcommands.md`
- Plan: `meta/plans/2026-09-05-0258-help-show-subcommands.md`
- Research: `meta/research/codebase/2026-09-05-0258-help-show-subcommands.md`
- Validation: `meta/validations/2026-09-05-0258-help-show-subcommands-validation.md`
  (result: pass)

Deliberately out of scope for this PR (0259's remit): colour, section
ordering, the sentence-vs-fragment register split between built-in and
sub-binary descriptions, and the AC-5 fixed wording. The ADR-surface move is
0260.

## Testing

- [x] Rust workspace check: `mise run cli:check` (exit 0)
- [x] Launcher unit + black-box tests: `cargo test -p accelerator` (0 failed)
- [x] Read-only CI mirror: `mise run check` (exit 0, all four components)
- [x] Phrasing guard + visualiser assertion: `pytest test_manifest.py -k "visualiser or phrasing"`
- [x] Three entry points print an identical listing (dead host): `diff <(--help) <(help)` and `diff <(--help) <(bare)` both empty
- [x] Bare exits 1 with the cue on stderr and the listing on stdout; `--help`/`help` exit 0
- [x] `config --help` still renders config's own help, not the top-level listing
- [x] `for_help()` fails open within its connect bound (unit-tested against a SYN-dropping host)

## Notes for Reviewers

- **`classify` routing** is the behavioural core. The bare-invocation arm keys
  on `DisplayHelpOnMissingArgumentOrSubcommand` with empty args (this clap
  version's actual kind for bare `accelerator`), keeping `MissingSubcommand` as
  a defensive fallback; the `args.is_empty()` guard keeps a missing *nested*
  subcommand (`config templates`) on its own per-command help.
- **Convergence is structural**: `render_full_listing` is the sole augmenting
  renderer and both listing causes resolve to it, so a signed-manifest
  end-to-end test is not required — the populated listing is unit-tested over a
  hand-built `Manifest`, and black-box covers the manifest-unavailable path.
- **Minor nit** (non-blocking): the `classify` doc comment references a root
  `arg_required_else_help` that the `Cli` struct does not carry — the behaviour
  is clap's default for a required subcommand field.

https://claude.ai/code/session_01JG4uFKzWEfo8LSdmGzNN1L
