### PR TITLE
[0245] Mark work item done

### DIFF
--- a/meta/prs/104-description.md
+++ b/meta/prs/104-description.md
@@ -1,0 +1,52 @@
+---
+type: "pr-description"
+id: "104"
+title: "[0245] Mark work item done"
+date: "2026-09-06T23:14:15+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0245"
+parent: "work-item:0245"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/104"
+pr_number: 104
+tags: ["work-item"]
+revision: "21d98be327e2aa3f8a1227b06f90cd147c2fa481"
+repository: "accelerator"
+last_updated: "2026-09-06T23:14:15+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0245] Mark work item done
+
+## Summary
+
+Closes work item 0245 by transitioning its status to `done`, now that the
+bare-accelerator conversion, its guarding lint, and the plan validation have
+merged via PR #103.
+
+## Changes
+
+- Set `status: ready → done` in the 0245 work item frontmatter and synced the
+  body `**Status**:` label to match.
+
+## Context
+
+- Work item: `meta/work/0245-invoke-accelerator-directly-in-skills.md`.
+- Implementation and validation landed in PR #103 (merged); the plan
+  (`meta/plans/2026-09-06-0245-…`) and its validation
+  (`meta/validations/2026-09-06-0245-…-validation.md`, result `pass`) are
+  already closed.
+
+## Testing
+
+- [x] Frontmatter validates: `accelerator corpus frontmatter validate --file meta/work/0245-invoke-accelerator-directly-in-skills.md`.
+- [x] Diff is exactly the two intended lines (frontmatter `status` and the body `**Status**:` label); no other fields touched.
+
+## Notes for Reviewers
+
+Lifecycle bookkeeping only — no code or behaviour changes. One acceptance
+criterion on 0245 remains manual (live-load `/accelerator:visualise` with no
+permission prompt), noted on PR #103; closing the work item reflects the
+merged implementation, not that manual step.

--- a/meta/work/0245-invoke-accelerator-directly-in-skills.md
+++ b/meta/work/0245-invoke-accelerator-directly-in-skills.md
@@ -5,7 +5,7 @@ title: "Invoke Accelerator Directly In Skills"
 date: "2026-08-31T12:11:13+00:00"
 author: "Toby Clemson"
 producer: "extract-work-items"
-status: "ready"
+status: "done"
 kind: "task"
 priority: "medium"
 parent: "work-item:0136"
@@ -21,7 +21,7 @@ external_id: "PP-775"
 # 0245: Invoke Accelerator Directly In Skills
 
 **Kind**: Task
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 


### PR DESCRIPTION

# [0245] Mark work item done

## Summary

Closes work item 0245 by transitioning its status to `done`, now that the
bare-accelerator conversion, its guarding lint, and the plan validation have
merged via PR #103.

## Changes

- Set `status: ready → done` in the 0245 work item frontmatter and synced the
  body `**Status**:` label to match.

## Context

- Work item: `meta/work/0245-invoke-accelerator-directly-in-skills.md`.
- Implementation and validation landed in PR #103 (merged); the plan
  (`meta/plans/2026-09-06-0245-…`) and its validation
  (`meta/validations/2026-09-06-0245-…-validation.md`, result `pass`) are
  already closed.

## Testing

- [x] Frontmatter validates: `accelerator corpus frontmatter validate --file meta/work/0245-invoke-accelerator-directly-in-skills.md`.
- [x] Diff is exactly the two intended lines (frontmatter `status` and the body `**Status**:` label); no other fields touched.

## Notes for Reviewers

Lifecycle bookkeeping only — no code or behaviour changes. One acceptance
criterion on 0245 remains manual (live-load `/accelerator:visualise` with no
permission prompt), noted on PR #103; closing the work item reflects the
merged implementation, not that manual step.
