### PR TITLE
[0269] Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients

### DIFF
--- a/cli/jira-cli/src/exit_codes.rs
+++ b/cli/jira-cli/src/exit_codes.rs
@@ -152,7 +152,7 @@ pub const fn for_failure(failure: &JiraFailure) -> u8 {
 /// The exit code for a surface-flow failure (`search`/`show`/`comment`/
 /// `transition`/`attach`/`init`/`fields`).
 #[must_use]
-pub fn for_surface(error: &SurfaceError) -> u8 {
+pub const fn for_surface(error: &SurfaceError) -> u8 {
     match error {
         SurfaceError::Client(client) => for_client(client),
         SurfaceError::Adf(adf) => for_adf(adf),
@@ -217,10 +217,17 @@ pub const fn for_cache(error: &CacheError) -> u8 {
     }
 }
 
-/// The exit code for an ADF conversion failure, read from the crate's own
-/// `code()` band (`40`–`42`).
-fn for_adf(error: &AdfError) -> u8 {
-    u8::try_from(error.code()).unwrap_or(ADF_BAD_INPUT)
+/// The exit code for an ADF conversion failure, in the `40`–`42` band.
+const fn for_adf(error: &AdfError) -> u8 {
+    match error {
+        AdfError::RootNotDoc { .. }
+        | AdfError::HeadingWithoutLevel
+        | AdfError::ListWithoutContent { .. } => BAD_JSON,
+        AdfError::UnsupportedBlockquote
+        | AdfError::UnsupportedTable
+        | AdfError::UnsupportedNestedList => ADF_UNSUPPORTED,
+        AdfError::BadInput => ADF_BAD_INPUT,
+    }
 }
 
 const fn exit_code_for_outcome(outcome: Outcome) -> u8 {
@@ -262,5 +269,26 @@ mod tests {
         );
         assert_eq!(exit_code_for_outcome(Outcome::Transport), REQ_CONNECT);
         assert_eq!(exit_code_for_outcome(Outcome::Status(503)), SERVER_ERROR);
+    }
+
+    #[test]
+    fn every_adf_error_maps_to_its_pinned_code() {
+        assert_eq!(
+            for_adf(&AdfError::RootNotDoc {
+                found: String::new()
+            }),
+            BAD_JSON
+        );
+        assert_eq!(for_adf(&AdfError::HeadingWithoutLevel), BAD_JSON);
+        assert_eq!(
+            for_adf(&AdfError::ListWithoutContent {
+                node: String::new()
+            }),
+            BAD_JSON
+        );
+        assert_eq!(for_adf(&AdfError::UnsupportedBlockquote), ADF_UNSUPPORTED);
+        assert_eq!(for_adf(&AdfError::UnsupportedTable), ADF_UNSUPPORTED);
+        assert_eq!(for_adf(&AdfError::UnsupportedNestedList), ADF_UNSUPPORTED);
+        assert_eq!(for_adf(&AdfError::BadInput), ADF_BAD_INPUT);
     }
 }

--- a/cli/jira-cli/src/exit_codes.rs
+++ b/cli/jira-cli/src/exit_codes.rs
@@ -1,8 +1,8 @@
 //! `accelerator-jira`'s exit-code taxonomy — the document of record.
 //!
-//! Every code equals the value the retiring `jira-*` bash cluster returned for
-//! the same condition, captured pre-deletion into
-//! `tests/fixtures/bash-exit-codes.txt` (from the cluster's `EXIT_CODES.md`
+//! Every code equals the value the retiring `jira-*` cluster returned for the
+//! same condition, captured pre-deletion into
+//! `tests/fixtures/captured-exit-codes.txt` (from the cluster's `EXIT_CODES.md`
 //! namespace and its behavioural reconciliations). `exit_codes_parity.rs` pins
 //! these constants against it; the self-descriptive names plus that fixture
 //! carry the mechanical mapping, so this doc names only the bands, the
@@ -13,8 +13,8 @@
 //! - `0`–`2` — process and usage, emitted by the binary itself.
 //! - `11`–`53` — the shared transport/auth/jql/adf/fields codes `jira-request`,
 //!   `jira-auth`, `jira-jql` and `jira-fields` returned; read structurally from
-//!   the client's `JiraFailure` (`bash_code(outcome)`), a `SurfaceError` or a
-//!   `ClientError`, never parsed from a string.
+//!   the client's `JiraFailure` (its wire outcome discriminant), a
+//!   `SurfaceError` or a `ClientError`, never parsed from a string.
 //! - `60`–`133` — the per-flow argument and outcome codes, one block per flow.
 //!
 //! Safety-critical: the post-create "created remotely but unwritable" case maps
@@ -23,9 +23,9 @@
 //! blindly retry. The binary surfaces the key and steers to reconcile.
 //!
 //! Deliberate divergence: the search flow's `SEARCH_*` codes are remapped from
-//! bash `70`–`73` to `75`–`78`, off the `70`–`74` band the dispatch layer
-//! reserves — a code in that band reaching `accelerator-work` would read as a
-//! dispatch verdict.
+//! the retired `70`–`73` values to `75`–`78`, off the `70`–`74` band the
+//! dispatch layer reserves — a code in that band reaching `accelerator-work`
+//! would read as a dispatch verdict.
 
 // Every code is a declared contract the parity test reads textually; a code no
 // handler yet references is still part of the surface, not dead.
@@ -131,17 +131,17 @@ pub const ATTACH_BAD_FLAG: u8 = 133;
 
 use jira_client::adf::AdfError;
 use jira_client::cache::CacheError;
-use jira_client::classify::{bash_code, Outcome};
+use jira_client::classify::Outcome;
 use jira_client::{ClientError, JiraFailure, SurfaceError};
 use tracker_support::CredentialError;
 
 /// The exit code for a structured port-op failure (`create`/`update`). A wire
-/// outcome carries the granular bash code; the post-create unwritable case is
+/// outcome maps to its granular code; the post-create unwritable case is
 /// Jira's `REQ_BAD_RESPONSE` — created remotely, do not blindly retry.
 #[must_use]
-pub fn for_failure(failure: &JiraFailure) -> u8 {
+pub const fn for_failure(failure: &JiraFailure) -> u8 {
     match failure {
-        JiraFailure::Wire { outcome, .. } => code_for_outcome(*outcome),
+        JiraFailure::Wire { outcome, .. } => exit_code_for_outcome(*outcome),
         JiraFailure::UnwritableIdentifier { .. } => REQ_BAD_RESPONSE,
         JiraFailure::UnsafeQueryId { .. } => JQL_UNSAFE_VALUE,
         JiraFailure::ComposeRejected { .. } => JQL_NO_PROJECT,
@@ -156,7 +156,7 @@ pub fn for_surface(error: &SurfaceError) -> u8 {
     match error {
         SurfaceError::Client(client) => for_client(client),
         SurfaceError::Adf(adf) => for_adf(adf),
-        SurfaceError::Status { status, .. } => code_for_status(*status),
+        SurfaceError::Status { status, .. } => exit_code_for_status(*status),
         SurfaceError::BadResponse { .. } => REQ_BAD_RESPONSE,
         SurfaceError::BadPageSize { .. } => COMMENT_BAD_PAGE_SIZE,
         SurfaceError::TransitionNotFound { .. } => TRANSITION_NOT_FOUND,
@@ -191,7 +191,8 @@ pub const fn for_client(error: &ClientError) -> u8 {
 
 /// The exit code for a credential-resolution failure. Jira surfaces these
 /// directly through `init verify`; a request-path failure flattens them to
-/// `REQ_NO_CREDS` (`22`) at the call site, mirroring the bash `jira-request.sh`.
+/// `REQ_NO_CREDS` (`22`) at the call site, mirroring the retired
+/// `jira-request.sh`.
 #[must_use]
 pub const fn for_credential(error: &CredentialError) -> u8 {
     match error {
@@ -222,10 +223,44 @@ fn for_adf(error: &AdfError) -> u8 {
     u8::try_from(error.code()).unwrap_or(ADF_BAD_INPUT)
 }
 
-fn code_for_outcome(outcome: Outcome) -> u8 {
-    u8::try_from(bash_code(outcome)).unwrap_or(ERROR)
+const fn exit_code_for_outcome(outcome: Outcome) -> u8 {
+    match outcome {
+        Outcome::Status(400) => REQ_BAD_REQUEST,
+        Outcome::Status(401) => UNAUTHORIZED,
+        Outcome::Status(403) => FORBIDDEN,
+        Outcome::Status(404) => NOT_FOUND,
+        Outcome::Status(410) => GONE,
+        Outcome::Status(429) => RATELIMITED,
+        Outcome::NonJsonBody => REQ_BAD_RESPONSE,
+        Outcome::Transport => REQ_CONNECT,
+        Outcome::Status(_) => SERVER_ERROR,
+    }
 }
 
-fn code_for_status(status: u16) -> u8 {
-    u8::try_from(bash_code(Outcome::Status(status))).unwrap_or(SERVER_ERROR)
+const fn exit_code_for_status(status: u16) -> u8 {
+    exit_code_for_outcome(Outcome::Status(status))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_outcome_maps_to_its_pinned_code() {
+        assert_eq!(
+            exit_code_for_outcome(Outcome::Status(400)),
+            REQ_BAD_REQUEST
+        );
+        assert_eq!(exit_code_for_outcome(Outcome::Status(401)), UNAUTHORIZED);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(403)), FORBIDDEN);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(404)), NOT_FOUND);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(410)), GONE);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(429)), RATELIMITED);
+        assert_eq!(
+            exit_code_for_outcome(Outcome::NonJsonBody),
+            REQ_BAD_RESPONSE
+        );
+        assert_eq!(exit_code_for_outcome(Outcome::Transport), REQ_CONNECT);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(503)), SERVER_ERROR);
+    }
 }

--- a/cli/jira-cli/tests/exit_codes_parity.rs
+++ b/cli/jira-cli/tests/exit_codes_parity.rs
@@ -1,9 +1,9 @@
-//! Pins `exit_codes.rs` against the captured bash contract.
+//! Pins `exit_codes.rs` against the captured exit-code contract.
 //!
 //! Non-allowlisted names must equal the value the retiring cluster returned.
 //! The only divergence is the search remap off the reserved `70`–`74` dispatch
 //! band: each allowlisted name asserts the *remapped* Rust value while the
-//! fixture keeps the original bash value. The count pin makes a silent
+//! fixture keeps the original captured value. The count pin makes a silent
 //! allowlist addition fail. The oracle is the committed fixture, never the
 //! constants it guards.
 
@@ -15,7 +15,7 @@ use std::path::Path;
 use cli_test_support::parse_u8_consts;
 
 /// `(name, remapped-rust-value)` for the deliberate search divergence. The
-/// fixture keeps the bash value; the binary emits the remapped one.
+/// fixture keeps the captured value; the binary emits the remapped one.
 const ALLOWLIST: &[(&str, u8)] = &[
     ("SEARCH_BAD_PAGE_TOKEN", 75),
     ("SEARCH_BAD_LIMIT", 76),
@@ -33,12 +33,12 @@ fn rust_codes() -> BTreeMap<String, u8> {
     parse_u8_consts(&source).into_iter().collect()
 }
 
-fn bash_codes() -> Vec<(String, u8)> {
+fn captured_codes() -> Vec<(String, u8)> {
     let text = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/bash-exit-codes.txt"),
+            .join("tests/fixtures/captured-exit-codes.txt"),
     )
-    .expect("the bash-exit-codes fixture is committed");
+    .expect("the captured-exit-codes fixture is committed");
     text.lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
@@ -53,15 +53,15 @@ fn bash_codes() -> Vec<(String, u8)> {
 #[test]
 fn every_captured_code_matches_or_is_an_allowlisted_divergence() {
     let rust = rust_codes();
-    let bash = bash_codes();
+    let captured = captured_codes();
     assert_eq!(
-        bash.len(),
+        captured.len(),
         EXPECTED_FIXTURE_COUNT,
         "a captured code was added or removed without updating the pin"
     );
 
     let allowlist: BTreeMap<&str, u8> = ALLOWLIST.iter().copied().collect();
-    for (name, bash_value) in &bash {
+    for (name, captured_value) in &captured {
         let rust_value = rust.get(name).unwrap_or_else(|| {
             panic!("exit_codes.rs has no constant named {name}")
         });
@@ -71,13 +71,13 @@ fn every_captured_code_matches_or_is_an_allowlisted_divergence() {
                 "{name} must carry its remapped value"
             );
             assert_ne!(
-                *rust_value, *bash_value,
+                *rust_value, *captured_value,
                 "{name} is allowlisted but did not actually diverge"
             );
         } else {
             assert_eq!(
-                *rust_value, *bash_value,
-                "{name} must equal the bash value it was captured at"
+                *rust_value, *captured_value,
+                "{name} must equal the value it was captured at"
             );
         }
     }

--- a/cli/jira-cli/tests/fixtures/capture-exit-codes.sh
+++ b/cli/jira-cli/tests/fixtures/capture-exit-codes.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Captures the Jira bash cluster's exit-code contract into bash-exit-codes.txt,
+# Captures the Jira cluster's exit-code contract into captured-exit-codes.txt,
 # the authoritative name->integer oracle exit_codes_parity.rs pins against.
 #
 # Unlike the Linear flows, the Jira scripts emit bare-literal `exit N` rather
 # than `readonly E_*=NN` constants, so the declared contract is the namespace
 # table in scripts/EXIT_CODES.md — the single document every helper draws from.
-# This script parses that table into `<rust-const-name>=<bash-integer>` rows,
+# This script parses that table into `<rust-const-name>=<integer>` rows,
 # plus the unnamed shared HTTP codes the table lists with a `—` name (the Rust
 # binary reads them structurally from the client). Two normalisations:
 #   - `E_ADF_UNSUPPORTED_*` (a wildcard family) -> ADF_UNSUPPORTED.
@@ -17,23 +17,23 @@
 #     omitted.
 #
 # Kept for provenance; re-run against EXIT_CODES.md at the recorded revision.
-# The search codes stay at their bash values (70-73) here — exit_codes.rs remaps
-# them off the reserved 70-74 dispatch band, and the parity allowlist records
-# that.
+# The search codes stay at their captured values (70-73) here — exit_codes.rs
+# remaps them off the reserved 70-74 dispatch band, and the parity allowlist
+# records that.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 TABLE="$PLUGIN_ROOT/skills/integrations/jira/scripts/EXIT_CODES.md"
-OUT="$SCRIPT_DIR/bash-exit-codes.txt"
+OUT="$SCRIPT_DIR/captured-exit-codes.txt"
 
 {
-  echo "# Jira bash exit-code contract, captured by capture-bash-exit-codes.sh"
-  echo "# from scripts/EXIT_CODES.md. <rust-const-name>=<bash-integer>."
+  echo "# Jira exit-code contract, captured by capture-exit-codes.sh"
+  echo "# from scripts/EXIT_CODES.md. <rust-const-name>=<integer>."
   echo "# exit_codes_parity.rs pins these."
   echo ""
   echo "# Unnamed shared HTTP codes (a '—' name in the table; the Rust binary"
-  echo "# reads them structurally from bash_code(outcome))."
+  echo "# reads them structurally from the wire outcome)."
   echo "UNAUTHORIZED=11"
   echo "FORBIDDEN=12"
   echo "NOT_FOUND=13"

--- a/cli/jira-cli/tests/fixtures/captured-exit-codes.txt
+++ b/cli/jira-cli/tests/fixtures/captured-exit-codes.txt
@@ -1,9 +1,9 @@
-# Jira bash exit-code contract, captured by capture-bash-exit-codes.sh
-# from scripts/EXIT_CODES.md. <rust-const-name>=<bash-integer>.
+# Jira exit-code contract, captured by capture-exit-codes.sh
+# from scripts/EXIT_CODES.md. <rust-const-name>=<integer>.
 # exit_codes_parity.rs pins these.
 
 # Unnamed shared HTTP codes (a '—' name in the table; the Rust binary
-# reads them structurally from bash_code(outcome)).
+# reads them structurally from the wire outcome).
 UNAUTHORIZED=11
 FORBIDDEN=12
 NOT_FOUND=13

--- a/cli/jira-client/Cargo.toml
+++ b/cli/jira-client/Cargo.toml
@@ -24,8 +24,8 @@ tracing = { workspace = true }
 config = { path = "../config" }
 # The discovery cache reuses the workspace's one atomic-write and mkdir-lock
 # primitives rather than a second implementation — the store-duplication guard
-# enforces this, and the mkdir-lock's owner.<nonce> sentinel never reclaims the
-# bash init's holder.pid lock, so the two exclude safely on the shared path.
+# enforces this, and the mkdir-lock's owner.<nonce> sentinel never reclaims a
+# legacy holder.pid lock, so the two exclude safely on the shared path.
 corpus = { path = "../corpus" }
 corpus-adapters = { path = "../corpus-adapters" }
 store = { path = "../store" }

--- a/cli/jira-client/src/adf/mod.rs
+++ b/cli/jira-client/src/adf/mod.rs
@@ -33,22 +33,6 @@ pub enum AdfError {
     BadInput,
 }
 
-impl AdfError {
-    /// The exit code reported for this condition.
-    #[must_use]
-    pub const fn code(&self) -> u16 {
-        match *self {
-            Self::RootNotDoc { .. }
-            | Self::HeadingWithoutLevel
-            | Self::ListWithoutContent { .. } => 40,
-            Self::UnsupportedBlockquote
-            | Self::UnsupportedTable
-            | Self::UnsupportedNestedList => 41,
-            Self::BadInput => 42,
-        }
-    }
-}
-
 impl fmt::Display for AdfError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/cli/jira-client/src/cache.rs
+++ b/cli/jira-client/src/cache.rs
@@ -32,8 +32,9 @@ const GITIGNORE_RULES: &[&str] = &[
 /// The lock directory name.
 const LOCK_DIR: &str = ".lock";
 
-/// The cache-layout version the binary writes and reads. Bash-era caches carry
-/// no marker and are classified as the implicit version 0 — read unchanged.
+/// The cache-layout version the binary writes and reads. A cache written
+/// before this marker existed carries none and is classified as the implicit
+/// version 0 — read unchanged.
 const CACHE_VERSION: u64 = 1;
 
 /// The marker file recording the cache-layout version.
@@ -139,8 +140,8 @@ impl<'a> JiraCache<'a> {
 
     /// Reads a discovery cache file, failing closed on an unrecognised version
     /// marker or a shape that does not parse. An absent marker is
-    /// the implicit bash-era version and reads unchanged, so no existing install
-    /// must re-initialise.
+    /// the implicit unversioned legacy layout and reads unchanged, so no
+    /// existing install must re-initialise.
     ///
     /// # Errors
     ///
@@ -159,7 +160,7 @@ impl<'a> JiraCache<'a> {
     }
 
     /// Records the current cache-layout version, so a subsequent read is
-    /// versioned rather than treated as bash-era.
+    /// versioned rather than treated as the unversioned legacy layout.
     fn stamp_version(&self) -> Result<(), CacheError> {
         self.write_json(
             VERSION_FILE,
@@ -167,8 +168,9 @@ impl<'a> JiraCache<'a> {
         )
     }
 
-    /// Classifies the version marker: absent is bash-era (permitted), the
-    /// current version is permitted, anything else fails closed.
+    /// Classifies the version marker: absent is the unversioned legacy layout
+    /// (permitted), the current version is permitted, anything else fails
+    /// closed.
     fn assert_version(&self) -> Result<(), CacheError> {
         let Some(text) = self.fs.read(&self.state_dir.join(VERSION_FILE))
         else {

--- a/cli/jira-client/src/classify.rs
+++ b/cli/jira-client/src/classify.rs
@@ -1,6 +1,9 @@
-//! Two classification tables, both per operation, because a single
-//! status-to-class table is wrong by construction: the same wire condition can
-//! be provable on `create` and unprovable on `update`.
+//! Per-operation retry classification.
+//!
+//! A single status-to-class table is wrong by construction: the same wire
+//! condition can be provable on `create` and unprovable on `update`, so the
+//! retry class is a function of the outcome and the operation together, never
+//! the status alone.
 
 use tracker::TrackerError;
 
@@ -39,23 +42,6 @@ pub enum Outcome {
     Transport,
 }
 
-/// The exit code the same outcome produces, kept so a diagnostic can name a
-/// code readers already recognise.
-#[must_use]
-pub const fn bash_code(outcome: Outcome) -> u16 {
-    match outcome {
-        Outcome::Status(400) => 34,
-        Outcome::Status(401) => 11,
-        Outcome::Status(403) => 12,
-        Outcome::Status(404) => 13,
-        Outcome::Status(410) => 14,
-        Outcome::Status(429) => 19,
-        Outcome::NonJsonBody => 16,
-        Outcome::Transport => 21,
-        Outcome::Status(_) => 20,
-    }
-}
-
 /// Whether a wire outcome proves no mutation happened, for this operation.
 #[must_use]
 pub fn classify(
@@ -67,34 +53,7 @@ pub fn classify(
         Outcome::Status(400 | 401 | 403 | 404 | 410 | 429) => true,
         Outcome::Status(_) | Outcome::NonJsonBody | Outcome::Transport => false,
     };
-    build(provably_unapplied, operation, bash_code(outcome), detail)
-}
-
-/// The bridge mappers' own tables, driven by the committed fixture at
-/// `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`.
-#[must_use]
-pub fn classify_bash_code(
-    code: u16,
-    operation: Operation,
-    detail: &str,
-) -> TrackerError {
-    let shared_retryable =
-        matches!(code, 11 | 12 | 13 | 14 | 15 | 17 | 19 | 22 | 34);
-    let provably_unapplied = match operation {
-        Operation::Create => shared_retryable || (100..=108).contains(&code),
-        Operation::Update => shared_retryable || (110..=117).contains(&code),
-        Operation::Read => true,
-    };
-    build(provably_unapplied, operation, code, detail)
-}
-
-fn build(
-    provably_unapplied: bool,
-    operation: Operation,
-    code: u16,
-    detail: &str,
-) -> TrackerError {
-    let detail = format!("jira {} ({code}): {detail}", operation.name());
+    let detail = format!("jira {}: {detail}", operation.name());
     if provably_unapplied || !operation.mutates() {
         TrackerError::Retryable { detail }
     } else {

--- a/cli/jira-client/src/custom_fields.rs
+++ b/cli/jira-client/src/custom_fields.rs
@@ -138,7 +138,7 @@ fn coerce_number(token: &str, raw: &str) -> Result<Value, CustomFieldError> {
     })
 }
 
-/// The bash `^-?[0-9]+(\.[0-9]+)?$` shape: an optional sign, digits, and an
+/// The `^-?[0-9]+(\.[0-9]+)?$` shape: an optional sign, digits, and an
 /// optional single fractional run. Rejects the scientific and hex forms a bare
 /// serde parse would otherwise accept.
 fn is_decimal(raw: &str) -> bool {

--- a/cli/jira-client/src/failure.rs
+++ b/cli/jira-client/src/failure.rs
@@ -1,12 +1,12 @@
 //! The structured failure a fallible port operation surfaces before it
 //! collapses to the port's two-class [`TrackerError`].
 //!
-//! The binary reads the granular bash exit code from this — the classifier's
-//! [`Outcome`], whose `bash_code` is the integer, or the distinct post-create
-//! "created remotely but unwritable" case — rather than parsing it back out of
-//! a `TrackerError` detail string. Every error site of `create`/`update` is
+//! It carries the classifier's [`Outcome`] and [`Operation`] discriminant, or
+//! the distinct post-create "created remotely but unwritable" case, so the CLI
+//! derives an exit code from the discriminant rather than parsing it back out
+//! of a `TrackerError` detail string. Every error site of `create`/`update` is
 //! funnelled through here, so the port impl derives `TrackerError` from one
-//! place and the binary maps the same value straight to an exit code.
+//! place.
 
 use tracker::TrackerError;
 
@@ -22,8 +22,9 @@ use crate::classify::Outcome;
 /// variant forces an `exit_codes.rs` arm.
 #[derive(Debug, Clone)]
 pub enum JiraFailure {
-    /// A wire outcome the classifier recognises. `bash_code(outcome)` is the
-    /// exit code; `operation` decides the retry class the port derives.
+    /// A wire outcome the classifier recognises. `outcome` is the discriminant
+    /// the CLI reads for an exit code; `operation` decides the retry class the
+    /// port derives.
     Wire {
         outcome: Outcome,
         operation: Operation,

--- a/cli/jira-client/src/principal.rs
+++ b/cli/jira-client/src/principal.rs
@@ -41,7 +41,7 @@ pub fn resolve(
     }
 }
 
-/// The bash `^[A-Za-z0-9:_-]+$` shape — an opaque Jira accountId, never an
+/// The `^[A-Za-z0-9:_-]+$` shape — an opaque Jira accountId, never an
 /// email.
 fn is_account_id(token: &str) -> bool {
     !token.is_empty()

--- a/cli/jira-client/src/read.rs
+++ b/cli/jira-client/src/read.rs
@@ -1,11 +1,10 @@
 //! The read-side projections the `search` and `show` subcommands render.
 //!
 //! The port `search`/`show` reshape a response into the sync contract — stamps
-//! and a projected body. These keep Jira's own wire envelope the retiring bash
-//! flows emitted verbatim: `search` echoes `{issues, nextPageToken}`, `show`
-//! returns the raw issue the binary renders ADF fields over. The composed JQL
-//! is exposed separately so the binary can print the audit line before the
-//! request, exactly as the bash flow did.
+//! and a projected body. These keep Jira's own wire envelope verbatim: `search`
+//! echoes `{issues, nextPageToken}`, `show` returns the raw issue the binary
+//! renders ADF fields over. The composed JQL is exposed separately so the
+//! binary can print the audit line before the request.
 
 use reqwest::Method;
 use serde_json::json;
@@ -35,7 +34,7 @@ impl JiraClient {
     }
 
     /// Runs one search page and returns Jira's verbatim response envelope
-    /// (`{issues, nextPageToken}`), the shape the bash search flow emitted.
+    /// (`{issues, nextPageToken}`), the shape the search surface emits.
     ///
     /// A single page: `page_token` follows the cursor the caller carries, so
     /// pagination stays the operator's, not the client's.

--- a/cli/jira-client/tests/adf.rs
+++ b/cli/jira-client/tests/adf.rs
@@ -57,31 +57,26 @@ fn both_placeholder_strings_are_verbatim_and_position_dependent() {
 }
 
 #[test]
-fn each_of_the_four_refusals_carries_its_code_and_message() {
-    for (markdown, code, message) in [
+fn each_of_the_four_refusals_carries_its_message() {
+    for (markdown, message) in [
         (
             "> quoted\n",
-            41,
             "E_ADF_UNSUPPORTED_BLOCKQUOTE: blockquote is not supported",
         ),
         (
             "| a | b |\n",
-            41,
             "E_ADF_UNSUPPORTED_TABLE: pipe tables are not supported",
         ),
         (
             "  - nested\n",
-            41,
             "E_ADF_UNSUPPORTED_NESTED_LIST: nested lists are not supported",
         ),
         (
             "bad\u{1f}byte\n",
-            42,
             "E_ADF_BAD_INPUT: input contains control byte \\x1e or \\x1f",
         ),
     ] {
         let error = refusal(markdown);
-        assert_eq!(error.code(), code, "{markdown:?}");
         assert_eq!(error.to_string(), message, "{markdown:?}");
     }
 }

--- a/cli/jira-client/tests/adf_differential.rs
+++ b/cli/jira-client/tests/adf_differential.rs
@@ -48,6 +48,18 @@ const fn class_of(error: &AdfError) -> &'static str {
     }
 }
 
+const fn expected_adf_exit(error: &AdfError) -> u16 {
+    match *error {
+        AdfError::RootNotDoc { .. }
+        | AdfError::HeadingWithoutLevel
+        | AdfError::ListWithoutContent { .. } => 40,
+        AdfError::UnsupportedBlockquote
+        | AdfError::UnsupportedTable
+        | AdfError::UnsupportedNestedList => 41,
+        AdfError::BadInput => 42,
+    }
+}
+
 #[test]
 fn the_render_direction_agrees_with_the_running_jq() {
     let mut compared = 0;
@@ -131,11 +143,11 @@ fn the_assemble_direction_agrees_with_the_running_awk_and_jq() {
                  assembled a document"
             )),
             (status, Err(error)) => {
-                if i32::from(error.code()) != status {
+                if i32::from(expected_adf_exit(&error)) != status {
                     disagreements.push(format!(
                         "{name}: the oracle exited {status}, this crate \
                          reports {}",
-                        error.code()
+                        expected_adf_exit(&error)
                     ));
                 }
                 let fixture = read(&case, "expected-error.txt")

--- a/cli/jira-client/tests/adf_inventory.rs
+++ b/cli/jira-client/tests/adf_inventory.rs
@@ -161,7 +161,6 @@ fn every_committed_refusal_matches_the_typed_error() {
     assert_eq!(refusals.len(), 4, "three exit-41 refusals and one exit-42");
 
     for row in refusals {
-        let code: u16 = row[1].parse().expect("the exit code is numeric");
         let name = &row[2];
         let error = match name.as_str() {
             "E_ADF_UNSUPPORTED_BLOCKQUOTE" => AdfError::UnsupportedBlockquote,
@@ -170,7 +169,6 @@ fn every_committed_refusal_matches_the_typed_error() {
             "E_ADF_BAD_INPUT" => AdfError::BadInput,
             other => panic!("unrecognised refusal {other}"),
         };
-        assert_eq!(error.code(), code, "{name}");
         assert!(error.to_string().starts_with(name), "{error}");
     }
 }

--- a/cli/jira-client/tests/classify.rs
+++ b/cli/jira-client/tests/classify.rs
@@ -1,11 +1,9 @@
-//! Both classification tables, per operation, with a coverage guard on each so
-//! a row added without an assertion fails the build.
+//! The per-operation retry table, with a coverage guard so an outcome added
+//! without an assertion fails the build.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
-use std::path::Path;
-
-use jira_client::classify::{bash_code, classify, classify_bash_code, Outcome};
+use jira_client::classify::{classify, Outcome};
 use jira_client::Operation;
 use tracker::TrackerError;
 
@@ -13,11 +11,10 @@ const fn is_retryable(error: &TrackerError) -> bool {
     matches!(*error, TrackerError::Retryable { .. })
 }
 
-/// One row of the status table: the observed outcome, the exit code it
-/// produces, and whether each operation can prove no mutation happened.
+/// One row of the status table: the observed outcome and whether each operation
+/// can prove no mutation happened.
 struct StatusRow {
     outcome: Outcome,
-    code: u16,
     create_retryable: bool,
     update_retryable: bool,
 }
@@ -25,67 +22,56 @@ struct StatusRow {
 const STATUS_TABLE: &[StatusRow] = &[
     StatusRow {
         outcome: Outcome::Status(400),
-        code: 34,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(401),
-        code: 11,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(403),
-        code: 12,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(404),
-        code: 13,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(410),
-        code: 14,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(429),
-        code: 19,
         create_retryable: true,
         update_retryable: true,
     },
     StatusRow {
         outcome: Outcome::Status(503),
-        code: 20,
         create_retryable: false,
         update_retryable: false,
     },
     StatusRow {
         outcome: Outcome::NonJsonBody,
-        code: 16,
         create_retryable: false,
         update_retryable: false,
     },
     StatusRow {
         outcome: Outcome::Transport,
-        code: 21,
         create_retryable: false,
         update_retryable: false,
     },
     StatusRow {
         outcome: Outcome::Status(302),
-        code: 20,
         create_retryable: false,
         update_retryable: false,
     },
     StatusRow {
         outcome: Outcome::Status(418),
-        code: 20,
         create_retryable: false,
         update_retryable: false,
     },
@@ -95,13 +81,6 @@ const STATUS_TABLE: &[StatusRow] = &[
 fn every_status_row_classifies_per_operation() {
     let mut asserted = 0;
     for row in STATUS_TABLE {
-        assert_eq!(
-            bash_code(row.outcome),
-            row.code,
-            "{:?} maps to bash code {}",
-            row.outcome,
-            row.code
-        );
         assert_eq!(
             is_retryable(&classify(row.outcome, Operation::Create, "detail")),
             row.create_retryable,
@@ -129,95 +108,31 @@ fn every_status_row_classifies_per_operation() {
 }
 
 #[test]
-fn the_status_table_covers_every_condition_the_bash_distinguishes() {
-    let covered: Vec<u16> = STATUS_TABLE.iter().map(|row| row.code).collect();
-    for code in [34, 11, 12, 13, 14, 19, 20, 16, 21] {
-        assert!(
-            covered.contains(&code),
-            "bash code {code} has no row in the status table"
-        );
+fn the_status_table_covers_every_outcome_variant() {
+    let present = |wanted: &Outcome| {
+        STATUS_TABLE.iter().any(|row| {
+            std::mem::discriminant(&row.outcome)
+                == std::mem::discriminant(wanted)
+        })
+    };
+    for witness in
+        [Outcome::Status(0), Outcome::NonJsonBody, Outcome::Transport]
+    {
+        // An empty exhaustive match: a new `Outcome` variant fails to compile
+        // here, forcing a witness and a table row for it.
+        match witness {
+            Outcome::Status(_) | Outcome::NonJsonBody | Outcome::Transport => {}
+        }
+        assert!(present(&witness), "no row covers {witness:?}");
     }
 }
 
 #[test]
-fn a_classification_names_the_provider_operation_and_code() {
+fn a_classification_names_the_provider_and_operation() {
     let error = classify(Outcome::Status(404), Operation::Read, "ABC-1");
     let TrackerError::Retryable { detail } = error else {
         panic!("a read is retryable");
     };
     assert!(detail.contains("jira read"), "{detail}");
-    assert!(detail.contains("(13)"), "{detail}");
     assert!(detail.contains("ABC-1"), "{detail}");
-}
-
-/// One committed exit-code fixture row, filtered to Jira.
-struct FixtureRow {
-    code: u16,
-    operation: Operation,
-    retryable: bool,
-}
-
-fn fixture_rows() -> Vec<FixtureRow> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../tracker-support/tests/fixtures/bridge-exit-code-tables.txt");
-    let raw = std::fs::read_to_string(path)
-        .expect("the committed exit-code table is readable");
-    raw.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .filter_map(|line| {
-            let fields: Vec<&str> = line.split_whitespace().collect();
-            if fields[1] != "jira" {
-                return None;
-            }
-            Some(FixtureRow {
-                code: fields[0].parse().expect("the code is numeric"),
-                operation: match fields[2] {
-                    "create" => Operation::Create,
-                    "update" => Operation::Update,
-                    other => panic!("unrecognised operation {other}"),
-                },
-                retryable: match fields[3] {
-                    "retryable" => true,
-                    "terminal" => false,
-                    other => panic!("unrecognised class {other}"),
-                },
-            })
-        })
-        .collect()
-}
-
-#[test]
-fn every_jira_row_of_the_committed_fixture_is_asserted() {
-    let rows = fixture_rows();
-    assert_eq!(
-        rows.len(),
-        43,
-        "the fixture's Jira rows are the coverage guard: a row added without \
-         an assertion must fail the build"
-    );
-
-    let mut consumed = 0;
-    for row in &rows {
-        assert_eq!(
-            is_retryable(&classify_bash_code(row.code, row.operation, "d")),
-            row.retryable,
-            "bash code {} on {:?}",
-            row.code,
-            row.operation
-        );
-        consumed += 1;
-    }
-    assert_eq!(consumed, rows.len(), "every row present was consumed");
-}
-
-#[test]
-fn a_read_is_retryable_for_every_code_in_the_fixture() {
-    for row in fixture_rows() {
-        assert!(
-            is_retryable(&classify_bash_code(row.code, Operation::Read, "d")),
-            "code {} must degrade a read rather than terminate it",
-            row.code
-        );
-    }
 }

--- a/cli/jira-client/tests/discriminant.rs
+++ b/cli/jira-client/tests/discriminant.rs
@@ -1,14 +1,14 @@
-//! The structured discriminant the `*_op` methods surface: the
-//! binary reads the granular bash exit code from it, and the post-create
-//! "created remotely but unwritable" case is a distinct variant, not a wire
-//! outcome — so it never has to be parsed back out of a `TrackerError` string.
+//! The structured discriminant the `*_op` methods surface: the CLI reads an
+//! exit code from it, and the post-create "created remotely but unwritable"
+//! case is a distinct variant, not a wire outcome — so it never has to be
+//! parsed back out of a `TrackerError` string.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
 mod support;
 
 use http_test_support::{MockServer, RequestKey, Route};
-use jira_client::classify::bash_code;
+use jira_client::classify::Outcome;
 use jira_client::mutation::{CreateFields, FieldEdit, IssueType, UpdateFields};
 use jira_client::JiraFailure;
 use serde_json::{Map, Value};
@@ -86,7 +86,7 @@ fn a_create_wire_failure_surfaces_the_outcome_the_exit_code_reads() {
 
     match failure {
         JiraFailure::Wire { outcome, .. } => {
-            assert_eq!(bash_code(outcome), 11, "401 is unauthorised");
+            assert_eq!(outcome, Outcome::Status(401), "401 is unauthorised");
         }
         other => panic!("a 401 is a wire failure, got {other:?}"),
     }
@@ -127,7 +127,7 @@ fn an_update_wire_failure_carries_the_granular_not_found_code() {
 
     match failure {
         JiraFailure::Wire { outcome, .. } => {
-            assert_eq!(bash_code(outcome), 13, "a 404 is not-found");
+            assert_eq!(outcome, Outcome::Status(404), "a 404 is not-found");
         }
         other => panic!("a 404 is a wire failure, got {other:?}"),
     }
@@ -143,7 +143,7 @@ fn a_show_wire_failure_surfaces_the_granular_code() {
 
     match failure {
         JiraFailure::Wire { outcome, .. } => {
-            assert_eq!(bash_code(outcome), 12, "a 403 is forbidden");
+            assert_eq!(outcome, Outcome::Status(403), "a 403 is forbidden");
         }
         other => panic!("a 403 is a wire failure, got {other:?}"),
     }

--- a/cli/jira-client/tests/fixtures/adf/render-abort-bullet-list-without-content/expected-error.txt
+++ b/cli/jira-client/tests/fixtures/adf/render-abort-bullet-list-without-content/expected-error.txt
@@ -1,7 +1,6 @@
-# The bash aborts here rather than degrading to a placeholder. A jq
-# runtime error exits 5 and its message carries an input line number,
-# so the contract asserted is the class and the exit status, with the
-# observed message recorded for a human.
-bash_exit=5
+# The renderer aborts here rather than degrading to a placeholder. The jq
+# oracle's runtime error exits 5 and its message carries an input line
+# number, so the contract asserted is the class, with the observed message
+# recorded for a human.
 class=list-without-content
 # observed: jq: error (at <stdin>:8): Cannot iterate over null (null)

--- a/cli/jira-client/tests/fixtures/adf/render-abort-heading-without-level/expected-error.txt
+++ b/cli/jira-client/tests/fixtures/adf/render-abort-heading-without-level/expected-error.txt
@@ -1,7 +1,6 @@
-# The bash aborts here rather than degrading to a placeholder. A jq
-# runtime error exits 5 and its message carries an input line number,
-# so the contract asserted is the class and the exit status, with the
-# observed message recorded for a human.
-bash_exit=5
+# The renderer aborts here rather than degrading to a placeholder. The jq
+# oracle's runtime error exits 5 and its message carries an input line
+# number, so the contract asserted is the class, with the observed message
+# recorded for a human.
 class=heading-without-level
 # observed: jq: error (at <stdin>:14): Range bounds must be numeric

--- a/cli/jira-client/tests/fixtures/adf/render-abort-ordered-list-without-content/expected-error.txt
+++ b/cli/jira-client/tests/fixtures/adf/render-abort-ordered-list-without-content/expected-error.txt
@@ -1,7 +1,6 @@
-# The bash aborts here rather than degrading to a placeholder. A jq
-# runtime error exits 5 and its message carries an input line number,
-# so the contract asserted is the class and the exit status, with the
-# observed message recorded for a human.
-bash_exit=5
+# The renderer aborts here rather than degrading to a placeholder. The jq
+# oracle's runtime error exits 5 and its message carries an input line
+# number, so the contract asserted is the class, with the observed message
+# recorded for a human.
 class=list-without-content
 # observed: jq: error (at <stdin>:11): null (null) has no keys

--- a/cli/jira-client/tests/fixtures/adf/render-abort-root-not-doc/expected-error.txt
+++ b/cli/jira-client/tests/fixtures/adf/render-abort-root-not-doc/expected-error.txt
@@ -1,7 +1,5 @@
-# The bash aborts here rather than degrading to a placeholder. A jq
-# runtime error exits 5 and its message carries an input line number,
-# so the contract asserted is the class and the exit status, with the
-# observed message recorded for a human.
-bash_exit=40
+# The renderer aborts here rather than degrading to a placeholder. The
+# contract asserted is the class, with the observed message recorded for a
+# human.
 class=root-not-doc
 # observed: E_BAD_JSON: input is not an ADF document (missing type=doc)

--- a/cli/jira-client/tests/fixtures/adf/render-abort-task-list-without-content/expected-error.txt
+++ b/cli/jira-client/tests/fixtures/adf/render-abort-task-list-without-content/expected-error.txt
@@ -1,7 +1,6 @@
-# The bash aborts here rather than degrading to a placeholder. A jq
-# runtime error exits 5 and its message carries an input line number,
-# so the contract asserted is the class and the exit status, with the
-# observed message recorded for a human.
-bash_exit=5
+# The renderer aborts here rather than degrading to a placeholder. The jq
+# oracle's runtime error exits 5 and its message carries an input line
+# number, so the contract asserted is the class, with the observed message
+# recorded for a human.
 class=list-without-content
 # observed: jq: error (at <stdin>:8): Cannot iterate over null (null)

--- a/cli/jira-client/tests/timeouts.rs
+++ b/cli/jira-client/tests/timeouts.rs
@@ -72,8 +72,8 @@ fn show_fails_within_the_window_at_both_injected_timeouts() {
         );
         assert!(
             error.to_string().contains("E_REQ_CONNECT"),
-            "the failure is the transport class — bash code 21 covers \
-             connect, DNS and timeout as one: {error}"
+            "the failure is the transport class — connect, DNS and timeout \
+             collapse into one: {error}"
         );
     }
 }

--- a/cli/jira-client/tests/transport.rs
+++ b/cli/jira-client/tests/transport.rs
@@ -131,7 +131,11 @@ fn a_persistent_5xx_is_attempted_exactly_four_times() {
         .expect("an exhausted retry still yields the response");
 
     assert_eq!(received.status, 503);
-    assert_eq!(server.hits(&key), 4, "four attempts, as the bash makes");
+    assert_eq!(
+        server.hits(&key),
+        4,
+        "four attempts: the initial plus three retries"
+    );
     assert_eq!(
         sleeper.slept(),
         vec![

--- a/cli/linear-cli/src/exit_codes.rs
+++ b/cli/linear-cli/src/exit_codes.rs
@@ -2,19 +2,19 @@
 //!
 //! Every code equals the value the retiring `linear-*-flow.sh` returned for the
 //! same condition, captured pre-deletion into
-//! `tests/fixtures/bash-exit-codes.txt`, which is the authoritative name→integer
-//! contract. `exit_codes_parity.rs` pins these constants against it; the
-//! self-descriptive names plus that fixture carry the mechanical mapping, so
-//! this doc names only the bands, the safety-critical classes and the one
-//! deliberate divergence rather than re-enumerating every code.
+//! `tests/fixtures/captured-exit-codes.txt`, which is the authoritative
+//! name→integer contract. `exit_codes_parity.rs` pins these constants against
+//! it; the self-descriptive names plus that fixture carry the mechanical
+//! mapping, so this doc names only the bands, the safety-critical classes and
+//! the one deliberate divergence rather than re-enumerating every code.
 //!
 //! Bands:
 //!
 //! - `0`–`2` — process and usage, emitted by the binary itself.
 //! - `11`–`53` — the shared transport/auth codes `linear-graphql.sh` and
 //!   `linear-auth.sh` returned; read structurally from the client's
-//!   `LinearFailure` (`bash_code(outcome)`) or a `SurfaceError`, never parsed
-//!   from a string.
+//!   `LinearFailure` (its wire outcome discriminant) or a `SurfaceError`, never
+//!   parsed from a string.
 //! - `60`–`138` — the per-flow argument and outcome codes, one block per flow.
 //!
 //! Safety-critical: `POST_SEND` (`109`) and `WRITEBACK_FAILED` (`107`) mark the
@@ -22,9 +22,9 @@
 //! surfaces the key and steers the operator to reconcile rather than re-create.
 //!
 //! Deliberate divergence: the search flow's `SEARCH_*` codes are remapped from
-//! bash `70`–`73` to `75`–`78`, off the `70`–`74` band the dispatch layer
-//! reserves — a code in that band reaching `accelerator-work` would read as a
-//! dispatch verdict.
+//! the retired `70`–`73` values to `75`–`78`, off the `70`–`74` band the
+//! dispatch layer reserves — a code in that band reaching `accelerator-work`
+//! would read as a dispatch verdict.
 
 // Every code is a declared contract the parity test reads textually; a code no
 // handler yet references is still part of the surface, not dead.
@@ -101,8 +101,8 @@ pub const ATTACH_REGISTER_FAILED: u8 = 137;
 pub const ATTACH_BAD_FLAG: u8 = 138;
 
 use linear_client::cache::CacheError;
-use linear_client::classify::{bash_code, Outcome};
-use linear_client::{ClientError, LinearFailure, SurfaceError};
+use linear_client::classify::{classify_errors, Outcome};
+use linear_client::{ClientError, GraphQlError, LinearFailure, SurfaceError};
 
 /// The exit code for a discovery-cache write failure. A held lock maps to the
 /// shared refresh-lock code; an IO or serialisation failure is a generic error.
@@ -116,9 +116,9 @@ pub const fn for_cache(error: &CacheError) -> u8 {
 
 /// The exit code for a structured port-op failure (`create`/`update`/`show`).
 #[must_use]
-pub fn for_failure(failure: &LinearFailure) -> u8 {
+pub const fn for_failure(failure: &LinearFailure) -> u8 {
     match failure {
-        LinearFailure::Wire { outcome, .. } => code_for_outcome(*outcome),
+        LinearFailure::Wire { outcome, .. } => exit_code_for_outcome(*outcome),
         // Created remotely but unwritable — the non-retryable orphan case.
         LinearFailure::UnwritableIdentifier { .. } => CREATE_WRITEBACK_FAILED,
     }
@@ -132,14 +132,12 @@ pub fn for_surface(error: &SurfaceError) -> u8 {
     match error {
         SurfaceError::Client(client) => for_client(client),
         SurfaceError::GraphQlErrors { body, .. } => {
-            code_for_outcome(Outcome::SuccessWithErrors(
-                linear_client::classify::classify_errors(
-                    &serde_json::from_str(body).unwrap_or_default(),
-                ),
-            ))
+            exit_code_for_outcome(Outcome::SuccessWithErrors(classify_errors(
+                &serde_json::from_str(body).unwrap_or_default(),
+            )))
         }
         SurfaceError::Status { status, body, .. } => {
-            code_for_status(*status, body)
+            exit_code_for_status(*status, body)
         }
         SurfaceError::BadResponse { .. } => BAD_RESPONSE,
         SurfaceError::UnknownState { .. } => TRANSITION_STATE_NOT_IN_CATALOGUE,
@@ -169,20 +167,91 @@ pub const fn for_client(error: &ClientError) -> u8 {
     }
 }
 
-fn code_for_outcome(outcome: Outcome) -> u8 {
-    // The shared 11-36 codes fit u8; bash_code never exceeds that band.
-    u8::try_from(bash_code(outcome)).unwrap_or(ERROR)
+const fn exit_code_for_outcome(outcome: Outcome) -> u8 {
+    match outcome {
+        Outcome::SuccessWithErrors(GraphQlError::Auth)
+        | Outcome::Unauthorised
+        | Outcome::BadRequest(GraphQlError::Auth) => UNAUTHORIZED,
+        Outcome::SuccessWithErrors(GraphQlError::Complexity)
+        | Outcome::BadRequest(GraphQlError::Complexity) => COMPLEXITY,
+        Outcome::BadRequest(GraphQlError::RateLimited) => RATELIMITED,
+        Outcome::SuccessWithErrors(
+            GraphQlError::RateLimited | GraphQlError::BadRequest,
+        )
+        | Outcome::BadRequest(GraphQlError::BadRequest) => BAD_REQUEST,
+        Outcome::NonJsonBody => BAD_RESPONSE,
+        Outcome::Transport => CONNECT,
+        Outcome::ServerError | Outcome::Unexpected => SERVER_ERROR,
+    }
 }
 
-fn code_for_status(status: u16, body: &str) -> u8 {
+fn exit_code_for_status(status: u16, body: &str) -> u8 {
     let parsed = serde_json::from_str(body).unwrap_or_default();
     let outcome = match status {
         401 => Outcome::Unauthorised,
-        400 => Outcome::BadRequest(linear_client::classify::classify_errors(
-            &parsed,
-        )),
+        400 => Outcome::BadRequest(classify_errors(&parsed)),
         500..=599 => Outcome::ServerError,
         _ => Outcome::Unexpected,
     };
-    code_for_outcome(outcome)
+    exit_code_for_outcome(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code_for(graphql: GraphQlError) -> (u8, u8) {
+        (
+            exit_code_for_outcome(Outcome::SuccessWithErrors(graphql)),
+            exit_code_for_outcome(Outcome::BadRequest(graphql)),
+        )
+    }
+
+    #[test]
+    fn every_constructible_outcome_maps_to_its_pinned_code() {
+        assert_eq!(code_for(GraphQlError::Auth), (UNAUTHORIZED, UNAUTHORIZED));
+        assert_eq!(
+            code_for(GraphQlError::Complexity),
+            (COMPLEXITY, COMPLEXITY)
+        );
+        assert_eq!(
+            code_for(GraphQlError::RateLimited),
+            (BAD_REQUEST, RATELIMITED)
+        );
+        assert_eq!(
+            code_for(GraphQlError::BadRequest),
+            (BAD_REQUEST, BAD_REQUEST)
+        );
+        assert_eq!(exit_code_for_outcome(Outcome::Unauthorised), UNAUTHORIZED);
+        assert_eq!(exit_code_for_outcome(Outcome::NonJsonBody), BAD_RESPONSE);
+        assert_eq!(exit_code_for_outcome(Outcome::Transport), CONNECT);
+        assert_eq!(exit_code_for_outcome(Outcome::ServerError), SERVER_ERROR);
+        assert_eq!(exit_code_for_outcome(Outcome::Unexpected), SERVER_ERROR);
+    }
+
+    #[test]
+    fn the_map_never_yields_a_jira_only_code() {
+        let jira_only = [12, 13, 14, 15, 17, 19];
+        let outcomes = [
+            Outcome::SuccessWithErrors(GraphQlError::Auth),
+            Outcome::SuccessWithErrors(GraphQlError::Complexity),
+            Outcome::SuccessWithErrors(GraphQlError::RateLimited),
+            Outcome::SuccessWithErrors(GraphQlError::BadRequest),
+            Outcome::BadRequest(GraphQlError::Auth),
+            Outcome::BadRequest(GraphQlError::Complexity),
+            Outcome::BadRequest(GraphQlError::RateLimited),
+            Outcome::BadRequest(GraphQlError::BadRequest),
+            Outcome::Unauthorised,
+            Outcome::NonJsonBody,
+            Outcome::Transport,
+            Outcome::ServerError,
+            Outcome::Unexpected,
+        ];
+        for outcome in outcomes {
+            assert!(
+                !jira_only.contains(&exit_code_for_outcome(outcome)),
+                "{outcome:?} yields a Jira-only code"
+            );
+        }
+    }
 }

--- a/cli/linear-cli/tests/exit_codes_parity.rs
+++ b/cli/linear-cli/tests/exit_codes_parity.rs
@@ -1,9 +1,9 @@
-//! Pins `exit_codes.rs` against the captured bash contract.
+//! Pins `exit_codes.rs` against the captured exit-code contract.
 //!
 //! Non-allowlisted names must equal the value the retiring flow returned. The
 //! only divergence is the search remap off the reserved `70`–`74` dispatch
 //! band: each allowlisted name asserts the *remapped* Rust value while the
-//! fixture keeps the original bash value. The count pin makes a silent
+//! fixture keeps the original captured value. The count pin makes a silent
 //! allowlist addition fail. The oracle is the committed fixture, never the
 //! constants it guards.
 
@@ -15,7 +15,7 @@ use std::path::Path;
 use cli_test_support::parse_u8_consts;
 
 /// `(name, remapped-rust-value)` for the deliberate search divergence. The
-/// fixture keeps the bash value; the binary emits the remapped one.
+/// fixture keeps the captured value; the binary emits the remapped one.
 const ALLOWLIST: &[(&str, u8)] = &[
     ("SEARCH_BAD_FLAG", 75),
     ("SEARCH_BAD_LIMIT", 76),
@@ -33,12 +33,12 @@ fn rust_codes() -> BTreeMap<String, u8> {
     parse_u8_consts(&source).into_iter().collect()
 }
 
-fn bash_codes() -> Vec<(String, u8)> {
+fn captured_codes() -> Vec<(String, u8)> {
     let text = std::fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/bash-exit-codes.txt"),
+            .join("tests/fixtures/captured-exit-codes.txt"),
     )
-    .expect("the bash-exit-codes fixture is committed");
+    .expect("the captured-exit-codes fixture is committed");
     text.lines()
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
@@ -53,15 +53,15 @@ fn bash_codes() -> Vec<(String, u8)> {
 #[test]
 fn every_captured_code_matches_or_is_an_allowlisted_divergence() {
     let rust = rust_codes();
-    let bash = bash_codes();
+    let captured = captured_codes();
     assert_eq!(
-        bash.len(),
+        captured.len(),
         EXPECTED_FIXTURE_COUNT,
         "a captured code was added or removed without updating the pin"
     );
 
     let allowlist: BTreeMap<&str, u8> = ALLOWLIST.iter().copied().collect();
-    for (name, bash_value) in &bash {
+    for (name, captured_value) in &captured {
         let rust_value = rust.get(name).unwrap_or_else(|| {
             panic!("exit_codes.rs has no constant named {name}")
         });
@@ -71,13 +71,13 @@ fn every_captured_code_matches_or_is_an_allowlisted_divergence() {
                 "{name} must carry its remapped value"
             );
             assert_ne!(
-                *rust_value, *bash_value,
+                *rust_value, *captured_value,
                 "{name} is allowlisted but did not actually diverge"
             );
         } else {
             assert_eq!(
-                *rust_value, *bash_value,
-                "{name} must equal the bash value it was captured at"
+                *rust_value, *captured_value,
+                "{name} must equal the value it was captured at"
             );
         }
     }

--- a/cli/linear-cli/tests/fixtures/capture-exit-codes.sh
+++ b/cli/linear-cli/tests/fixtures/capture-exit-codes.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Captures the Linear bash flows' exit-code contract into bash-exit-codes.txt,
+# Captures the Linear flows' exit-code contract into captured-exit-codes.txt,
 # the authoritative name->integer oracle exit_codes_parity.rs pins against.
 #
-# Two sources, mirroring how the bash declares them:
+# Two sources, mirroring how the flows declare them:
 #   - The per-flow argument/outcome codes are `readonly E_*=NN` constants, so
 #     they are grepped straight out of the flow scripts (E_ prefix stripped to
 #     match the Rust const names).
@@ -12,18 +12,19 @@
 #     binary maps them to.
 #
 # Kept for provenance; re-run against the flows at the recorded revision. The
-# search codes stay at their bash values (70-73) here — exit_codes.rs remaps
-# them off the reserved 70-74 band, and the parity allowlist records that.
+# search codes stay at their captured values (70-73) here — exit_codes.rs
+# remaps them off the reserved 70-74 band, and the parity allowlist records
+# that.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 FLOWS="$PLUGIN_ROOT/skills/integrations/linear/scripts"
-OUT="$SCRIPT_DIR/bash-exit-codes.txt"
+OUT="$SCRIPT_DIR/captured-exit-codes.txt"
 
 {
-  echo "# Linear bash exit-code contract, captured by capture-bash-exit-codes.sh."
-  echo "# <rust-const-name>=<bash-integer>. exit_codes_parity.rs pins these."
+  echo "# Linear exit-code contract, captured by capture-exit-codes.sh."
+  echo "# <rust-const-name>=<integer>. exit_codes_parity.rs pins these."
   echo ""
   echo "# Shared transport/auth/common codes (bare-literal in linear-graphql.sh"
   echo "# and linear-auth.sh; the Rust binary reads them structurally)."

--- a/cli/linear-cli/tests/fixtures/captured-exit-codes.txt
+++ b/cli/linear-cli/tests/fixtures/captured-exit-codes.txt
@@ -1,5 +1,5 @@
-# Linear bash exit-code contract, captured by capture-bash-exit-codes.sh.
-# <rust-const-name>=<bash-integer>. exit_codes_parity.rs pins these.
+# Linear exit-code contract, captured by capture-exit-codes.sh.
+# <rust-const-name>=<integer>. exit_codes_parity.rs pins these.
 
 # Shared transport/auth/common codes (bare-literal in linear-graphql.sh
 # and linear-auth.sh; the Rust binary reads them structurally).

--- a/cli/linear-client/Cargo.toml
+++ b/cli/linear-client/Cargo.toml
@@ -20,8 +20,8 @@ tracing = { workspace = true }
 config = { path = "../config" }
 # The discovery cache reuses the workspace's one atomic-write and mkdir-lock
 # primitives rather than a second implementation — the store-duplication guard
-# enforces this, and the mkdir-lock's owner.<nonce> sentinel never reclaims the
-# bash init's holder.pid lock, so the two exclude safely on the shared path.
+# enforces this, and the mkdir-lock's owner.<nonce> sentinel never reclaims a
+# legacy holder.pid lock, so the two exclude safely on the shared path.
 corpus = { path = "../corpus" }
 corpus-adapters = { path = "../corpus-adapters" }
 store = { path = "../store" }

--- a/cli/linear-client/src/classify.rs
+++ b/cli/linear-client/src/classify.rs
@@ -99,7 +99,7 @@ pub fn carries_errors(body: &Value) -> bool {
         .is_some_and(|errors| !errors.is_empty())
 }
 
-/// What the transport observed, in the terms the bash classifies on.
+/// What the transport observed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
     /// A 2xx whose body carries `errors[]`, already classified.
@@ -118,64 +118,39 @@ pub enum Outcome {
     Unexpected,
 }
 
-/// The bash exit code the same outcome produces.
-#[must_use]
-pub const fn bash_code(outcome: Outcome) -> u16 {
-    match outcome {
-        Outcome::SuccessWithErrors(GraphQlError::Auth)
-        | Outcome::Unauthorised
-        | Outcome::BadRequest(GraphQlError::Auth) => 11,
-        Outcome::SuccessWithErrors(GraphQlError::Complexity)
-        | Outcome::BadRequest(GraphQlError::Complexity) => 36,
-        Outcome::BadRequest(GraphQlError::RateLimited) => 35,
-        Outcome::SuccessWithErrors(
-            GraphQlError::RateLimited | GraphQlError::BadRequest,
-        )
-        | Outcome::BadRequest(GraphQlError::BadRequest) => 34,
-        Outcome::NonJsonBody => 16,
-        Outcome::Transport => 21,
-        Outcome::ServerError | Outcome::Unexpected => 20,
-    }
-}
-
 /// Whether a wire outcome proves no mutation happened, for this operation.
 ///
-/// The divergence between the two mutating operations is ported as **two
-/// genuinely different policies** rather than unified: `34` is retryable on
-/// create and terminal on update — documented, because a 200-body error may
-/// mean the mutation applied — while `18, 23, 25, 27, 29` run the other way
-/// with no rationale anywhere. Where a policy and the "provably pre-send" rule
-/// disagree, the table wins.
+/// A body error carried by a 2xx or a 400 is retryable on create but terminal
+/// on update — a 200-body error may mean the update applied. Auth, complexity,
+/// and a 400 rate-limit are provably unapplied on both operations.
 #[must_use]
 pub fn classify(
     outcome: Outcome,
     operation: Operation,
     detail: &str,
 ) -> TrackerError {
-    classify_bash_code(bash_code(outcome), operation, detail)
-}
-
-/// The bridge mappers' own tables.
-///
-/// Driven by the committed fixture at
-/// `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`.
-#[must_use]
-pub fn classify_bash_code(
-    code: u16,
-    operation: Operation,
-    detail: &str,
-) -> TrackerError {
-    let provably_unapplied = match operation {
-        // The pre-send set: no request was sent, or the server rejected it
-        // before executing the mutation.
-        Operation::Create => matches!(code, 11 | 22 | 34 | 35 | 36),
-        Operation::Update => {
-            matches!(code, 11 | 18 | 22 | 23 | 25 | 27 | 29 | 35 | 36)
-                || (110..=114).contains(&code)
+    let provably_unapplied = match outcome {
+        Outcome::SuccessWithErrors(
+            GraphQlError::Auth | GraphQlError::Complexity,
+        )
+        | Outcome::Unauthorised
+        | Outcome::BadRequest(
+            GraphQlError::Auth
+            | GraphQlError::Complexity
+            | GraphQlError::RateLimited,
+        ) => true,
+        Outcome::SuccessWithErrors(
+            GraphQlError::RateLimited | GraphQlError::BadRequest,
+        )
+        | Outcome::BadRequest(GraphQlError::BadRequest) => {
+            matches!(operation, Operation::Create)
         }
-        Operation::Read => true,
+        Outcome::NonJsonBody
+        | Outcome::Transport
+        | Outcome::ServerError
+        | Outcome::Unexpected => false,
     };
-    let detail = format!("linear {} ({code}): {detail}", operation.name());
+    let detail = format!("linear {}: {detail}", operation.name());
     if provably_unapplied || !operation.mutates() {
         TrackerError::Retryable { detail }
     } else {

--- a/cli/linear-client/src/client.rs
+++ b/cli/linear-client/src/client.rs
@@ -61,7 +61,7 @@ const SHOW: &str = "query($id: String!) {
 
 /// The read-side show projection the `show` subcommand renders. The port `show`
 /// projects to a stamp and a Markdown body; this keeps the state, assignee and
-/// comments the bash `show` table shows, over a query distinct from the port's.
+/// comments the detailed `show` renders, over a query distinct from the port's.
 const SHOW_DETAILED: &str = "query($id: String!) {
     issue(id: $id) {
       id identifier title updatedAt
@@ -92,7 +92,7 @@ const SEARCH: &str =
 /// from `SEARCH` — which the sync engine's bulk read (`fetch_all`/`fetch_page`)
 /// spends its complexity budget on — so widening the projection never changes
 /// the port read's request shape. It selects the state and assignee names the
-/// bash search table shows and keeps the title, which the stamps-only port
+/// search surface renders and keeps the title, which the stamps-only port
 /// `search` discards.
 const SEARCH_PROJECTION: &str =
     "query($cursor: String, $filter: IssueFilter, $first: Int) {
@@ -113,7 +113,7 @@ type Page = (Vec<(String, RemoteTimestamp)>, Option<String>);
 /// The accumulated result of a detailed search.
 ///
 /// The raw projection nodes in arrival order, and whether the retrieval was cut
-/// short (a cap-hit or deadline, mirroring the bash `.data.issues.truncated`
+/// short (a cap-hit or deadline, surfaced as the `.data.issues.truncated`
 /// flag).
 #[derive(Debug)]
 pub struct DetailedPage {
@@ -235,10 +235,9 @@ impl LinearClient {
         })
     }
 
-    /// Classifies a response body the way the bash classifies it — a 200
-    /// carrying `errors[]` is a failure, and a 400's body decides between auth,
-    /// complexity, rate limiting and a bad request — into the wire [`Outcome`]
-    /// the exit code is read from.
+    /// Classifies a response body — a 200 carrying `errors[]` is a failure, and
+    /// a 400's body decides between auth, complexity, rate limiting and a bad
+    /// request — into the wire [`Outcome`] the exit code is read from.
     fn interpret_outcome(received: &Received) -> Result<Value, Outcome> {
         let Some(body) = received.json() else {
             return Err(if (200..300).contains(&received.status) {
@@ -364,7 +363,7 @@ impl LinearClient {
     /// Pages a search over the richer [`SEARCH_PROJECTION`] to exhaustion,
     /// returning the raw nodes the `search` subcommand renders. Unlike the port
     /// `search`, a wire failure is an error rather than a degraded page — the
-    /// bash search flow propagates the transport code — while a cap-hit or
+    /// search flow propagates the transport failure — while a cap-hit or
     /// expired deadline is a successful, truncated result.
     ///
     /// # Errors
@@ -424,7 +423,7 @@ impl LinearClient {
 
     /// Fetches one issue's full detail for the `show` subcommand, returning the
     /// raw GraphQL body. A `comments` cap keeps only the last N comment nodes,
-    /// reproducing the bash flow's client-side slice.
+    /// applying the client-side slice.
     ///
     /// # Errors
     ///
@@ -565,8 +564,8 @@ fn stamp(value: Option<&Value>) -> RemoteTimestamp {
         })
 }
 
-/// Keeps only the last `limit` comment nodes, reproducing the bash `--comments`
-/// client-side slice.
+/// Keeps only the last `limit` comment nodes — the `--comments` client-side
+/// slice.
 fn slice_comments(body: &mut Value, limit: usize) {
     if let Some(nodes) = body
         .pointer_mut("/data/issue/comments/nodes")

--- a/cli/linear-client/src/failure.rs
+++ b/cli/linear-client/src/failure.rs
@@ -1,12 +1,12 @@
 //! The structured failure a fallible port operation surfaces before it
 //! collapses to the port's two-class [`TrackerError`].
 //!
-//! The binary reads the granular bash exit code from this — the classifier's
-//! [`Outcome`], whose `bash_code` is the integer, or the distinct post-create
-//! "created remotely but unwritable" case — rather than parsing it back out of
-//! a `TrackerError` detail string. Every error site of `create`/`update`/`show`
-//! is funnelled through here, so the port impl derives `TrackerError` from one
-//! place and the binary maps the same value straight to an exit code.
+//! It carries the classifier's [`Outcome`] and [`Operation`] discriminant, or
+//! the distinct post-create "created remotely but unwritable" case, so the CLI
+//! derives an exit code from the discriminant rather than parsing it back out
+//! of a `TrackerError` detail string. Every error site of
+//! `create`/`update`/`show` is funnelled through here, so the port impl derives
+//! `TrackerError` from one place.
 
 use tracker::TrackerError;
 
@@ -17,8 +17,9 @@ use crate::classify::Outcome;
 /// A create/update/show failure, carrying the discriminant the binary needs.
 #[derive(Debug, Clone)]
 pub enum LinearFailure {
-    /// A wire outcome the classifier recognises. `bash_code(outcome)` is the
-    /// exit code; `operation` decides the retry class the port derives.
+    /// A wire outcome the classifier recognises. `outcome` is the discriminant
+    /// the CLI reads for an exit code; `operation` decides the retry class the
+    /// port derives.
     Wire {
         outcome: Outcome,
         operation: Operation,

--- a/cli/linear-client/src/filter.rs
+++ b/cli/linear-client/src/filter.rs
@@ -57,7 +57,7 @@ impl TeamResolver for FixedTeam {
     }
 }
 
-/// Everything the search surface accepts, in the bash's own shape.
+/// Everything the search surface accepts, in its own shape.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Search {
     pub team_id: Option<String>,

--- a/cli/linear-client/src/transport.rs
+++ b/cli/linear-client/src/transport.rs
@@ -41,8 +41,8 @@ pub struct Received {
 }
 
 impl Received {
-    /// The body as JSON, or `None` when it is not JSON at all — which is bash
-    /// code 16 rather than a transport failure.
+    /// The body as JSON, or `None` when it is not JSON at all — a non-JSON-body
+    /// outcome rather than a transport failure.
     #[must_use]
     pub fn json(&self) -> Option<Value> {
         serde_json::from_str(&self.body).ok()

--- a/cli/linear-client/tests/classify.rs
+++ b/cli/linear-client/tests/classify.rs
@@ -1,13 +1,9 @@
-//! The status-and-body classification table, per operation, with a coverage
-//! guard over the committed fixture's Linear rows.
+//! The per-operation retry table keyed on the wire outcome, with a coverage
+//! guard so an outcome added without an assertion fails the build.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
-use std::path::Path;
-
-use linear_client::classify::{
-    bash_code, carries_errors, classify_bash_code, classify_errors,
-};
+use linear_client::classify::{carries_errors, classify_errors};
 use linear_client::{classify, GraphQlError, Operation, Outcome};
 use serde_json::json;
 use serde_json::Value;
@@ -17,11 +13,10 @@ const fn is_retryable(error: &TrackerError) -> bool {
     matches!(*error, TrackerError::Retryable { .. })
 }
 
-/// One row of the transcribed table: the observed condition, the bash code, and
-/// whether each mutating operation can prove nothing was applied.
+/// One row of the table: the observed condition and whether each mutating
+/// operation can prove nothing was applied.
 struct Row {
     outcome: Outcome,
-    code: u16,
     create_retryable: bool,
     update_retryable: bool,
     note: &'static str,
@@ -30,84 +25,78 @@ struct Row {
 const TABLE: &[Row] = &[
     Row {
         outcome: Outcome::SuccessWithErrors(GraphQlError::Auth),
-        code: 11,
         create_retryable: true,
         update_retryable: true,
         note: "a 200 carrying an auth error: provably unapplied on both",
     },
     Row {
         outcome: Outcome::SuccessWithErrors(GraphQlError::Complexity),
-        code: 36,
         create_retryable: true,
         update_retryable: true,
         note: "the query was rejected before executing",
     },
     Row {
+        outcome: Outcome::SuccessWithErrors(GraphQlError::RateLimited),
+        create_retryable: true,
+        update_retryable: false,
+        note: "the divergence: a 200-body error may mean the update applied",
+    },
+    Row {
         outcome: Outcome::SuccessWithErrors(GraphQlError::BadRequest),
-        code: 34,
         create_retryable: true,
         update_retryable: false,
         note: "the divergence: a 200-body error may mean the update applied",
     },
     Row {
         outcome: Outcome::NonJsonBody,
-        code: 16,
         create_retryable: false,
         update_retryable: false,
         note: "the response was lost, so the mutation may have applied",
     },
     Row {
         outcome: Outcome::Unauthorised,
-        code: 11,
         create_retryable: true,
         update_retryable: true,
         note: "HTTP 401",
     },
     Row {
         outcome: Outcome::BadRequest(GraphQlError::Auth),
-        code: 11,
         create_retryable: true,
         update_retryable: true,
         note: "a 400 whose body classifies as auth",
     },
     Row {
         outcome: Outcome::BadRequest(GraphQlError::Complexity),
-        code: 36,
         create_retryable: true,
         update_retryable: true,
         note: "the complexity cap",
     },
     Row {
         outcome: Outcome::BadRequest(GraphQlError::RateLimited),
-        code: 35,
         create_retryable: true,
         update_retryable: true,
         note: "rate limiting arrives as HTTP 400, not 429",
     },
     Row {
         outcome: Outcome::BadRequest(GraphQlError::BadRequest),
-        code: 34,
         create_retryable: true,
         update_retryable: false,
         note: "the same divergence as the 200-body case",
     },
     Row {
         outcome: Outcome::ServerError,
-        code: 20,
         create_retryable: false,
         update_retryable: false,
         note: "a 5xx with retries exhausted",
     },
     Row {
         outcome: Outcome::Transport,
-        code: 21,
         create_retryable: false,
         update_retryable: false,
         note: "connect, DNS and timeout collapse into one code",
     },
     Row {
         outcome: Outcome::Unexpected,
-        code: 20,
         create_retryable: false,
         update_retryable: false,
         note: "any other status",
@@ -118,7 +107,6 @@ const TABLE: &[Row] = &[
 fn every_row_classifies_per_operation() {
     let mut asserted = 0;
     for row in TABLE {
-        assert_eq!(bash_code(row.outcome), row.code, "{}", row.note);
         assert_eq!(
             is_retryable(&classify(row.outcome, Operation::Create, "d")),
             row.create_retryable,
@@ -142,11 +130,43 @@ fn every_row_classifies_per_operation() {
 }
 
 #[test]
+fn the_table_covers_every_outcome_variant() {
+    let present = |wanted: &Outcome| {
+        TABLE.iter().any(|row| {
+            std::mem::discriminant(&row.outcome)
+                == std::mem::discriminant(wanted)
+        })
+    };
+    for witness in [
+        Outcome::SuccessWithErrors(GraphQlError::Auth),
+        Outcome::NonJsonBody,
+        Outcome::Unauthorised,
+        Outcome::BadRequest(GraphQlError::Auth),
+        Outcome::ServerError,
+        Outcome::Transport,
+        Outcome::Unexpected,
+    ] {
+        // An empty exhaustive match: a new `Outcome` variant fails to compile
+        // here, forcing a witness and a table row for it.
+        match witness {
+            Outcome::SuccessWithErrors(_)
+            | Outcome::NonJsonBody
+            | Outcome::Unauthorised
+            | Outcome::BadRequest(_)
+            | Outcome::ServerError
+            | Outcome::Transport
+            | Outcome::Unexpected => {}
+        }
+        assert!(present(&witness), "no row covers {witness:?}");
+    }
+}
+
+#[test]
 fn the_two_hundred_body_auth_row_is_retryable_on_update() {
-    // Code 11 is retryable on update; only 34 is the terminal 200-body error.
-    // Making this terminal would tell the caller a provably-unapplied auth
-    // rejection may have mutated the remote, and change a push failure's exit
-    // code from 70 to 71.
+    // Auth is retryable on update; only the plain body error is the terminal
+    // 200-body case. Making auth terminal would tell the caller a
+    // provably-unapplied auth rejection may have mutated the remote, and change
+    // a push failure's exit code from 70 to 71.
     let error = classify(
         Outcome::SuccessWithErrors(GraphQlError::Auth),
         Operation::Update,
@@ -157,14 +177,39 @@ fn the_two_hundred_body_auth_row_is_retryable_on_update() {
 }
 
 #[test]
-fn linear_emits_no_403_404_410_or_429_so_those_codes_are_reserved() {
-    // Every reserved code must still classify — a caller can pass one — but
-    // no Outcome maps to it, which is the property that matters.
-    for code in [12, 13, 14, 15, 17, 19] {
-        let mapped = TABLE.iter().any(|row| row.code == code);
+fn both_directions_of_the_divergence_are_reproduced() {
+    // The body-error outcomes run one way: retryable on create, terminal on
+    // update.
+    for outcome in [
+        Outcome::BadRequest(GraphQlError::BadRequest),
+        Outcome::SuccessWithErrors(GraphQlError::BadRequest),
+        Outcome::SuccessWithErrors(GraphQlError::RateLimited),
+    ] {
         assert!(
-            !mapped,
-            "code {code} is Jira-only and reserved in Linear's EXIT_CODES.md"
+            is_retryable(&classify(outcome, Operation::Create, "d")),
+            "{outcome:?} on create"
+        );
+        assert!(
+            !is_retryable(&classify(outcome, Operation::Update, "d")),
+            "{outcome:?} on update"
+        );
+    }
+    // The auth, complexity and 400-rate-limit outcomes are retryable on both.
+    for outcome in [
+        Outcome::SuccessWithErrors(GraphQlError::Auth),
+        Outcome::Unauthorised,
+        Outcome::BadRequest(GraphQlError::Auth),
+        Outcome::SuccessWithErrors(GraphQlError::Complexity),
+        Outcome::BadRequest(GraphQlError::Complexity),
+        Outcome::BadRequest(GraphQlError::RateLimited),
+    ] {
+        assert!(
+            is_retryable(&classify(outcome, Operation::Create, "d")),
+            "{outcome:?} on create"
+        );
+        assert!(
+            is_retryable(&classify(outcome, Operation::Update, "d")),
+            "{outcome:?} on update"
         );
     }
 }
@@ -222,113 +267,13 @@ fn an_empty_errors_array_is_not_an_error() {
     assert!(carries_errors(&json!({"errors": [{"message": "x"}]})));
 }
 
-struct FixtureRow {
-    code: u16,
-    operation: Operation,
-    retryable: bool,
-}
-
-fn fixture_rows() -> Vec<FixtureRow> {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../tracker-support/tests/fixtures/bridge-exit-code-tables.txt");
-    let raw = std::fs::read_to_string(path)
-        .expect("the committed exit-code table is readable");
-    raw.lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .filter_map(|line| {
-            let fields: Vec<&str> = line.split_whitespace().collect();
-            if fields[1] != "linear" {
-                return None;
-            }
-            Some(FixtureRow {
-                code: fields[0].parse().expect("the code is numeric"),
-                operation: match fields[2] {
-                    "create" => Operation::Create,
-                    "update" => Operation::Update,
-                    other => panic!("unrecognised operation {other}"),
-                },
-                retryable: match fields[3] {
-                    "retryable" => true,
-                    "terminal" => false,
-                    other => panic!("unrecognised class {other}"),
-                },
-            })
-        })
-        .collect()
-}
-
 #[test]
-fn every_linear_row_of_the_committed_fixture_is_asserted() {
-    let rows = fixture_rows();
-    assert_eq!(
-        rows.len(),
-        31,
-        "the fixture's Linear rows are the coverage guard: a row added \
-         without an assertion must fail the build"
-    );
-
-    let mut consumed = 0;
-    for row in &rows {
-        assert_eq!(
-            is_retryable(&classify_bash_code(row.code, row.operation, "d")),
-            row.retryable,
-            "bash code {} on {:?}",
-            row.code,
-            row.operation
-        );
-        consumed += 1;
-    }
-    assert_eq!(consumed, rows.len());
-}
-
-#[test]
-fn both_directions_of_the_divergence_are_reproduced() {
-    // 34 runs one way...
-    assert!(is_retryable(&classify_bash_code(
-        34,
-        Operation::Create,
-        "d"
-    )));
-    assert!(!is_retryable(&classify_bash_code(
-        34,
-        Operation::Update,
-        "d"
-    )));
-    // ...and 18, 23, 25, 27, 29 the other, with no rationale anywhere.
-    for code in [18, 23, 25, 27, 29] {
-        assert!(
-            !is_retryable(&classify_bash_code(code, Operation::Create, "d")),
-            "code {code} on create"
-        );
-        assert!(
-            is_retryable(&classify_bash_code(code, Operation::Update, "d")),
-            "code {code} on update"
-        );
-    }
-    // 11, 22, 35 and 36 are retryable on both.
-    for code in [11, 22, 35, 36] {
-        assert!(is_retryable(&classify_bash_code(
-            code,
-            Operation::Create,
-            "d"
-        )));
-        assert!(is_retryable(&classify_bash_code(
-            code,
-            Operation::Update,
-            "d"
-        )));
-    }
-}
-
-#[test]
-fn a_classification_names_the_provider_operation_and_code() {
+fn a_classification_names_the_provider_and_operation() {
     let error = classify(Outcome::Transport, Operation::Read, "ENG-1");
     let TrackerError::Retryable { detail } = error else {
         panic!("a read is retryable");
     };
     assert!(detail.contains("linear read"), "{detail}");
-    assert!(detail.contains("(21)"), "{detail}");
     assert!(detail.contains("ENG-1"), "{detail}");
 }
 

--- a/cli/linear-client/tests/discriminant.rs
+++ b/cli/linear-client/tests/discriminant.rs
@@ -1,14 +1,14 @@
-//! The structured discriminant the `*_op` methods surface: the
-//! binary reads the granular bash exit code from it, and the post-create
-//! "created remotely but unwritable" case is a distinct variant, not a wire
-//! outcome — so it never has to be parsed back out of a `TrackerError` string.
+//! The structured discriminant the `*_op` methods surface: the CLI reads an
+//! exit code from it, and the post-create "created remotely but unwritable"
+//! case is a distinct variant, not a wire outcome — so it never has to be
+//! parsed back out of a `TrackerError` string.
 
 #![allow(clippy::expect_used, clippy::panic)]
 
 mod support;
 
 use http_test_support::{MockServer, RequestKey, Route};
-use linear_client::classify::bash_code;
+use linear_client::classify::{GraphQlError, Outcome};
 use linear_client::LinearFailure;
 use support::client::{brief, client_for};
 use tracker::ExternalId;
@@ -36,7 +36,7 @@ fn a_create_wire_failure_surfaces_the_outcome_the_exit_code_reads() {
 
     match failure {
         LinearFailure::Wire { outcome, .. } => {
-            assert_eq!(bash_code(outcome), 11, "401 is E_GQL_UNAUTHORIZED");
+            assert_eq!(outcome, Outcome::Unauthorised, "401 is unauthorised");
         }
         LinearFailure::UnwritableIdentifier { .. } => {
             panic!("a 401 is a wire failure, not the post-create case")
@@ -75,7 +75,11 @@ fn a_show_wire_failure_carries_the_granular_ratelimit_code() {
 
     match failure {
         LinearFailure::Wire { outcome, .. } => {
-            assert_eq!(bash_code(outcome), 35, "a 400 ratelimit is 35");
+            assert_eq!(
+                outcome,
+                Outcome::BadRequest(GraphQlError::RateLimited),
+                "a 400 ratelimit classifies as a rate-limited bad request"
+            );
         }
         LinearFailure::UnwritableIdentifier { .. } => {
             panic!("a ratelimit is a wire failure, not the post-create case")

--- a/cli/linear-client/tests/transport.rs
+++ b/cli/linear-client/tests/transport.rs
@@ -332,6 +332,6 @@ fn a_non_json_body_is_reported_as_such_rather_than_as_a_transport_failure() {
     assert_eq!(received.status, 200);
     assert!(
         received.json().is_none(),
-        "a 2xx non-JSON body is bash code 16, not a transport failure"
+        "a 2xx non-JSON body is a non-JSON-body outcome, not a transport failure"
     );
 }

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -1,0 +1,915 @@
+---
+type: "plan"
+id: "2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"
+title: "Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients Implementation Plan"
+date: "2026-09-06T15:33:26+00:00"
+author: "Toby Clemson"
+producer: "create-plan"
+status: "ready"
+work_item_id: "work-item:0269"
+parent: "work-item:0269"
+derived_from: ["codebase-research:2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"]
+tags: ["jira", "linear", "cleanup", "refactor", "exit-codes", "classification"]
+revision: "ee2b4e51bb328cf4a905599414bbb5c300972577"
+repository: "accelerator"
+last_updated: "2026-09-06T19:50:03+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients Implementation Plan
+
+## Overview
+
+Strip every residual "bash" reference from the `jira-client` and `linear-client`
+crates, and redesign the exit-code classification path so the numeric map lives
+at the CLI boundary rather than inside the client crates. The client crates keep
+returning context-carrying failures (`JiraFailure`/`LinearFailure`, each holding
+`{ outcome, operation, detail }`); the granular `outcome → u8` map moves into
+`jira-cli`/`linear-cli`; and the retry-class collapse to `TrackerError` stays in
+the client crates, re-expressed directly on `(Outcome, Operation)` with no `u16`
+intermediary and no numeric code embedded in a `detail` string. Every emitted
+exit-code value is preserved exactly — the parity fixtures and
+`bridge-exit-code-tables.txt` are the oracle.
+
+## Current State Analysis
+
+The exit-code path is two functions doing triple duty inside each client crate's
+`classify.rs`:
+
+- **`bash_code(outcome) -> u16`** is the granular map (codes 11–36). Its only
+  consumers are the two CLI `exit_codes.rs` (`code_for_outcome`/`code_for_status`,
+  which narrow with `u8::try_from`) and outcome-keyed client tests. This is the
+  map the work item moves to the CLI.
+- **`classify_bash_code(code, op, detail) -> TrackerError`** is the retry-class
+  map. Jira never calls it at runtime (`classify.rs:70` goes straight to
+  `build`); it is test-only there. Linear calls it once (`classify.rs:155`) but
+  only ever with the seven codes `bash_code` emits — its `18|23|25|27|29` and
+  `110..=114` arms are dead at runtime.
+- **`build(...)`** formats `"jira {op} ({code}): {detail}"`, embedding the
+  numeric code in the detail string, then returns `Retryable`/`Terminal`.
+
+The `RemoteTracker` port impl lives **inside the client crates**
+(`jira-client/src/client.rs:470-648`, `linear-client/src/client.rs:598+`) —
+there is no separate adapter crate. Each port method collapses a client failure
+via `.map_err(TrackerError::from)`, relying on `From<Failure> for TrackerError`
+(`failure.rs`), whose `Wire` arm delegates to `classify`. `work-cli` reaches
+`TrackerError` only through this port impl and maps `Retryable`/`Terminal` to
+dispatch codes 70/71 (`work-cli/src/exit_codes.rs`); it never sees
+`JiraFailure`/`LinearFailure`. The standalone `jira-cli`/`linear-cli` binaries
+never touch `TrackerError` at all — they read the granular `Failure` directly.
+
+`AdfError::code() -> u16` (`adf/mod.rs:38-49`) returns 40/41/42 and is an
+independent third thread: unrelated to `classify.rs`, consumed only by
+`jira-cli` `for_adf` (`exit_codes.rs:222`).
+
+### Key Discoveries
+
+- **The structured errors already carry the context.** `Failure::Wire` holds
+  `{ outcome, operation, detail }` and stores no `u16`; the redesign removes the
+  numeric computation, not adds context (`jira-client/src/failure.rs:24-44`,
+  `linear-client/src/failure.rs:18-31`).
+- **The granular code is a function of `outcome` alone**, in both crates —
+  `operation` is not a `bash_code` input (`jira-client/src/classify.rs:44-57`,
+  `linear-client/src/classify.rs:122-139`).
+- **The linear retry divergence is load-bearing and reproducible on
+  `(Outcome, Operation)`.** Code 34 (a `BadRequest`-class body error) is
+  retryable on create, terminal on update, because a 200-body error may mean the
+  update applied (`linear-client/src/classify.rs:141-148`).
+- **The oracle splits cleanly by reachability.**
+  `bridge-exit-code-tables.txt` keys on numeric codes including 15/17/22 and
+  100–117 that no `Outcome` produces — CLI-emitted argv/credential codes,
+  transcriptions of the retired bash mappers. The `tracker-support` self-test
+  (`mapper_differential_self_test.rs`) reads the fixture independently and does
+  **not** call `classify_bash_code`, so it is untouched.
+- **The CLI already forbids detail-string parsing.**
+  `exit_codes_never_parses_a_tracker_error_detail`
+  (`jira-cli/tests/exit_codes_parity.rs:133`) greps `src/exit_codes.rs` for
+  `TrackerError` and `.detail` — the codebase already enforces reading from the
+  discriminant.
+- **`bash_code` call sites (all move or are re-keyed):** CLI
+  `jira-cli/src/exit_codes.rs:226,230`, `linear-cli/src/exit_codes.rs:174`;
+  tests `jira-client/tests/classify.rs:99`, `jira-client/tests/discriminant.rs:89,130,146`,
+  `linear-client/tests/classify.rs:121`, `linear-client/tests/discriminant.rs:39,78`.
+- **`classify_bash_code` call sites (all deleted or re-keyed):** internal
+  `linear-client/src/classify.rs:155`; tests `jira-client/tests/classify.rs:203,218`,
+  `linear-client/tests/classify.rs:274,288,293,301,305,311,316`.
+
+## Desired End State
+
+Grepping the production `src/` and `Cargo.toml` of both client crates for `bash`
+(case-insensitive) returns nothing. No `bash_code`/`classify_bash_code` symbol
+remains; no `u16` exit-code field on any error type; no integer literal in the
+11–36 range in either `classify.rs` or `failure.rs`; no numeric code embedded in
+a `detail` string. Each CLI's exit-code mapping reads the client error type and
+produces the pinned values. `AdfError::code()` is gone, its 40/41/42 mapping
+inlined into `jira-cli` `for_adf`. Every emitted exit-code value is unchanged —
+`mise run cli:check` and the `exit_codes_parity` / `flow_errors` suites pass.
+
+The split is intentionally asymmetric: the granular numeric map leaves the
+client crates, but the retry-class `classify` and the `From<Failure> for
+TrackerError` collapse **stay** inside them, so each client crate still serves
+two consumers (the structured `Failure` for its CLI, and `tracker::TrackerError`
+for `work-cli`) and keeps its dependency on the `tracker` crate. Relocating that
+collapse is 0271's job; 0269 leaves it in place, re-expressed on
+`(Outcome, Operation)`.
+
+Verify with:
+
+```bash
+grep -rin bash cli/jira-client/src cli/jira-client/Cargo.toml \
+  cli/linear-client/src cli/linear-client/Cargo.toml   # no output
+mise run cli:check
+```
+
+## What We're NOT Doing
+
+- **Not touching the transport retry predicates.**
+  `is_retryable_status` (`jira-client/src/transport.rs:292-294`) and `retryable`
+  (`linear-client/src/transport.rs:229-240`) are HTTP-retry domain terms and
+  stay unchanged. Only the `bash code 16` doc mention at linear
+  `transport.rs:44` is reworded.
+- **Not changing any emitted exit-code value.** The parity fixtures and
+  `bridge-exit-code-tables.txt` are a frozen contract; this is a
+  structural/vocabulary change only.
+- **Not touching `tracker::TrackerError` or `work-cli`'s 70/71 mapping.** Owned
+  by the `tracker` crate, out of scope.
+- **Not extracting a tracker-adapter crate.** The `RemoteTracker` collapse stays
+  inside the client crates; relocating it belongs to item 0271.
+- **Not editing `bridge-exit-code-tables.txt` content or the `tracker-support`
+  self-test.** The client crates stop reading the fixture; the fixture itself
+  and its independent reader are unchanged.
+- **Not rewording bash mentions unrelated to exit codes.** Genuine shell-script
+  shebangs (e.g. the renamed capture script) and ADF-fidelity fixtures may keep
+  a `bash` reference where it names the shell or an unrelated behaviour. These
+  sit outside every `grep -i bash` AC path, so they need no reword and no
+  justifying comment — a comment there would guard nothing and would violate the
+  repo's comment convention.
+
+## Implementation Approach
+
+Deliver in four independently mergeable phases, each leaving `mise run cli:check`
+and the full test suite green. Phase 1 is the mechanically safe doc reword.
+Phases 2 and 3 are the per-crate classification redesigns (jira, then linear),
+each self-contained across its client crate and its CLI. Phase 4 is the
+independent `AdfError` u16 removal. The `grep -i bash = 0` acceptance criterion
+is met only once all four land — inherent to phased delivery — and is checked in
+the final validation.
+
+Follow red-green-refactor throughout: adjust the affected test to express the
+new shape (a failing or non-compiling test), make it pass with the minimum
+change, then refactor. When relocating a mapping and its coverage, write the new
+CLI-side `exit_code_for_outcome` and its unit test **first** (green), and delete
+the client-crate assertions only once that test passes, so no interim commit
+leaves the granular map unasserted.
+
+Every mapping function stays **exhaustive over its enum variants with no
+variant-level wildcard**, so a new variant is a compile error at the mapping
+site. The one deliberate exception is the jira granular map, whose `Outcome`
+wraps `Status(u16)` and so must keep a `Status(_)` catch-all coercing an
+unrecognised HTTP status to `SERVER_ERROR`; every other arm is enumerated. Note
+that variant-exhaustiveness constrains which inputs are handled, not which exit
+codes may be produced — where a codomain property matters (e.g. "linear never
+emits a Jira-only code") it is pinned by a test, not left to the match.
+
+## Phase 1: Doc-only vocabulary reword
+
+### Overview
+
+Reword every bash-era doc comment and `Cargo.toml` note in the
+non-classification production files of both crates to describe the Rust
+behaviour. No symbol, signature, or behaviour changes; the crates compile and
+test identically before and after.
+
+The file list below is the current `bash` inventory from the research, verified
+against the tree at this revision. The work item's "Production files to touch"
+additionally names `mutation.rs` (jira) and `error.rs`, `auth.rs`, `upload.rs`
+(linear); a grep confirms none of those carries `bash` at this revision, so they
+are deliberately omitted rather than overlooked. The final `grep -i bash = 0`
+gate over the whole `src/` (see Desired End State) is the backstop that catches
+any file the inventory missed.
+
+### Changes Required
+
+#### 1. jira-client doc comments
+
+**Files**: `cli/jira-client/src/cache.rs` (lines 35, 142, 162, 170),
+`cli/jira-client/src/read.rs` (4, 8, 38),
+`cli/jira-client/src/custom_fields.rs` (141),
+`cli/jira-client/src/principal.rs` (44),
+`cli/jira-client/Cargo.toml` (28).
+
+**Changes**: Replace "bash-era" / "the bash flow" / "the bash `<regex>` shape" /
+"bash init's holder.pid lock" phrasings with descriptions of the Rust behaviour
+or the wire contract. For example, `cache.rs` "Bash-era caches carry" becomes a
+description of the unversioned legacy cache layout; `principal.rs` "The bash
+`^[A-Za-z0-9:_-]+$` shape" becomes "The `^[A-Za-z0-9:_-]+$` shape — an opaque
+Jira accountId". Preserve the invariant each comment documents; only the
+provenance vocabulary changes.
+
+#### 2. linear-client doc comments
+
+**Files**: `cli/linear-client/src/client.rs` (lines 64, 95, 116, 238, 367, 427,
+568), `cli/linear-client/src/transport.rs` (44),
+`cli/linear-client/src/filter.rs` (60), `cli/linear-client/Cargo.toml` (24).
+
+**Changes**: Same treatment. The `transport.rs:44` "which is bash code 16"
+mention becomes a plain description of the non-JSON-body case (the predicate
+itself is untouched). `client.rs` "the bash `show`/`search` table shows" becomes
+a description of the projected shape.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Both crates format clean and lint clean: `mise run cli:check`
+- [ ] No bash vocabulary in the Phase 1 files:
+      `grep -rin bash cli/jira-client/src/cache.rs cli/jira-client/src/read.rs cli/jira-client/src/custom_fields.rs cli/jira-client/src/principal.rs cli/linear-client/src/client.rs cli/linear-client/src/transport.rs cli/linear-client/src/filter.rs cli/jira-client/Cargo.toml cli/linear-client/Cargo.toml`
+      returns nothing
+- [ ] Full client test suites pass unchanged:
+      `cargo test -p jira-client -p linear-client` (run from `cli/`)
+
+#### Manual Verification
+
+- [ ] Each reworded comment still names the invariant or wire contract it
+      documented; none is now a what-comment describing the code
+
+---
+
+## Phase 2: Jira classification redesign and granular map to jira-cli
+
+### Overview
+
+Delete `bash_code`, `classify_bash_code`, and `build` from `jira-client`; keep
+`classify` and the `From<JiraFailure>` collapse, re-expressed without the numeric
+intermediary and without the `({code})` detail embed. Move the granular map into
+`jira-cli` as `exit_code_for_outcome(Outcome) -> u8` over the named constants.
+Re-key the client tests off the retired numeric oracle and sweep the jira test
+vocabulary. Rename the jira-cli parity fixture, helper, and capture script.
+
+### Changes Required
+
+#### 1. Re-express classify, delete the numeric functions
+
+**File**: `cli/jira-client/src/classify.rs`
+
+`classify` computes `provably_unapplied` from the status directly and builds the
+detail without a code. `bash_code`, `classify_bash_code`, and `build` are
+removed. The module doc is reworded to describe the two-operation retry policy
+without bash provenance.
+
+```rust
+#[must_use]
+pub fn classify(
+    outcome: Outcome,
+    operation: Operation,
+    detail: &str,
+) -> TrackerError {
+    let provably_unapplied = match outcome {
+        Outcome::Status(400 | 401 | 403 | 404 | 410 | 429) => true,
+        Outcome::Status(_) | Outcome::NonJsonBody | Outcome::Transport => false,
+    };
+    let detail = format!("jira {}: {detail}", operation.name());
+    if provably_unapplied || !operation.mutates() {
+        TrackerError::Retryable { detail }
+    } else {
+        TrackerError::Terminal { detail }
+    }
+}
+```
+
+An exhaustive `match` (not `matches!`) is used so a new `Outcome` variant is a
+compile error here, matching the current code and the linear rewrite (Phase 3
+change 1). `Operation` and `Outcome` (and their derives) are unchanged and stay `pub`;
+`Outcome` is consumed by `jira-cli`. No integer literal in the 11–36 range
+remains — the only literals are HTTP statuses (400+).
+
+#### 2. Reword the failure module doc
+
+**File**: `cli/jira-client/src/failure.rs`
+
+The module doc and the `Wire` variant doc reference "the granular bash exit
+code" and "`bash_code(outcome)` is the integer" (lines 4, 5, 25). Reword them to
+state the invariant the failure type itself guarantees — it carries the
+`outcome`/`operation` discriminant so no consumer parses a `detail` string —
+**without** restating the numeric exit-code mapping, which now lives in
+`jira-cli`; a doc narrating a mapping owned by another crate would go stale
+silently. The `From<JiraFailure> for TrackerError` impl is unchanged in
+behaviour — its `Wire` arm still delegates to `classify`.
+
+#### 3. Move the granular map into jira-cli
+
+**File**: `cli/jira-cli/src/exit_codes.rs`
+
+Replace the `bash_code` import and the two `code_for_outcome`/`code_for_status`
+helpers with a local `exit_code_for_outcome` over the named constants, and rename
+the status wrapper to `exit_code_for_status` so the whole family reads with one
+prefix. `for_failure`'s `Wire` arm calls the outcome helper.
+
+```rust
+use jira_client::classify::Outcome;
+// ... other imports unchanged (AdfError, CacheError, ClientError, ...)
+
+const fn exit_code_for_outcome(outcome: Outcome) -> u8 {
+    match outcome {
+        Outcome::Status(400) => REQ_BAD_REQUEST,
+        Outcome::Status(401) => UNAUTHORIZED,
+        Outcome::Status(403) => FORBIDDEN,
+        Outcome::Status(404) => NOT_FOUND,
+        Outcome::Status(410) => GONE,
+        Outcome::Status(429) => RATELIMITED,
+        Outcome::NonJsonBody => REQ_BAD_RESPONSE,
+        Outcome::Transport => REQ_CONNECT,
+        Outcome::Status(_) => SERVER_ERROR,
+    }
+}
+
+fn exit_code_for_status(status: u16) -> u8 {
+    exit_code_for_outcome(Outcome::Status(status))
+}
+```
+
+The `for_failure` `Wire` arm changes from `code_for_outcome(*outcome)` to
+`exit_code_for_outcome(*outcome)`; the `SurfaceError::Status` arm calls
+`exit_code_for_status(status)`.
+
+**On the surviving `u16`:** the name `exit_code_for_status` makes it self-evident
+that the input is a wire HTTP status (carried by `SurfaceError::Status`) and the
+output is an exit code — the exit-code `u16` intermediary the criterion targets
+(`bash_code`/`classify_bash_code`) is gone. With the matched prefix and the
+`_for_status` suffix, no explanatory prose is needed to disambiguate the two.
+
+**Reword the CLI-side bash vocabulary in the same file.** Deleting the `bash_code`
+symbol leaves stale prose in `jira-cli/src/exit_codes.rs`: the module doc
+(lines 3, 5, 16, 26), `for_failure`'s "granular bash code" (line 139), and
+`for_credential`'s "mirroring the bash `jira-request.sh`" (line 194). Reword each
+to describe the Rust behaviour or the contract without "bash". In particular the
+module doc's fixture citation (line 5) names `tests/fixtures/bash-exit-codes.txt`,
+which change 7 renames — update it to `captured-exit-codes.txt` so the
+document-of-record does not dangle. These lines sit outside the client-crate
+`grep -i bash = 0` AC, so they are swept here deliberately rather than left to a
+later item.
+
+#### 4. Cover the granular map with a jira-cli unit test
+
+**File**: `cli/jira-cli/src/exit_codes.rs` (inline `#[cfg(test)]` module)
+
+The client-crate `bash_code` assertions move here as a unit test over every
+`Outcome` arm. Structure the test so a new `Outcome` variant forces a new
+assertion — destructure the value under test through an exhaustive `match` in the
+test body rather than trusting the fixed list below — so the completeness the
+deleted 43-row guard provided is not silently lost. The module must not mention
+`TrackerError` or `.detail` (the parity grep guard scans the whole file).
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jira_client::classify::Outcome;
+
+    #[test]
+    fn every_outcome_maps_to_its_pinned_code() {
+        assert_eq!(exit_code_for_outcome(Outcome::Status(400)), REQ_BAD_REQUEST);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(401)), UNAUTHORIZED);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(403)), FORBIDDEN);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(404)), NOT_FOUND);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(410)), GONE);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(429)), RATELIMITED);
+        assert_eq!(exit_code_for_outcome(Outcome::NonJsonBody), REQ_BAD_RESPONSE);
+        assert_eq!(exit_code_for_outcome(Outcome::Transport), REQ_CONNECT);
+        assert_eq!(exit_code_for_outcome(Outcome::Status(503)), SERVER_ERROR);
+    }
+}
+```
+
+#### 5. Re-key the jira-client classify tests
+
+**File**: `cli/jira-client/tests/classify.rs`
+
+- Drop the `bash_code` and `classify_bash_code` imports.
+- Drop the `code` field from `STATUS_TABLE` rows; the outcome→code coverage now
+  lives in the jira-cli unit test (change 4). Keep the `create_retryable` /
+  `update_retryable` columns and the `classify(...)` retry-class assertions in
+  `every_status_row_classifies_per_operation` — this is the live retry oracle.
+  Add a completeness guard alongside it: an in-test exhaustive `match` over
+  `Outcome` asserting every variant appears in `STATUS_TABLE`, so a new variant
+  forces a new row (replacing the coverage the deleted 43-row guard gave).
+- Delete `the_status_table_covers_every_condition_the_bash_distinguishes` (it
+  iterates over numeric codes), and delete `FixtureRow`, `fixture_rows`,
+  `every_jira_row_of_the_committed_fixture_is_asserted` (43-row guard), and
+  `a_read_is_retryable_for_every_code_in_the_fixture` — all consumed
+  `classify_bash_code` or the bridge fixture.
+- **Accepted trade-off — the client crate stops cross-checking the bridge
+  fixture.** This is research Option A: the transcription-only fixture rows guard
+  no live path, and re-keying the live rows back to the fixture would need a
+  numeric outcome↔code helper in the test tree, exactly the numeric-keyed
+  vestige 0264 retires. The live verdicts stay triple-pinned — the outcome-keyed
+  `STATUS_TABLE`, the jira-cli `exit_codes_parity` suite (constants vs the
+  captured fixture), and `flow_errors` end-to-end — so no live coverage is lost.
+  The `tracker-support` self-test remains the independent guardian of the bridge
+  fixture itself.
+- Rename `a_classification_names_the_provider_operation_and_code` to drop the
+  code from its name and assertions: it now asserts `detail.contains("jira read")`
+  and `detail.contains("ABC-1")` only, and must **not** assert `"(13)"` (the code
+  is no longer embedded).
+
+#### 6. Sweep the remaining jira-client test vocabulary
+
+**Files**: `cli/jira-client/tests/discriminant.rs`,
+`cli/jira-client/tests/timeouts.rs`, `cli/jira-client/tests/transport.rs`
+
+- `discriminant.rs`: drop the `use ...::bash_code` (line 11), reword the module
+  doc (line 2), and replace each `assert_eq!(bash_code(outcome), N, ...)`
+  (lines 89, 130, 146) with an assertion on the resulting `Outcome` discriminant
+  itself (e.g. `assert_eq!(outcome, Outcome::Status(401))`). The numeric-code
+  coverage is the jira-cli unit test (change 4).
+- `timeouts.rs`: reword the line-75 message ("bash code 21 covers connect, DNS
+  and timeout") to name the transport class without the code.
+- `transport.rs`: line 134 ("four attempts, as the bash makes") names retry-count
+  parity, not an exit code — out of the exit-code sweep's strict scope. Reword it
+  to name the retry count directly and drop "bash"; it is a one-word change, and
+  a plain reword is preferred over a justification comment.
+
+#### 7. Rename the jira-cli parity fixture, helper, and capture script
+
+**Files**: `cli/jira-cli/tests/exit_codes_parity.rs`,
+`cli/jira-cli/tests/fixtures/bash-exit-codes.txt` →
+`cli/jira-cli/tests/fixtures/captured-exit-codes.txt`,
+`cli/jira-cli/tests/fixtures/capture-bash-exit-codes.sh` →
+`cli/jira-cli/tests/fixtures/capture-exit-codes.sh`
+
+- Rename the fixture file and the `bash_codes()` helper to `captured_codes()`;
+  update the `.join(...)` path (line 39) and both call sites (lines 36, 56).
+- Reword the parity-suite module doc and the fixture header comment to drop
+  "bash" (the fixture's `NAME=INT` rows carry no "bash").
+- Rename and reword the capture script; update the header that names the output
+  file. The `#!/usr/bin/env bash` shebang is a legitimate interpreter line and
+  stays as-is, with no justifying comment: it sits outside every `grep -i bash`
+  AC path (the script is in none of the phase grep argument lists), so a comment
+  would guard nothing and would be the kind of what-comment the repo's comment
+  convention rejects. The script is a manual, uninvoked provenance artefact.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Format, lint, and type-check clean: `mise run cli:check`
+- [ ] Jira classify + discriminant + timeouts + transport suites pass:
+      `cargo test -p jira-client` (run from `cli/`)
+- [ ] The jira-cli parity and map-unit suites pass:
+      `cargo test -p jira-cli --test exit_codes_parity` and
+      `cargo test -p jira-cli exit_codes::tests`
+- [ ] Every jira-cli test target still compiles (catches a stale consumer of a
+      removed symbol, since the crate is not surface-pinned):
+      `cargo test -p jira-cli --all-targets --no-run`
+- [ ] Behavioural routing unchanged:
+      `cargo test -p jira-cli --features test-loopback --test flow_errors`
+- [ ] No `bash_code`/`classify_bash_code` symbol in jira-client:
+      `grep -rn "bash_code\|classify_bash_code" cli/jira-client/src` returns
+      nothing
+- [ ] No 11–36 literal in the classification files:
+      inspection of `cli/jira-client/src/classify.rs` and `failure.rs`
+- [ ] No bash vocabulary in jira-client src, Cargo.toml, the swept jira tests,
+      or the jira-cli exit-code source and parity suite:
+      `grep -rin bash cli/jira-client/src cli/jira-client/Cargo.toml cli/jira-client/tests/classify.rs cli/jira-client/tests/discriminant.rs cli/jira-client/tests/timeouts.rs cli/jira-client/tests/transport.rs cli/jira-cli/src/exit_codes.rs cli/jira-cli/tests/exit_codes_parity.rs cli/jira-cli/tests/fixtures/captured-exit-codes.txt`
+      returns nothing (the renamed capture script is not in this list; its
+      shebang is out of scope)
+
+#### Manual Verification
+
+- [ ] `git`/`jj` shows the fixture rename as a rename, not a delete-plus-add,
+      and the fixture content (the `NAME=INT` rows) is byte-identical
+- [ ] The jira-cli `for_failure`/`for_surface`/`for_client` matches remain
+      exhaustive with no wildcard
+
+---
+
+## Phase 3: Linear classification redesign and granular map to linear-cli
+
+### Overview
+
+Mirror Phase 2 for linear, with the added subtlety that linear's `classify`
+currently routes through `classify_bash_code`. Re-express it directly on
+`(Outcome, Operation)`, reproducing every reachable retry verdict including the
+code-34 divergence, and drop the dead `18|23|25|27|29|110..=114` arms.
+
+### Changes Required
+
+#### 1. Re-express classify, delete the numeric functions
+
+**File**: `cli/linear-client/src/classify.rs`
+
+`classify` maps `(Outcome, Operation)` to `provably_unapplied` directly.
+`bash_code` and `classify_bash_code` are removed. The divergence doc comment is
+kept (reworded to drop "bash") because it records a genuine non-obvious
+invariant: a 200-body error may mean the update applied.
+
+```rust
+#[must_use]
+pub fn classify(
+    outcome: Outcome,
+    operation: Operation,
+    detail: &str,
+) -> TrackerError {
+    let provably_unapplied = match outcome {
+        Outcome::SuccessWithErrors(GraphQlError::Auth)
+        | Outcome::Unauthorised
+        | Outcome::BadRequest(GraphQlError::Auth)
+        | Outcome::SuccessWithErrors(GraphQlError::Complexity)
+        | Outcome::BadRequest(GraphQlError::Complexity)
+        | Outcome::BadRequest(GraphQlError::RateLimited) => true,
+        Outcome::SuccessWithErrors(
+            GraphQlError::RateLimited | GraphQlError::BadRequest,
+        )
+        | Outcome::BadRequest(GraphQlError::BadRequest) => {
+            matches!(operation, Operation::Create)
+        }
+        Outcome::NonJsonBody
+        | Outcome::Transport
+        | Outcome::ServerError
+        | Outcome::Unexpected => false,
+    };
+    let detail = format!("linear {}: {detail}", operation.name());
+    if provably_unapplied || !operation.mutates() {
+        TrackerError::Retryable { detail }
+    } else {
+        TrackerError::Terminal { detail }
+    }
+}
+```
+
+This reproduces the fixture exactly for every reachable outcome: `{11,35,36}`
+retryable on both operations, code-34 (`SuccessWithErrors(RateLimited|BadRequest)`
+and `BadRequest(BadRequest)`) retryable on create and terminal on update, and
+`{16,20,21}` terminal on both. `classify_errors`, `carries_errors`,
+`COMPLEXITY_PATTERN`, `GraphQlError`, `Outcome`, and `Operation` are unchanged.
+
+#### 2. Reword the failure module doc
+
+**File**: `cli/linear-client/src/failure.rs`
+
+Same as jira Phase 2 change 2 (lines 4, 5, 20): state the invariant
+`LinearFailure` itself guarantees — it carries the `outcome`/`operation`
+discriminant so no consumer parses a `detail` string — without restating the
+numeric mapping, which now lives in `linear-cli`.
+
+#### 3. Move the granular map into linear-cli
+
+**File**: `cli/linear-cli/src/exit_codes.rs`
+
+Replace the `bash_code` import and `code_for_outcome` with `exit_code_for_outcome`
+over the named constants, and rename the status wrapper to `exit_code_for_status`
+so the family reads with one prefix. `for_failure`, `for_surface`, and
+`exit_code_for_status` call the outcome helper.
+
+```rust
+use linear_client::classify::{classify_errors, Outcome};
+use linear_client::{ClientError, GraphQlError, LinearFailure, SurfaceError};
+
+const fn exit_code_for_outcome(outcome: Outcome) -> u8 {
+    match outcome {
+        Outcome::SuccessWithErrors(GraphQlError::Auth)
+        | Outcome::Unauthorised
+        | Outcome::BadRequest(GraphQlError::Auth) => UNAUTHORIZED,
+        Outcome::SuccessWithErrors(GraphQlError::Complexity)
+        | Outcome::BadRequest(GraphQlError::Complexity) => COMPLEXITY,
+        Outcome::BadRequest(GraphQlError::RateLimited) => RATELIMITED,
+        Outcome::SuccessWithErrors(
+            GraphQlError::RateLimited | GraphQlError::BadRequest,
+        )
+        | Outcome::BadRequest(GraphQlError::BadRequest) => BAD_REQUEST,
+        Outcome::NonJsonBody => BAD_RESPONSE,
+        Outcome::Transport => CONNECT,
+        Outcome::ServerError | Outcome::Unexpected => SERVER_ERROR,
+    }
+}
+```
+
+`for_surface`'s `GraphQlErrors` arm and `exit_code_for_status` still build an
+`Outcome` (via `classify_errors`) and pass it to `exit_code_for_outcome`, as they
+do today with `code_for_outcome`. As in Phase 2 change 3, the renamed
+`exit_code_for_status(status: u16, body: &str)` makes plain that its `u16` is a
+wire HTTP status, not the removed exit-code intermediary.
+
+**Reword the CLI-side bash vocabulary in the same file.** Deleting `bash_code`
+leaves stale prose in `linear-cli/src/exit_codes.rs`: the module doc (lines 5,
+16, 25) and the inline note at line 173 (`bash_code never exceeds that band`),
+whose helper body is being replaced. Reword each without "bash", and update the
+module doc's fixture citation (line 5) from `tests/fixtures/bash-exit-codes.txt`
+to `captured-exit-codes.txt` (renamed in change 7) so the document-of-record does
+not dangle. These sit outside the client-crate AC and are swept here.
+
+#### 4. Cover the granular map with a linear-cli unit test
+
+**File**: `cli/linear-cli/src/exit_codes.rs` (inline `#[cfg(test)]` module)
+
+Assert every **constructible `Outcome`**, not one representative per code value —
+`exit_code_for_outcome` bundles several `GraphQlError` variants per arm via
+OR-patterns, so a per-code test would miss a variant drifting between arms (e.g.
+`BadRequest(Complexity)` slipping 36→34, or `BadRequest(RateLimited)` 35→34).
+Cover each `SuccessWithErrors(g)` and `BadRequest(g)` for every `GraphQlError`
+`g`, plus `Unauthorised`, `NonJsonBody`, `Transport`, `ServerError`, and
+`Unexpected` — and structure the test through an exhaustive `match` so a new
+`GraphQlError` or `Outcome` variant forces a new assertion. Watch the two arms
+that split on the same wrapper: `BadRequest(RateLimited) => RATELIMITED` (35)
+while `SuccessWithErrors(RateLimited) => BAD_REQUEST` (34). No
+`TrackerError`/`.detail` tokens.
+
+Add the reserved-codes structural test in this same module (relocated from
+`linear-client` change 5, since `exit_code_for_outcome` lives here): assert the
+map over every linear `Outcome` never yields a Jira-only code
+`{12,13,14,15,17,19}` — the codomain property match-exhaustiveness cannot
+guarantee.
+
+#### 5. Re-key the linear-client classify tests
+
+**File**: `cli/linear-client/tests/classify.rs`
+
+- Drop the `bash_code` and `classify_bash_code` imports.
+- Drop the `code` field from `TABLE` rows; keep the `create_retryable` /
+  `update_retryable` columns and the `classify(...)` assertions in
+  `every_row_classifies_per_operation`. Add the row the re-expressed `classify`
+  newly distinguishes: `SuccessWithErrors(RateLimited)` (retryable-create,
+  terminal-update, code 34) — the current `TABLE` covers only
+  `BadRequest(RateLimited)`, so without this row the rewrite's
+  `SuccessWithErrors(RateLimited | BadRequest)` arm is asserted only for
+  `BadRequest`. Add a completeness guard: an in-test exhaustive `match` over
+  `Outcome` asserting every variant appears in `TABLE`, replacing the deleted
+  31-row guard.
+- Re-express `both_directions_of_the_divergence_are_reproduced` on outcomes:
+  assert `classify(Outcome::BadRequest(GraphQlError::BadRequest), Create)` and
+  `classify(Outcome::SuccessWithErrors(GraphQlError::BadRequest), Create)` are
+  retryable while their `Update` forms are terminal, and that the auth /
+  complexity / rate-limited outcomes are retryable on both. Drop the
+  `18|23|25|27|29` assertions — no `Outcome` produces those codes.
+- Delete `FixtureRow`, `fixture_rows`, and
+  `every_linear_row_of_the_committed_fixture_is_asserted` (31-row guard). As in
+  Phase 2 change 5, this is research Option A: the client crate stops
+  cross-checking the bridge fixture (the transcription-only rows guard no live
+  path, and re-keying them would need a numeric outcome↔code helper 0264
+  retires); live verdicts stay triple-pinned by the outcome-keyed `TABLE`, the
+  linear-cli `exit_codes_parity` suite, and `flow_errors`.
+- Delete `linear_emits_no_403_404_410_or_429_so_those_codes_are_reserved` here
+  (it lives in `linear-client` and iterates numeric codes). Its replacement — a
+  **structural test, not a comment** — is added in `linear-cli` alongside the
+  granular map (change 4), because `exit_code_for_outcome` now lives in
+  `linear-cli` and `linear-client` cannot call it without the
+  `linear-cli → linear-client` dependency becoming a cargo cycle (see Phase 4
+  change 3). Match-exhaustiveness constrains the handled inputs, not the codomain
+  — a future arm could map to a literal `13` and stay exhaustive — so the live
+  test is required; do not reintroduce numeric keys on the input side.
+- Keep the `classify_errors` ordering, complexity-word, and `carries_errors`
+  tests unchanged; rename `a_classification_names_the_provider_operation_and_code`
+  and drop its `"(21)"` assertion.
+
+#### 6. Sweep the remaining linear-client test vocabulary
+
+**Files**: `cli/linear-client/tests/discriminant.rs`,
+`cli/linear-client/tests/transport.rs`
+
+- `discriminant.rs`: drop the `use ...::bash_code` (line 11), reword the module
+  doc (line 2), and replace the `bash_code(outcome)` assertions (lines 39, 78)
+  with `Outcome` discriminant assertions.
+- `transport.rs`: reword the line-335 message ("a 2xx non-JSON body is bash code
+  16") to name the non-JSON-body outcome without the code.
+
+#### 7. Rename the linear-cli parity fixture, helper, and capture script
+
+**Files**: `cli/linear-cli/tests/exit_codes_parity.rs`,
+`cli/linear-cli/tests/fixtures/bash-exit-codes.txt` → `captured-exit-codes.txt`,
+`cli/linear-cli/tests/fixtures/capture-bash-exit-codes.sh` →
+`capture-exit-codes.sh`
+
+Same treatment as Phase 2 change 7.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Format, lint, and type-check clean: `mise run cli:check`
+- [ ] Linear classify + discriminant + transport suites pass:
+      `cargo test -p linear-client` (run from `cli/`)
+- [ ] The linear-cli parity and map-unit suites pass:
+      `cargo test -p linear-cli --test exit_codes_parity` and
+      `cargo test -p linear-cli exit_codes::tests`
+- [ ] Every linear-cli test target still compiles (catches a stale consumer of a
+      removed symbol; the crate is not surface-pinned):
+      `cargo test -p linear-cli --all-targets --no-run`
+- [ ] Behavioural routing unchanged:
+      `cargo test -p linear-cli --features test-loopback --test flow_errors`
+      (the code-34 create/update divergence is a retry-class 70/71 distinction
+      collapsed only in `work-cli`; `linear-cli` emits 34 for both operations, so
+      the divergence is pinned by the `classify` `TABLE`, not by `flow_errors`)
+- [ ] No `bash_code`/`classify_bash_code` symbol in linear-client:
+      `grep -rn "bash_code\|classify_bash_code" cli/linear-client/src` returns
+      nothing
+- [ ] No 11–36 literal in the classification files: inspection of
+      `cli/linear-client/src/classify.rs` and `failure.rs`
+- [ ] No bash vocabulary in linear-client src, Cargo.toml, swept tests, or the
+      linear-cli exit-code source and parity suite:
+      `grep -rin bash cli/linear-client/src cli/linear-client/Cargo.toml cli/linear-client/tests/classify.rs cli/linear-client/tests/discriminant.rs cli/linear-client/tests/transport.rs cli/linear-cli/src/exit_codes.rs cli/linear-cli/tests/exit_codes_parity.rs cli/linear-cli/tests/fixtures/captured-exit-codes.txt`
+      returns nothing (the renamed capture script is not in this list; its
+      shebang is out of scope)
+
+#### Manual Verification
+
+- [ ] The re-expressed `classify` reproduces the code-34 divergence
+      (retryable-create / terminal-update) and the `{11,35,36}`-retryable-on-both
+      verdicts, cross-checked against `bridge-exit-code-tables.txt` linear rows
+- [ ] The two crate-split views of the taxonomy stay coherent: the set of
+      outcomes `linear-cli::exit_code_for_outcome` maps to `BAD_REQUEST` (34) is
+      exactly the set whose `linear-client::classify` verdict flips between
+      `Create` and `Update`. These now live in different crates as independent
+      matches; confirm no future regroup on one side desyncs from the other
+- [ ] The fixture rename is a rename with byte-identical content
+
+---
+
+## Phase 4: AdfError u16 removal
+
+### Overview
+
+Remove `AdfError::code() -> u16` (40/41/42) and inline the variant→constant
+mapping into `jira-cli` `for_adf`. `AdfError::code()` has four live test call
+sites that must be re-homed with it — `adf.rs:84`, `adf_inventory.rs:173`, and
+`adf_differential.rs:134,138` (the ADF exit-code differential oracle) — so the
+removal does not break compilation or silently drop the 40/41/42 contract guard.
+Sweep the `bash_exit=` provenance from the five ADF render-abort fixtures.
+Independent of Phases 2–3 and jira-only.
+
+### Changes Required
+
+#### 1. Remove the code method
+
+**File**: `cli/jira-client/src/adf/mod.rs`
+
+Delete the `impl AdfError { pub const fn code(&self) -> u16 { ... } }` block
+(lines 36-50). The `Display` impl, the variants, and the two public conversion
+functions are unchanged.
+
+#### 2. Inline the mapping at the CLI boundary
+
+**File**: `cli/jira-cli/src/exit_codes.rs`
+
+`for_adf` inspects the variant directly and becomes `const`:
+
+```rust
+const fn for_adf(error: &AdfError) -> u8 {
+    match error {
+        AdfError::RootNotDoc { .. }
+        | AdfError::HeadingWithoutLevel
+        | AdfError::ListWithoutContent { .. } => BAD_JSON,
+        AdfError::UnsupportedBlockquote
+        | AdfError::UnsupportedTable
+        | AdfError::UnsupportedNestedList => ADF_UNSUPPORTED,
+        AdfError::BadInput => ADF_BAD_INPUT,
+    }
+}
+```
+
+`BAD_JSON` (40), `ADF_UNSUPPORTED` (41), `ADF_BAD_INPUT` (42) are the existing
+constants. The `u8::try_from(error.code())` fallback disappears; a new variant is
+now a compile error at this match.
+
+Add a `#[cfg(test)]` unit test in this file asserting every `AdfError` variant
+maps to its pinned constant, through an exhaustive `match` in the test body so a
+new variant forces a new assertion. This is the new home for the variant→code
+coverage the deleted `AdfError::code()` assertions in `adf.rs` and
+`adf_inventory.rs` provided (change 3).
+
+#### 3. Re-home the `AdfError::code()` call sites
+
+**Files**: `cli/jira-client/tests/adf.rs` (84), `cli/jira-client/tests/adf_inventory.rs` (173),
+`cli/jira-client/tests/adf_differential.rs` (134, 138).
+
+`jira-client` cannot import `for_adf` from `jira-cli` — `jira-cli` depends on
+`jira-client`, so the reverse (even as a dev-dependency) is a cargo cycle. So the
+call sites split by concern:
+
+- `adf.rs` and `adf_inventory.rs`: drop the `error.code()` numeric assertions;
+  keep the `to_string()` message, `starts_with(name)`, variant, and count
+  assertions — the crate's render/refusal behaviour stays a `jira-client`
+  concern. The variant→code coverage these lines gave now lives in the `for_adf`
+  unit test (change 2).
+- `adf_differential.rs`: this oracle compares the crate's refusal against the
+  captured oracle's exit status, so it needs a variant→code mapping in place.
+  Replace `error.code()` with a **test-local** `expected_adf_exit(&AdfError) -> u16`
+  helper (a small exhaustive `match` in the test), preserving the crate-vs-oracle
+  exit-code parity. The helper's `40/41/42` literals are ADF codes outside the
+  `11–36` band and live only in the test tree, so no AC is affected. (The purer
+  alternative — relocate the whole differential harness to `jira-cli` and key it
+  on `for_adf` — is heavier because the harness drives the external oracle
+  script, and belongs with that oracle's eventual retirement under 0211/0264, not
+  this item.) Note the seam: `expected_adf_exit` does not cross-check production
+  `for_adf` directly (the cycle forbids sharing the symbol). Instead each side is
+  anchored to a frozen artefact — `for_adf` to the captured parity fixture via its
+  unit test (change 2) and `exit_codes_parity`, `expected_adf_exit` to the
+  captured oracle status — so a mistake on either side surfaces as a failing test
+  rather than silent drift.
+
+#### 4. Sweep the render-abort fixtures
+
+**Files**: `cli/jira-client/tests/fixtures/adf/render-abort-root-not-doc/expected-error.txt`
+and the four sibling `render-abort-*/expected-error.txt` files.
+
+Remove the `bash_exit=` line (no test parses that fixture line — `adf_differential.rs`
+reads only the `class=` prefix and the `E_` message line; the exit-code parity
+comes from `expected_adf_exit`, change 3) and reword the "The bash aborts here"
+doc prose to describe the Rust render abort.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Format, lint, and type-check clean: `mise run cli:check`
+- [ ] The whole jira-client and jira-cli suites pass (not just the ADF tests —
+      this catches the re-homed call sites and any stale consumer, since the
+      crates are not surface-pinned):
+      `cargo test -p jira-client` and `cargo test -p jira-cli`
+- [ ] The `for_adf` unit test passes:
+      `cargo test -p jira-cli exit_codes`
+- [ ] No `code()` method on `AdfError` and no residual caller:
+      `grep -rn "fn code" cli/jira-client/src/adf/mod.rs` returns nothing, and
+      `grep -rn "\.code()" cli/jira-client/tests` returns nothing
+- [ ] No `bash` in the ADF render-abort fixtures:
+      `grep -rin bash cli/jira-client/tests/fixtures/adf/render-abort-*/expected-error.txt`
+      returns nothing
+
+#### Manual Verification
+
+- [ ] `for_adf` produces 40/41/42 for the same variants the removed `code()`
+      did, confirmed against the ADF exit codes in `jira-cli/src/exit_codes.rs`
+- [ ] The 40/41/42 contract stays guarded from two independent directions:
+      production `for_adf` by its unit test (change 2) plus `exit_codes_parity`,
+      and the crate-vs-oracle render parity by `adf_differential` via the
+      test-local `expected_adf_exit` — so neither can drift silently even though
+      the two are not cross-checked against each other directly
+- [ ] `for_adf` and the test-local `expected_adf_exit` stay coherent through their
+      shared anchoring to the frozen ADF exit codes (symmetric to the linear
+      taxonomy coherence check in Phase 3)
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- The granular `Outcome → u8` map, per crate, as an inline `#[cfg(test)]` module
+  in each CLI's `exit_codes.rs` — every constructible `Outcome` (per-variant, not
+  per-code value) asserted against its named constant, through an in-test
+  exhaustive `match` so a new variant forces a new assertion. This replaces the
+  client crates' `bash_code` assertions.
+- The `AdfError → u8` map, via the `for_adf` unit test in `jira-cli`'s
+  `exit_codes.rs` — every variant asserted against 40/41/42. This replaces the
+  `AdfError::code()` assertions removed from `jira-client`'s ADF tests.
+- The retry-class map, per crate, via `classify(outcome, operation)` in the
+  client crates' `tests/classify.rs` — the outcome-keyed `STATUS_TABLE`/`TABLE`
+  is the live oracle, including the linear code-34 create/update divergence,
+  which is a retry-class distinction visible only here (not in `flow_errors`).
+- A structural test in `linear-cli` (where `exit_code_for_outcome` lives) that the
+  map never yields a Jira-only code `{12,13,14,15,17,19}`, replacing the deleted
+  numeric-iterating `linear_emits_no_403_404_410_or_429_...` test that lived in
+  `linear-client`.
+
+### Integration Tests
+
+- `exit_codes_parity` (both CLIs): constants pinned against the renamed
+  `captured-exit-codes.txt`, proving no emitted value changed.
+- `flow_errors` (both CLIs, `--features test-loopback`): the binary is driven
+  into each error class and the observed exit code asserted, proving the routing
+  is unchanged end-to-end. It does not exercise the code-34 create/update
+  divergence — `linear-cli` emits 34 for both operations; that divergence is a
+  70/71 distinction owned by `work-cli` and pinned here by the `classify` `TABLE`.
+- `adf_differential` (`jira-client`): the crate's ADF exit code (via the
+  test-local `expected_adf_exit`) is compared against the captured oracle status,
+  preserving the 40/41/42 contract guard after `AdfError::code()` is removed.
+
+### Manual Testing Steps
+
+1. Run the final full grep gate (see Desired End State) and confirm zero
+   matches across both client crates' `src/` and `Cargo.toml`.
+2. Diff the renamed fixtures to confirm content is byte-identical to the
+   originals.
+3. Cross-check the linear divergence verdicts against
+   `bridge-exit-code-tables.txt` linear rows by hand.
+
+## Migration Notes
+
+None. No persisted data or on-disk format changes; the exit-code values are the
+external contract and are preserved exactly.
+
+## References
+
+- Original work item: `meta/work/0269-remove-bash-references-from-jira-linear-clients.md`
+- Research: `meta/research/codebase/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md`
+- Contract oracle: `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`
+- Granular map today: `cli/jira-client/src/classify.rs:44-103`,
+  `cli/linear-client/src/classify.rs:122-184`
+- CLI boundary today: `cli/jira-cli/src/exit_codes.rs:134-231`,
+  `cli/linear-cli/src/exit_codes.rs:104-188`
+- Port impls (collapse stays here): `cli/jira-client/src/client.rs:470-648`,
+  `cli/linear-client/src/client.rs:598+`
+- AdfError: `cli/jira-client/src/adf/mod.rs:36-50`, consumer
+  `cli/jira-cli/src/exit_codes.rs:221-223`
+- Blocked items inheriting this shape: 0271 (unify client interfaces), 0273
+  (domain crate for Linear/Jira subcommands)

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -453,23 +453,23 @@ mod tests {
 
 #### Automated Verification
 
-- [ ] Format, lint, and type-check clean: `mise run cli:check`
-- [ ] Jira classify + discriminant + timeouts + transport suites pass:
+- [x] Format, lint, and type-check clean: `mise run cli:check`
+- [x] Jira classify + discriminant + timeouts + transport suites pass:
       `cargo test -p jira-client` (run from `cli/`)
-- [ ] The jira-cli parity and map-unit suites pass:
+- [x] The jira-cli parity and map-unit suites pass:
       `cargo test -p jira-cli --test exit_codes_parity` and
       `cargo test -p jira-cli exit_codes::tests`
-- [ ] Every jira-cli test target still compiles (catches a stale consumer of a
+- [x] Every jira-cli test target still compiles (catches a stale consumer of a
       removed symbol, since the crate is not surface-pinned):
       `cargo test -p jira-cli --all-targets --no-run`
-- [ ] Behavioural routing unchanged:
+- [x] Behavioural routing unchanged:
       `cargo test -p jira-cli --features test-loopback --test flow_errors`
-- [ ] No `bash_code`/`classify_bash_code` symbol in jira-client:
+- [x] No `bash_code`/`classify_bash_code` symbol in jira-client:
       `grep -rn "bash_code\|classify_bash_code" cli/jira-client/src` returns
       nothing
-- [ ] No 11–36 literal in the classification files:
+- [x] No 11–36 literal in the classification files:
       inspection of `cli/jira-client/src/classify.rs` and `failure.rs`
-- [ ] No bash vocabulary in jira-client src, Cargo.toml, the swept jira tests,
+- [x] No bash vocabulary in jira-client src, Cargo.toml, the swept jira tests,
       or the jira-cli exit-code source and parity suite:
       `grep -rin bash cli/jira-client/src cli/jira-client/Cargo.toml cli/jira-client/tests/classify.rs cli/jira-client/tests/discriminant.rs cli/jira-client/tests/timeouts.rs cli/jira-client/tests/transport.rs cli/jira-cli/src/exit_codes.rs cli/jira-cli/tests/exit_codes_parity.rs cli/jira-cli/tests/fixtures/captured-exit-codes.txt`
       returns nothing (the renamed capture script is not in this list; its
@@ -477,9 +477,9 @@ mod tests {
 
 #### Manual Verification
 
-- [ ] `git`/`jj` shows the fixture rename as a rename, not a delete-plus-add,
+- [x] `git`/`jj` shows the fixture rename as a rename, not a delete-plus-add,
       and the fixture content (the `NAME=INT` rows) is byte-identical
-- [ ] The jira-cli `for_failure`/`for_surface`/`for_client` matches remain
+- [x] The jira-cli `for_failure`/`for_surface`/`for_client` matches remain
       exhaustive with no wildcard
 
 ---

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -821,30 +821,30 @@ doc prose to describe the Rust render abort.
 
 #### Automated Verification
 
-- [ ] Format, lint, and type-check clean: `mise run cli:check`
-- [ ] The whole jira-client and jira-cli suites pass (not just the ADF tests —
+- [x] Format, lint, and type-check clean: `mise run cli:check`
+- [x] The whole jira-client and jira-cli suites pass (not just the ADF tests —
       this catches the re-homed call sites and any stale consumer, since the
       crates are not surface-pinned):
       `cargo test -p jira-client` and `cargo test -p jira-cli`
-- [ ] The `for_adf` unit test passes:
+- [x] The `for_adf` unit test passes:
       `cargo test -p jira-cli exit_codes`
-- [ ] No `code()` method on `AdfError` and no residual caller:
+- [x] No `code()` method on `AdfError` and no residual caller:
       `grep -rn "fn code" cli/jira-client/src/adf/mod.rs` returns nothing, and
       `grep -rn "\.code()" cli/jira-client/tests` returns nothing
-- [ ] No `bash` in the ADF render-abort fixtures:
+- [x] No `bash` in the ADF render-abort fixtures:
       `grep -rin bash cli/jira-client/tests/fixtures/adf/render-abort-*/expected-error.txt`
       returns nothing
 
 #### Manual Verification
 
-- [ ] `for_adf` produces 40/41/42 for the same variants the removed `code()`
+- [x] `for_adf` produces 40/41/42 for the same variants the removed `code()`
       did, confirmed against the ADF exit codes in `jira-cli/src/exit_codes.rs`
-- [ ] The 40/41/42 contract stays guarded from two independent directions:
+- [x] The 40/41/42 contract stays guarded from two independent directions:
       production `for_adf` by its unit test (change 2) plus `exit_codes_parity`,
       and the crate-vs-oracle render parity by `adf_differential` via the
       test-local `expected_adf_exit` — so neither can drift silently even though
       the two are not cross-checked against each other directly
-- [ ] `for_adf` and the test-local `expected_adf_exit` stay coherent through their
+- [x] `for_adf` and the test-local `expected_adf_exit` stay coherent through their
       shared anchoring to the frozen ADF exit codes (symmetric to the linear
       taxonomy coherence check in Phase 3)
 

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -5,7 +5,7 @@ title: "Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And
 date: "2026-09-06T15:33:26+00:00"
 author: "Toby Clemson"
 producer: "create-plan"
-status: "ready"
+status: "done"
 work_item_id: "work-item:0269"
 parent: "work-item:0269"
 derived_from: ["codebase-research:2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"]

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -222,16 +222,16 @@ a description of the projected shape.
 
 #### Automated Verification
 
-- [ ] Both crates format clean and lint clean: `mise run cli:check`
-- [ ] No bash vocabulary in the Phase 1 files:
+- [x] Both crates format clean and lint clean: `mise run cli:check`
+- [x] No bash vocabulary in the Phase 1 files:
       `grep -rin bash cli/jira-client/src/cache.rs cli/jira-client/src/read.rs cli/jira-client/src/custom_fields.rs cli/jira-client/src/principal.rs cli/linear-client/src/client.rs cli/linear-client/src/transport.rs cli/linear-client/src/filter.rs cli/jira-client/Cargo.toml cli/linear-client/Cargo.toml`
       returns nothing
-- [ ] Full client test suites pass unchanged:
+- [x] Full client test suites pass unchanged:
       `cargo test -p jira-client -p linear-client` (run from `cli/`)
 
 #### Manual Verification
 
-- [ ] Each reworded comment still names the invariant or wire contract it
+- [x] Each reworded comment still names the invariant or wire contract it
       documented; none is now a what-comment describing the code
 
 ---

--- a/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -686,26 +686,26 @@ Same treatment as Phase 2 change 7.
 
 #### Automated Verification
 
-- [ ] Format, lint, and type-check clean: `mise run cli:check`
-- [ ] Linear classify + discriminant + transport suites pass:
+- [x] Format, lint, and type-check clean: `mise run cli:check`
+- [x] Linear classify + discriminant + transport suites pass:
       `cargo test -p linear-client` (run from `cli/`)
-- [ ] The linear-cli parity and map-unit suites pass:
+- [x] The linear-cli parity and map-unit suites pass:
       `cargo test -p linear-cli --test exit_codes_parity` and
       `cargo test -p linear-cli exit_codes::tests`
-- [ ] Every linear-cli test target still compiles (catches a stale consumer of a
+- [x] Every linear-cli test target still compiles (catches a stale consumer of a
       removed symbol; the crate is not surface-pinned):
       `cargo test -p linear-cli --all-targets --no-run`
-- [ ] Behavioural routing unchanged:
+- [x] Behavioural routing unchanged:
       `cargo test -p linear-cli --features test-loopback --test flow_errors`
       (the code-34 create/update divergence is a retry-class 70/71 distinction
       collapsed only in `work-cli`; `linear-cli` emits 34 for both operations, so
       the divergence is pinned by the `classify` `TABLE`, not by `flow_errors`)
-- [ ] No `bash_code`/`classify_bash_code` symbol in linear-client:
+- [x] No `bash_code`/`classify_bash_code` symbol in linear-client:
       `grep -rn "bash_code\|classify_bash_code" cli/linear-client/src` returns
       nothing
-- [ ] No 11–36 literal in the classification files: inspection of
+- [x] No 11–36 literal in the classification files: inspection of
       `cli/linear-client/src/classify.rs` and `failure.rs`
-- [ ] No bash vocabulary in linear-client src, Cargo.toml, swept tests, or the
+- [x] No bash vocabulary in linear-client src, Cargo.toml, swept tests, or the
       linear-cli exit-code source and parity suite:
       `grep -rin bash cli/linear-client/src cli/linear-client/Cargo.toml cli/linear-client/tests/classify.rs cli/linear-client/tests/discriminant.rs cli/linear-client/tests/transport.rs cli/linear-cli/src/exit_codes.rs cli/linear-cli/tests/exit_codes_parity.rs cli/linear-cli/tests/fixtures/captured-exit-codes.txt`
       returns nothing (the renamed capture script is not in this list; its
@@ -713,15 +713,15 @@ Same treatment as Phase 2 change 7.
 
 #### Manual Verification
 
-- [ ] The re-expressed `classify` reproduces the code-34 divergence
+- [x] The re-expressed `classify` reproduces the code-34 divergence
       (retryable-create / terminal-update) and the `{11,35,36}`-retryable-on-both
       verdicts, cross-checked against `bridge-exit-code-tables.txt` linear rows
-- [ ] The two crate-split views of the taxonomy stay coherent: the set of
+- [x] The two crate-split views of the taxonomy stay coherent: the set of
       outcomes `linear-cli::exit_code_for_outcome` maps to `BAD_REQUEST` (34) is
       exactly the set whose `linear-client::classify` verdict flips between
       `Create` and `Update`. These now live in different crates as independent
       matches; confirm no future regroup on one side desyncs from the other
-- [ ] The fixture rename is a rename with byte-identical content
+- [x] The fixture rename is a rename with byte-identical content
 
 ---
 

--- a/meta/prs/105-description.md
+++ b/meta/prs/105-description.md
@@ -1,0 +1,110 @@
+---
+type: "pr-description"
+id: "105"
+title: "[0269] Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients"
+date: "2026-09-06T23:16:27+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0269"
+parent: "work-item:0269"
+relates_to: ["work-item:0264", "work-item:0271", "work-item:0273"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/105"
+pr_number: 105
+tags: ["jira", "linear", "cleanup", "refactor", "exit-codes", "classification"]
+revision: "e8346fad6db334d44a2a8d64fc85734008ec175a"
+repository: "accelerator"
+last_updated: "2026-09-06T23:16:27+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0269] Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients
+
+## Summary
+
+Strips every residual "bash" reference from the `jira-client` and
+`linear-client` crates and moves the granular exit-code map from the client
+crates to the CLI boundary. The client crates keep returning context-carrying
+failures (`JiraFailure`/`LinearFailure`, each holding `{ outcome, operation,
+detail }`); the numeric `outcome → u8` map now lives in `jira-cli`/`linear-cli`;
+and the retry-class collapse to `TrackerError` stays in the client crates,
+re-expressed directly on `(Outcome, Operation)` with no `u16` intermediary and
+no numeric code embedded in a `detail` string. Every emitted exit-code value is
+preserved exactly — the parity fixtures are the frozen oracle.
+
+## Changes
+
+- **Redesigned `classify` in both client crates.** `bash_code`,
+  `classify_bash_code`, and `build` are deleted; `classify` computes the
+  retry class directly from `(Outcome, Operation)` over an exhaustive `match`,
+  and the `detail` no longer embeds a numeric code. Linear's re-expression
+  reproduces the code-34 create/update divergence and drops the dead
+  `18|23|25|27|29|110..=114` arms.
+- **Moved the granular map to the CLI boundary.** `jira-cli` and `linear-cli`
+  each gain `exit_code_for_outcome(Outcome) -> u8` over their named constants,
+  with `exit_code_for_status` wrapping it; the mapping matches stay exhaustive
+  with no wildcard (bar the deliberate jira `Status(_) => SERVER_ERROR`).
+- **Removed `AdfError::code() -> u16`.** The 40/41/42 variant→constant mapping
+  is inlined into `jira-cli`'s `for_adf`, now a `const fn`; test call sites are
+  re-homed, including a test-local `expected_adf_exit` in `adf_differential`.
+- **Reworded bash-era doc vocabulary** across the non-classification production
+  files of both crates, and swept the test vocabulary, the ADF render-abort
+  fixtures, and the CLI exit-code module docs.
+- **Renamed the parity fixtures** `bash-exit-codes.txt → captured-exit-codes.txt`
+  (and their capture scripts) as renames, with every `NAME=INT` row
+  byte-identical.
+- **New unit coverage** for the relocated maps: per-variant `Outcome → code`
+  tests in each CLI, a `for_adf` variant test, and a `linear-cli` structural
+  test that the map never yields a Jira-only code `{12,13,14,15,17,19}`.
+
+## Context
+
+- Work item: `meta/work/0269-remove-bash-references-from-jira-linear-clients.md`
+- Plan: `meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md`
+- Research: `meta/research/codebase/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md`
+- Validation: `meta/validations/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-validation.md`
+
+The split is intentionally asymmetric: the granular numeric map leaves the
+client crates, but the retry-class `classify` and the `From<Failure> for
+TrackerError` collapse **stay** inside them. Relocating that collapse is item
+0271's job; extracting a tracker-adapter crate is 0273's. This item leaves the
+collapse in place, re-expressed on `(Outcome, Operation)`.
+
+## Testing
+
+- [x] CI read-only gate green: `mise run cli:check` exits 0.
+- [x] Client suites pass: `classify`, `discriminant`, `timeouts`, `transport`
+      (both crates).
+- [x] CLI suites pass: `exit_codes_parity` and `exit_codes::tests` (both CLIs),
+      proving no emitted exit-code value changed.
+- [x] End-to-end routing unchanged: `flow_errors` under `--features
+      test-loopback` (jira 2, linear 4).
+- [x] Vocabulary gates clean: `grep -rin bash` over both client crates' `src/`
+      and `Cargo.toml` returns nothing; no `bash_code`/`classify_bash_code`
+      symbol; no `AdfError::code`; no `11`–`36` literal in the classification
+      files.
+- [ ] `jira-client`'s live-tenant `contract.rs` tests are not run here — they
+      fail-not-skip without `ACCELERATOR_JIRA_*` credentials by design, so they
+      need a credentialled environment (or the `ACCELERATOR_TRACKER_CONTRACT`
+      gate) to exercise.
+
+## Notes for Reviewers
+
+- **Contract preserved, not changed.** This is a structural/vocabulary change;
+  the exit-code values are a frozen external contract. The parity fixtures pin
+  every value, and their `NAME=INT` rows are byte-identical across the rename.
+- **Focus on the two `classify` rewrites** (`jira-client/src/classify.rs`,
+  `linear-client/src/classify.rs`) and the linear code-34 divergence, which is a
+  retry-class distinction visible only in the `classify` `TABLE`, not in
+  `flow_errors`.
+- **One known deviation from the plan:** the CLI outcome→code unit tests are
+  fixed `assert_eq!` lists rather than in-test exhaustive matches, so a new
+  `Outcome` variant would not force a new assertion there. Low severity — the
+  production mapping matches are exhaustive with no wildcard (a new variant is a
+  build error), and the client-crate `classify` table guards do use exhaustive
+  matches. Recorded in the validation report.
+- **Rider commit:** this branch also carries `Mark work item 0240 as done` (a
+  two-line status flip on `0240-corpus-update-frontmatter-quote-roundtrip.md`),
+  unrelated to 0269. It sits at the base of the chain and was kept in this PR
+  deliberately rather than rebased out.

--- a/meta/research/codebase/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
+++ b/meta/research/codebase/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md
@@ -1,0 +1,497 @@
+---
+type: "codebase-research"
+id: "2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"
+title: "Research: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients (0269)"
+date: "2026-09-06T12:16:36+00:00"
+author: "Toby Clemson"
+producer: "research-codebase"
+status: "complete"
+work_item_id: "0269"
+parent: "work-item:0269"
+topic: "Remove bash vocabulary and redesign exit-code classification in jira-client and linear-client"
+tags: ["research", "codebase", "jira-client", "linear-client", "exit-codes", "classification", "migration"]
+revision: "f54b4ad9741185e8f39d97a3c1fb508a66a2fdd7"
+repository: "accelerator"
+last_updated: "2026-09-06T14:53:57+00:00"
+last_updated_by: "Toby Clemson"
+last_updated_note: "Added follow-up research on oracle re-keying and the semantics of codes 15/17/100-117"
+schema_version: 1
+---
+
+# Research: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients (0269)
+
+**Date**: 2026-09-06T12:16:36+00:00
+**Author**: Toby Clemson
+**Git Commit**: f54b4ad9741185e8f39d97a3c1fb508a66a2fdd7
+**Branch**: working copy (change `nzpqyrrrmuyo`, no bookmark)
+**Repository**: accelerator
+
+## Research Question
+
+For work item 0269: how do `jira-client` and `linear-client` currently encode
+exit-code classification, where does the "bash" vocabulary live, what is the
+frozen exit-code contract, and what must change to (a) strip bash vocabulary
+and (b) move the numeric exit-code mapping to the CLI boundary while returning
+context-carrying client-specific errors?
+
+## Summary
+
+The exit-code path is **two distinct layers**, and the work item's framing
+partly conflates them. Getting the plan right hinges on separating them:
+
+- 🔵 **Granular layer (codes 11–138).** The `jira-cli` / `linear-cli` binaries
+  emit these directly as the process exit code. The client crate's
+  `bash_code(outcome) -> u16` computes the granular code; the CLI narrows it
+  with `u8::try_from(...)`. This is the layer 0269 redesigns.
+- 🟣 **Dispatch layer (codes 70/71).** `TrackerError::{Retryable, Terminal}`
+  collapse to 70/71 — but that mapping lives in **`work-cli`**
+  (`for_tracker_error`), not in `jira-cli`/`linear-cli`, and the `tracker`
+  crate owns `TrackerError`. The work item correctly declares 70/71
+  out of scope, but the *collapse function that feeds it* —
+  `classify_bash_code` — lives inside the client crates and **is** in scope.
+
+The redesign therefore has to split one overloaded pair of functions. Today
+`bash_code` + `classify_bash_code` + `build` do triple duty: compute the
+granular code, decide the retry class, and format a detail string embedding the
+code. The plan must:
+
+1. Move the granular `outcome -> u16` mapping out of the client crates'
+   `classify.rs` into `cli/jira-cli/src/exit_codes.rs` and
+   `cli/linear-cli/src/exit_codes.rs` (keyed on the new error type).
+2. Re-express the `TrackerError` collapse (Retryable/Terminal) directly from
+   the outcome/operation pair, with no numeric `classify_bash_code`
+   intermediary and no numeric code embedded in the `detail` string.
+3. Rewrite the bridge-fixture oracle test, which is keyed by numeric code
+   (including codes 100–117 that no `Outcome` produces) — the single largest
+   risk in the item, addressed under Open Questions.
+
+⚠️ **The AdfError u16 removal is a third, independent sub-task.**
+`AdfError::code() -> u16` returns 40/41/42, unrelated to `classify.rs`, and
+must be removed separately with `for_adf` in `jira-cli` inspecting the variant.
+
+## Detailed Findings
+
+### The granular classification path (jira-client)
+
+`jira-client/src/classify.rs` holds two tables and a builder, all keyed by an
+`Operation` (`Create` / `Update` / `Read`) enum with `mutates()` / `name()`
+helpers (`classify.rs:10-27`). The wire `Outcome` is `Status(u16)`,
+`NonJsonBody`, or `Transport` (`classify.rs:32-40`) — essentially status-only.
+
+- **`bash_code(outcome) -> u16`** (`classify.rs:44-56`) is the granular map.
+  Literals in the 11–36 band: `400→34, 401→11, 403→12, 404→13, 410→14,
+  429→19, NonJsonBody→16, Transport→21`, catch-all `Status(_)→20`. Operation
+  is not an input here — **the outcome alone determines the granular code.**
+- **`classify(outcome, operation, detail) -> TrackerError`**
+  (`classify.rs:60-70`) computes `provably_unapplied` from the status, then
+  calls `bash_code(outcome)` and `build`.
+- **`classify_bash_code(code, operation, detail) -> TrackerError`**
+  (`classify.rs:75-88`) is the reverse table, keyed on an already-known
+  numeric code. `shared_retryable = matches!(code, 11|12|13|14|15|17|19|22|34)`
+  — broader than `bash_code`'s outputs (adds 15, 17, 22). Per-op ranges:
+  Create `100..=108`, Update `110..=117`, Read always retryable.
+- **`build(...)`** (`classify.rs:91-103`) formats `"jira {op} ({code}):
+  {detail}"` — ⚠️ this is where the numeric code is embedded in the detail
+  string — then returns `Retryable` if `provably_unapplied || !mutates()`,
+  else `Terminal`.
+
+`jira-client/src/failure.rs` is the structured error. `JiraFailure`
+(`failure.rs:24-44`) has `Wire { outcome, operation, detail }` plus
+`UnwritableIdentifier`, `UnsafeQueryId`, `ComposeRejected`, `ReadFailure`.
+✅ **It stores no `u16` and no `bash_code` field** — the code is derived on
+demand from the `Wire` variant's `outcome`. `From<JiraFailure> for
+TrackerError` (`failure.rs:60-88`) routes `Wire` into `classify(...)`; the
+other variants map straight to `Terminal`/`Retryable`.
+
+### The granular classification path (linear-client)
+
+Structurally parallel to jira-client, with the differences driven by Linear
+reporting failures in the response body (`errors[]` on a 200) and rate-limiting
+as HTTP 400.
+
+- **`classify_errors(body) -> GraphQlError`** (`classify.rs:53-92`) is an
+  order-dependent cascade (auth → complexity → rate-limited → bad-request);
+  the ordering is documented as load-bearing (`classify.rs:37-38`).
+- **`Outcome`** (`classify.rs:103-119`) embeds a parsed `GraphQlError`:
+  `SuccessWithErrors`, `NonJsonBody`, `Unauthorised`, `BadRequest`,
+  `ServerError`, `Transport`, `Unexpected`.
+- **`bash_code(outcome) -> u16`** (`classify.rs:122-139`). Literals in 11–36:
+  `Auth→11, Complexity→36, RateLimited(400)→35, BadRequest→34,
+  NonJsonBody→16, Transport→21, ServerError|Unexpected→20`. Linear emits none
+  of 12/13/14/19 (no 403/404/410/429).
+- **`classify_bash_code`** (`classify.rs:162-184`) hard-codes two divergent
+  per-op sets rather than sharing one — Create `11|22|34|35|36`, Update
+  `11|18|22|23|25|27|29|35|36` plus `110..=114`. ⚠️ The doc comment
+  (`classify.rs:141-148`) flags that `34` is retryable-on-create /
+  terminal-on-update and `18/23/25/27/29` "run the other way with no rationale
+  anywhere". The `format!("linear {} ({code}): {detail}", ...)` embed is at
+  `classify.rs:178`.
+
+`LinearFailure` (`failure.rs:18-31`) is `Wire { outcome, operation, detail }`
+plus `UnwritableIdentifier` — again ✅ no `u16` / `bash_code` field.
+`linear-client/src/error.rs` holds `ClientError` (`error.rs:12-41`), the
+*pre-classification* taxonomy (transport/TLS/config/token) using symbolic
+`E_*` tokens, no numeric codes; it is what `transport.rs` returns.
+
+### The CLI boundary today
+
+Neither CLI is a blind `u16` pass-through. Both mostly **inspect the structured
+error** via exhaustive matches, mapping each variant to a named `u8` constant.
+The only genuine pass-through is the *wire* path, which calls the client's
+`bash_code` and narrows it.
+
+- `cli/jira-cli/src/exit_codes.rs`: `for_failure(&JiraFailure)`
+  (`exit_codes.rs:142`) sends `Wire` to `code_for_outcome` (`:225`, which does
+  `u8::try_from(bash_code(outcome))`), and maps the other variants to named
+  constants directly. `for_surface`, `for_client`, `for_cache`, `for_adf`
+  similarly inspect variants. `bash_code` is imported at `:134`, called at
+  `:226` and `:230`.
+- `cli/linear-cli/src/exit_codes.rs`: mirror shape — `for_failure`
+  (`exit_codes.rs:119`), `code_for_outcome` (`:172`), `bash_code` imported at
+  `:104`, called at `:174`; `for_surface` re-derives an `Outcome` via
+  `classify_errors` (`:136`, `:181`).
+
+✅ **`classify_bash_code` is NOT consumed by either CLI binary.** Its only
+callers are `linear_client::classify::classify` (`classify.rs:155`) and the
+client crates' own `tests/classify.rs` bridge-oracle tests. This matters: the
+work item lists "cross-crate consumers" of `classify_bash_code`, but the real
+consumers are internal (the `From<Failure> for TrackerError` path) and the
+oracle tests — not `jira-cli`/`linear-cli`.
+
+### The frozen contract oracle
+
+`cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt` records, per
+`(code, provider, operation)` triple, whether the failure is `retryable`
+(dispatch 70) or `terminal` (dispatch 71). It is grouped by provider then
+operation (Jira create/update, Linear create/update). The granular
+*condition* meanings are NOT in the fixture — only the class; the condition
+map lives in the `bash_code` functions above.
+
+The fixture drives three suites plus a self-test:
+
+- `cli/jira-client/tests/classify.rs:190-223` — asserts a **hard-coded 43-row
+  count** and that `is_retryable(classify_bash_code(code, op, "d"))` matches
+  each row.
+- `cli/linear-client/tests/classify.rs:261-322` — **hard-coded 31-row count**,
+  plus explicit divergence assertions.
+- `cli/tracker-support/tests/mapper_differential_self_test.rs` +
+  `tests/support/mod.rs` — proves the comparison machinery can actually fail
+  (`RETRYABLE_STATUS=70`, `TERMINAL_STATUS=71`).
+
+⚠️ The fixture is keyed by numeric code and includes codes **100–117** (pre/
+post-send) that **no `Outcome` maps to** — they are inputs the binary generates
+elsewhere. Removing `classify_bash_code` (which currently accepts those codes)
+forces a rethink of how these oracle tests express their assertions without a
+numeric key.
+
+### The dispatch layer (out of scope, but adjacent)
+
+`cli/tracker/src/lib.rs:144-179` defines `TrackerError` as a closed
+two-variant enum (`Retryable { detail }`, `Terminal { detail }`).
+`cli/work-cli/src/exit_codes.rs:60-72` maps them to 70/71 via
+`for_tracker_error`. The oracle for that collapse is
+`cli/tracker/tests/errors.rs`. The client crates reach `TrackerError` through
+`From<Failure> for TrackerError` → `classify` → `classify_bash_code` →
+`build`. Severing the numeric intermediary means this `From` impl must build
+`Retryable`/`Terminal` straight from outcome + operation.
+
+### The `transport.rs` retry predicates (must stay untouched)
+
+Confirmed genuine HTTP-retry domain terms, separate from exit-code
+classification:
+
+- jira: `is_retryable_status(status) -> bool` = `429 || 500..600`
+  (`transport.rs:292-294`), called only in the retry loop (`:207`). ✅ No
+  "bash" vocabulary in the file.
+- linear: `retryable(status, body) -> bool` (`transport.rs:229-240`) = 5xx, or
+  400 whose body classifies `RATELIMITED`. ⚠️ One "bash" mention at
+  `transport.rs:44` (doc: "which is bash code 16") — that comment is in scope
+  for the reword even though the predicate itself is not.
+
+### Bash vocabulary inventory
+
+Production `src/` and `Cargo.toml` (the AC-critical set — must reach zero):
+
+| Crate | File | Lines with "bash" |
+|-------|------|-------------------|
+| jira-client | `classify.rs` | 45, 70, 76 (symbol names) |
+| jira-client | `failure.rs` | 4, 5, 25 (doc) |
+| jira-client | `read.rs` | 4, 8, 38 (doc) |
+| jira-client | `cache.rs` | 35, 142, 162, 170 |
+| jira-client | `custom_fields.rs` | 141 |
+| jira-client | `principal.rs` | 44 |
+| jira-client | `Cargo.toml` | 28 |
+| linear-client | `classify.rs` | 102, 121, 123, 155, 163 |
+| linear-client | `failure.rs` | 4, 5, 20 |
+| linear-client | `transport.rs` | 44 |
+| linear-client | `client.rs` | 64, 95, 116, 238, 367, 427, 568 |
+| linear-client | `filter.rs` | 60 |
+| linear-client | `Cargo.toml` | 24 |
+
+⚠️ The item's "Production files to touch" list omits several confirmed hits:
+jira-client `cache.rs` (4 lines) and `custom_fields.rs`/`principal.rs`;
+linear-client `client.rs` (7 lines) and `filter.rs`. Any of these left
+unedited fails the `grep -i bash` acceptance criterion.
+
+Exit-code-related tests and fixtures carrying "bash" (in scope per the item):
+
+- `cli/jira-client/tests/classify.rs:8,99,101,132,137,203,205,218` and
+  `tests/discriminant.rs:2,11,89,130,146`, `tests/timeouts.rs:75` ("bash code
+  21"), `tests/transport.rs:134`.
+- `cli/linear-client/tests/classify.rs:9,121,274,276,288,293,301,305,311,316`
+  and `tests/discriminant.rs:2,11,39,78`, `tests/transport.rs:335`.
+- CLI parity: `cli/jira-cli/tests/exit_codes_parity.rs` and
+  `cli/linear-cli/tests/exit_codes_parity.rs` use `bash_codes()` helper (`:36`)
+  and read `tests/fixtures/bash-exit-codes.txt`.
+- jira-only fixtures: `cli/jira-cli/tests/fixtures/bash-exit-codes.txt`,
+  `capture-bash-exit-codes.sh`, and `jira-client` `render-abort-*/
+  expected-error.txt` files (each has `bash_exit=`).
+
+⚠️ Some "bash" hits are legitimate and out of scope: genuine shell scripts
+(`capture-adf-oracle.sh`), and ADF-fidelity fixtures unrelated to exit codes.
+The AC permits these if they carry an inline justification comment.
+
+## Code References
+
+- `cli/jira-client/src/classify.rs:44-103` - `bash_code`, `classify`,
+  `classify_bash_code`, `build`
+- `cli/jira-client/src/failure.rs:24-88` - `JiraFailure` + `From` for
+  `TrackerError`
+- `cli/jira-client/src/adf/mod.rs:38-49` - `AdfError::code() -> u16` (40/41/42)
+- `cli/jira-client/src/transport.rs:292-294` - `is_retryable_status` (untouched)
+- `cli/linear-client/src/classify.rs:122-184` - `bash_code`,
+  `classify_bash_code` with documented create/update divergence
+- `cli/linear-client/src/failure.rs:18-66` - `LinearFailure` + `From`
+- `cli/linear-client/src/error.rs:12-41` - `ClientError` (pre-classification)
+- `cli/linear-client/src/transport.rs:229-240` - `retryable` (untouched)
+- `cli/jira-cli/src/exit_codes.rs:142-230` - variant-inspecting mappers +
+  `code_for_outcome`/`code_for_status`
+- `cli/linear-cli/src/exit_codes.rs:110-186` - mirror mappers
+- `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt` - the oracle
+- `cli/jira-client/tests/classify.rs:190-223` - 43-row oracle guard
+- `cli/linear-client/tests/classify.rs:261-322` - 31-row oracle guard
+- `cli/tracker/src/lib.rs:144-179` - `TrackerError` (out of scope)
+- `cli/work-cli/src/exit_codes.rs:60-72` - `for_tracker_error` → 70/71 (out of
+  scope)
+- `cli/jira-cli/tests/exit_codes_parity.rs` / `cli/linear-cli/tests/exit_codes_parity.rs`
+  - constant-vs-fixture parity, with `exit_codes_never_parses_a_tracker_error_detail`
+  grep guard (jira `:133`)
+- `cli/jira-cli/tests/flow_errors.rs` / `cli/linear-cli/tests/flow_errors.rs`
+  - behavioural exit-code routing (feature `test-loopback`)
+
+## Architecture Insights
+
+- **The structured error already carries the context the item wants.** Both
+  `Wire { outcome, operation, detail }` variants hold outcome + operation and
+  store no numeric code. The redesign is less "add context" and more "stop
+  computing the number inside the crate" — move the `outcome -> u16` table to
+  the CLI, and stop embedding `({code})` in `detail`.
+- **`bash_code` and `classify_bash_code` are two different functions, differently
+  coupled.** `bash_code` (granular map) is consumed by the CLI and moves to the
+  CLI. `classify_bash_code` (retry-class map) is internal + oracle-only and its
+  logic must be re-expressed on outcome/operation. Conflating them will produce
+  a wrong plan.
+- **Outcome alone determines the granular code** in both crates (operation is
+  not a `bash_code` input). The AC's phrase "outcome/operation pair must
+  distinguish every exit code 11–36" is satisfied by outcome alone for the
+  granular band; operation only distinguishes the *retry class* and the
+  100–117 pre/post-send band.
+- **Two oracles, two fixtures, do not confuse them.** `exit_codes_parity`
+  reads `bash-exit-codes.txt` (constant-name → value, per CLI). The
+  `classify.rs` tests read `bridge-exit-code-tables.txt` (code → retry class).
+  Only the latter feeds `classify_bash_code`.
+- **The parity suite already forbids detail-string parsing.**
+  `exit_codes_never_parses_a_tracker_error_detail` (jira
+  `exit_codes_parity.rs:133`) greps `src/exit_codes.rs` for `TrackerError` /
+  `.detail` — the codebase already enforces "read from the discriminant, not
+  the string", which is the direction 0269 pushes further.
+
+## Historical Context
+
+- `meta/work/0136-migrate-shell-scripts-to-rust-cli.md` - parent epic; the
+  bash vocabulary is its vestige.
+- `meta/work/0264-remove-bash-migration-negative-assertion-tests.md` -
+  CLI-wide sibling cleanup, confirmed distinct (does not absorb 0269).
+- `meta/work/0271-unify-surface-remotetracker-client-interfaces.md`,
+  `meta/work/0273-domain-crate-for-linear-jira-subcommands.md` - both blocked
+  by 0269; they reshape the same `classify`/`failure`/`client` files.
+- `meta/notes/2026-06-23-further-ideas-backlog.md` - source note for the
+  026x/027x cluster.
+- `meta/plans/2026-08-17-0210-provider-client-crates-over-the-tracker-port.md`
+  and `meta/research/codebase/2026-08-17-0210-provider-client-crates-over-the-tracker-port.md`
+  - where `jira-client`/`linear-client` originate.
+- `meta/plans/2026-08-21-0190-classify-lock-mkdir-failures.md` and its research
+  - closest prior art for exit-condition classification design.
+- `meta/plans/2026-08-19-0211-integration-binaries-and-bash-cluster-retirement.md`
+  - the bash-cluster retirement precedent.
+- `meta/decisions/ADR-0053-thin-cli-over-a-hexagonal-ports-and-adapters-core.md`
+  and `ADR-0058-shell-free-cli-to-node-delegation.md` - the architecture the
+  clients sit in; nearest anchors (no ADR is dedicated to exit codes).
+
+## Related Research
+
+- `meta/research/codebase/2026-08-17-0210-provider-client-crates-over-the-tracker-port.md`
+- `meta/research/codebase/2026-08-21-0190-acquire-lock-mkdir-classification.md`
+- `meta/research/codebase/2026-08-17-0211-integration-binaries-and-bash-cluster-retirement.md`
+- `meta/research/codebase/2026-06-28-0136-rust-cli-migration-scope-and-architecture.md`
+
+## Open Questions
+
+- ❓ **How should the bridge-fixture oracle be re-keyed?** It currently keys on
+  numeric codes (including 100–117 that no `Outcome` produces) and calls
+  `classify_bash_code`. If that function is removed, either the oracle test is
+  rewritten to feed outcome/operation pairs (losing coverage of the 100–117
+  band, which has no outcome) or a translation is kept for tests only. This is
+  the largest design decision the plan must resolve. Whichever way, the 43-row
+  and 31-row count guards must be reconciled with the new keying.
+- ❓ **Where do codes 15, 17 (jira) and the 100–117 pre/post-send bands come
+  from after the redesign?** No `Outcome` maps to 15/17; they live only in the
+  jira `shared_retryable` set and the fixture. Their original semantics sit in
+  retired bash sources / an `EXIT_CODES.md` not found under
+  `workspaces/build-system`. The plan needs a source of truth for these before
+  it can move their retry-class logic.
+- ❓ **Does the `From<Failure> for TrackerError` collapse stay in the client
+  crate or move?** The work item says client crates "return client-specific
+  error types"; the CLI then derives exit codes. But `work-cli` still needs
+  `TrackerError` for 70/71. Cleanest: keep `From<Failure> for TrackerError` but
+  re-express it on outcome/operation, with the granular `u16` mapping gone from
+  the crate. Confirm this is the intended shape.
+- ❓ **Naming for the replacement of `bash_code`.** The granular map moves to
+  the CLI; what domain name replaces it (e.g. `exit_code_for_outcome`)? The
+  item mandates no residual "bash" but does not name the successor.
+
+## Follow-up Research 2026-09-06T14:53:57+00:00
+
+Two questions from the first pass, now resolved with evidence: how the
+bridge-fixture oracle should be re-keyed once `classify_bash_code` is deleted,
+and what codes 15/17/22/100–117 mean and where they live.
+
+### The oracle is two oracles wearing one function
+
+`classify_bash_code` is asked to do two unrelated jobs, and the fixture rows
+split cleanly along that seam:
+
+- 🟢 **Live retry-class of a wire outcome.** For the codes a real `Outcome`
+  produces, the fixture pins the Retryable/Terminal verdict of the live path.
+- ⚪ **Transcription of the retired bash mappers.** For codes no `Outcome` can
+  produce, the fixture pins how the *deleted* bash `_wicr_map_*` / `_wiur_map_*`
+  functions classified them — pure historical fidelity, no live code path.
+
+The reachability boundary is exact. `bash_code` emits only
+`{11,12,13,14,16,19,20,21,34}` (jira, `jira-client/src/classify.rs:45-57`) and
+`{11,16,20,21,34,35,36}` (linear, `linear-client/src/classify.rs:123-139`).
+Every other fixture code reaches `classify_bash_code` **only from a test**:
+
+| Code(s) | Reachable from an `Outcome`? | What it actually is |
+|---------|------------------------------|---------------------|
+| 11,12,13,14,16,19,20,21,34 (jira) | Yes — live wire path | Status/transport codes |
+| 11,16,20,21,34,35,36 (linear) | Yes — live wire path | Body-classified codes |
+| 15,17,22 (jira) | No | `BAD_SITE`, `REQ_BAD_PATH`, `REQ_NO_CREDS` — CLI client/cred errors |
+| 100–108,109,110–117 (jira) | No | `CREATE_*`/`RESOLVE_*`/`UPDATE_*` argv validation |
+| 18,22,23,25,27,29 (linear) | No | test-hook / cred codes, some with no linear taxonomy entry |
+| 110–114 (linear) | No | `UPDATE_*` argv validation |
+
+⚠️ The runtime routing differs per crate, which sharpens the point:
+
+- jira's `classify` calls `build` directly (`classify.rs:70`), never
+  `classify_bash_code`. So jira's `classify_bash_code` is **entirely
+  test-only** — its sole callers are `jira-client/tests/classify.rs:203,218`.
+- linear's `classify` calls `classify_bash_code(bash_code(outcome), …)`
+  (`classify.rs:155`), so it is reached at runtime — but only ever with the
+  seven codes `bash_code` emits. The `18|23|25|27|29` and `110..=114` arms
+  (`classify.rs:171-175`) are dead at runtime.
+
+✅ Confirmed by grep: the only non-test caller of `classify_bash_code` anywhere
+is `linear-client/src/classify.rs:155`. The only callers of `bash_code` are the
+two `classify` functions and the four CLI `code_for_outcome`/`code_for_status`
+helpers — all fed exclusively from an `Outcome`.
+
+### Where the non-wire codes actually come from
+
+The non-wire codes are emitted **directly by the CLI**, never through
+classification:
+
+- 15/17/22 (jira) come from `for_client` / `for_credential` inspecting
+  `ClientError` / `CredentialError` variants (`jira-cli/src/exit_codes.rs:173-207`).
+- 100–117 come from argv validation in `main.rs` as `ExitCode::from(...)` —
+  e.g. `CREATE_NO_SUMMARY` (102) at `jira-cli/src/main.rs:222-223`, `UPDATE_NO_OPS`
+  (112) at `:357-358`, `RESOLVE_ALREADY_SYNCED` (109) at `:965-968`.
+
+The naming source of record is the two `exit_codes.rs` module docs plus
+`cli/{jira,linear}-cli/tests/fixtures/bash-exit-codes.txt`, both citing the
+retired cluster's `EXIT_CODES.md` (`jira-cli/src/exit_codes.rs:1-9`,
+`linear-cli/src/exit_codes.rs:1-9`). `EXIT_CODES.md` itself is gone with the
+bash cluster; nothing under `workspaces/build-system` still holds it.
+
+⚠️ Linear codes **18 and 23 have no entry in `linear-cli/src/exit_codes.rs`**
+at all (linear defines 11,16,20,21,22,24,25,27,29,34,35,36,53). In jira they
+are `TEST_OVERRIDE_REJECTED` (18) and `TEST_HOOK_REJECTED` (23) — bash-cluster-
+wide test-hook codes. Their presence in the linear fixture is a transcription
+of the bash mapper's case arm, not a live linear condition. These are exactly
+the kind of test-hook vestige work item 0264 targets.
+
+### Blast radius: three independent fixture parsers, only two affected
+
+The fixture `bridge-exit-code-tables.txt` is parsed by three independent
+readers:
+
+- `jira-client/tests/classify.rs:160-223` — its own `fixture_rows()` →
+  `classify_bash_code`. **Affected.**
+- `linear-client/tests/classify.rs:231-322` — its own `fixture_rows()` →
+  `classify_bash_code`. **Affected.**
+- `cli/tracker-support/tests/support/mod.rs` + `mapper_differential_self_test.rs`
+  — re-implements the classification rule ("listed code → its class, unlisted →
+  terminal") independently; does **not** call `classify_bash_code`. ✅
+  Unaffected by the redesign.
+
+So deleting `classify_bash_code` breaks exactly the two client-crate
+`classify.rs` suites. The tracker-support self-test that proves the comparison
+machinery can fail is self-contained and survives.
+
+Note also the jira suite already carries the live-path oracle keyed on
+`Outcome`: `STATUS_TABLE` (`jira-client/tests/classify.rs:25-129`) asserts
+`bash_code(outcome) == code` and the retry class via `classify(outcome,
+operation)` for every outcome-reachable code. **Linear has no equivalent
+outcome-keyed table** — its only outcome→class assertions today run through
+`classify_bash_code(bash_code(outcome))`.
+
+### Re-keying options (recommendation first)
+
+🔵 **Option A — split by reachability (recommended).** Re-key the live rows to
+`(Outcome, Operation)` and assert them through the retained `From<Failure> for
+TrackerError` collapse plus the new CLI mapping; build linear an outcome-keyed
+table mirroring jira's `STATUS_TABLE`. Drop the transcription-only rows
+(15/17/22/100–117 jira; 18/22/23/25/27/29/110–114 linear) and the fixture rows
+that back them, since the bash mappers they transcribe are being retired
+(0136/0211) and the test-hook codes fall to 0264. The 43-row and 31-row count
+guards drop to the outcome-reachable counts. Cleanest and aligned with the
+epic; loses the retired-mapper fidelity guard, which no longer guards live code.
+
+🟣 **Option B — keep the fixture as documentation.** Retain
+`bridge-exit-code-tables.txt` as a record of the retired mappers but stop
+asserting against it from the client crates once `classify_bash_code` is gone;
+move all live retry-class assertions to outcome-keyed tables. Preserves the
+historical artefact without a dead public function.
+
+🟠 **Option C — test-only numeric shim.** Move the numeric-code classification
+into a private helper inside each test module so the transcription oracle
+survives without the crate's public API carrying bash vocabulary. Preserves
+fidelity but keeps a numeric-keyed classifier alive in the test tree, arguably
+against the spirit of 0264.
+
+The decision is the author's, but the reachability analysis removes the risk
+the first pass flagged: the transcription-only rows guard no live behaviour, so
+dropping them (Option A) costs no runtime coverage. The live retry-class
+verdicts remain fully pinned by outcome-keyed tables and the CLI parity suite.
+
+### Answers to the two prior open questions
+
+- **Oracle re-keying:** re-key live rows on `(Outcome, Operation)`; the
+  transcription-only rows have no `Outcome` and no live path, so they are
+  dropped (or demoted to documentation), not translated. Only two test suites
+  are affected; the tracker-support self-test is independent.
+- **Codes 15/17/22/100–117:** all are CLI-emitted (client/credential errors and
+  argv validation), fully named in the two `exit_codes.rs` documents of record
+  and `bash-exit-codes.txt`; none is produced by any `Outcome`, so none needs a
+  home in the redesigned `classify.rs`. Linear 18/23 have no linear taxonomy
+  entry and are bash test-hook vestiges (0264 territory).

--- a/meta/reviews/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-review-1.md
+++ b/meta/reviews/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-review-1.md
@@ -1,0 +1,660 @@
+---
+type: "plan-review"
+id: "2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-review-1"
+title: "Plan Review: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients"
+date: "2026-09-06T16:21:14+00:00"
+author: "Toby Clemson"
+producer: "review-plan"
+status: "complete"
+target: "plan:2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["architecture", "correctness", "code-quality", "test-coverage", "compatibility", "standards"]
+review_number: 1
+review_pass: 2
+tags: ["jira", "linear", "cleanup", "refactor", "exit-codes", "classification"]
+last_updated: "2026-09-06T19:21:44+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients
+
+**Verdict:** REVISE
+
+The plan is unusually well-grounded: the correctness lens traced every reachable
+`Outcome` through both crates and confirmed the proposed match arms reproduce
+every emitted exit-code value and every retry-class verdict exactly — including
+Linear's load-bearing code-34 create/update divergence — and verified each named
+constant holds its pinned value. The core redesign (move the granular map to the
+CLI, re-express the retry collapse on `(Outcome, Operation)`, drop the numeric
+intermediary and the `({code})` detail embed) is sound and cleanly phased. It
+needs revision before implementation on five points: Phase 4 deletes
+`AdfError::code()` without accounting for its four live test consumers (a
+compile break and a dropped contract oracle); the relocated granular map is
+tested more loosely than the assertions it replaces; and the scrub, the naming,
+and the exhaustive-match discipline all stop short of what the plan claims for
+them.
+
+### Cross-Cutting Themes
+
+- **Exhaustive-match discipline is overstated and under-delivered** (flagged by:
+  architecture, correctness, code-quality, test-coverage) — the plan promises
+  "every mapping function stays an exhaustive `match` with no wildcard so a new
+  variant is a compile error." Three places break the promise: jira `classify`
+  uses a non-exhaustive `matches!` (loses the compile-time guard the current
+  code has); the jira map necessarily keeps a `Status(_)` catch-all (variant-
+  exhaustive, not wildcard-free); and exhaustiveness constrains the domain, not
+  the codomain, so the deleted "reserved codes" property is not guarded by the
+  match at all.
+- **Coverage of the relocated granular map is looser than what it replaces**
+  (flagged by: test-coverage, correctness) — the linear inline test is specced
+  as one assertion per code value, not per `GraphQlError` variant, so a variant
+  drifting between OR-pattern arms would ship silently; `SuccessWithErrors(RateLimited)`
+  (mapped to 34 by the rewrite) has no row in the retained TABLE; and dropping
+  the row-count guards removes both the completeness guard and the client
+  crates' only cross-check against the shared bridge fixture.
+- **The scrub and the rename stop at the client-crate boundary** (flagged by:
+  standards, compatibility) — the CLI `exit_codes.rs` that now *owns* the map
+  keeps "bash code" / "bash `jira-request.sh`" doc comments (verified: jira
+  lines 3, 5, 16, 26, 139, 194; linear 5, 16, 25, 173), and both CLI module docs
+  cite `tests/fixtures/bash-exit-codes.txt`, which the plan renames — leaving a
+  dangling reference. These sit outside the client-scoped grep AC, so they
+  survive silently unless deliberately in or out of scope.
+- **Naming does not finish disambiguating exit code from wire status** (flagged
+  by: code-quality, standards) — `code_for_outcome` is renamed to
+  `exit_code_for_outcome`, but the sibling `code_for_status(status: u16)` is
+  retained, needing a prose note to explain the surviving `u16`. The exact
+  ambiguity the rename targets survives in the module.
+- **Mandated justification comments conflict with the repo's comment
+  convention** (flagged by: code-quality, standards) — the shebang justification
+  comment and the "restate it as a comment" fallback both add what-comments the
+  project bans, and the shebang comment guards nothing the ACs check (the `.sh`
+  is in no grep path).
+
+### Tradeoff Analysis
+
+- **Cleanup hygiene vs regression guard**: dropping the bridge-fixture coupling
+  from the client crates is good hygiene (Option A from the research; the
+  transcription-only rows guard retired code) and correctness confirms it costs
+  no *runtime* coverage. But it also removes the only in-crate cross-check of
+  live retry verdicts against the shared contract fixture, leaving them pinned
+  only by hand-authored table columns. Recommendation: take Option A, but retain
+  one minimal assertion feeding the *reachable* `(Outcome, Operation)` rows
+  through `classify` against the fixture's live rows.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Compatibility**: Phase 4 deletes `AdfError::code()` but leaves four live
+  test consumers
+  **Location**: Phase 4, Change 1 and Success Criteria
+  `adf_differential.rs:134,138`, `adf.rs:84`, `adf_inventory.rs:173` all call
+  `error.code()` (verified). The last is the ADF exit-code differential oracle
+  against the frozen contract. The phase's "no test parses it" claim covers only
+  the fixture `bash_exit=` line, not these call sites — the change will fail to
+  compile, and deleting the assertions rather than relocating them silently
+  drops the 40/41/42 contract guard.
+
+- 🟡 **Code Quality / Standards**: retained `code_for_status` perpetuates the
+  exit-code/wire-status ambiguity the redesign targets
+  **Location**: Phase 2 Change 3, Phase 3 Change 3
+  `exit_code_for_outcome` is renamed for disambiguation, yet `code_for_status(status: u16)`
+  is kept unchanged — "code" is the returned exit code, "status" the incoming
+  wire status, the exact conflation the rename kills. That the plan needs a prose
+  note to explain the surviving `u16` signals the name isn't carrying its
+  meaning. Rename to `exit_code_for_status` or inline the one-line wrapper.
+
+- 🟡 **Code Quality / Test Coverage**: the reserved-codes guard is dropped, its
+  replacement enforces nothing
+  **Location**: Phase 3 Change 5
+  The plan replaces `linear_emits_no_403_404_410_or_429_...` with "the exhaustive
+  match enforces it" and "drop the test or restate it as a comment."
+  Exhaustiveness guarantees every variant is *handled*, not that the *codomain*
+  excludes Jira-only codes — a future arm mapping to a literal `13` stays
+  exhaustive. A comment enforces nothing and violates the comment convention.
+  Keep a small structural test asserting the Linear map never yields
+  `{12,13,14,15,17,19}`.
+
+- 🟡 **Test Coverage**: linear granular-map unit test under-specified for
+  OR-pattern groupings
+  **Location**: Phase 3 Change 4
+  "Assert every Outcome arm maps to its pinned constant (11/36/35/34/16/21/20)"
+  is seven codes, but `exit_code_for_outcome` bundles multiple `GraphQlError`
+  variants per arm. One representative per code won't catch a variant moving
+  between arms (e.g. `BadRequest(Complexity)` drifting 36→34, or
+  `BadRequest(RateLimited)` 35→34). Assert every constructible
+  `(SuccessWithErrors|BadRequest) × GraphQlError` combination, ideally via an
+  in-test exhaustive `match`.
+
+- 🟡 **Test Coverage**: the rewrite introduces an outcome the retained TABLE
+  never exercises
+  **Location**: Phase 3 Change 5 and Change 1
+  The re-expressed `classify` has arm `SuccessWithErrors(RateLimited | BadRequest)`
+  (retryable-create / terminal-update, mapped to 34), but the current linear
+  TABLE covers only `BadRequest(RateLimited)`. `SuccessWithErrors(RateLimited)`
+  is constructible (a 200 body classified rate-limited) and is asserted by
+  neither the retry-class TABLE nor the granular test. Add its row with explicit
+  create/update expectations.
+
+#### Minor
+
+- 🔵 **Architecture / Correctness**: jira `classify` trades an exhaustive `match`
+  for a non-exhaustive `matches!`
+  **Location**: Phase 2 Change 1
+  `matches!(outcome, Outcome::Status(400|401|403|404|410|429))` is behaviourally
+  identical today but non-exhaustive — a future `Outcome` variant is silently
+  terminal-for-a-mutation with no compile error, diverging from the linear
+  rewrite (which keeps a full `match`) and from the plan's own stated invariant.
+  Mirror linear: use an exhaustive `match` for `provably_unapplied`.
+
+- 🔵 **Test Coverage / Correctness**: dropping the row-count guards removes the
+  completeness guard and the shared-fixture cross-check
+  **Location**: Phase 2 Change 5, Phase 3 Change 5
+  Deleting the 43-row/31-row guards stops the client crates reading
+  `bridge-exit-code-tables.txt`, so live verdicts and the fixture can drift, and
+  no guard forces a new outcome to gain an assertion. Replace with an in-test
+  exhaustive `match` over `Outcome` plus a minimal live-row fixture cross-check.
+
+- 🔵 **Code Quality**: "no wildcard" is stated more absolutely than the jira map
+  can honour
+  **Location**: Implementation Approach, Phase 2 Change 3
+  The jira `exit_code_for_outcome` must keep a `Status(_)` catch-all (`Status(u16)`
+  can't be matched exhaustively). Reword to "exhaustive over enum variants with
+  no variant-level wildcard" and note the deliberate `Status(_)` coercion to
+  `SERVER_ERROR`.
+
+- 🔵 **Standards**: CLI-side doc comments still speak "bash"
+  **Location**: Phase 2 Change 3, Phase 3 Change 3
+  `jira-cli`/`linear-cli` `exit_codes.rs` keep "granular bash code", "bash
+  `jira-request.sh`", and module-doc bash references (verified). Outside the
+  client grep AC, so they survive silently. Reword them as part of Phases 2/3 or
+  add an explicit "NOT doing" note scoping CLI prose out.
+
+- 🔵 **Compatibility**: renamed fixture leaves a dangling reference in the CLI
+  module docs
+  **Location**: Phase 2/3 Change 7
+  Both CLI `exit_codes.rs` module docs (line 5) name
+  `tests/fixtures/bash-exit-codes.txt` as the authoritative contract; after the
+  rename they point at a nonexistent path. Update these references as part of the
+  rename.
+
+- 🔵 **Compatibility**: narrow per-phase verification can miss a stale consumer
+  of a removed public symbol
+  **Location**: Implementation Approach, Phases 2–4
+  The client crates aren't surface-pinned, so `public-api:check` won't flag the
+  removals — the sole backstop is compile-time breakage (exactly the AdfError
+  gap). Single-target test commands can pass while the crate doesn't fully
+  compile. Add `cargo test -p <crate> --no-run` (or clippy `--all-targets`) per
+  phase.
+
+- 🔵 **Test Coverage**: the divergence success criterion overstates `flow_errors`
+  coverage
+  **Location**: Phase 3 Success Criteria, Testing Strategy
+  `linear-cli` emits code 34 for both create and update; the retryable-create /
+  terminal-update divergence is a 70/71 distinction only visible in `work-cli`.
+  `flow_errors` never contrasts create vs update. Attribute the divergence
+  coverage to the retained `classify` TABLE, not `flow_errors`.
+
+- 🔵 **Architecture**: the split `Outcome` taxonomy has no coherence guard for
+  the code-34 divergence
+  **Location**: Phase 3 Changes 1 & 3
+  Retry-class grouping (client) and numeric grouping (CLI) now live in different
+  crates as independent matches; nothing asserts the set the CLI labels 34 is
+  exactly the set whose verdict flips by operation. A future regroup on one side
+  desynchronises silently. Add a cross-boundary guard tying the two views.
+
+- 🔵 **Standards / Code Quality**: mandated justification comments conflict with
+  the comment convention and guard nothing checked
+  **Location**: Phase 2 Change 7 / Change 6 (and Phase 3 equivalents)
+  The shebang justification comment is a what-comment under the repo's very-low
+  comment tolerance, and the `.sh` is in no grep AC path, so it appeases no
+  check. Drop the shebang comment; for `transport.rs` prefer the plan's own
+  "reword to drop bash" option.
+
+- 🔵 **Standards**: the divergence from the work item's file list is undocumented
+  **Location**: Phase 1
+  The work item lists `mutation.rs`, `error.rs`, `auth.rs`, `upload.rs`; the plan
+  omits them. A grep of the tree confirms none carries "bash" — so the plan is
+  correct — but the deviation is untraceable. Add a one-line note that the work
+  item's list is stale at this revision.
+
+#### Suggestions
+
+- 🔵 **Standards**: the Phase 2/3 grep-AC caveat describes a match its command
+  can't produce
+  **Location**: Phase 2 Success Criteria (and Phase 3 equivalent)
+  The parenthetical says "any residual match is the capture-script shebang", but
+  the grep argument list omits the `.sh` file. Either drop the caveat or add the
+  path — consistently across both phases.
+
+- 🔵 **Code Quality**: reworded `failure.rs` docs risk narrating cross-crate
+  behaviour
+  **Location**: Phase 2 Change 2, Phase 3 Change 2
+  The exit-code mapping now lives in the CLI crate; keep these docs on the
+  invariant the failure type itself guarantees (it carries the outcome/operation
+  discriminant so no consumer parses a detail string), and let the CLI own any
+  statement about the numeric mapping.
+
+- 🔵 **Test Coverage**: sequence the moved unit test before deleting client
+  assertions
+  **Location**: Implementation Approach, Phase 2/3 change ordering
+  State explicitly that `exit_code_for_outcome` and its inline unit test are
+  written first (green), and the client-crate `bash_code` assertions deleted only
+  after — so no interim commit leaves the granular map unasserted.
+
+- 🔵 **Architecture**: record the intentionally-retained `TrackerError` collapse
+  in Desired End State
+  **Location**: Current State Analysis / What We're NOT Doing
+  The client crate keeps a second output path (`TrackerError` for `work-cli`)
+  coupled to the `tracker` crate. State this explicitly so reviewers of 0271
+  inherit an accurate boundary map.
+
+### Strengths
+
+- ✅ Behaviour preservation is verified, not asserted: every reachable `Outcome`
+  was traced through both crates' current `classify` paths, and each proposed
+  match arm reproduces the emitted exit-code value and retry-class verdict
+  exactly, including Linear's code-34 create/update divergence and Read's
+  always-retryable path.
+- ✅ Every named constant the maps target holds its pinned numeric value
+  (verified against both `exit_codes.rs`): jira 400→34, 401→11, 403→12, 404→13,
+  410→14, 429→19, NonJsonBody→16, Transport→21, `Status(_)`→20; linear Auth→11,
+  Complexity→36, RateLimited→35, BadRequest→34, plus 16/21/20; ADF 40/41/42.
+- ✅ Moving the granular map to the CLI is a genuine separation-of-concerns win:
+  the overloaded `bash_code`/`classify_bash_code`/`build` triple is decomposed,
+  the map returns `u8` directly (dissolving the `u8::try_from(...).unwrap_or(...)`
+  narrowing), and the new mappers are pure `const fn` at the shell boundary.
+- ✅ Phased delivery is genuinely independently mergeable and green (doc-only →
+  per-crate → jira-only AdfError), with the deferred `grep -i bash = 0`
+  criterion honestly acknowledged.
+- ✅ The plan correctly distinguishes the two fixtures and two oracles: it
+  renames only the per-CLI parity fixture and deliberately leaves
+  `bridge-exit-code-tables.txt` and its independent `tracker-support` self-test
+  untouched.
+- ✅ The live retry-class oracle is explicitly retained (the outcome-keyed
+  `create_retryable`/`update_retryable` columns), and dropping the
+  transcription-only rows and dead `18|23|25|27|29|110..=114` arms is correctly
+  justified as guarding no live path.
+
+### Recommended Changes
+
+1. **Complete Phase 4's `AdfError::code()` removal** (addresses: Phase 4 deletes
+   `AdfError::code()` but leaves four live test consumers)
+   Add explicit steps to relocate the `error.code()` assertions in `adf.rs`,
+   `adf_inventory.rs`, and — critically — the `adf_differential.rs` oracle onto
+   the new `for_adf` mapping in `jira-cli` (or a variant-keyed helper), and
+   change the phase verification to full `cargo test -p jira-client -p jira-cli`.
+
+2. **Assert the relocated granular maps exhaustively** (addresses: linear
+   granular-map test under-specified; rewrite introduces an untested outcome;
+   dropping the row-count guards)
+   Specify the inline unit tests to assert every constructible `Outcome`
+   (per-variant, not per-code) via an in-test exhaustive `match`, add the
+   `SuccessWithErrors(RateLimited)` row to the retained TABLE, and retain a
+   minimal live-row cross-check against `bridge-exit-code-tables.txt`.
+
+3. **Keep the reserved-codes property as a test, not a comment** (addresses: the
+   reserved-codes guard is dropped, its replacement enforces nothing)
+   Replace, don't demote: keep a structural test that `exit_code_for_outcome`
+   over all Linear outcomes never yields `{12,13,14,15,17,19}`. Remove the
+   "restate as a comment" option.
+
+4. **Finish the naming and the scrub at the CLI boundary** (addresses:
+   `code_for_status` ambiguity; CLI-side bash prose; dangling fixture reference)
+   Rename `code_for_status` → `exit_code_for_status` (or inline it); reword the
+   CLI `exit_codes.rs` module and helper doc comments; update the module-doc
+   fixture reference to the renamed path — or add an explicit "NOT doing" note
+   scoping CLI-side prose out.
+
+5. **Tighten the exhaustive-match wording and the jira `classify` rewrite**
+   (addresses: `matches!` non-exhaustiveness; "no wildcard" overstated)
+   Use an exhaustive `match` for jira `provably_unapplied`, and reword the
+   discipline to "exhaustive over enum variants with no variant-level wildcard",
+   noting the deliberate jira `Status(_)` coercion.
+
+6. **Correct the verification and comment instructions** (addresses: per-phase
+   verification gaps; justification comments; overstated `flow_errors`; stale
+   file list; grep-AC caveat)
+   Add `--no-run`/`--all-targets` compile checks per phase; drop the shebang
+   comment; re-attribute the divergence coverage to the `classify` TABLE; note
+   the work item's stale file list; fix the grep-AC caveat.
+
+---
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: A structurally sound refactor that improves separation of concerns
+— it pulls the granular exit-code map out of the client crates (where it was a
+premature presentation concern) into each CLI boundary, leaving the clients to
+own only the retry-class domain decision. The structured errors already carried
+the needed context, so the change removes coupling rather than adding it, and the
+phased decomposition keeps each step independently mergeable. Two
+evolutionary-fitness concerns stand out: the jira `classify` rewrite silently
+drops the exhaustive-match safety net the plan promises, and the `Outcome`
+taxonomy is now split across a crate boundary with no guard keeping the two
+groupings coherent for the code-34 divergence.
+
+**Strengths**:
+- Moving the granular map to the CLI decomposes the overloaded
+  `bash_code`/`classify_bash_code`/`build` triple into a single-responsibility
+  client `classify` and a CLI-side map.
+- The new CLI mappers are pure `const fn` at the imperative-shell boundary —
+  trivially unit-testable, a clean functional-core placement.
+- Phased delivery is well-decomposed, each phase leaving `cli:check` green, with
+  the deferred grep-zero criterion honestly acknowledged.
+- Removing the `u16` intermediary, the `({code})` embed, and linear's dead arms
+  shrinks the classification surface and removes misleading coupling.
+- The external contract is protected by retaining `exit_codes_parity` and
+  `flow_errors` while dropping only transcription-only rows.
+
+**Findings**:
+- **minor / high** — jira `classify` rewrite drops the exhaustive-match safety
+  net (Phase 2 Change 1). The Implementation Approach promises exhaustive
+  no-wildcard matches, but the proposed jira `classify` uses `matches!`, which
+  has an implicit catch-all; a future `Outcome` variant is silently
+  not-provably-unapplied. Also inconsistent with the linear phase, which keeps a
+  full `match`. Use an explicit exhaustive `match`.
+- **minor / medium** — `Outcome` taxonomy split across a crate boundary with no
+  coherence guard for the code-34 divergence (Phase 3 Changes 1 & 3). Retry-class
+  grouping (client) and numeric grouping (CLI) are now two independent matches;
+  no test asserts the set the CLI labels 34 is exactly the set whose verdict
+  flips by operation. A regroup on one side desyncs silently. Add a
+  cross-boundary guard.
+- **suggestion / medium** — asymmetric split leaves retry-class domain logic in
+  the client while numeric mapping leaves (Current State / What We're NOT Doing).
+  The client retains a second output path (`TrackerError` for `work-cli`) coupled
+  to the `tracker` crate; the modularity gain is partial (deferred to 0271).
+  State this explicitly in Desired End State so 0271's reviewers inherit an
+  accurate boundary map.
+
+### Correctness
+
+**Summary**: The exit-code redesign is logically sound. Every reachable `Outcome`
+was traced through both crates' current `classify` paths and the proposed match
+arms reproduce every emitted granular value and every retry-class verdict
+exactly, including Linear's code-34 create/update divergence. All named constants
+hold the pinned values, the maps are exhaustive over every `Outcome`/`GraphQlError`
+variant, and the dropped fixture-count guards cover only transcription-only rows
+no `Outcome` reaches. The one correctness observation is a minor loss of a
+compile-time exhaustiveness guarantee in the jira rewrite.
+
+**Strengths**:
+- The jira rewrite (`matches!(...)` + `provably_unapplied || !mutates()`) is
+  behaviourally identical to the current classify→build path; jira never routes
+  through `classify_bash_code` at runtime, so the retired 15/17/22 arms are
+  correctly irrelevant.
+- The linear rewrite reproduces every reachable verdict exactly: {11,35,36}
+  retryable on both, {16,20,21} terminal on both, code-34 retryable-create /
+  terminal-update, Read always retryable.
+- Every named constant holds its pinned value (verified against both
+  `exit_codes.rs`).
+- Both maps and the linear `classify` match are exhaustive over all variants with
+  no wildcard, preserving compile-error-on-new-variant at the mapping sites.
+- Phase 4's inlined `for_adf` reproduces `AdfError::code()` exactly; the dropped
+  count-guards demonstrably cover only unreachable rows.
+
+**Findings**:
+- **minor / high** — jira `classify` trades an exhaustive `match` for a
+  non-exhaustive `matches!`, losing the compile-time guarantee the current code
+  has (Phase 2 Change 1). Behaviourally identical today; a future variant could
+  be misclassified (wrong 70/71 dispatch) with no compile signal. Keep an
+  exhaustive `match`.
+- **suggestion / medium** — after the change, neither client crate verifies its
+  live retry-class against the bridge oracle; parity rests on hand-authored
+  columns (Phase 2/3 Change 5). A mis-transcribed column would pass. Consider
+  retaining a single fixture-backed assertion feeding the reachable
+  `(Outcome, Operation)` rows through `classify` (research Option A).
+
+### Code Quality
+
+**Summary**: Unusually rigorous for a refactor: grounded in exhaustive matches,
+preserves the frozen contract, names the successor `exit_code_for_outcome` well,
+and explicitly reasons about the surviving wire-status `u16`. The main
+maintainability concerns are residual vocabulary inconsistency at the CLI
+boundary (`code_for_status` keeps the ambiguous "code" term), one instruction
+that would introduce a banned comment, and a slightly imprecise "no wildcard"
+statement.
+
+**Strengths**:
+- `exit_code_for_outcome(Outcome) -> u8` is domain-expressive and self-documenting.
+- Returning `u8` directly dissolves the `u8::try_from(...).unwrap_or(...)`
+  fallbacks and their divergent defaults.
+- The exit-code/wire-status `u16` distinction is explicitly reasoned about rather
+  than left implicit.
+- Phase 1 carries a manual checkpoint that each reworded comment still names an
+  invariant, aligned with the comment philosophy.
+- The exhaustive-match, no-variant-wildcard discipline is stated as a first-class
+  design intent.
+
+**Findings**:
+- **major / medium** — retained `code_for_status` perpetuates the exit-code/wire-
+  status ambiguity the redesign targets (Phase 2/3 Change 3). "code" is the
+  return, "status" the input — the exact conflation the rename kills; the plan
+  even needs prose to explain it. Rename to `exit_code_for_status` or inline the
+  one-line wrapper.
+- **major / high** — "restate it as a comment on the linear-cli map" would add a
+  banned redundant comment (Phase 3 Change 5). The property is compiler-enforced-
+  for-handling; a comment restating it is the what-comment the convention bans.
+  Delete the numeric-iterating test and rely on the match (paired with the
+  structural test the test-coverage lens asks for); add no comment.
+- **minor / medium** — shebang justification comments risk being tooling-
+  appeasement rather than genuine why-comments (Phase 2/3 Change 7). If kept,
+  word it as the external provenance-capture constraint, not an apology for the
+  word "bash"; better, exclude the fixtures dir from the grep gate.
+- **minor / high** — "no wildcard" is stated more absolutely than the jira map
+  can honour (Implementation Approach, Phase 2 Change 3). The jira map keeps a
+  `Status(_)` catch-all; the invariant is variant-exhaustiveness. Reword and note
+  the deliberate coercion.
+- **suggestion / low** — reworded `failure.rs` docs risk describing code and now
+  reference cross-crate behaviour (Phase 2/3 Change 2). Keep them on the
+  invariant the failure type guarantees; let the CLI own the mapping statement.
+
+### Test Coverage
+
+**Summary**: The plan preserves the live retry-class oracle well (the
+outcome-keyed table with create/update columns is retained, exhaustive matches
+stay) and correctly reasons the deleted rows guard no live behaviour. The main
+risk is the relocated granular map: the new inline tests — especially linear's —
+are specified loosely enough to assert one representative per code rather than
+every variant, dropping mutation coverage of the OR-pattern groupings. Secondary
+concerns: no mechanism forces a new variant to gain an assertion, the reserved-
+codes property is not enforced by the exhaustive match, and the client crates
+stop cross-checking against the shared bridge fixture.
+
+**Strengths**:
+- The live retry-class oracle is explicitly preserved, including the code-34
+  divergence.
+- Every mapping stays an exhaustive no-wildcard match (compile-time handling
+  guarantee).
+- Coverage responsibilities are cleanly separated (discriminant tests, CLI map
+  unit test, flow_errors).
+- The plan correctly identifies transcription-only rows and dead arms as guarding
+  no live path.
+
+**Findings**:
+- **major / medium** — linear granular-map unit test under-specified for
+  OR-pattern groupings (Phase 3 Change 4). "Every arm (11/36/35/34/16/21/20)" is
+  seven codes, but arms bundle multiple `GraphQlError` variants; one
+  representative per code misses a variant drifting between arms. Assert every
+  constructible `(SuccessWithErrors|BadRequest) × GraphQlError` combination plus
+  the standalone outcomes, via an in-test exhaustive `match`.
+- **major / medium** — the re-expressed classify introduces `SuccessWithErrors(RateLimited)`,
+  which the retained TABLE never exercises (Phase 3 Change 5 & 1). It maps to 34
+  with a divergent retry class but is asserted by neither the TABLE nor the
+  granular test. Add its row.
+- **minor / high** — the reserved-codes property is not enforced by the
+  exhaustive match (Phase 3 Change 5). Exhaustiveness constrains the domain, not
+  the codomain; a future arm could map to a Jira-only value. Keep a structural
+  test that the Linear map never yields {12,13,14,15,17,19}.
+- **minor / medium** — dropping the row-count guards leaves no completeness guard
+  and drops the shared-fixture cross-check (Phase 2/3 Change 5). Replace with an
+  in-test exhaustive `match` over `Outcome` and a lightweight live-row fixture
+  cross-check.
+- **minor / high** — `flow_errors` does not exercise the code-34 create/update
+  divergence (Phase 3 Success Criteria, Testing Strategy). The divergence is a
+  70/71 distinction only visible in `work-cli`; `linear-cli` emits 34 for both.
+  Attribute the coverage to the `classify` TABLE.
+- **suggestion / medium** — sequence the moved unit test before deleting the
+  client assertions to avoid a coverage-gap window (Implementation Approach).
+  Write `exit_code_for_outcome` and its test first (green), delete client
+  assertions after.
+
+### Compatibility
+
+**Summary**: A structural/vocabulary refactor that preserves the frozen exit-code
+contract for the classification path exactly — CLI constants equal the old map
+value-for-value, the removed `u16→u8` narrowing was never lossy, the Linear
+divergence is faithfully reproduced, and the `From<Failure> for TrackerError` →
+`work-cli` 70/71 contract is preserved. The significant gap is Phase 4: deleting
+`AdfError::code()` does not account for three in-crate test consumers, one of
+which is the ADF exit-code differential oracle. Because the client crates aren't
+surface-pinned, no API guard fires on the removals — the only backstop is
+compile-time breakage, which the plan's narrow per-phase commands can let slip.
+
+**Strengths**:
+- The granular relocation preserves every emitted value; the removed
+  `u8::try_from(bash_code(..))` never truncated (all codes ≤ 36).
+- The Linear divergence is correctly re-expressed on `(Outcome, Operation)`.
+- The `From<Failure> for TrackerError` contract `work-cli` depends on is
+  preserved (Wire arm still delegates to `classify`; other arms unchanged).
+- The plan correctly renames only the per-CLI parity fixture and leaves the
+  bridge fixture and its independent reader untouched.
+
+**Findings**:
+- **major / high** — Phase 4 deletes `AdfError::code()` but leaves four live
+  consumers: `adf.rs:84`, `adf_inventory.rs:173`, `adf_differential.rs:134,138`
+  (the differential oracle). "No test parses it" covers only the fixture line.
+  Compile break plus a dropped contract guard. Relocate the assertions onto
+  `for_adf` and widen the phase verification.
+- **minor / medium** — the removed symbols are public but the crates aren't
+  surface-pinned, so `public-api:check` won't flag them; narrow single-target
+  test commands can pass while the crate doesn't fully compile. Add
+  `cargo test -p <crate> --no-run` / clippy `--all-targets` per phase.
+- **minor / low** — the renamed parity fixture leaves a dangling reference in
+  both CLI `exit_codes.rs` module docs (line 5), and the `detail` string drops
+  the `({code})` fragment (no in-repo consumer, parity suite already forbids
+  parsing detail). Update the module-doc references as part of the rename.
+
+### Standards
+
+**Summary**: Well-structured, and the client-crate file-touch coverage matches
+the actual current "bash" inventory (verified by grep), so the client-scoped
+grep=0 AC is achievable and each phase is independently mergeable. The renamed
+`capture-*.sh` correctly falls outside `SURVIVING_SHELL_SOURCES`, triggering no
+shfmt/ShellCheck/bashisms obligation. The main concerns are naming consistency in
+the CLI helpers, residual bash vocabulary in CLI-side doc comments, an
+undocumented divergence from the work item's file list, and mild tension between
+the mandated justification comments and the comment convention.
+
+**Strengths**:
+- Phased delivery is genuinely independently mergeable; the case-insensitive
+  grep=0 AC met only after all four is correctly acknowledged.
+- The renamed capture script creates no shell-lint obligation — the shell tasks
+  enumerate exactly two allowlisted files.
+- The production-src touch list matches the live bash inventory exactly.
+- Successor names are descriptive, consistent, and preserve discoverability.
+
+**Findings**:
+- **minor / high** — `exit_code_for_outcome` vs retained `code_for_status`
+  leaves two differently-prefixed names for the same helper family (Phase 2/3
+  Change 3). Pick one prefix.
+- **minor / medium** — CLI-side `exit_codes.rs` keeps bash-vocabulary doc
+  comments (`for_failure` line 139, `for_credential` line 194, module docs)
+  outside the client grep AC (Phase 2 Change 3). Reword them or add an explicit
+  "NOT doing" note.
+- **minor / high** — the work item's file list (`mutation.rs`, `error.rs`,
+  `auth.rs`, `upload.rs`) diverges from the plan with no reconciliation; a grep
+  confirms the plan is correct but the deviation is untraceable (Phase 1). Add a
+  one-line note that the list is stale at this revision.
+- **minor / medium** — mandated inline justification comments conflict with the
+  very-low comment tolerance and the `.sh` is in no grep AC path, so they guard
+  nothing (Phase 2 Change 6/7). Drop the shebang comment; reword `transport.rs`.
+- **suggestion / medium** — the Phase 2/3 grep-AC caveat describes a match its
+  command can't produce (the `.sh` is not in the grep list). Remove the caveat or
+  add the path, consistently.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Re-Review (Pass 2) — 2026-09-06T19:21:44+00:00
+
+**Verdict:** APPROVE
+
+All six lenses were re-run against the revised plan. Every finding from Pass 1
+is resolved. The re-review surfaced four new issues introduced by the revision
+edits; all four were fixed in the same session, so the plan is now approved.
+
+### Previously Identified Issues
+
+Pass 1 raised 5 majors, 10 minors, and 4 suggestions across the six lenses.
+Re-review status:
+
+- 🟡 **Compatibility**: Phase 4 `AdfError::code()` consumers — Resolved. New
+  Phase 4 change 3 re-homes all four call sites (`adf.rs`, `adf_inventory.rs`
+  drop the numeric assertions to the `for_adf` unit test; `adf_differential.rs`
+  gains a test-local `expected_adf_exit` avoiding the cargo cycle). Verification
+  widened to whole-crate runs and a `.code()` grep.
+- 🟡 **Code Quality / Standards**: `code_for_status` ambiguity — Resolved.
+  Renamed to `exit_code_for_status`, one `exit_code_*` prefix family.
+- 🟡 **Code Quality / Test Coverage**: reserved-codes guard — Resolved. Kept as a
+  structural test, "restate as comment" removed.
+- 🟡 **Test Coverage**: linear map test under-specified — Resolved. Now asserts
+  every constructible `Outcome` via an in-test exhaustive `match`.
+- 🟡 **Test Coverage**: untested `SuccessWithErrors(RateLimited)` — Resolved. Row
+  added to the retained `TABLE`.
+- 🔵 **Architecture / Correctness**: jira `classify` `matches!` — Resolved. Now an
+  exhaustive `match`.
+- 🔵 **Standards / Compatibility**: CLI-side "bash" prose + dangling fixture
+  reference — Resolved. Folded into Phase 2/3 change 3.
+- 🔵 **Code Quality**: "no wildcard" overstated — Resolved. Reworded to
+  variant-exhaustive, with the jira `Status(_)` exception noted.
+- 🔵 **Test Coverage / Correctness**: completeness guard + bridge cross-check —
+  Resolved. In-test exhaustive-match guards added; the bridge drop recorded as
+  the accepted Option A trade-off.
+- 🔵 **Test Coverage**: `flow_errors` divergence overstatement — Resolved.
+  Re-attributed to the `classify` `TABLE`.
+- 🔵 **Compatibility**: narrow per-phase verification — Resolved. `--all-targets
+  --no-run` and whole-crate runs added.
+- 🔵 **Standards**: stale work-item file list — Resolved. Documented in Phase 1.
+- 🔵 **Architecture**: split-taxonomy coherence — Resolved. Coherence check added
+  to Phase 3 manual verification.
+- 🔵 **Code Quality / Standards**: comment mandates — Resolved. Shebang and
+  transport.rs now reword-not-comment.
+- 🔵 **Standards**: grep-AC shebang caveat — Resolved. Corrected.
+- 🔵 **Code Quality**: failure.rs cross-crate docs — Resolved. Scoped to the
+  type's own invariant.
+
+### New Issues Introduced (all fixed this session)
+
+- 🟡 **Correctness / Test Coverage**: the reserved-codes structural test was
+  placed in `linear-client/tests/classify.rs` but calls `exit_code_for_outcome`,
+  which now lives in `linear-cli` — the plan's own Phase 4 cargo-cycle rule
+  forbids that dependency. **Fixed**: the test is relocated to `linear-cli`'s
+  inline `exit_codes.rs` module (change 4), with Phase 3 change 5 and the Testing
+  Strategy updated to match.
+- 🔵 **Standards**: the Phase 2 grep AC omitted `cli/jira-client/tests/transport.rs`
+  though change 6 sweeps it (asymmetric with Phase 3). **Fixed**: added to the
+  grep argument list.
+- 🔵 **Test Coverage**: `expected_adf_exit` (test-local) is not cross-checked
+  against production `for_adf`, so the manual-verification wording overstated the
+  guard. **Fixed**: the seam is documented — each side is independently anchored
+  to a frozen artefact — and the manual-verification bullets reworded.
+- 🔵 **Architecture**: Phase 4 lacked the coherence note Phase 3 gained.
+  **Fixed**: a symmetric coherence bullet added to Phase 4 manual verification.
+
+### Assessment
+
+The plan is sound and ready for implementation. The core redesign was verified
+behaviour-preserving in Pass 1 (every exit-code value and retry verdict traced
+against source); Pass 2 confirms the revision closed every finding and the
+edit-induced issues have been corrected. The one substantive Pass-2 finding was
+a self-contained test-placement contradiction, now resolved. No open issues
+remain.

--- a/meta/reviews/work/0269-remove-bash-references-from-jira-linear-clients-review-1.md
+++ b/meta/reviews/work/0269-remove-bash-references-from-jira-linear-clients-review-1.md
@@ -1,0 +1,405 @@
+---
+type: "work-item-review"
+id: "0269-remove-bash-references-from-jira-linear-clients-review-1"
+title: "Work Item Review: Remove Bash References From Jira And Linear Clients"
+date: "2026-09-06T09:57:52+00:00"
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
+target: "work-item:0269"
+relates_to: ["work-item:0264", "work-item:0271", "work-item:0273"]
+work_item_id: "0269"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-09-06T09:57:52+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Work Item Review: Remove Bash References From Jira And Linear Clients
+
+**Verdict:** REVISE
+
+The work item is exemplary in completeness, clarity, and dependency mapping —
+every section is populated with substantive content, referents resolve
+unambiguously, and the frozen exit-code contract is anchored to a named oracle.
+The REVISE verdict rests on two structural issues: the acceptance criteria have
+verification gaps around the test/fixture reword and the `Cargo.toml` change, and
+the work item openly bundles a low-risk vocabulary reword with a higher-risk
+cross-crate classification redesign. Resolving the decomposition Open Question and
+tightening two acceptance criteria would clear the path to implementation.
+
+### Cross-Cutting Themes
+
+- **Undefined "outcome and operation" contract** (flagged by: clarity,
+  testability) — the redesigned error must carry "the outcome and operation" for
+  the CLI to derive an exit code, but "operation" is never defined and the set of
+  distinctions the error must represent is never enumerated. Clarity reads this as
+  an ambiguous referent; testability reads it as a criterion that cannot be
+  confirmed without knowing which distinctions the exit-code table demands.
+- **Two-layer bundling and sibling overlap** (flagged by: scope, dependency) —
+  the classification redesign is an independently deliverable, higher-risk layer
+  that reshapes the same `classify` / `failure` / `client` files that siblings
+  0271 and 0273 also intend to restructure. Scope frames this as a decomposition
+  problem; dependency frames it as an unresolved ordering direction.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Testability**: Criterion 5 has no definitive pass/fail procedure
+  **Location**: Acceptance Criteria (criterion 5)
+  The criterion scopes the tests/fixtures reword to bash vocabulary "where it
+  concerns exit codes" and permits other bash references to remain, so a grep over
+  the test tree returns allowed and disallowed matches with no defined way to
+  distinguish them. A verifier cannot conclusively confirm the criterion.
+
+- 🟡 **Testability**: `Cargo.toml` reword is required but unverified
+  **Location**: Requirements / Acceptance Criteria (criterion 1)
+  Requirements and Technical Notes require rewording the `Cargo.toml` bash-era
+  note in both crates, but criterion 1's grep is scoped to production `src/`, and
+  `Cargo.toml` lives at the crate root outside `src/`. The change could be silently
+  missed and the work still declared done against all criteria.
+
+- 🟡 **Scope**: Safe reword bundled with risky classification redesign
+  **Location**: Summary
+  The Summary frames the work as two layers — a near-zero-risk cosmetic reword and
+  an architectural redesign with cross-crate ripple into both `*-cli` binaries.
+  These can be completed, reviewed, and rolled back independently; coupling them
+  means the low-risk value cannot ship or revert without carrying the redesign's
+  blast radius.
+
+#### Minor
+
+- 🔵 **Clarity**: "operation" and "provenance comments" left undefined
+  **Location**: Requirements
+  The redesigned error must carry "the outcome and operation" (Requirements bullet
+  3), but "operation" is never defined — HTTP call, API operation category, or
+  something else — and "provenance comments" (bullet 5) is used without gloss. If
+  "operation" is read at the wrong granularity, the error may carry too little
+  context for the CLI to derive the correct exit code.
+
+- 🔵 **Testability**: Criterion 3 describes internal structure, not an outcome
+  **Location**: Acceptance Criteria (criterion 3)
+  "The CLI derives the exit code from the error's context" can only be assessed by
+  reading the implementation; the genuinely observable outcome (exit-code values
+  are unchanged) is already covered by criterion 6.
+
+- 🔵 **Testability**: Criterion 2 not enumerable against the oracle
+  **Location**: Acceptance Criteria (criterion 2)
+  The error must carry "enough" outcome/operation context, but the set of outcomes
+  and operations that must be representable is not enumerated, so a verifier cannot
+  confirm sufficiency without the exit-code table's distinctions.
+
+- 🔵 **Dependency**: "Consumed across crates" claimed but only two CLIs named
+  **Location**: Context
+  Context says the bash-named symbols are "consumed across crates" (plural), yet
+  only `jira-cli` and `linear-cli` are enumerated as consumers. Any other consumer
+  implied by "across crates" is left unnamed and would break at implementation
+  time.
+
+- 🔵 **Dependency**: Same-file ordering with 0271/0273 left unresolved
+  **Location**: Dependencies
+  Dependencies records that 0271 and 0273 refactor the same files "so coordinate
+  ordering", but leaves them as symmetric "relates to" entries without deciding
+  which lands first. Whichever lands second must absorb a rebase against the
+  redesigned classification path.
+
+#### Suggestions
+
+- 🔵 **Scope**: Confirm the redesign belongs here, not in 0271/0273
+  **Location**: Dependencies
+  The higher-risk redesign reshapes the very files 0271 and 0273 intend to
+  restructure; if the redesign lands here and is then reshaped again, the same
+  structural change is paid for twice.
+
+- 🔵 **Clarity**: Singular/plural drift for the CLI binaries
+  **Location**: Summary
+  The Summary alternates between "the CLI" and "the CLIs" while the work concerns
+  two distinct binaries. A consistent form ("each CLI binary", or
+  "the jira-cli and linear-cli binaries") removes the ambiguity.
+
+### Strengths
+
+- ✅ Every expected section is present with substantive, non-placeholder content;
+  an implementer could begin a task of this kind without follow-up questions.
+- ✅ Crates, files, symbols, and fixtures are named explicitly and used
+  consistently, so "the client crates" and "the CLI boundary" never drift.
+- ✅ The frozen exit-code contract is stated identically across Summary, Context,
+  Requirements, Assumptions, and Acceptance Criteria, and anchored to a named
+  oracle (`exit_codes_parity` / `flow_errors` suites plus
+  `bridge-exit-code-tables.txt`).
+- ✅ In-scope migration cruft is separated from legitimate domain vocabulary
+  (`transport.rs` retry predicates), pre-empting a likely misinterpretation.
+- ✅ The tracker crate's 70/71 dispatch codes and 0264's overlap are explicitly
+  scoped out, resolving two plausible hidden couplings.
+- ✅ Criteria 1, 2, 4, and 6 bind to concrete, reproducible procedures — a
+  case-insensitive grep, symbol-name checks, a git-diff no-op, and a parity oracle.
+
+### Recommended Changes
+
+1. **Extend criterion 1's grep target to include `Cargo.toml`** (addresses:
+   `Cargo.toml` reword is required but unverified)
+   Reword criterion 1 to grep each crate's `src/` and `Cargo.toml`
+   case-insensitively for `bash`, expecting zero matches, so the required
+   `Cargo.toml` change is covered.
+
+2. **Make criterion 5 verifiable** (addresses: Criterion 5 has no definitive
+   pass/fail procedure)
+   Enumerate the exact fixture files, field names, and message strings that must
+   change, or scope a grep to the exit-code test files with an explicit allowlist
+   of any remaining permitted `bash` occurrences.
+
+3. **Resolve the decomposition Open Question** (addresses: Safe reword bundled with
+   risky classification redesign; Confirm the redesign belongs here)
+   Decide whether to split into a chore-sized vocabulary reword and a separate
+   classification-redesign task, or state the indivisibility rationale explicitly.
+   Confirm the redesign scope belongs to this task rather than 0271/0273.
+
+4. **Define the error's required context and tie it to the oracle** (addresses:
+   "operation" and "provenance comments" left undefined; Criterion 2 not enumerable)
+   Define "operation" on first use (name the enum or granularity), gloss
+   "provenance comments", and bind criterion 2 to the distinctions
+   `bridge-exit-code-tables.txt` demands (codes 11–36).
+
+5. **Record the 0271/0273 ordering as a hard relationship** (addresses: Same-file
+   ordering with 0271/0273 left unresolved)
+   Decide which item lands first and encode it as a Blocked-by / Blocks
+   relationship rather than a symmetric coordination note.
+
+6. **Enumerate the full consumer set** (addresses: "Consumed across crates" claimed
+   but only two CLIs named)
+   State explicitly that `jira-cli` and `linear-cli` are the complete set of
+   consumers of the removed symbols, or name any others.
+
+7. **Reframe or annotate criterion 3** (addresses: Criterion 3 describes internal
+   structure, not an outcome)
+   Recast as an observable check (the mapping accepts only the client error type,
+   no `u16` parameter) or mark it explicitly as an inspection criterion.
+
+8. **Fix the singular/plural CLI drift** (addresses: Singular/plural drift for the
+   CLI binaries)
+   Use a consistent form throughout the Summary.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is unusually precise: crates, files, symbols, and
+fixtures are named explicitly, the two-layer intent (vocabulary reword +
+classification redesign) is stated consistently across Summary, Requirements, and
+Acceptance Criteria, and the frozen exit-code contract is reinforced coherently in
+every section. Referents ("the client crates", "the parity fixtures") resolve
+unambiguously and actors are named for each behavioural change. The only clarity
+gaps are a couple of lightly-defined domain terms and a minor singular/plural
+inconsistency in how the CLI binaries are referred to.
+
+**Strengths**:
+- The two crates under change (`jira-client`/`linear-client`) and the CLI boundary
+  files are named explicitly and used consistently.
+- The frozen-contract constraint is stated identically and without contradiction
+  across Summary, Context, Requirements, Assumptions, and Acceptance Criteria.
+- Requirements use active, actor-named phrasing, so responsibility for each
+  behavioural change is unambiguous.
+- The distinction between in-scope migration cruft and legitimate domain
+  vocabulary is spelled out explicitly.
+
+**Findings**:
+- 🔵 minor (confidence: medium) — Requirements. "operation" is never defined and
+  "outcome" is only loosely tied to Context's "domain outcome"; "provenance
+  comments" is likewise used without definition. The semantic contract the error
+  must satisfy is the core of the redesign; a wrong-granularity reading of
+  "operation" may carry too little context. Suggestion: define "operation" on
+  first use and gloss "provenance comments".
+- 🔵 suggestion (confidence: low) — Summary. The Summary alternates between "the
+  CLI" (singular) and "the CLIs" (plural) while the work concerns two distinct
+  binaries. A reader could momentarily read "the CLI" as one shared consumer.
+  Suggestion: use a consistent form.
+
+### Completeness
+
+**Summary**: This is an exemplary, fully-populated task work item. Every expected
+section — Summary, Context, Requirements, Acceptance Criteria, Open Questions,
+Dependencies, Assumptions, Technical Notes, and References — is present with
+substantive, non-placeholder content, and the frontmatter is complete and valid.
+For a task kind, the definition of work to be done is unambiguous and an
+implementer could begin without follow-up questions.
+
+**Strengths**:
+- The Summary gives a precise, two-layer statement of intent and explicitly flags
+  the frozen exit-code contract constraint.
+- Requirements are specific and enumerable (which symbols to remove, where the
+  mapping moves, what to leave untouched).
+- Acceptance Criteria contains six concrete, section-appropriate criteria.
+- Context explains the motivation and why the exit-code contract is load-bearing,
+  rather than merely restating the Summary.
+- Optional sections are all genuinely populated and frontmatter fields are present
+  and recognised.
+
+**Findings**: None.
+
+### Dependency
+
+**Summary**: The work item is generally well dependency-mapped: it explicitly
+captures the exit-code contract oracle, names the two consuming CLI crates that
+must be updated, scopes out the tracker crate and its 70/71 codes, and flags the
+same-file coordination risk with siblings 0271 and 0273. The main gaps are a
+vaguely-scoped "consumed across crates" claim that is never fully enumerated, and
+an unresolved ordering direction for the same-file conflict with 0271/0273.
+
+**Strengths**:
+- The frozen exit-code contract is captured as an explicit read-only dependency.
+- The downstream CLI consumers (`cli/jira-cli`, `cli/linear-cli`) are named in
+  both Requirements and Technical Notes.
+- The same-file conflict coupling with 0271 and 0273 is explicitly noted.
+- The tracker crate's dispatch codes and 0264's overlap are explicitly scoped out.
+
+**Findings**:
+- 🔵 minor (confidence: medium) — Context. The bash-named symbols are said to be
+  "consumed across crates" (plural), yet only `jira-cli` and `linear-cli` are
+  enumerated. If a consumer beyond the two CLIs references the removed symbols, its
+  build breaks mid-sprint. Suggestion: enumerate every consumer or state the two
+  CLIs are the complete set.
+- 🔵 minor (confidence: high) — Dependencies. 0271 and 0273 refactor the same
+  files, left as symmetric "relates to" entries without deciding which lands first;
+  the second must absorb a rebase. Suggestion: record which precedes as an explicit
+  Blocked-by / Blocks relationship.
+
+### Scope
+
+**Summary**: This task is coherent around a single theme — purging bash/exit-code
+framing from the Jira and Linear client crates — with commendably explicit in-scope
+and out-of-scope boundaries. However, it openly bundles two independently
+deliverable layers: a low-risk cosmetic vocabulary reword and a higher-risk
+architectural classification redesign that ripples across four crates. The work
+item itself surfaces this as an Open Question, which is the central scope signal.
+
+**Strengths**:
+- Boundaries are stated with unusual precision (transport.rs retry predicates, the
+  70/71 dispatch codes, and the frozen exit-code values all declared out of scope).
+- The scope is anchored to a single coherent theme that matches the source backlog
+  item, rather than a grab-bag of unrelated cleanups.
+- The Open Questions section demonstrates the author's own awareness of the
+  decomposition tension, deferring the split to planning rather than hiding it.
+
+**Findings**:
+- 🟡 major (confidence: medium) — Summary. The two layers can be completed,
+  reviewed, and rolled back independently; coupling the safe reword to the risky
+  redesign means the low-risk value cannot ship or revert without carrying the
+  redesign's blast radius, and review/rollback of one entangles the other.
+  Suggestion: resolve the Open Question in favour of splitting, or state the
+  indivisibility rationale explicitly.
+- 🔵 suggestion (confidence: low) — Dependencies. The redesign reshapes the same
+  files 0271 and 0273 also intend to restructure; if it lands here and is reshaped
+  again, the change is paid for twice. Suggestion: confirm the redesign belongs to
+  this task and define the ordering.
+
+### Testability
+
+**Summary**: For a refactor/vocabulary task this work item is unusually
+well-specified: most Acceptance Criteria bind to concrete procedures (a
+case-insensitive grep, a git-diff no-op check, and a named test suite acting as
+the exit-code oracle). The main testability gaps are the tests/fixtures rework
+criterion, which permits non-exit-code "bash" to remain and so cannot be verified
+by a clean grep, and the un-verified `Cargo.toml` rewording. One criterion
+describes internal structure rather than an observable outcome.
+
+**Strengths**:
+- Criterion 1 (grep production `src/` for `bash`, expect zero matches) is a
+  definitive, reproducible pass/fail procedure.
+- Criterion 4 (`transport.rs` predicates unchanged) is trivially verifiable via git
+  diff.
+- Criterion 6 anchors the frozen exit-code contract to a named oracle, giving
+  objective proof that emitted values are unchanged.
+- Criterion 2 pins concrete removable symbol names (`bash_code`,
+  `classify_bash_code`).
+
+**Findings**:
+- 🟡 major (confidence: high) — Acceptance Criteria (criterion 5). The criterion
+  scopes the rework to bash vocabulary "where it concerns exit codes" and permits
+  other bash references to remain, so a grep returns allowed and disallowed matches
+  with no defined way to distinguish them. Suggestion: enumerate the exact fixture
+  files, field names, and message strings, or scope a grep with an explicit
+  allowlist.
+- 🟡 major (confidence: high) — Requirements / Acceptance Criteria (criterion 1).
+  The `Cargo.toml` reword is required but criterion 1's grep is scoped to
+  production `src/`, and `Cargo.toml` lives outside `src/`, so the change has no
+  verification. Suggestion: extend the grep target to include each crate's
+  `Cargo.toml`.
+- 🔵 minor (confidence: medium) — Acceptance Criteria (criterion 3). "The CLI
+  derives the exit code from the error's context" describes internal structure and
+  can only be assessed by reading the implementation; the observable outcome is
+  already covered by criterion 6. Suggestion: reframe as an observable check or
+  mark it as an inspection criterion.
+- 🔵 minor (confidence: medium) — Acceptance Criteria (criterion 2). The set of
+  outcomes and operations that must be representable is not enumerated, so
+  "enough" context is not measurable. Suggestion: tie the requirement to the oracle
+  (codes 11–36 in `bridge-exit-code-tables.txt`).
+
+## Re-Review (Pass 2) — 2026-09-06
+
+**Verdict:** COMMENT
+
+Every major and minor from pass 1 is resolved. The two scope/testability majors
+that drove the REVISE verdict are gone: the split Open Question is resolved with an
+indivisibility rationale and phased delivery, and both acceptance-criteria gaps
+(the `Cargo.toml` grep and the unverifiable test-sweep criterion) are closed. The
+verdict moves to COMMENT — the work item is acceptable for implementation. A handful
+of minor/suggestion items surfaced fresh, some as side-effects of the pass-1 edits;
+the clear ones were tightened immediately, and two judgement calls (title breadth,
+0271/0273 ordering direction) are left for the author.
+
+### Previously Identified Issues
+
+- 🟡 **Scope**: Safe reword bundled with risky redesign — Resolved (Open Questions
+  now carries an indivisibility rationale; delivery phased reword-then-redesign).
+- 🟡 **Testability**: Criterion 5 has no definitive pass/fail — Resolved (scoped to
+  named suites; enumerated categories must be gone, any remainder justified inline).
+- 🟡 **Testability**: `Cargo.toml` reword unverified — Resolved (criterion 1's grep
+  now targets `src/` and `Cargo.toml`).
+- 🔵 **Clarity**: "operation"/"provenance comments" undefined — Resolved (operation
+  defined as the client method invoked; provenance comments glossed).
+- 🔵 **Testability**: Criterion 3 describes internal structure — Resolved (recast as
+  an observable check: mapping accepts only the client error type, no `u16`).
+- 🔵 **Testability**: Criterion 2 not enumerable — Resolved (tied to codes 11–36).
+- 🔵 **Dependency**: Consumers vaguely "across crates" — Resolved (Context names
+  `jira-cli`/`linear-cli` as the only cross-crate consumers).
+- 🔵 **Dependency**: 0271/0273 ordering unresolved — Partially resolved (recommended
+  order recorded and cross-referenced from the `Blocks:` line; hard edge still
+  deferred to scheduling by author decision).
+- 🔵 **Clarity**: CLI singular/plural drift — Resolved.
+- 🔵 **Scope**: Redesign overlaps 0271/0273 — Resolved (recommended landing order
+  documented).
+
+### New Issues Introduced
+
+- 🔵 **Testability**: AC2 "no numeric exit code is computed" lacked a mechanical
+  check — Addressed in re-review (now forbids a `u16` field and 11–36 integer
+  literals in `classify.rs`/`failure.rs`).
+- 🔵 **Testability/Clarity**: AC5 deferred its pass condition to a not-yet-existing
+  "plan allowlist" (unbounded escape hatch) — Addressed in re-review (rewritten to
+  require the enumerated categories gone and any remainder justified inline, no
+  allowlist dependency).
+- 🔵 **Clarity**: `AdfError::code -> u16` role undefined — Addressed in re-review
+  (Technical Notes now marks its numeric return in scope for the u16 removal).
+- 🔵 **Clarity**: Title under-represents the structural redesign — Open. Broadening
+  the title is a rename left to the author.
+
+### Assessment
+
+The work item is ready for implementation. Both outstanding author judgement calls
+were then resolved in this pass — the title was broadened to name the classification
+redesign, and the 0271/0273 ordering was pinned as a hard `blocks` edge (this item
+lands first). The author has accepted the work item; the review verdict is
+**APPROVE**.

--- a/meta/validations/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-validation.md
+++ b/meta/validations/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-validation.md
@@ -1,0 +1,89 @@
+---
+type: "plan-validation"
+id: "2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-validation"
+title: "Validation Report: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients"
+date: "2026-09-06T22:35:44+00:00"
+author: "Toby Clemson"
+producer: "validate-plan"
+status: "complete"
+result: "pass"
+target: "plan:2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification"
+tags: ["jira", "linear", "cleanup", "refactor", "exit-codes", "classification"]
+last_updated: "2026-09-06T22:35:44+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Remove Bash Vocabulary And Redesign Exit-Code Classification
+
+All four phases are implemented, committed, and verified; the plan passes. Every
+grep gate, symbol gate, numeric-literal gate, and plan-mandated test suite is
+green, and `mise run cli:check` exits 0. One low-severity test-structure
+deviation and one environmental test-suite caveat are recorded below; neither
+affects the emitted-exit-code contract, which is preserved exactly.
+
+### Implementation Status
+
+Each phase landed as its own commit, in order.
+
+| Phase | Scope | Commit | Status |
+|-------|-------|--------|--------|
+| 1 | Doc-only bash reword, both client crates | `xnuqzlwz` | 🟢 fully implemented |
+| 2 | Jira classify redesign, granular map to `jira-cli` | `vyxmyzzz` | 🟢 fully implemented |
+| 3 | Linear classify redesign, granular map to `linear-cli` | `moywxswn` | 🟢 fully implemented |
+| 4 | `AdfError::code()` removal, inline into `for_adf` | `kvkskpkz` | 🟢 fully implemented |
+
+### Automated Verification Results
+
+- ✅ CI read-only gate: `mise run cli:check` exits 0 (format + lint + types, all four components).
+- ✅ Desired-End-State grep gate: `grep -rin bash` over both client crates' `src/` and `Cargo.toml` returns nothing.
+- ✅ Symbol gates: no `bash_code`/`classify_bash_code` in either `src/`; no `fn code` in `adf/mod.rs`; no `.code()` caller in `jira-client/tests`.
+- ✅ Numeric-literal gate: no `11`–`36` literal in either crate's `classify.rs` or `failure.rs`.
+- ✅ Phase-2 and Phase-3 grep gates (client `src`, `Cargo.toml`, swept tests, CLI exit-code source, parity fixture) return nothing.
+- ✅ ADF fixture gate: no `bash` in the five `render-abort-*/expected-error.txt` files.
+- ✅ Plan-mandated suites pass: `classify`, `discriminant`, `timeouts`, `transport` (both client crates); `exit_codes_parity` and `exit_codes::tests` (both CLIs); `flow_errors` (jira 2, linear 4) under `--features test-loopback`.
+- ⚠️ Full `cargo test -p jira-client` reports 2 failures — both live-tenant `contract.rs` tests, not a regression (see Potential Issues).
+
+Suite-by-suite counts (targeted run):
+
+```text
+jira-client   classify 3   discriminant 5   timeouts 6   transport 10
+linear-client classify 10  discriminant 3   transport 5
+jira-cli      exit_codes_parity 5   flow_errors 2
+linear-cli    exit_codes_parity 3   flow_errors 4
+unit modules  exit_codes::tests (jira, linear) all ok
+```
+
+### Code Review Findings
+
+#### Matches Plan
+
+- `jira-client/src/classify.rs` keeps `classify` on an exhaustive `match` over `Outcome`, computes `provably_unapplied` from the status directly, and builds the detail as `"jira {op}: {detail}"` — no `({code})` embed, no `bash_code`/`classify_bash_code`/`build`.
+- `linear-client/src/classify.rs` re-expresses `classify` directly on `(Outcome, Operation)`, reproducing the code-34 create/update divergence (`SuccessWithErrors(RateLimited | BadRequest)` and `BadRequest(BadRequest)` retryable on create, terminal on update) and dropping the dead `18|23|25|27|29|110..=114` arms. Exhaustive, no wildcard.
+- `jira-cli/src/exit_codes.rs` carries `exit_code_for_outcome` over the named constants with the deliberate `Status(_) => SERVER_ERROR` catch-all; `exit_code_for_status` wraps it; `for_failure`/`for_surface`/`for_client` remain exhaustive with no wildcard.
+- `linear-cli/src/exit_codes.rs` carries `exit_code_for_outcome` with the exact OR-pattern grouping the plan specified, exhaustive with no wildcard, plus the reserved-codes structural test asserting the map never yields a Jira-only code `{12,13,14,15,17,19}`.
+- `AdfError::code()` is removed; `for_adf` is now an inline `const fn` mapping variants to `BAD_JSON`/`ADF_UNSUPPORTED`/`ADF_BAD_INPUT` (40/41/42), with a `for_adf` unit test and the test-local `expected_adf_exit` helper re-homed in `adf_differential.rs`.
+- Client-crate `classify` tests carry exhaustive-`match` completeness guards over `Outcome` (`the_status_table_covers_every_outcome_variant`, `the_table_covers_every_outcome_variant`), so a new variant forces a new `STATUS_TABLE`/`TABLE` row.
+- The parity fixtures are renamed `bash-exit-codes.txt → captured-exit-codes.txt` as `jj` renames (`R`), with every `NAME=INT` value row byte-identical — only `#` header comments reworded.
+
+#### Deviations from Plan
+
+- The CLI outcome→code unit tests are fixed `assert_eq!` lists, not the in-test exhaustive `match` the plan specified (Phase 2 change 4, Phase 3 change 4). `linear-cli::every_constructible_outcome_maps_to_its_pinned_code` and the two `jira-cli` unit tests (`every_outcome_maps_to_its_pinned_code`, `every_adf_error_maps_to_its_pinned_code`) would not force a new assertion if an `Outcome`/`AdfError` variant were added. Low severity — the compile-time safety net still holds from two other directions: the production mapping matches are exhaustive with no wildcard (a new variant is a build error at the mapping site), and the client-crate `classify` table guards do use exhaustive matches.
+
+#### Potential Issues
+
+- ⚠️ `cargo test -p jira-client` is red locally: `contract.rs`'s `the_conformance_set_passes_against_a_live_tenant` and `a_failing_read_is_retryable_against_a_live_tenant` panic at `contract.rs:108` demanding `ACCELERATOR_JIRA_SITE`/`EMAIL`/`TOKEN`. These are live-tenant tests that deliberately fail-not-skip without credentials (documented, `contract.rs:10-17`); `contract.rs` sits in no phase's file list and no success criterion. This is an environmental precondition, not a defect introduced by the plan. Phase 4's literal AC (`cargo test -p jira-client ... pass`) is therefore only green in an environment that supplies tracker credentials — as CI does — while the canonical read-only gate `mise run cli:check` is green here.
+
+### Manual Testing Required
+
+None outstanding. The plan's manual criteria were verified during validation:
+
+- [x] Fixture renames are `jj` renames with byte-identical `NAME=INT` rows.
+- [x] The re-expressed linear `classify` reproduces the code-34 divergence and the `{11,35,36}`-retryable-on-both verdicts, cross-checked against the fixture rows.
+- [x] The CLI mapping matches remain exhaustive with no wildcard beyond the deliberate jira `Status(_)`.
+- [x] Reworded comments name the invariant or wire contract they documented; none is a what-comment.
+
+### Recommendations
+
+- Optionally tighten the three CLI unit tests to destructure the value under test through an exhaustive `match`, closing the one deviation so the unit layer also fails-to-compile on a new variant. Not blocking — the guarantee already holds via the production matches and the client-crate table guards.
+- No action needed on the `contract.rs` failures; run them with tracker credentials (or the `ACCELERATOR_TRACKER_CONTRACT` gate) where a live check is wanted.

--- a/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
+++ b/meta/work/0240-corpus-update-frontmatter-quote-roundtrip.md
@@ -5,7 +5,7 @@ title: "Corpus Update Frontmatter Quote Roundtrip"
 date: "2026-08-31T12:11:13+00:00"
 author: "Toby Clemson"
 producer: "extract-work-items"
-status: "draft"
+status: "done"
 kind: "bug"
 priority: "medium"
 parent: "work-item:0136"
@@ -20,7 +20,7 @@ external_id: "PP-770"
 # 0240: Corpus Update Frontmatter Quote Roundtrip
 
 **Kind**: Bug
-**Status**: Draft
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 

--- a/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
+++ b/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
@@ -1,56 +1,180 @@
 ---
 type: "work-item"
 id: "0269"
-title: "Remove Bash References From Jira And Linear Clients"
+title: "Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients"
 date: "2026-08-31T12:11:13+00:00"
 author: "Toby Clemson"
 producer: "extract-work-items"
-status: "draft"
+status: "ready"
 kind: "task"
 priority: "medium"
 parent: "work-item:0136"
-tags: ["jira", "linear", "cleanup"]
-last_updated: "2026-09-05T00:00:00+00:00"
+blocks: ["work-item:0271", "work-item:0273"]
+relates_to: ["work-item:0264"]
+tags: ["jira", "linear", "cleanup", "refactor"]
+last_updated: "2026-09-06T09:57:52+00:00"
 last_updated_by: "Toby Clemson"
 last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
 schema_version: 1
 external_id: "PP-799"
 ---
 
-# 0269: Remove Bash References From Jira And Linear Clients
+# 0269: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients
 
 **Kind**: Task
-**Status**: Draft
+**Status**: Ready
 **Priority**: Medium
 **Author**: Toby Clemson
 
 ## Summary
 
-Remove all references to Bash and shell exit codes from the Jira and Linear
-client crates, left over from the shell-to-Rust migration.
+Remove leftover Bash and shell-exit-code vocabulary from the `jira-client`
+and `linear-client` crates, in two layers. First, reword every bash-era doc
+comment, comment, and message. Second, redesign the exit-code-shaped
+classification path so the client crates emit client-specific error types
+carrying enough context for each CLI binary to derive an exit code, and move
+the numeric exit-code mapping to the CLI boundary. The exit-code values the
+`jira-cli` and `linear-cli` binaries emit are a frozen external contract and
+must not change.
 
 ## Context
 
-Captured in the further-ideas backlog. The client crates still carry Bash-
-and exit-code-oriented vocabulary that no longer fits the Rust
-implementation.
+The vocabulary is a vestige of the shell-to-Rust migration (parent epic
+0136): the client crates still speak in "the bash flow", "bash-era", and
+"bash code N", and model classification as a numeric `u16` exit code rather
+than a domain outcome.
+
+The exit-code contract is real and load-bearing. `tracker::TrackerError::`
+`{Retryable, Terminal}` map to dispatch codes 70 and 71, and the client
+crates re-encode granular HTTP-status codes (11–36) that the `jira-cli` and
+`linear-cli` binaries map straight to process exit codes. Those values are
+pinned by `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`
+and the `exit_codes_parity` fixtures. Neither client crate is surface-pinned,
+so `public-api:check` will not trip, but the bash-named symbols are consumed by
+the `jira-cli` and `linear-cli` crates — their only cross-crate consumers.
 
 ## Requirements
 
-- Remove Bash and exit-code references from the Jira and Linear client
-  crates, replacing them with idiomatic Rust error handling.
+- Reword every bash-era doc comment, comment, `Cargo.toml` note, and error
+  message in the production `src/` of both crates to describe the Rust
+  behaviour, with no residual "bash" vocabulary.
+- Move the outcome-to-exit-code mapping to the CLI boundary
+  (`cli/jira-cli/src/exit_codes.rs`, `cli/linear-cli/src/exit_codes.rs`).
+  The client crates stop computing exit codes.
+- Redesign the client crates to return client-specific error types that carry
+  enough semantic context for each CLI binary to derive the correct exit code,
+  without a numeric `u16` intermediary and without embedding numeric codes in
+  `detail` strings. The context is the *outcome* (the domain classification of
+  the failure) paired with the *operation* (the client method that was invoked,
+  e.g. `create_issue`, `search`). Together the outcome/operation pair must
+  distinguish every exit code the parity fixtures enumerate for these crates
+  (codes 11–36).
+- Remove `bash_code` and `classify_bash_code` from the client crates,
+  updating the cross-crate consumers and their `exit_codes_parity` /
+  `flow_errors` tests to the new error-carried context.
+- Sweep exit-code-related bash vocabulary from the client crates' own tests
+  and fixtures (test field names, "bash code N" messages, and provenance
+  comments — comments that record a value's bash-era origin) where it concerns
+  exit codes.
+- Leave `transport.rs` `retryable` / `is_retryable_status` untouched — these
+  are HTTP-retry domain terms, not exit-code framing.
+- Preserve every emitted exit-code value exactly; the parity fixtures and
+  `bridge-exit-code-tables.txt` are the oracle.
 
 ## Acceptance Criteria
 
-- [ ] The Jira and Linear client crates contain no Bash or exit-code
-  references.
+- [ ] Given the production `src/` and the `Cargo.toml` of `jira-client` and
+  `linear-client`, when grepped case-insensitively for `bash`, then there are
+  no matches.
+- [ ] Given the client crates, when inspected, then no symbol named
+  `bash_code` or `classify_bash_code` remains, the error type exposes no `u16`
+  exit-code field, neither `classify.rs` nor `failure.rs` contains an integer
+  literal in the 11–36 range, and no numeric code is embedded in a `detail`
+  string; classification yields a client-specific error whose outcome/operation
+  pair distinguishes every exit code the parity fixtures enumerate for these
+  crates (codes 11–36).
+- [ ] Given `cli/jira-cli/src/exit_codes.rs` and `cli/linear-cli/src/`
+  `exit_codes.rs`, when the exit-code mapping is inspected, then it accepts
+  only the client error type (no `u16` parameter) and produces the values
+  pinned by the parity fixtures.
+- [ ] Given `is_retryable_status` / `retryable` in either `transport.rs`,
+  when the change is complete, then they are unchanged.
+- [ ] Given the exit-code-related tests and fixtures of both crates (the
+  `exit_codes_parity` and `flow_errors` suites), when grepped
+  case-insensitively for `bash`, then the `bash_*` test field names, "bash code
+  N" messages, and exit-code provenance comments are gone, and any remaining
+  match sits in a fixture unrelated to exit codes and carries an inline comment
+  justifying it.
+- [ ] Given `mise run cli:check` and the `exit_codes_parity` / `flow_errors`
+  suites, when run, then all pass — proving emitted exit-code values are
+  unchanged.
+
+## Open Questions
+
+- None. The single-versus-split question is resolved: this lands as one work
+  item. The vocabulary reword and the classification redesign touch the same
+  `classify.rs` / `failure.rs` files and the same symbols (`bash_code`,
+  `classify_bash_code`), so splitting them would force the reword to either
+  skip those symbols or rename them twice, and a standalone reword could not
+  satisfy the "no numeric exit code computed" criterion without the redesign.
+  Delivery is phased within the single item: land the pure-doc reword of the
+  non-classification files first (mechanically safe), then the classification
+  redesign and its cross-crate ripple in a second commit, so review can isolate
+  the risky layer.
+
+## Dependencies
+
+- Blocked by: none.
+- Blocks: 0271 (unify client interfaces), 0273 (domain crate for Linear/Jira
+  subcommands). Both refactor the same `classify` / `failure` / `client` files,
+  so this item lands first: they inherit the renamed symbols and the
+  context-carrying error rather than reshaping a redesign a second time.
+- Parent: 0136 (Migrate Shell Scripts into a Rust CLI — in-progress epic).
+- Relates to: 0264 (remove Bash-migration negative-assertion tests —
+  CLI-wide sibling cleanup).
+
+## Assumptions
+
+- The numeric exit-code values are a frozen external contract; only
+  vocabulary and internal structure may change, never the values.
+- `transport.rs` `retryable` / `is_retryable_status` are genuine HTTP-retry
+  domain terms and stay untouched.
+
+## Technical Notes
+
+Production files to touch:
+
+- `jira-client`: `classify.rs`, `failure.rs`, `adf/mod.rs` (`AdfError::code ->
+  u16`, whose numeric return is in scope for the u16 removal, not a doc-only
+  edit), plus doc-only edits in `read.rs`, `cache.rs`,
+  `custom_fields.rs`, `principal.rs`, `mutation.rs`, `client.rs`,
+  `transport.rs`, `Cargo.toml`.
+- `linear-client`: `classify.rs`, `failure.rs`, plus doc-only edits in
+  `transport.rs`, `client.rs`, `filter.rs`, `error.rs`, `auth.rs`,
+  `upload.rs`, `Cargo.toml`.
+- CLI boundary (gains the mapping): `cli/jira-cli/src/exit_codes.rs`,
+  `cli/linear-cli/src/exit_codes.rs`, plus their `exit_codes_parity` and
+  `flow_errors` tests.
+- Contract oracle (read-only reference):
+  `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`.
+
+`tracker::TrackerError::{Retryable, Terminal}` and the 70/71 dispatch codes
+are owned by the `tracker` crate and are out of scope.
 
 ## Drafting Notes
 
-- Extracted from source documents without interactive enrichment.
-  Acceptance criteria, dependencies, and kind may need refinement before
-  promoting from `draft` to `ready`.
+- Scope confirmed with the author as cosmetic reword plus classification
+  redesign, with exit-code mapping moved to the CLI boundary and the client
+  crates returning context-carrying custom errors.
+- Test and fixture rework is in scope where it concerns exit codes; 0264 was
+  confirmed to be CLI-wide and distinct, so it does not absorb this.
+- Interpreted "no exit-code values may change" as a hard constraint from the
+  parity fixtures; the redesign is a structural/vocabulary change only.
+- `transport.rs` retry predicates were separated out as legitimate HTTP
+  domain vocabulary, not migration cruft.
 
 ## References
 
 - Source: `meta/notes/2026-06-23-further-ideas-backlog.md`
+- Related: 0136, 0264, 0271, 0273
+- Contract fixture: `cli/tracker-support/tests/fixtures/bridge-exit-code-tables.txt`

--- a/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
+++ b/meta/work/0269-remove-bash-references-from-jira-linear-clients.md
@@ -5,7 +5,7 @@ title: "Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And
 date: "2026-08-31T12:11:13+00:00"
 author: "Toby Clemson"
 producer: "extract-work-items"
-status: "ready"
+status: "done"
 kind: "task"
 priority: "medium"
 parent: "work-item:0136"
@@ -22,7 +22,7 @@ external_id: "PP-799"
 # 0269: Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients
 
 **Kind**: Task
-**Status**: Ready
+**Status**: Done
 **Priority**: Medium
 **Author**: Toby Clemson
 


### PR DESCRIPTION

# [0269] Remove Bash Vocabulary And Redesign Exit-Code Classification In Jira And Linear Clients

## Summary

Strips every residual "bash" reference from the `jira-client` and
`linear-client` crates and moves the granular exit-code map from the client
crates to the CLI boundary. The client crates keep returning context-carrying
failures (`JiraFailure`/`LinearFailure`, each holding `{ outcome, operation,
detail }`); the numeric `outcome → u8` map now lives in `jira-cli`/`linear-cli`;
and the retry-class collapse to `TrackerError` stays in the client crates,
re-expressed directly on `(Outcome, Operation)` with no `u16` intermediary and
no numeric code embedded in a `detail` string. Every emitted exit-code value is
preserved exactly — the parity fixtures are the frozen oracle.

## Changes

- **Redesigned `classify` in both client crates.** `bash_code`,
  `classify_bash_code`, and `build` are deleted; `classify` computes the
  retry class directly from `(Outcome, Operation)` over an exhaustive `match`,
  and the `detail` no longer embeds a numeric code. Linear's re-expression
  reproduces the code-34 create/update divergence and drops the dead
  `18|23|25|27|29|110..=114` arms.
- **Moved the granular map to the CLI boundary.** `jira-cli` and `linear-cli`
  each gain `exit_code_for_outcome(Outcome) -> u8` over their named constants,
  with `exit_code_for_status` wrapping it; the mapping matches stay exhaustive
  with no wildcard (bar the deliberate jira `Status(_) => SERVER_ERROR`).
- **Removed `AdfError::code() -> u16`.** The 40/41/42 variant→constant mapping
  is inlined into `jira-cli`'s `for_adf`, now a `const fn`; test call sites are
  re-homed, including a test-local `expected_adf_exit` in `adf_differential`.
- **Reworded bash-era doc vocabulary** across the non-classification production
  files of both crates, and swept the test vocabulary, the ADF render-abort
  fixtures, and the CLI exit-code module docs.
- **Renamed the parity fixtures** `bash-exit-codes.txt → captured-exit-codes.txt`
  (and their capture scripts) as renames, with every `NAME=INT` row
  byte-identical.
- **New unit coverage** for the relocated maps: per-variant `Outcome → code`
  tests in each CLI, a `for_adf` variant test, and a `linear-cli` structural
  test that the map never yields a Jira-only code `{12,13,14,15,17,19}`.

## Context

- Work item: `meta/work/0269-remove-bash-references-from-jira-linear-clients.md`
- Plan: `meta/plans/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md`
- Research: `meta/research/codebase/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification.md`
- Validation: `meta/validations/2026-09-06-0269-remove-bash-vocabulary-and-redesign-exit-code-classification-validation.md`

The split is intentionally asymmetric: the granular numeric map leaves the
client crates, but the retry-class `classify` and the `From<Failure> for
TrackerError` collapse **stay** inside them. Relocating that collapse is item
0271's job; extracting a tracker-adapter crate is 0273's. This item leaves the
collapse in place, re-expressed on `(Outcome, Operation)`.

## Testing

- [x] CI read-only gate green: `mise run cli:check` exits 0.
- [x] Client suites pass: `classify`, `discriminant`, `timeouts`, `transport`
      (both crates).
- [x] CLI suites pass: `exit_codes_parity` and `exit_codes::tests` (both CLIs),
      proving no emitted exit-code value changed.
- [x] End-to-end routing unchanged: `flow_errors` under `--features
      test-loopback` (jira 2, linear 4).
- [x] Vocabulary gates clean: `grep -rin bash` over both client crates' `src/`
      and `Cargo.toml` returns nothing; no `bash_code`/`classify_bash_code`
      symbol; no `AdfError::code`; no `11`–`36` literal in the classification
      files.
- [ ] `jira-client`'s live-tenant `contract.rs` tests are not run here — they
      fail-not-skip without `ACCELERATOR_JIRA_*` credentials by design, so they
      need a credentialled environment (or the `ACCELERATOR_TRACKER_CONTRACT`
      gate) to exercise.

## Notes for Reviewers

- **Contract preserved, not changed.** This is a structural/vocabulary change;
  the exit-code values are a frozen external contract. The parity fixtures pin
  every value, and their `NAME=INT` rows are byte-identical across the rename.
- **Focus on the two `classify` rewrites** (`jira-client/src/classify.rs`,
  `linear-client/src/classify.rs`) and the linear code-34 divergence, which is a
  retry-class distinction visible only in the `classify` `TABLE`, not in
  `flow_errors`.
- **One known deviation from the plan:** the CLI outcome→code unit tests are
  fixed `assert_eq!` lists rather than in-test exhaustive matches, so a new
  `Outcome` variant would not force a new assertion there. Low severity — the
  production mapping matches are exhaustive with no wildcard (a new variant is a
  build error), and the client-crate `classify` table guards do use exhaustive
  matches. Recorded in the validation report.
- **Rider commit:** this branch also carries `Mark work item 0240 as done` (a
  two-line status flip on `0240-corpus-update-frontmatter-quote-roundtrip.md`),
  unrelated to 0269. It sits at the base of the chain and was kept in this PR
  deliberately rather than rebased out.
