### PR TITLE
Mint a fresh releaser token for each release push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -650,6 +650,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # The push in Finalise below authenticates with a freshly-minted
+          # token, not this one — the checkout credential is dead by then (see
+          # the Refresh step). Persisting it would leave a host-matched
+          # extraheader that collides with the fresh token on the push, so drop
+          # it; the public repo clones and pulls anonymously regardless.
+          persist-credentials: false
 
       - name: Install dependencies
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
@@ -702,9 +708,20 @@ jobs:
             dist/release/manifest.json
             dist/release/manifest.minisig
 
+      # A GitHub App token lives 60 minutes; the cross-compile above routinely
+      # outlives it, so the checkout token is dead by now. Mint a fresh one
+      # immediately before the push and hand it to git via RELEASER_TOKEN.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        name: Refresh releaser token for the push
+        id: push-token
+        with:
+          client-id: ${{ vars.ACCELERATOR_RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.ACCELERATOR_RELEASER_SECRET }}
+
       - name: Finalise prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_TOKEN: ${{ steps.push-token.outputs.token }}
         run: mise run prerelease:finalise
 
   approve-release:
@@ -775,6 +792,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Each Finalise below authenticates with a freshly-minted token, not
+          # this one — the checkout credential is dead by then (see the Refresh
+          # steps). Persisting it would leave a host-matched extraheader that
+          # collides with the fresh token on the push, so drop it; the public
+          # repo clones and pulls anonymously regardless.
+          persist-credentials: false
 
       - name: Install dependencies
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
@@ -830,9 +853,19 @@ jobs:
             dist/release/manifest.json
             dist/release/manifest.minisig
 
+      # Fresh token for the push: the checkout token expired during the
+      # cross-compile above (a GitHub App token lives 60 minutes).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        name: Refresh releaser token for the stable push
+        id: push-token-stable
+        with:
+          client-id: ${{ vars.ACCELERATOR_RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.ACCELERATOR_RELEASER_SECRET }}
+
       - name: Finalise stable release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_TOKEN: ${{ steps.push-token-stable.outputs.token }}
         run: mise run release:finalise
 
       - name: Prepare post-stable prerelease
@@ -854,9 +887,19 @@ jobs:
             dist/release/manifest.json
             dist/release/manifest.minisig
 
+      # The post-stable prepare above cross-compiled again, so mint another
+      # fresh token for this second push (a GitHub App token lives 60 minutes).
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        name: Refresh releaser token for the post-stable push
+        id: push-token-poststable
+        with:
+          client-id: ${{ vars.ACCELERATOR_RELEASER_CLIENT_ID }}
+          private-key: ${{ secrets.ACCELERATOR_RELEASER_SECRET }}
+
       - name: Finalise post-stable prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASER_TOKEN: ${{ steps.push-token-poststable.outputs.token }}
         run: mise run prerelease:finalise
 
   # Build (npm lifecycle scripts included) runs unprivileged; only the

--- a/meta/prs/106-description.md
+++ b/meta/prs/106-description.md
@@ -1,0 +1,84 @@
+---
+type: "pr-description"
+id: "106"
+title: "Mint a fresh releaser token for each release push"
+date: "2026-09-08T12:23:25+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/106"
+pr_number: 106
+tags: []
+revision: "1bea682df848105853df95003d7dde2cceb9ed39"
+repository: "accelerator"
+last_updated: "2026-09-08T12:23:25+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Mint a fresh releaser token for each release push
+
+## Summary
+
+The Main pipeline has been failing on every push to `main`: the `prerelease`
+job bumps the version, commits it, then fails at `git push` with
+`fatal: could not read Username for 'https://github.com': Device not
+configured`. The push credential — a GitHub App token minted at checkout —
+expires after 60 minutes, and the four-target cross-compile in `*:prepare`
+routinely runs longer, so the token is dead by the time `finalise` pushes.
+This PR mints a fresh token immediately before each push instead.
+
+## Changes
+
+- **Re-mint the releaser App token right before each finalise step**
+  (`.github/workflows/main.yml`): one in the `prerelease` job, two in the
+  `release` job (stable and post-stable), each seconds before its push.
+- **Push over a token-authenticated remote URL** (`tasks/git.py`): `git.push`
+  injects `RELEASER_TOKEN` into the origin URL, left unexpanded so the shell
+  substitutes it at push time and the secret never enters this process's
+  arguments. Local dev has no `RELEASER_TOKEN` and pushes through the
+  developer's own `origin` credential unchanged.
+- **Drop `persist-credentials` on the release checkouts**: the stale checkout
+  credential leaves a host-matched `extraheader` that would collide with the
+  fresh token on the push. The repository is public, so clone and pull work
+  anonymously without it.
+- **Regression guards** (`tests/unit/tasks/`): a new `test_git.py` pins the
+  token-URL push and the `origin` fallback; new `test_workflows.py` cases
+  assert every finalise step is preceded by a fresh App-token step wired
+  through `RELEASER_TOKEN`, and that neither publishing checkout persists
+  credentials.
+
+## Context
+
+No linked work item — a direct fix for the red Main pipeline on `main`. Root
+cause confirmed across the recent failing runs: token minted at checkout
+(e.g. `00:18:29`), push attempted 69 minutes later (`01:27:30`), well past the
+GitHub App token's hard 60-minute TTL. The one recent run that succeeded had a
+warm cargo cache and finished the compile under the hour. Direct pushes to
+`main` are required because the branch ruleset mandates pull requests; only
+the releaser App (a bypass actor) can push the version bump, so the fix keeps
+the App token and refreshes it rather than switching to `GITHUB_TOKEN`.
+
+## Testing
+
+- [x] `mise run build-system:check` — format, lint, types, and actionlint all
+  pass.
+- [x] `uv run pytest tests/unit/tasks` — 2786 passed, including the new
+  `git.push` and workflow-wiring guards.
+- [ ] End-to-end release push — cannot be reproduced locally; the fix rests on
+  the 60-minute TTL, the public-repo anonymous-fetch guarantee (confirmed via
+  anonymous `ls-remote`), and the unit + actionlint coverage. Verified in CI on
+  merge.
+
+## Notes for Reviewers
+
+- The token reaches `git` as `https://x-access-token:${RELEASER_TOKEN}@...`
+  built in Python with the variable **left literal**; the child shell expands
+  it. Confirm you are comfortable that the token stays out of `argv` and logs
+  (invoke does not echo the command; the App-token output is auto-masked).
+- The top-of-job App-token step and App-token checkout are retained (public
+  repo, so only the clone uses them) to satisfy the existing app-token wiring
+  guards; the push no longer depends on that credential.
+- The `release` job now mints the token three times per run in total (once at
+  checkout, once per finalise). Each installation-token mint is cheap and
+  self-revoking at post-job.

--- a/tasks/git.py
+++ b/tasks/git.py
@@ -1,3 +1,5 @@
+import os
+
 from invoke import Context, task
 
 from . import version
@@ -43,13 +45,30 @@ def push(context: Context, target_version: str | None = None) -> None:
     that never reached main and wedging the release. We push the one explicit
     version tag rather than --tags so the result never depends on which tags
     happen to be present in the runner's checkout.
+
+    Under CI the push authenticates with a GitHub App token supplied in
+    RELEASER_TOKEN, minted immediately beforehand. The checkout credential
+    cannot serve here: a GitHub App token lives 60 minutes and the four-target
+    cross-compile in *:prepare routinely outlives it, so by finalise the
+    persisted credential is dead. The token reaches git through the remote URL,
+    left unexpanded in the command so the shell substitutes it at push time and
+    the secret never enters this process's arguments. Local dev has no
+    RELEASER_TOKEN and pushes through the developer's own `origin` credential.
     """
     resolved_version = target_version or version.read(
         context, print_to_stdout=False
     )
-    context.run(
-        f"git push --atomic origin HEAD 'refs/tags/v{resolved_version}'"
-    )
+    tag_ref = f"refs/tags/v{resolved_version}"
+    if os.environ.get("RELEASER_TOKEN"):
+        origin = context.run(
+            "git remote get-url origin", hide=True
+        ).stdout.strip()
+        remote = origin.replace(
+            "https://", "https://x-access-token:${RELEASER_TOKEN}@", 1
+        )
+        context.run(f"git push --atomic {remote} HEAD '{tag_ref}'")
+    else:
+        context.run(f"git push --atomic origin HEAD '{tag_ref}'")
 
 
 @task

--- a/tests/unit/tasks/test_git.py
+++ b/tests/unit/tasks/test_git.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+import pytest
+from invoke import Context
+
+import tasks.git as tg
+
+
+@pytest.fixture
+def ctx():
+    m = MagicMock(spec=Context)
+    m.run.return_value = MagicMock(return_code=0, stdout="")
+    return m
+
+
+def _commands(ctx):
+    return [call.args[0] for call in ctx.run.call_args_list]
+
+
+class TestPush:
+    def test_pushes_to_origin_without_a_releaser_token(
+        self, ctx, mocker, monkeypatch
+    ):
+        monkeypatch.delenv("RELEASER_TOKEN", raising=False)
+        mocker.patch.object(tg.version, "read", return_value="1.2.3")
+
+        tg.push(ctx)
+
+        assert "git push --atomic origin HEAD 'refs/tags/v1.2.3'" in _commands(
+            ctx
+        )
+
+    def test_pushes_over_a_token_authenticated_url_when_present(
+        self, ctx, mocker, monkeypatch
+    ):
+        # The push credential must be minted at push time, not at checkout: a
+        # GitHub App token expires after an hour and the cross-compile in
+        # *:prepare routinely outlives it.
+        monkeypatch.setenv("RELEASER_TOKEN", "ghs_secret_value")
+        mocker.patch.object(tg.version, "read", return_value="1.2.3")
+
+        def run(command, *args, **kwargs):
+            if command == "git remote get-url origin":
+                return MagicMock(
+                    return_code=0,
+                    stdout="https://github.com/atomicinnovation/accelerator\n",
+                )
+            return MagicMock(return_code=0, stdout="")
+
+        ctx.run.side_effect = run
+
+        tg.push(ctx)
+
+        push = next(c for c in _commands(ctx) if c.startswith("git push"))
+        assert (
+            "x-access-token:${RELEASER_TOKEN}@github.com/"
+            "atomicinnovation/accelerator" in push
+        )
+        # The shell expands the token at push time; Python must never bake the
+        # literal secret into the command, or it would leak into process args.
+        assert "ghs_secret_value" not in push
+        assert "origin" not in push

--- a/tests/unit/tasks/test_workflows.py
+++ b/tests/unit/tasks/test_workflows.py
@@ -312,6 +312,57 @@ def test_publishing_job_checks_out_with_app_token(wf, job_name):
     )
 
 
+# --- Fresh app token at push time --------------------------------------
+#
+# The checkout token is minted at job start, but a GitHub App token expires
+# after 60 minutes and the four-target cross-compile in *:prepare routinely
+# outlives it — so by the time release.py:_publish runs `git push` the checkout
+# credential is dead, and the push fell back to an interactive prompt the
+# headless runner cannot answer ("could not read Username ... Device not
+# configured"). Each finalise step must therefore be immediately preceded by a
+# fresh create-github-app-token step whose output is handed to the push as
+# RELEASER_TOKEN. The checkout must also NOT persist its soon-stale credential,
+# whose host-matched extraheader would otherwise collide with the fresh token.
+
+PUSH_TOKEN_ENV = "RELEASER_TOKEN"
+
+
+@pytest.mark.parametrize("job_name", PUBLISHING_JOBS)
+def test_publishing_checkout_does_not_persist_credentials(wf, job_name):
+    checkout = _checkout_step(wf["jobs"][job_name])
+    with_ = checkout.get("with") or {}
+    assert with_.get("persist-credentials") is False, (
+        f"{job_name} must set persist-credentials: false so the stale checkout "
+        "extraheader cannot collide with the fresh push token"
+    )
+
+
+@pytest.mark.parametrize("job_name", PUBLISHING_JOBS)
+def test_each_finalise_is_preceded_by_a_fresh_push_token(wf, job_name):
+    steps = wf["jobs"][job_name].get("steps") or []
+    finalises = _indices(steps, _named("Finalise"))
+    assert finalises, f"{job_name} has no Finalise step"
+    for index in finalises:
+        minted = steps[index - 1]
+        assert _step_action(minted) == APP_TOKEN_ACTION, (
+            f"{job_name}'s finalise at step {index} must be immediately "
+            "preceded by a fresh app-token step — the checkout token has "
+            "expired by the time *:prepare finishes compiling"
+        )
+        token_id = minted.get("id")
+        assert token_id and token_id != "app-token", (
+            "the push-token refresh step needs its own id, distinct from the "
+            "checkout's app-token step"
+        )
+        env = steps[index].get("env") or {}
+        assert f"steps.{token_id}.outputs.token" in str(
+            env.get(PUSH_TOKEN_ENV, "")
+        ), (
+            f"{job_name}'s finalise must hand the fresh token to the push as "
+            f"{PUSH_TOKEN_ENV}"
+        )
+
+
 # --- Encoded negative tests: each mutation breaks exactly one invariant, so
 #     the guard's own discriminating power is under test and cannot rot. ---
 


### PR DESCRIPTION

# Mint a fresh releaser token for each release push

## Summary

The Main pipeline has been failing on every push to `main`: the `prerelease`
job bumps the version, commits it, then fails at `git push` with
`fatal: could not read Username for 'https://github.com': Device not
configured`. The push credential — a GitHub App token minted at checkout —
expires after 60 minutes, and the four-target cross-compile in `*:prepare`
routinely runs longer, so the token is dead by the time `finalise` pushes.
This PR mints a fresh token immediately before each push instead.

## Changes

- **Re-mint the releaser App token right before each finalise step**
  (`.github/workflows/main.yml`): one in the `prerelease` job, two in the
  `release` job (stable and post-stable), each seconds before its push.
- **Push over a token-authenticated remote URL** (`tasks/git.py`): `git.push`
  injects `RELEASER_TOKEN` into the origin URL, left unexpanded so the shell
  substitutes it at push time and the secret never enters this process's
  arguments. Local dev has no `RELEASER_TOKEN` and pushes through the
  developer's own `origin` credential unchanged.
- **Drop `persist-credentials` on the release checkouts**: the stale checkout
  credential leaves a host-matched `extraheader` that would collide with the
  fresh token on the push. The repository is public, so clone and pull work
  anonymously without it.
- **Regression guards** (`tests/unit/tasks/`): a new `test_git.py` pins the
  token-URL push and the `origin` fallback; new `test_workflows.py` cases
  assert every finalise step is preceded by a fresh App-token step wired
  through `RELEASER_TOKEN`, and that neither publishing checkout persists
  credentials.

## Context

No linked work item — a direct fix for the red Main pipeline on `main`. Root
cause confirmed across the recent failing runs: token minted at checkout
(e.g. `00:18:29`), push attempted 69 minutes later (`01:27:30`), well past the
GitHub App token's hard 60-minute TTL. The one recent run that succeeded had a
warm cargo cache and finished the compile under the hour. Direct pushes to
`main` are required because the branch ruleset mandates pull requests; only
the releaser App (a bypass actor) can push the version bump, so the fix keeps
the App token and refreshes it rather than switching to `GITHUB_TOKEN`.

## Testing

- [x] `mise run build-system:check` — format, lint, types, and actionlint all
  pass.
- [x] `uv run pytest tests/unit/tasks` — 2786 passed, including the new
  `git.push` and workflow-wiring guards.
- [ ] End-to-end release push — cannot be reproduced locally; the fix rests on
  the 60-minute TTL, the public-repo anonymous-fetch guarantee (confirmed via
  anonymous `ls-remote`), and the unit + actionlint coverage. Verified in CI on
  merge.

## Notes for Reviewers

- The token reaches `git` as `https://x-access-token:${RELEASER_TOKEN}@...`
  built in Python with the variable **left literal**; the child shell expands
  it. Confirm you are comfortable that the token stays out of `argv` and logs
  (invoke does not echo the command; the App-token output is auto-masked).
- The top-of-job App-token step and App-token checkout are retained (public
  repo, so only the clone uses them) to satisfy the existing app-token wiring
  guards; the push no longer depends on that credential.
- The `release` job now mints the token three times per run in total (once at
  checkout, once per finalise). Each installation-token mint is cheap and
  self-revoking at post-job.
