### PR TITLE
[0285] Targeted pull of remote-only work items and resolution normalisation

### DIFF
--- a/cli/work-adapters/src/author.rs
+++ b/cli/work-adapters/src/author.rs
@@ -15,26 +15,60 @@
 //! of its own. `InProcessProbe`'s own test suite, including
 //! `vcs-adapters/tests/user_name.rs`, covers that behaviour.
 
+use std::path::Path;
+
 use vcs_adapters::library::InProcessProbe;
 use work::create::VcsIdentityProbe;
 
-/// The configured VCS user name (jj's or git's `user.name`, jj-colocated
-/// wins), or `None` on any failure — unconfigured, no repository, or the
-/// probe could not answer.
+/// The configured VCS user name for the repository containing `start`.
+///
+/// jj's or git's `user.name` (jj-colocated wins), or `None` on any failure —
+/// unconfigured, no repository, or the probe could not answer.
+#[must_use]
+pub fn vcs_user_at(start: &Path) -> Option<String> {
+    let probe = InProcessProbe;
+    vcs::user_name(start, &probe, &probe, &probe)
+}
+
+/// The configured VCS user name for the repository containing the process
+/// working directory. See [`vcs_user_at`].
 #[must_use]
 pub fn current_vcs_user() -> Option<String> {
     let cwd = std::env::current_dir().ok()?;
-    let probe = InProcessProbe;
-    vcs::user_name(&cwd, &probe, &probe, &probe)
+    vcs_user_at(&cwd)
 }
 
 /// The real, `vcs`/`vcs-adapters`-backed implementation of
-/// `work::create::VcsIdentityProbe`.
+/// `work::create::VcsIdentityProbe`, reading the process working directory's
+/// repository.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct VcsBackedIdentityProbe;
 
 impl VcsIdentityProbe for VcsBackedIdentityProbe {
     fn current_user_name(&self) -> Option<String> {
         current_vcs_user()
+    }
+}
+
+/// A [`VcsIdentityProbe`] that reads a named repository's identity.
+///
+/// An operation that already knows the repository it acts on resolves its
+/// author from that repository rather than the process working directory —
+/// where the process runs is not necessarily the repository being synced.
+#[derive(Debug, Clone, Copy)]
+pub struct RepositoryIdentityProbe<'a> {
+    root: &'a Path,
+}
+
+impl<'a> RepositoryIdentityProbe<'a> {
+    #[must_use]
+    pub const fn new(root: &'a Path) -> Self {
+        Self { root }
+    }
+}
+
+impl VcsIdentityProbe for RepositoryIdentityProbe<'_> {
+    fn current_user_name(&self) -> Option<String> {
+        vcs_user_at(self.root)
     }
 }

--- a/cli/work-adapters/src/sync/run.rs
+++ b/cli/work-adapters/src/sync/run.rs
@@ -92,12 +92,19 @@ pub struct SyncPorts<'a> {
 ///
 /// `All` is payload-free so `SyncRequest::corpus` is the single source of the
 /// reconciled set — a construction site cannot desync the two, and the
-/// invariant `reconciled() ⊆ corpus` holds structurally. `Targeted` also gates
-/// untracked-remote discovery off, so a narrowed set can never re-import the
-/// items it left out.
+/// invariant `reconciled() ⊆ corpus` holds structurally. `Targeted` gates the
+/// untracked-remote *search* off, so a narrowed set can never re-import the
+/// items it left out, and carries a third set beyond `corpus` and the
+/// reconciled `items`: `pull_ids`, confirmed remote-only ids the run imports
+/// by id in place of a discovery search. An id already bound to a local file
+/// must not appear in `pull_ids`; the engine enforces this at the injection
+/// point (see the discovery branch), so a caller need not pre-filter.
 pub enum ItemSelection<'a> {
     All,
-    Targeted(&'a [LocalItem]),
+    Targeted {
+        items: &'a [LocalItem],
+        pull_ids: &'a [ExternalId],
+    },
 }
 
 pub struct SyncRequest<'a> {
@@ -130,13 +137,16 @@ impl<'a> SyncRequest<'a> {
     pub const fn reconciled(&self) -> &'a [LocalItem] {
         match self.selection {
             ItemSelection::All => self.corpus,
-            ItemSelection::Targeted(items) => items,
+            ItemSelection::Targeted { items, .. } => items,
         }
     }
 
+    /// Whether the untracked-remote *search* is suppressed. A targeted run
+    /// reaches remote-only items by id through `pull_ids`, not through the
+    /// unkeyed discovery search, so the search is always off under `Targeted`.
     #[must_use]
-    pub const fn discovery_suppressed(&self) -> bool {
-        matches!(self.selection, ItemSelection::Targeted(_))
+    pub const fn discovery_search_suppressed(&self) -> bool {
+        matches!(self.selection, ItemSelection::Targeted { .. })
     }
 }
 
@@ -172,9 +182,14 @@ pub enum DiscoveryStatus {
     Ran { found: usize },
     /// The run was push-only, so discovery was deliberately not run.
     SkippedPushOnly,
-    /// The run named explicit targets, so discovery was deliberately not run:
-    /// a targeted pull reaches only items already tracked locally.
+    /// The run named explicit targets, so the untracked-remote search was
+    /// deliberately not run and no remote-only target was pulled by id.
     SkippedTargeted,
+    /// The run named explicit targets and pulled `attempted` confirmed
+    /// remote-only ids by id, in place of an untracked search. `attempted` is
+    /// the count gated into the run, not the count that applied — a per-item
+    /// `CreateFromRemote` failure still counts here.
+    TargetedPull { attempted: usize },
     /// The search failed transiently (network). Maps to `RETRYABLE` (70), the
     /// fate a failed read carries.
     Failed { detail: String },
@@ -492,6 +507,19 @@ struct Discovered {
     complete: bool,
 }
 
+/// Whether any local item in `corpus` already carries `candidate` as its
+/// `external_id`, compared by canonical key so a cosmetic spelling difference
+/// folds equal — the same folding untracked discovery applies. Shared by the
+/// targeted-pull filter (so a `pull_id` already bound locally is never
+/// re-imported) and the create-from-local double-binding guard.
+fn corpus_carries(corpus: &[LocalItem], candidate: &ExternalId) -> bool {
+    let key = canonical_external_key(candidate);
+    corpus
+        .iter()
+        .filter_map(|item| item.external_id.as_ref())
+        .any(|external| canonical_external_key(external) == key)
+}
+
 /// The untracked remote issues: a `search` over `scope` minus the
 /// canonicalised set of local `external_id`s. A stored id differing from a
 /// search result only cosmetically folds equal and is excluded.
@@ -727,6 +755,71 @@ struct PreparedRun<'a> {
     dossiers: Vec<ConflictDossier>,
 }
 
+/// The remote-side ids a run imports and the discovery line that describes how
+/// they were found. A `Targeted` run pulls its confirmed `pull_ids` by id,
+/// dropping any already bound in the corpus; a full run resolves its scope and
+/// searches for untracked issues; a push-only full run does neither.
+///
+/// Computed from reads only, so the combined gate in [`prepare_run`] can bound
+/// every write — planned pulls, planned pushes, and both create paths — before
+/// a single one runs.
+///
+/// # Errors
+///
+/// [`RunError::DiscoveryUnconfigured`] when a full run's scope names no valid
+/// target; [`RunError::DiscoveryIncomplete`] when the untracked search is cut
+/// short.
+fn untracked_to_import(
+    ports: &SyncPorts<'_>,
+    request: &SyncRequest<'_>,
+) -> Result<(Vec<ExternalId>, DiscoveryStatus), RunError> {
+    Ok(match &request.selection {
+        ItemSelection::Targeted { pull_ids, .. } => {
+            let confirmed: Vec<ExternalId> = pull_ids
+                .iter()
+                .filter(|id| !corpus_carries(request.corpus, id))
+                .cloned()
+                .collect();
+            if confirmed.is_empty() {
+                (Vec::new(), DiscoveryStatus::SkippedTargeted)
+            } else {
+                let attempted = confirmed.len();
+                (confirmed, DiscoveryStatus::TargetedPull { attempted })
+            }
+        }
+        ItemSelection::All
+            if matches!(request.direction, SyncDirection::PushOnly) =>
+        {
+            (Vec::new(), DiscoveryStatus::SkippedPushOnly)
+        }
+        ItemSelection::All => {
+            let resolved = ports
+                .tracker
+                .resolve_scope(&request.scope)
+                .map_err(|error| RunError::DiscoveryUnconfigured {
+                    detail: error.detail,
+                })?;
+            match discover_untracked(ports.tracker, &resolved, request.corpus) {
+                Ok(discovered) if !discovered.complete => {
+                    return Err(RunError::DiscoveryIncomplete {
+                        found: discovered.ids.len(),
+                    });
+                }
+                Ok(discovered) => {
+                    let found = discovered.ids.len();
+                    (discovered.ids, DiscoveryStatus::Ran { found })
+                }
+                Err(error) => (
+                    Vec::new(),
+                    DiscoveryStatus::Failed {
+                        detail: error.into_detail(),
+                    },
+                ),
+            }
+        }
+    })
+}
+
 /// Gathers facts, plans, discovers both create sets, and refuses before any
 /// write when the plan's pull or push count exceeds its bound.
 ///
@@ -777,42 +870,7 @@ fn prepare_run<'a>(
 
     let read_failure = facts.read_failure.clone();
 
-    // Untracked-remote discovery and unsynced-local creates are computed from
-    // reads only, so the combined gate below can bound every write — planned
-    // pulls, planned pushes, and both create paths — before a single one runs.
-    // A non-push-only run resolves its scope first: a missing or unresolvable
-    // key refuses the whole run here, before the apply/push phase, so nothing
-    // is sent.
-    let (untracked, discovery) = if request.discovery_suppressed() {
-        (Vec::new(), DiscoveryStatus::SkippedTargeted)
-    } else if matches!(request.direction, SyncDirection::PushOnly) {
-        (Vec::new(), DiscoveryStatus::SkippedPushOnly)
-    } else {
-        let resolved =
-            ports
-                .tracker
-                .resolve_scope(&request.scope)
-                .map_err(|error| RunError::DiscoveryUnconfigured {
-                    detail: error.detail,
-                })?;
-        match discover_untracked(ports.tracker, &resolved, request.corpus) {
-            Ok(discovered) if !discovered.complete => {
-                return Err(RunError::DiscoveryIncomplete {
-                    found: discovered.ids.len(),
-                });
-            }
-            Ok(discovered) => {
-                let found = discovered.ids.len();
-                (discovered.ids, DiscoveryStatus::Ran { found })
-            }
-            Err(error) => (
-                Vec::new(),
-                DiscoveryStatus::Failed {
-                    detail: error.into_detail(),
-                },
-            ),
-        }
-    };
+    let (untracked, discovery) = untracked_to_import(ports, request)?;
     let creates_from_local =
         unsynced_creates(&plan, request.reconciled(), request.direction);
 
@@ -911,12 +969,8 @@ pub fn run<'a>(
         plan.actions.len() + untracked.len() + creates_from_local.len(),
     );
     let mut blank_local_hash: Vec<String> = Vec::new();
-    let corpus_carries = |candidate: &ExternalId| {
-        request
-            .corpus
-            .iter()
-            .any(|item| item.external_id.as_ref() == Some(candidate))
-    };
+    let carries =
+        |candidate: &ExternalId| corpus_carries(request.corpus, candidate);
 
     {
         let mut applier = ItemApplier::new(
@@ -955,7 +1009,7 @@ pub fn run<'a>(
                 item,
                 request,
                 ports.author,
-                &corpus_carries,
+                &carries,
                 run_start_epoch,
             ));
         }

--- a/cli/work-adapters/tests/sync_create.rs
+++ b/cli/work-adapters/tests/sync_create.rs
@@ -297,7 +297,7 @@ fn run_sync_targeted(
 }
 
 /// A targeted run carrying confirmed remote-only `pull_ids`, reconciling
-/// `targeted` and importing `pull_ids` by id. The seam Phase 3's CLI drives.
+/// `targeted` and importing `pull_ids` by id. The seam the CLI drives.
 #[allow(clippy::too_many_arguments)]
 fn run_sync_targeted_pull(
     ports: &Ports<'_>,
@@ -1029,7 +1029,7 @@ fn planned_writes_over_bound_refuse_before_any_create_from_remote(
     Ok(())
 }
 
-// --- 0285: targeted pull of remote-only ids ---------------------------------
+// --- targeted pull of remote-only ids ---------------------------------------
 
 #[test]
 fn a_targeted_pull_id_creates_the_file_and_counts_as_a_pull(
@@ -1337,9 +1337,6 @@ fn of_two_pull_ids_one_show_failure_reports_one_success(
 #[test]
 fn a_mixed_run_writes_the_targeted_union_and_no_non_targeted_item(
 ) -> Result<(), TestError> {
-    // AC7: a run mixing a resolved reconcile item and a remote-only pull_id,
-    // over a corpus that also holds a non-targeted item, writes exactly the
-    // two targeted items and nothing else.
     let fixture = Fixture::new()?;
     let stamp_moved =
         RemoteTimestamp::Reported("2026-07-01T00:00:00Z".to_owned());
@@ -1434,8 +1431,6 @@ fn a_mixed_run_writes_the_targeted_union_and_no_non_targeted_item(
 #[test]
 fn a_discovery_import_and_a_targeted_pull_author_identically(
 ) -> Result<(), TestError> {
-    // AC2 parity: the same stub issue imported via discovery and via a
-    // targeted pull_id allocates an identical id, filename, and baseline entry.
     let via_discovery = {
         let fixture = Fixture::new()?;
         let tracker = RecordingTracker::holding(vec![(
@@ -1507,8 +1502,7 @@ fn a_discovery_import_and_a_targeted_pull_author_identically(
     assert_eq!(via_discovery.0, via_pull.0, "identical id allocation");
     assert_eq!(via_discovery.1, via_pull.1, "identical authored file");
     // The document-level watermark legitimately differs — a full sync advances
-    // it, a targeted run does not — so compare the per-item baseline entry, the
-    // subject of the allocation-parity criterion.
+    // it, a targeted run does not — so compare the per-item baseline entry.
     let (discovery_baseline, _) = work_adapters::sync::baseline::Baseline::read(
         via_discovery.2.as_deref(),
     );

--- a/cli/work-adapters/tests/sync_create.rs
+++ b/cli/work-adapters/tests/sync_create.rs
@@ -62,6 +62,13 @@ impl Spy {
     fn write_count(&self) -> usize {
         self.writes.borrow().len()
     }
+
+    fn content(&self, path: &str) -> Option<String> {
+        self.files
+            .borrow()
+            .get(Path::new(path))
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+    }
 }
 
 impl FileReader for Spy {
@@ -272,7 +279,10 @@ fn run_sync_targeted(
     let resolutions: BTreeMap<String, Resolution> = BTreeMap::new();
     let request = SyncRequest {
         corpus,
-        selection: ItemSelection::Targeted(targeted),
+        selection: ItemSelection::Targeted {
+            items: targeted,
+            pull_ids: &[],
+        },
         direction,
         strategy: RetrievalStrategy::Bulk,
         resolutions: &resolutions,
@@ -282,6 +292,98 @@ fn run_sync_targeted(
         integrations_root,
         integration: "jira",
         scope,
+    };
+    run(&sync_ports, &mut store, &request)
+}
+
+/// A targeted run carrying confirmed remote-only `pull_ids`, reconciling
+/// `targeted` and importing `pull_ids` by id. The seam Phase 3's CLI drives.
+#[allow(clippy::too_many_arguments)]
+fn run_sync_targeted_pull(
+    ports: &Ports<'_>,
+    corpus: &[LocalItem],
+    targeted: &[LocalItem],
+    pull_ids: &[ExternalId],
+    integrations_root: &Path,
+    direction: SyncDirection,
+    max_pulls: usize,
+    max_pushes: usize,
+    mode: RunMode,
+) -> Result<RunReport, RunError> {
+    let clock = FixedClock(1_700_000_000);
+    let status = AlwaysClean;
+    let sync_ports = SyncPorts {
+        tracker: ports.tracker,
+        status: &status,
+        writer: ports.spy,
+        clock: &clock,
+        author: ports.author,
+    };
+    let mut store =
+        BaselineStore::new(PathBuf::from(BASELINE_PATH), ports.spy, ports.spy);
+    let resolutions: BTreeMap<String, Resolution> = BTreeMap::new();
+    let request = SyncRequest {
+        corpus,
+        selection: ItemSelection::Targeted {
+            items: targeted,
+            pull_ids,
+        },
+        direction,
+        strategy: RetrievalStrategy::Bulk,
+        resolutions: &resolutions,
+        max_pulls,
+        max_pushes,
+        mode,
+        integrations_root,
+        integration: "jira",
+        scope: SearchScope::default(),
+    };
+    run(&sync_ports, &mut store, &request)
+}
+
+/// A targeted-pull run at a chosen `epoch` over the fixture's persistent spy,
+/// so a sequence of runs shares one baseline document — the recovery and
+/// watermark scenarios need "run at E1, then E2, against one baseline".
+#[allow(clippy::too_many_arguments)]
+fn run_at(
+    fixture: &Fixture,
+    tracker: &RecordingTracker,
+    author: &RecordingAuthor,
+    corpus: &[LocalItem],
+    targeted: &[LocalItem],
+    pull_ids: &[ExternalId],
+    epoch: u64,
+) -> Result<RunReport, RunError> {
+    let clock = FixedClock(epoch);
+    let status = AlwaysClean;
+    let sync_ports = SyncPorts {
+        tracker,
+        status: &status,
+        writer: &fixture.spy,
+        clock: &clock,
+        author,
+    };
+    let mut store = BaselineStore::new(
+        PathBuf::from(BASELINE_PATH),
+        &fixture.spy,
+        &fixture.spy,
+    );
+    let resolutions: BTreeMap<String, Resolution> = BTreeMap::new();
+    let request = SyncRequest {
+        corpus,
+        selection: ItemSelection::Targeted {
+            items: targeted,
+            pull_ids,
+        },
+        direction: SyncDirection::Bidirectional,
+        strategy: RetrievalStrategy::Bulk,
+        resolutions: &resolutions,
+        max_pulls: 25,
+        max_pushes: 25,
+        mode: RunMode::Apply,
+        integrations_root: fixture.dir.path(),
+        integration: "jira",
+        scope: SearchScope::default(),
     };
     run(&sync_ports, &mut store, &request)
 }
@@ -927,6 +1029,657 @@ fn planned_writes_over_bound_refuse_before_any_create_from_remote(
     Ok(())
 }
 
+// --- 0285: targeted pull of remote-only ids ---------------------------------
+
+#[test]
+fn a_targeted_pull_id_creates_the_file_and_counts_as_a_pull(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(vec![(
+        ExternalId::new("ENG-7".to_owned()),
+        issue("Seven\nremote body"),
+    )]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &[],
+        &[],
+        &[ExternalId::new("ENG-7".to_owned())],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .map_err(|_| "a single remote-only pull within bounds must proceed")?;
+
+    assert_eq!(
+        *author.authored.borrow(),
+        vec![ExternalId::new("ENG-7".to_owned())],
+        "the remote-only id is imported through create-from-remote"
+    );
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::TargetedPull { attempted: 1 }
+    );
+    let create = report
+        .reported
+        .iter()
+        .find(|item| item.planned.action == Action::CreateFromRemote)
+        .expect("one create-from-remote row");
+    assert!(matches!(create.outcome, ItemOutcome::Applied));
+    Ok(())
+}
+
+#[test]
+fn an_empty_confirmed_set_still_reports_skipped_targeted(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(Vec::new());
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &[],
+        &[],
+        &[],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .map_err(|_| "a reconcile-only targeted run must proceed")?;
+
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::SkippedTargeted,
+        "an empty pull set leaves the discovery line unchanged"
+    );
+    assert!(author.authored.borrow().is_empty());
+    Ok(())
+}
+
+#[test]
+fn targeted_pulls_over_max_pulls_refuse_with_no_creation(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(vec![
+        (ExternalId::new("ENG-1".to_owned()), issue("One\nbody")),
+        (ExternalId::new("ENG-2".to_owned()), issue("Two\nbody")),
+    ]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let error = run_sync_targeted_pull(
+        &ports,
+        &[],
+        &[],
+        &[
+            ExternalId::new("ENG-1".to_owned()),
+            ExternalId::new("ENG-2".to_owned()),
+        ],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        1,
+        25,
+        RunMode::Apply,
+    )
+    .err()
+    .expect("two remote-only pulls against a bound of one must refuse");
+
+    match error {
+        RunError::Refused {
+            pulls,
+            new_local_files,
+            ..
+        } => {
+            assert_eq!(pulls, 2);
+            assert_eq!(new_local_files, 2);
+        }
+        other => panic!("expected Refused, got {other:?}"),
+    }
+    assert!(
+        author.authored.borrow().is_empty(),
+        "the gate must refuse before any create-from-remote write"
+    );
+    assert!(
+        !tracker
+            .calls()
+            .iter()
+            .any(|call| matches!(call, Call::Show { .. })),
+        "no per-issue show fan-out before the gate"
+    );
+    assert_eq!(fixture.spy.write_count(), 0);
+    Ok(())
+}
+
+#[test]
+fn a_previewed_targeted_pull_reports_a_create_without_writing(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(vec![(
+        ExternalId::new("ENG-5".to_owned()),
+        issue("Five\nbody"),
+    )]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &[],
+        &[],
+        &[ExternalId::new("ENG-5".to_owned())],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Preview,
+    )
+    .map_err(|_| "a previewed pull within bounds must not refuse")?;
+
+    assert!(
+        author.authored.borrow().is_empty(),
+        "preview authors nothing"
+    );
+    assert_eq!(fixture.spy.write_count(), 0, "preview writes nothing");
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::TargetedPull { attempted: 1 }
+    );
+    let create = report
+        .reported
+        .iter()
+        .find(|item| item.planned.action == Action::CreateFromRemote)
+        .expect("one create-from-remote row");
+    assert!(matches!(create.outcome, ItemOutcome::NotApplied));
+    Ok(())
+}
+
+#[test]
+fn a_pull_id_already_bound_in_the_corpus_is_filtered_out(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    // A corpus file already carries ENG-1 (in a cosmetically different
+    // spelling), so a pull_id naming it must fold equal and be dropped.
+    let bound_path = fixture.dir.path().join("0001.md");
+    std::fs::write(
+        &bound_path,
+        "---\nid: \"0001\"\nexternal_id: \"eng-1\"\n---\n\nBody\n",
+    )?;
+    let corpus = vec![LocalItem {
+        id: "0001".to_owned(),
+        path: bound_path,
+        external_id: Some(ExternalId::new("eng-1".to_owned())),
+    }];
+    let tracker = RecordingTracker::holding(vec![(
+        ExternalId::new("ENG-1".to_owned()),
+        issue("One\nbody"),
+    )]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &corpus,
+        &[],
+        &[ExternalId::new("ENG-1".to_owned())],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .map_err(|_| "a fully-filtered pull set is a reconcile-only run")?;
+
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::SkippedTargeted,
+        "a pull_id already bound locally leaves nothing to pull"
+    );
+    assert!(
+        author.authored.borrow().is_empty(),
+        "no second author for an already-bound id"
+    );
+    Ok(())
+}
+
+#[test]
+fn of_two_pull_ids_one_show_failure_reports_one_success(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let tracker = RecordingTracker::holding(vec![(
+        ExternalId::new("ENG-1".to_owned()),
+        issue("One\nbody"),
+    )])
+    .failing_show(
+        ExternalId::new("ENG-2".to_owned()),
+        TrackerError::Retryable {
+            detail: "connection reset".to_owned(),
+        },
+    );
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &[],
+        &[],
+        &[
+            ExternalId::new("ENG-1".to_owned()),
+            ExternalId::new("ENG-2".to_owned()),
+        ],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .map_err(|_| "a per-id show failure must not abort the batch")?;
+
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::TargetedPull { attempted: 2 },
+        "attempted counts the ids gated in, not the ids applied"
+    );
+    let applied = report
+        .reported
+        .iter()
+        .filter(|item| {
+            item.planned.action == Action::CreateFromRemote
+                && matches!(item.outcome, ItemOutcome::Applied)
+        })
+        .count();
+    let failed = report
+        .reported
+        .iter()
+        .filter(|item| {
+            item.planned.action == Action::CreateFromRemote
+                && matches!(item.outcome, ItemOutcome::Failed(_))
+        })
+        .count();
+    assert_eq!((applied, failed), (1, 1), "one success, one failure");
+    assert_eq!(
+        *author.authored.borrow(),
+        vec![ExternalId::new("ENG-1".to_owned())],
+        "only the readable id is authored"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_mixed_run_writes_the_targeted_union_and_no_non_targeted_item(
+) -> Result<(), TestError> {
+    // AC7: a run mixing a resolved reconcile item and a remote-only pull_id,
+    // over a corpus that also holds a non-targeted item, writes exactly the
+    // two targeted items and nothing else.
+    let fixture = Fixture::new()?;
+    let stamp_moved =
+        RemoteTimestamp::Reported("2026-07-01T00:00:00Z".to_owned());
+
+    // Item A: remotely modified, local unchanged → decides Pull, writes A.
+    let a_external = ExternalId::new("ENG-1".to_owned());
+    let a_path = fixture.dir.path().join("0001.md");
+    let a_content =
+        "---\nstatus: ready\nexternal_id: \"ENG-1\"\n---\n\nBody text\n";
+    std::fs::write(&a_path, a_content)?;
+    let a_local_hash = work_adapters::sync::digest::local(a_content)?;
+
+    // Item B: non-targeted, present in the corpus only.
+    let b_external = ExternalId::new("ENG-2".to_owned());
+    let b_path = fixture.dir.path().join("0002.md");
+    std::fs::write(
+        &b_path,
+        "---\nstatus: ready\nexternal_id: \"ENG-2\"\n---\n\nUntouched\n",
+    )?;
+
+    fixture.spy.seed(
+        BASELINE_PATH,
+        &baseline_document(&[format!(
+            "\"0001\":{{\"remote_updated_at\":\"2026-06-01T00:00:00Z\",\
+             \"remote_hash\":\"stale\",\"local_hash\":\"{a_local_hash}\"}}"
+        )]),
+    );
+
+    let tracker = RecordingTracker::holding(vec![
+        (
+            a_external.clone(),
+            RemoteIssue {
+                updated: stamp_moved,
+                body: "Title\nRemote body\n".to_owned(),
+            },
+        ),
+        (ExternalId::new("ENG-9".to_owned()), issue("Nine\nbody")),
+    ]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+    let ports = Ports {
+        tracker: &tracker,
+        author: &author,
+        spy: &fixture.spy,
+    };
+
+    let corpus = vec![
+        LocalItem {
+            id: "0001".to_owned(),
+            path: a_path.clone(),
+            external_id: Some(a_external),
+        },
+        LocalItem {
+            id: "0002".to_owned(),
+            path: b_path.clone(),
+            external_id: Some(b_external),
+        },
+    ];
+
+    let report = run_sync_targeted_pull(
+        &ports,
+        &corpus,
+        std::slice::from_ref(&corpus[0]),
+        &[ExternalId::new("ENG-9".to_owned())],
+        fixture.dir.path(),
+        SyncDirection::Bidirectional,
+        25,
+        25,
+        RunMode::Apply,
+    )
+    .map_err(|_| "a mixed targeted run within bounds must proceed")?;
+
+    assert_eq!(
+        *author.authored.borrow(),
+        vec![ExternalId::new("ENG-9".to_owned())],
+        "only the remote-only id is created"
+    );
+    assert!(
+        fixture.spy.content(&a_path.display().to_string()).is_some(),
+        "the reconciled targeted item A is written"
+    );
+    assert!(
+        fixture.spy.content(&b_path.display().to_string()).is_none(),
+        "the non-targeted item B must not be written"
+    );
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::TargetedPull { attempted: 1 }
+    );
+    Ok(())
+}
+
+#[test]
+fn a_discovery_import_and_a_targeted_pull_author_identically(
+) -> Result<(), TestError> {
+    // AC2 parity: the same stub issue imported via discovery and via a
+    // targeted pull_id allocates an identical id, filename, and baseline entry.
+    let via_discovery = {
+        let fixture = Fixture::new()?;
+        let tracker = RecordingTracker::holding(vec![(
+            ExternalId::new("ENG-7".to_owned()),
+            issue("Seven\nremote body"),
+        )])
+        .discovering(
+            vec![(
+                ExternalId::new("ENG-7".to_owned()),
+                RemoteTimestamp::NotReported,
+            )],
+            true,
+        );
+        let author = RecordingAuthor::new(fixture.dir.path());
+        let ports = Ports {
+            tracker: &tracker,
+            author: &author,
+            spy: &fixture.spy,
+        };
+        run_sync(
+            &ports,
+            &[],
+            fixture.dir.path(),
+            SyncDirection::PullOnly,
+            scoped(),
+            25,
+            25,
+            RunMode::Apply,
+        )
+        .map_err(|_| "the discovery import must proceed")?;
+        let authored = author.authored.borrow().clone();
+        let path = fixture.dir.path().join("9000.md");
+        let file = std::fs::read_to_string(&path)?;
+        let baseline = fixture.spy.content(BASELINE_PATH);
+        (authored, file, baseline)
+    };
+
+    let via_pull = {
+        let fixture = Fixture::new()?;
+        let tracker = RecordingTracker::holding(vec![(
+            ExternalId::new("ENG-7".to_owned()),
+            issue("Seven\nremote body"),
+        )]);
+        let author = RecordingAuthor::new(fixture.dir.path());
+        let ports = Ports {
+            tracker: &tracker,
+            author: &author,
+            spy: &fixture.spy,
+        };
+        run_sync_targeted_pull(
+            &ports,
+            &[],
+            &[],
+            &[ExternalId::new("ENG-7".to_owned())],
+            fixture.dir.path(),
+            SyncDirection::Bidirectional,
+            25,
+            25,
+            RunMode::Apply,
+        )
+        .map_err(|_| "the targeted pull must proceed")?;
+        let authored = author.authored.borrow().clone();
+        let path = fixture.dir.path().join("9000.md");
+        let file = std::fs::read_to_string(&path)?;
+        let baseline = fixture.spy.content(BASELINE_PATH);
+        (authored, file, baseline)
+    };
+
+    assert_eq!(via_discovery.0, via_pull.0, "identical id allocation");
+    assert_eq!(via_discovery.1, via_pull.1, "identical authored file");
+    // The document-level watermark legitimately differs — a full sync advances
+    // it, a targeted run does not — so compare the per-item baseline entry, the
+    // subject of the allocation-parity criterion.
+    let (discovery_baseline, _) = work_adapters::sync::baseline::Baseline::read(
+        via_discovery.2.as_deref(),
+    );
+    let (pull_baseline, _) =
+        work_adapters::sync::baseline::Baseline::read(via_pull.2.as_deref());
+    assert_eq!(
+        discovery_baseline.get("9000"),
+        pull_baseline.get("9000"),
+        "identical baseline entry"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_re_run_reconciles_the_pulled_id_and_advances_its_watermark(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let external = ExternalId::new("ENG-7".to_owned());
+    let tracker = RecordingTracker::holding(vec![(
+        external.clone(),
+        issue("Seven\nremote body"),
+    )]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+
+    run_at(
+        &fixture,
+        &tracker,
+        &author,
+        &[],
+        &[],
+        std::slice::from_ref(&external),
+        1_000,
+    )
+    .map_err(|_| "the initial pull must proceed")?;
+    let created = fixture.dir.path().join("9000.md");
+    assert!(created.exists(), "the pull authored a local file");
+
+    let corpus = vec![LocalItem {
+        id: "9000".to_owned(),
+        path: created,
+        external_id: Some(external.clone()),
+    }];
+    let report = run_at(
+        &fixture,
+        &tracker,
+        &author,
+        &corpus,
+        &corpus,
+        std::slice::from_ref(&external),
+        2_000,
+    )
+    .map_err(|_| "the re-run must proceed")?;
+
+    assert_eq!(
+        report.discovery,
+        DiscoveryStatus::SkippedTargeted,
+        "the now-local id is reconciled, not re-pulled"
+    );
+    assert_eq!(
+        author.authored.borrow().len(),
+        1,
+        "no duplicate author on the re-run"
+    );
+    let written = fixture
+        .spy
+        .content(BASELINE_PATH)
+        .expect("the re-run writes the baseline");
+    let (baseline, _) =
+        work_adapters::sync::baseline::Baseline::read(Some(&written));
+    assert_eq!(
+        baseline
+            .get("9000")
+            .expect("the pulled item has a baseline entry")
+            .local_synced_at,
+        2_000,
+        "the watermark advanced to the re-run epoch"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_pull_whose_baseline_write_fails_recovers_on_re_run(
+) -> Result<(), TestError> {
+    let fixture = Fixture::new()?;
+    let external = ExternalId::new("ENG-7".to_owned());
+    let tracker = RecordingTracker::holding(vec![(
+        external.clone(),
+        issue("Seven\nremote body"),
+    )]);
+    let author = RecordingAuthor::new(fixture.dir.path());
+
+    // Run 1: the file is authored, then the baseline write fails.
+    {
+        let clock = FixedClock(1_000);
+        let status = AlwaysClean;
+        let failing = FailingWrite;
+        let sync_ports = SyncPorts {
+            tracker: &tracker,
+            status: &status,
+            writer: &failing,
+            clock: &clock,
+            author: &author,
+        };
+        let mut store = BaselineStore::new(
+            PathBuf::from(BASELINE_PATH),
+            &fixture.spy,
+            &failing,
+        );
+        let resolutions: BTreeMap<String, Resolution> = BTreeMap::new();
+        let request = SyncRequest {
+            corpus: &[],
+            selection: ItemSelection::Targeted {
+                items: &[],
+                pull_ids: std::slice::from_ref(&external),
+            },
+            direction: SyncDirection::Bidirectional,
+            strategy: RetrievalStrategy::Bulk,
+            resolutions: &resolutions,
+            max_pulls: 25,
+            max_pushes: 25,
+            mode: RunMode::Apply,
+            integrations_root: fixture.dir.path(),
+            integration: "jira",
+            scope: SearchScope::default(),
+        };
+        let report = run(&sync_ports, &mut store, &request).map_err(|_| {
+            "the run yields a report; the per-item create fails"
+        })?;
+        let create = report
+            .reported
+            .iter()
+            .find(|item| item.planned.action == Action::CreateFromRemote)
+            .expect("a create-from-remote row");
+        assert!(
+            matches!(create.outcome, ItemOutcome::Failed(_)),
+            "a failed baseline write fails the create"
+        );
+    }
+    let created = fixture.dir.path().join("9000.md");
+    assert!(
+        created.exists(),
+        "the file was authored before the baseline write failed"
+    );
+
+    // Run 2: the authored file is now in the corpus, so the pull_id folds equal
+    // and no duplicate is created.
+    let corpus = vec![LocalItem {
+        id: "9000".to_owned(),
+        path: created,
+        external_id: Some(external.clone()),
+    }];
+    let report = run_at(
+        &fixture,
+        &tracker,
+        &author,
+        &corpus,
+        &corpus,
+        std::slice::from_ref(&external),
+        2_000,
+    )
+    .map_err(|_| "the recovery re-run must proceed")?;
+
+    assert_eq!(report.discovery, DiscoveryStatus::SkippedTargeted);
+    assert_eq!(
+        author.authored.borrow().len(),
+        1,
+        "the id is authored once across both runs — no duplicate pull"
+    );
+    Ok(())
+}
+
 // --- Gap B: unsynced-local create -------------------------------------------
 
 #[test]
@@ -1236,6 +1989,19 @@ fn a_targeted_create_from_local_still_sees_a_non_targeted_double_bind(
 }
 
 // --- Small real-fs doubles for the marker-ordering test ---------------------
+
+/// A writer that fails every write, so a create can author its file (through
+/// the author's own `std::fs` write) and then fail at the baseline write.
+struct FailingWrite;
+
+impl AtomicWrite for FailingWrite {
+    fn write(&self, path: &Path, _bytes: &[u8]) -> Result<(), StoreError> {
+        Err(StoreError::Io {
+            path: path.display().to_string(),
+            detail: "injected write failure".to_owned(),
+        })
+    }
+}
 
 struct RealWrite;
 

--- a/cli/work-adapters/tests/sync_run.rs
+++ b/cli/work-adapters/tests/sync_run.rs
@@ -339,7 +339,10 @@ fn execute_targeted(
     let resolutions = BTreeMap::new();
     let mut req = request(
         &scenario.items,
-        ItemSelection::Targeted(targeted),
+        ItemSelection::Targeted {
+            items: targeted,
+            pull_ids: &[],
+        },
         &resolutions,
         scenario.dir.path(),
         max_pulls,
@@ -477,7 +480,10 @@ fn a_targeted_run_does_not_bury_a_non_targeted_local_edit(
         &tracker,
         dir.path(),
         &corpus,
-        ItemSelection::Targeted(std::slice::from_ref(&corpus[1])),
+        ItemSelection::Targeted {
+            items: std::slice::from_ref(&corpus[1]),
+            pull_ids: &[],
+        },
         m1 + 100,
     )
     .map_err(|_| "the targeted sync must proceed")?;

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -195,7 +195,7 @@ fn discovery_line(discovery: &DiscoveryStatus) -> String {
     }
 }
 
-fn render_report(report: &RunReport, suppressed: &[Suppressed]) -> String {
+fn render_report(report: &RunReport) -> String {
     let mut lines = Vec::new();
     let mut synced_count = 0usize;
     for item in &report.reported {
@@ -228,9 +228,6 @@ fn render_report(report: &RunReport, suppressed: &[Suppressed]) -> String {
     let summary_needed = synced_count > 0 || lines.is_empty();
     lines.sort();
     lines.push(discovery_line(&report.discovery));
-    for note in suppressed {
-        lines.push(suppression_line(note));
-    }
     if summary_needed {
         lines.push(format!("#\tsummary\tsynced\t{synced_count}"));
     }
@@ -363,20 +360,9 @@ fn persist_conflict_dossiers(
     }
 }
 
-/// A dual-shape target: a token that resolved locally but also keys some
-/// item's `external_id`. The local interpretation wins; the remote match is
-/// reported as suppressed rather than treated as ambiguity.
-#[derive(Debug)]
-struct Suppressed {
-    token: String,
-    local_id: String,
-    remote_id: String,
-}
-
 #[derive(Debug)]
 struct ResolvedTargets {
     items: Vec<LocalItem>,
-    suppressed: Vec<Suppressed>,
 }
 
 /// Why one `--target` token could not be resolved. Each carries a
@@ -390,6 +376,7 @@ enum TargetResolutionFailure {
     OutsideWorkDir(String),
     AmbiguousLocal(String),
     AmbiguousExternal(String),
+    LocalCollision(String),
 }
 
 impl TargetResolutionFailure {
@@ -400,7 +387,8 @@ impl TargetResolutionFailure {
             | Self::Unmanaged(message)
             | Self::OutsideWorkDir(message)
             | Self::AmbiguousLocal(message)
-            | Self::AmbiguousExternal(message) => message,
+            | Self::AmbiguousExternal(message)
+            | Self::LocalCollision(message) => message,
         }
     }
 
@@ -408,7 +396,8 @@ impl TargetResolutionFailure {
         match self {
             Self::Malformed(_)
             | Self::AmbiguousLocal(_)
-            | Self::AmbiguousExternal(_) => exit_codes::USAGE,
+            | Self::AmbiguousExternal(_)
+            | Self::LocalCollision(_) => exit_codes::USAGE,
             Self::NoMatch(_) | Self::Unmanaged(_) => {
                 exit_codes::RESOLVE_NOT_FOUND
             }
@@ -432,20 +421,21 @@ fn external_id_index(
     index
 }
 
-/// The remote match a dual-shape token names, if the token keys a *different*
-/// item than the local match — the local one wins and this is reported
-/// suppressed.
-fn suppressed_remote(
-    index: &BTreeMap<String, Vec<&LocalItem>>,
+/// The other local file a dual-shape token collides with: the token is
+/// `local_match`'s local id and simultaneously a *different* file's
+/// `external_id`. A genuine local/local collision, decidable entirely from the
+/// corpus, so the caller can name both files without any remote call.
+fn colliding_file<'a>(
+    index: &BTreeMap<String, Vec<&'a LocalItem>>,
     token: &str,
     local_match: &LocalItem,
-) -> Option<String> {
+) -> Option<&'a LocalItem> {
     let key = canonical_external_key(&ExternalId::new(token.to_owned()));
-    let other = index
+    index
         .get(&key)?
         .iter()
-        .find(|item| item.id != local_match.id)?;
-    other.external_id.as_ref().map(|id| id.as_str().to_owned())
+        .find(|item| item.id != local_match.id)
+        .copied()
 }
 
 /// Resolves each `--target` token to a local item, accumulating every failure
@@ -460,7 +450,6 @@ fn resolve_targets(
 ) -> Result<ResolvedTargets, Vec<TargetResolutionFailure>> {
     let index = external_id_index(corpus);
     let mut matched: Vec<&LocalItem> = Vec::new();
-    let mut suppressed: Vec<Suppressed> = Vec::new();
     let mut failures: Vec<TargetResolutionFailure> = Vec::new();
 
     for token in targets {
@@ -480,18 +469,18 @@ fn resolve_targets(
                         .unwrap_or(false)
                 });
                 match local_match {
-                    Some(item) => {
-                        if let Some(remote) =
-                            suppressed_remote(&index, token, item)
-                        {
-                            suppressed.push(Suppressed {
-                                token: token.clone(),
-                                local_id: item.id.clone(),
-                                remote_id: remote,
-                            });
-                        }
-                        matched.push(item);
-                    }
+                    Some(item) => match colliding_file(&index, token, item) {
+                        Some(other) => failures.push(
+                            TargetResolutionFailure::LocalCollision(format!(
+                                "'{token}' is the local id of {} and also \
+                                 the external_id recorded by {}; re-run with \
+                                 the path of the file you intended",
+                                item.path.display(),
+                                other.path.display()
+                            )),
+                        ),
+                        None => matched.push(item),
+                    },
                     None => failures.push(TargetResolutionFailure::Unmanaged(
                         format!(
                             "'{token}' resolves to a file that is not a \
@@ -546,7 +535,7 @@ fn resolve_targets(
         .filter(|item| seen.insert(item.id.clone()))
         .cloned()
         .collect();
-    Ok(ResolvedTargets { items, suppressed })
+    Ok(ResolvedTargets { items })
 }
 
 enum Scope {
@@ -557,7 +546,6 @@ enum Scope {
 struct SelectedTargets {
     scope: Scope,
     items: Vec<LocalItem>,
-    suppressed: Vec<Suppressed>,
 }
 
 /// A usage or ambiguity error is the most fundamental thing to fix, so it
@@ -588,14 +576,12 @@ fn build_selection(
         return Ok(SelectedTargets {
             scope: Scope::All,
             items: Vec::new(),
-            suppressed: Vec::new(),
         });
     }
     match resolve_targets(corpus, targets, resolver) {
         Ok(found) => Ok(SelectedTargets {
             scope: Scope::Targeted,
             items: found.items,
-            suppressed: found.suppressed,
         }),
         Err(failures) => {
             for failure in &failures {
@@ -604,15 +590,6 @@ fn build_selection(
             Err(ExitCode::from(highest_precedence_code(&failures)))
         }
     }
-}
-
-fn suppression_line(suppressed: &Suppressed) -> String {
-    format!(
-        "#\ttarget\tsuppressed\t{}\tlocal={}\tremote={}",
-        single_line(&suppressed.token),
-        single_line(&suppressed.local_id),
-        single_line(&suppressed.remote_id),
-    )
 }
 
 /// # Errors
@@ -805,7 +782,7 @@ pub fn run_sync(
                      resolve the work-item id scheme ({error})"
                 ),
             }
-            println!("{}", render_report(&report, &selected.suppressed));
+            println!("{}", render_report(&report));
             warn_outstanding_pushes(&integrations_root, &integration);
             ExitCode::from(exit_code_for_report(&report))
         }
@@ -879,7 +856,6 @@ mod tests {
     use super::highest_precedence_code;
     use super::render_report;
     use super::resolve_targets;
-    use super::suppression_line;
     use super::Scope;
     use super::TargetResolutionFailure;
     use crate::exit_codes;
@@ -904,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    fn a_local_id_wins_and_records_the_remote_match_as_suppressed() {
+    fn a_local_local_collision_is_a_usage_error_naming_both_files() {
         let dir = tempfile::tempdir().expect("tempdir");
         let local = target_item(dir.path(), "0001", None);
         let remote_holder = target_item(dir.path(), "0002", Some("0001"));
@@ -912,14 +888,33 @@ mod tests {
         let local_path = canonical(&corpus[0]);
         let resolver = |_token: &str| RunOutcome::Resolved(local_path.clone());
 
-        let matched = resolve_targets(&corpus, &["0001".to_owned()], &resolver)
-            .expect("the local id resolves");
+        let failures =
+            resolve_targets(&corpus, &["0001".to_owned()], &resolver)
+                .expect_err("a local/local collision must abort");
+
+        assert_eq!(failures.len(), 1);
+        assert!(matches!(
+            failures[0],
+            TargetResolutionFailure::LocalCollision(_)
+        ));
+        assert_eq!(failures[0].exit_code(), exit_codes::USAGE);
+        let message = failures[0].message();
+        assert!(message.contains("0001.md"), "names file A: {message}");
+        assert!(message.contains("0002.md"), "names file B: {message}");
+    }
+
+    #[test]
+    fn an_own_external_id_token_reconciles_with_no_collision() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let corpus = vec![target_item(dir.path(), "0002", Some("0002"))];
+        let local_path = canonical(&corpus[0]);
+        let resolver = |_token: &str| RunOutcome::Resolved(local_path.clone());
+
+        let matched = resolve_targets(&corpus, &["0002".to_owned()], &resolver)
+            .expect("a token equal to its own file's external_id resolves");
 
         assert_eq!(matched.items.len(), 1);
-        assert_eq!(matched.items[0].id, "0001");
-        assert_eq!(matched.suppressed.len(), 1);
-        assert_eq!(matched.suppressed[0].local_id, "0001");
-        assert_eq!(matched.suppressed[0].remote_id, "0001");
+        assert_eq!(matched.items[0].id, "0002");
     }
 
     #[test]
@@ -967,7 +962,6 @@ mod tests {
 
         assert_eq!(matched.items.len(), 1);
         assert_eq!(matched.items[0].id, "0002");
-        assert!(matched.suppressed.is_empty());
     }
 
     #[test]
@@ -1057,19 +1051,6 @@ mod tests {
 
         assert!(matches!(selected.scope, Scope::All));
         assert!(selected.items.is_empty());
-    }
-
-    #[test]
-    fn the_suppression_line_collapses_record_breaking_whitespace() {
-        let note = super::Suppressed {
-            token: "00\t01".to_owned(),
-            local_id: "00\n01".to_owned(),
-            remote_id: "PP-787".to_owned(),
-        };
-        assert_eq!(
-            suppression_line(&note),
-            "#\ttarget\tsuppressed\t00 01\tlocal=00 01\tremote=PP-787"
-        );
     }
 
     fn ok_render(section: &SectionDiff) -> String {
@@ -1165,7 +1146,7 @@ mod tests {
         ))
         .expect("golden readable");
 
-        assert_eq!(render_report(&report, &[]), golden);
+        assert_eq!(render_report(&report), golden);
     }
 
     #[test]
@@ -1180,7 +1161,7 @@ mod tests {
         };
 
         assert_eq!(
-            render_report(&report, &[]),
+            render_report(&report),
             "#\tdiscovery\tskipped\tpush-only\n#\tsummary\tsynced\t0"
         );
     }
@@ -1198,27 +1179,21 @@ mod tests {
 
     #[test]
     fn render_report_emits_each_discovery_status_line() {
-        assert!(render_report(
-            &report_with(DiscoveryStatus::Ran { found: 3 }),
-            &[]
-        )
-        .contains("#\tdiscovery\tran\tfound=3"));
-        assert!(render_report(
-            &report_with(DiscoveryStatus::SkippedPushOnly),
-            &[]
-        )
-        .contains("#\tdiscovery\tskipped\tpush-only"));
-        assert!(render_report(
-            &report_with(DiscoveryStatus::SkippedTargeted),
-            &[]
-        )
-        .contains("#\tdiscovery\tskipped\ttargeted"));
-        let failed = render_report(
-            &report_with(DiscoveryStatus::Failed {
-                detail: "connection refused".to_owned(),
-            }),
-            &[],
+        assert!(
+            render_report(&report_with(DiscoveryStatus::Ran { found: 3 }))
+                .contains("#\tdiscovery\tran\tfound=3")
         );
+        assert!(
+            render_report(&report_with(DiscoveryStatus::SkippedPushOnly))
+                .contains("#\tdiscovery\tskipped\tpush-only")
+        );
+        assert!(
+            render_report(&report_with(DiscoveryStatus::SkippedTargeted))
+                .contains("#\tdiscovery\tskipped\ttargeted")
+        );
+        let failed = render_report(&report_with(DiscoveryStatus::Failed {
+            detail: "connection refused".to_owned(),
+        }));
         assert!(
             failed.contains("#\tdiscovery\tfailed\tconnection refused"),
             "{failed}"
@@ -1227,12 +1202,9 @@ mod tests {
 
     #[test]
     fn a_failed_discovery_detail_is_flattened_to_one_record() {
-        let rendered = render_report(
-            &report_with(DiscoveryStatus::Failed {
-                detail: "line one\tsplit\nline two\r".to_owned(),
-            }),
-            &[],
-        );
+        let rendered = render_report(&report_with(DiscoveryStatus::Failed {
+            detail: "line one\tsplit\nline two\r".to_owned(),
+        }));
         let discovery = rendered
             .lines()
             .find(|line| line.starts_with("#\tdiscovery\tfailed"))

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -189,6 +189,9 @@ fn discovery_line(discovery: &DiscoveryStatus) -> String {
         DiscoveryStatus::SkippedTargeted => {
             "#\tdiscovery\tskipped\ttargeted".to_owned()
         }
+        DiscoveryStatus::TargetedPull { attempted } => {
+            format!("#\tdiscovery\ttargeted-pull\t{attempted}")
+        }
         DiscoveryStatus::Failed { detail } => {
             format!("#\tdiscovery\tfailed\t{}", single_line(detail))
         }
@@ -731,7 +734,10 @@ pub fn run_sync(
     };
     let selection = match selected.scope {
         Scope::All => ItemSelection::All,
-        Scope::Targeted => ItemSelection::Targeted(&selected.items),
+        Scope::Targeted => ItemSelection::Targeted {
+            items: &selected.items,
+            pull_ids: &[],
+        },
     };
     let request = SyncRequest {
         corpus: &items,
@@ -1191,6 +1197,10 @@ mod tests {
             render_report(&report_with(DiscoveryStatus::SkippedTargeted))
                 .contains("#\tdiscovery\tskipped\ttargeted")
         );
+        assert!(render_report(&report_with(DiscoveryStatus::TargetedPull {
+            attempted: 2
+        }))
+        .contains("#\tdiscovery\ttargeted-pull\t2"));
         let failed = render_report(&report_with(DiscoveryStatus::Failed {
             detail: "connection refused".to_owned(),
         }));

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -810,10 +810,22 @@ pub fn run_sync(
     };
 
     let baseline_path = baseline::path(&integrations_root, &integration);
+    let baseline_dir = baseline_path.parent().unwrap_or(&integrations_root);
+    // The integration's state directory holds the baseline, the conflict
+    // dossiers, and the pending-push markers. On a never-synced integration it
+    // does not exist yet, and the atomic-write containment check canonicalises
+    // this directory as its trusted root, so the first baseline write fails
+    // unless it is present. Create it up-front rather than relying on a later
+    // write to author it.
+    if let Err(error) = std::fs::create_dir_all(baseline_dir) {
+        eprintln!(
+            "could not create the integration state directory {}: {error}",
+            baseline_dir.display()
+        );
+        return ExitCode::from(exit_codes::ERROR);
+    }
     let file_reader = RealFs;
-    let corpus_store = FileCorpusStore::new(
-        baseline_path.parent().unwrap_or(&integrations_root),
-    );
+    let corpus_store = FileCorpusStore::new(baseline_dir);
     let mut baseline_store =
         BaselineStore::new(baseline_path, &file_reader, &corpus_store);
     let status = VcsWorkingCopyStatus::probed_from(&root);
@@ -1850,19 +1862,22 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("meta/work")).expect("mkdir");
         std::fs::create_dir_all(dir.path().join(".accelerator"))
             .expect("mkdir");
-        // A configured integration's state directory already exists; the
-        // baseline write into it (unchanged by this feature) needs its parent
-        // present, exactly as a full-sync discovery import does.
-        std::fs::create_dir_all(
-            dir.path().join(".accelerator/state/integrations/jira"),
-        )
-        .expect("mkdir integration state");
         std::fs::write(
             dir.path().join(".accelerator/config.md"),
             "---\nwork:\n  integration: jira\n---\n",
         )
         .expect("write config");
         dir
+    }
+
+    /// Whether the run persisted a baseline for the integration — proof the
+    /// create-from-remote sequence completed through its final baseline write,
+    /// not just that a file was authored.
+    fn baseline_written(dir: &Path) -> bool {
+        std::fs::read_to_string(
+            dir.join(".accelerator/state/integrations/jira/last-sync.json"),
+        )
+        .is_ok()
     }
 
     fn work_file(dir: &Path, id: &str, external: Option<&str>) {
@@ -1949,6 +1964,11 @@ mod tests {
             new_work_files(dir.path()).len(),
             1,
             "a remote-only target creates one new local file"
+        );
+        assert!(
+            baseline_written(dir.path()),
+            "the create-from-remote completes through its baseline write, even \
+             on a never-synced integration whose state dir does not yet exist"
         );
         assert!(
             fetch_all_contains(&tracker, "PP-999"),

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -366,32 +366,45 @@ fn persist_conflict_dossiers(
 #[derive(Debug)]
 struct ResolvedTargets {
     items: Vec<LocalItem>,
+    /// Tokens with no local match, de-duplicated by canonical key. Each is a
+    /// candidate for a remote-only pull, confirmed later by one `fetch_all`.
+    remote_candidates: Vec<ExternalId>,
 }
 
 /// Why one `--target` token could not be resolved. Each carries a
 /// user-facing message naming the offender; [`TargetResolutionFailure::exit_code`]
 /// is the single source of the code mapping.
+///
+/// The variants span two sequenced moments. The local and push-only variants
+/// are decided before the tracker is contacted, so a run carrying one aborts
+/// credential-free; [`Self::Absent`] and [`Self::Indeterminate`] are the
+/// outcomes of the post-credential `fetch_all` gate. Both fold into the same
+/// [`Self::exit_code`] and rank, so precedence is single-sourced across both.
 #[derive(Debug)]
 enum TargetResolutionFailure {
     Malformed(String),
-    NoMatch(String),
     Unmanaged(String),
     OutsideWorkDir(String),
     AmbiguousLocal(String),
     AmbiguousExternal(String),
     LocalCollision(String),
+    PushOnlyRemoteOnly(String),
+    Absent(String),
+    Indeterminate(String),
 }
 
 impl TargetResolutionFailure {
     fn message(&self) -> &str {
         match self {
             Self::Malformed(message)
-            | Self::NoMatch(message)
             | Self::Unmanaged(message)
             | Self::OutsideWorkDir(message)
             | Self::AmbiguousLocal(message)
             | Self::AmbiguousExternal(message)
-            | Self::LocalCollision(message) => message,
+            | Self::LocalCollision(message)
+            | Self::PushOnlyRemoteOnly(message)
+            | Self::Absent(message)
+            | Self::Indeterminate(message) => message,
         }
     }
 
@@ -400,11 +413,13 @@ impl TargetResolutionFailure {
             Self::Malformed(_)
             | Self::AmbiguousLocal(_)
             | Self::AmbiguousExternal(_)
-            | Self::LocalCollision(_) => exit_codes::USAGE,
-            Self::NoMatch(_) | Self::Unmanaged(_) => {
+            | Self::LocalCollision(_)
+            | Self::PushOnlyRemoteOnly(_) => exit_codes::USAGE,
+            Self::Unmanaged(_) | Self::Absent(_) => {
                 exit_codes::RESOLVE_NOT_FOUND
             }
             Self::OutsideWorkDir(_) => exit_codes::RESOLVE_OUTSIDE_WORKDIR,
+            Self::Indeterminate(_) => exit_codes::RETRYABLE,
         }
     }
 }
@@ -441,11 +456,12 @@ fn colliding_file<'a>(
         .copied()
 }
 
-/// Resolves each `--target` token to a local item, accumulating every failure
-/// so one run names all offenders. Local resolution wins over a remote match;
-/// a token that resolves locally to `NotFound`/`Invalid` cascades to the
-/// `external_id` index, while an ambiguous or out-of-directory local outcome
-/// does not.
+/// Resolves each `--target` token to a local item or a remote candidate,
+/// accumulating every failure so one run names all offenders. Local resolution
+/// wins; a token that resolves locally to `NotFound`/`Invalid` cascades to the
+/// `external_id` index, and a token that matches nothing locally becomes a
+/// remote candidate rather than an abort. An ambiguous or out-of-directory
+/// local outcome still fails.
 fn resolve_targets(
     corpus: &[LocalItem],
     targets: &[String],
@@ -453,6 +469,8 @@ fn resolve_targets(
 ) -> Result<ResolvedTargets, Vec<TargetResolutionFailure>> {
     let index = external_id_index(corpus);
     let mut matched: Vec<&LocalItem> = Vec::new();
+    let mut remote_candidates: Vec<ExternalId> = Vec::new();
+    let mut candidate_keys = std::collections::BTreeSet::new();
     let mut failures: Vec<TargetResolutionFailure> = Vec::new();
 
     for token in targets {
@@ -509,13 +527,10 @@ fn resolve_targets(
                 match index.get(&key).map(Vec::as_slice) {
                     Some([one]) => matched.push(one),
                     None | Some([]) => {
-                        failures.push(TargetResolutionFailure::NoMatch(
-                            format!(
-                                "no local item and no remote-tracked match \
-                                 for '{token}'; untracked remote issues are \
-                                 imported only by a full (untargeted) sync"
-                            ),
-                        ));
+                        if candidate_keys.insert(key) {
+                            remote_candidates
+                                .push(ExternalId::new(token.clone()));
+                        }
                     }
                     Some(_) => failures.push(
                         TargetResolutionFailure::AmbiguousExternal(format!(
@@ -538,7 +553,10 @@ fn resolve_targets(
         .filter(|item| seen.insert(item.id.clone()))
         .cloned()
         .collect();
-    Ok(ResolvedTargets { items })
+    Ok(ResolvedTargets {
+        items,
+        remote_candidates,
+    })
 }
 
 enum Scope {
@@ -549,15 +567,20 @@ enum Scope {
 struct SelectedTargets {
     scope: Scope,
     items: Vec<LocalItem>,
+    remote_candidates: Vec<ExternalId>,
 }
 
 /// A usage or ambiguity error is the most fundamental thing to fix, so it
-/// dominates the summary code: `USAGE` (2) > `RESOLVE_OUTSIDE_WORKDIR` (6) >
-/// `RESOLVE_NOT_FOUND` (3). Every offender is still named on stderr.
+/// dominates the summary code, with each successive class the next-most
+/// actionable: `USAGE` (2) > `RESOLVE_OUTSIDE_WORKDIR` (6) > `RESOLVE_NOT_FOUND`
+/// (3) > `RETRYABLE` (70). A batch carrying both an absent and an indeterminate
+/// token exits 3 by this rank, not by iteration order. Every offender is still
+/// named on stderr.
 fn highest_precedence_code(failures: &[TargetResolutionFailure]) -> u8 {
     let rank = |code: u8| match code {
-        exit_codes::USAGE => 3,
-        exit_codes::RESOLVE_OUTSIDE_WORKDIR => 2,
+        exit_codes::USAGE => 4,
+        exit_codes::RESOLVE_OUTSIDE_WORKDIR => 3,
+        exit_codes::RESOLVE_NOT_FOUND => 2,
         _ => 1,
     };
     failures
@@ -568,29 +591,102 @@ fn highest_precedence_code(failures: &[TargetResolutionFailure]) -> u8 {
 }
 
 /// Builds the reconciliation scope: `All` when no `--target` is given, else the
-/// resolved `Targeted` slice. On failure prints every offender and returns the
-/// highest-precedence exit code.
+/// resolved `Targeted` slice plus its remote candidates. On failure prints
+/// every offender and returns the highest-precedence exit code. A remote-only
+/// candidate under `--push-only` is contradictory and fails here, before any
+/// tracker contact, so the abort stays credential-free.
 fn build_selection(
     corpus: &[LocalItem],
     targets: &[String],
+    direction: SyncDirection,
     resolver: &dyn Fn(&str) -> RunOutcome,
 ) -> Result<SelectedTargets, ExitCode> {
     if targets.is_empty() {
         return Ok(SelectedTargets {
             scope: Scope::All,
             items: Vec::new(),
+            remote_candidates: Vec::new(),
         });
     }
     match resolve_targets(corpus, targets, resolver) {
-        Ok(found) => Ok(SelectedTargets {
-            scope: Scope::Targeted,
-            items: found.items,
-        }),
+        Ok(found) => {
+            if matches!(direction, SyncDirection::PushOnly)
+                && !found.remote_candidates.is_empty()
+            {
+                for candidate in &found.remote_candidates {
+                    eprintln!("{}", push_only_remote_only(candidate).message());
+                }
+                return Err(ExitCode::from(exit_codes::USAGE));
+            }
+            Ok(SelectedTargets {
+                scope: Scope::Targeted,
+                items: found.items,
+                remote_candidates: found.remote_candidates,
+            })
+        }
         Err(failures) => {
             for failure in &failures {
                 eprintln!("{}", failure.message());
             }
             Err(ExitCode::from(highest_precedence_code(&failures)))
+        }
+    }
+}
+
+fn push_only_remote_only(candidate: &ExternalId) -> TargetResolutionFailure {
+    TargetResolutionFailure::PushOnlyRemoteOnly(format!(
+        "'{}' has no local file and --push-only cannot pull a remote-only \
+         item; drop --push-only to import it",
+        candidate.as_str()
+    ))
+}
+
+/// Partitions a bulk read of the remote candidates: `found` become the
+/// confirmed pull ids (their stamps discarded — `create_from_remote` re-reads
+/// each body via `show`), while `absent` and `indeterminate` fold into the
+/// failure accumulator so the run aborts before any write. Any failure wins
+/// over the confirmed ids, holding the all-or-nothing zero-write property.
+fn partition_candidates(
+    outcome: tracker::FetchOutcome,
+) -> Result<Vec<ExternalId>, Vec<TargetResolutionFailure>> {
+    let absent = outcome.absent.into_iter().map(|id| {
+        TargetResolutionFailure::Absent(format!(
+            "no local file nor remote issue for '{}'",
+            id.as_str()
+        ))
+    });
+    let indeterminate = outcome.indeterminate.into_iter().map(|id| {
+        TargetResolutionFailure::Indeterminate(format!(
+            "remote read for '{}' was indeterminate; re-run when the tracker \
+             is reachable",
+            id.as_str()
+        ))
+    });
+    let failures: Vec<_> = absent.chain(indeterminate).collect();
+    if failures.is_empty() {
+        Ok(outcome.found.into_iter().map(|(id, _)| id).collect())
+    } else {
+        Err(failures)
+    }
+}
+
+/// Confirms the remote candidates through one `fetch_all`. A whole-call `Err`
+/// is a pre-flight fault the port cannot classify further — a credential fault
+/// is already caught upstream at `registry.resolve` (exit 74), so the remaining
+/// pre-flight fault is retryable — and maps to a single `Indeterminate` (exit
+/// 70), never a silent success.
+fn confirm_remote_candidates(
+    tracker: &dyn tracker::RemoteTracker,
+    candidates: &[ExternalId],
+) -> Result<Vec<ExternalId>, Vec<TargetResolutionFailure>> {
+    match tracker.fetch_all(candidates) {
+        Ok(outcome) => partition_candidates(outcome),
+        Err(error) => {
+            Err(vec![TargetResolutionFailure::Indeterminate(format!(
+                "the remote lookup for the named target(s) could not be \
+                 completed ({}); re-run when the tracker is reachable",
+                error.into_detail()
+            ))])
         }
     }
 }
@@ -671,10 +767,11 @@ pub fn run_sync(
     let resolver = |token: &str| {
         crate::resolve::resolve_with(&scheme, &canonical_work_dir, start, token)
     };
-    let selected = match build_selection(&items, &args.targets, &resolver) {
-        Ok(selected) => selected,
-        Err(code) => return code,
-    };
+    let selected =
+        match build_selection(&items, &args.targets, direction, &resolver) {
+            Ok(selected) => selected,
+            Err(code) => return code,
+        };
 
     let tracker = match registry.resolve(&integration) {
         Ok(tracker) => tracker,
@@ -692,6 +789,23 @@ pub fn run_sync(
         Err(error @ SelectionError::Unconfigured { .. }) => {
             eprintln!("{}", error.message());
             return ExitCode::from(exit_codes::UNCONFIGURED);
+        }
+    };
+
+    let pull_ids = if selected.remote_candidates.is_empty() {
+        Vec::new()
+    } else {
+        match confirm_remote_candidates(
+            tracker.as_ref(),
+            &selected.remote_candidates,
+        ) {
+            Ok(found) => found,
+            Err(failures) => {
+                for failure in &failures {
+                    eprintln!("{}", failure.message());
+                }
+                return ExitCode::from(highest_precedence_code(&failures));
+            }
         }
     };
 
@@ -736,7 +850,7 @@ pub fn run_sync(
         Scope::All => ItemSelection::All,
         Scope::Targeted => ItemSelection::Targeted {
             items: &selected.items,
-            pull_ids: &[],
+            pull_ids: &pull_ids,
         },
     };
     let request = SyncRequest {
@@ -835,7 +949,12 @@ pub fn run_sync(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used, clippy::unnecessary_wraps)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::unnecessary_wraps,
+    clippy::unimplemented
+)]
 mod tests {
     use corpus::WorkItemIdScheme;
     use tracker::RemoteTimestamp;
@@ -858,8 +977,11 @@ mod tests {
     use tracker::ExternalId;
     use work_adapters::sync::fetch::LocalItem;
 
+    use work::sync::SyncDirection;
+
     use super::build_selection;
     use super::highest_precedence_code;
+    use super::partition_candidates;
     use super::render_report;
     use super::resolve_targets;
     use super::Scope;
@@ -971,17 +1093,39 @@ mod tests {
     }
 
     #[test]
-    fn a_no_match_token_fails_with_a_not_found_code() {
+    fn a_no_local_match_token_becomes_a_remote_candidate() {
         let dir = tempfile::tempdir().expect("tempdir");
         let corpus = vec![target_item(dir.path(), "0002", Some("PP-787"))];
         let resolver = |_token: &str| RunOutcome::NotFound("nope".to_owned());
 
-        let failures =
-            resolve_targets(&corpus, &["9999".to_owned()], &resolver)
-                .expect_err("an unmatched token must fail");
+        let outcome = resolve_targets(&corpus, &["9999".to_owned()], &resolver)
+            .expect(
+                "a no-local-match token is a remote candidate, not a failure",
+            );
 
-        assert_eq!(failures.len(), 1);
-        assert_eq!(failures[0].exit_code(), exit_codes::RESOLVE_NOT_FOUND);
+        assert!(outcome.items.is_empty());
+        assert_eq!(outcome.remote_candidates.len(), 1);
+        assert_eq!(outcome.remote_candidates[0].as_str(), "9999");
+    }
+
+    #[test]
+    fn two_spellings_of_one_remote_only_token_collapse_to_one_candidate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let corpus = vec![target_item(dir.path(), "0002", Some("PP-787"))];
+        let resolver = |_token: &str| RunOutcome::NotFound("nope".to_owned());
+
+        let outcome = resolve_targets(
+            &corpus,
+            &["PP-999".to_owned(), "pp-999".to_owned()],
+            &resolver,
+        )
+        .expect("both spellings are remote candidates");
+
+        assert_eq!(
+            outcome.remote_candidates.len(),
+            1,
+            "two spellings of one issue fold to a single candidate"
+        );
     }
 
     #[test]
@@ -1016,11 +1160,12 @@ mod tests {
     fn every_failure_is_accumulated_with_usage_dominating_the_code() {
         let dir = tempfile::tempdir().expect("tempdir");
         let corpus = vec![target_item(dir.path(), "0002", Some("PP-787"))];
-        let resolver = |_token: &str| RunOutcome::NotFound("nope".to_owned());
+        let resolver =
+            |_token: &str| RunOutcome::OutsideWorkDir("outside".to_owned());
 
         let failures = resolve_targets(
             &corpus,
-            &["   ".to_owned(), "9999".to_owned()],
+            &["   ".to_owned(), "meta/outside.md".to_owned()],
             &resolver,
         )
         .expect_err("both tokens fail");
@@ -1029,7 +1174,132 @@ mod tests {
         assert_eq!(
             highest_precedence_code(&failures),
             exit_codes::USAGE,
-            "a malformed token dominates a no-match"
+            "a malformed token dominates an out-of-directory path"
+        );
+    }
+
+    #[test]
+    fn precedence_orders_usage_over_outside_over_not_found_over_retryable() {
+        let failures = vec![
+            TargetResolutionFailure::Indeterminate("retry".to_owned()),
+            TargetResolutionFailure::Absent("gone".to_owned()),
+        ];
+        assert_eq!(
+            highest_precedence_code(&failures),
+            exit_codes::RESOLVE_NOT_FOUND,
+            "an absent token dominates an indeterminate one by rank"
+        );
+
+        let with_outside = vec![
+            TargetResolutionFailure::Absent("gone".to_owned()),
+            TargetResolutionFailure::OutsideWorkDir("outside".to_owned()),
+            TargetResolutionFailure::Malformed("blank".to_owned()),
+        ];
+        assert_eq!(
+            highest_precedence_code(&with_outside),
+            exit_codes::USAGE,
+            "usage dominates outside-work-dir and not-found"
+        );
+    }
+
+    fn found_pair(id: &str) -> (ExternalId, tracker::RemoteTimestamp) {
+        (
+            ExternalId::new(id.to_owned()),
+            tracker::RemoteTimestamp::NotReported,
+        )
+    }
+
+    #[test]
+    fn partition_candidates_projects_found_ids_when_all_resolve() {
+        let outcome = tracker::FetchOutcome {
+            found: vec![found_pair("PP-1"), found_pair("PP-2")],
+            absent: Vec::new(),
+            indeterminate: Vec::new(),
+        };
+
+        let found = partition_candidates(outcome).expect("an all-found batch");
+
+        assert_eq!(found.len(), 2);
+        assert_eq!(found[0].as_str(), "PP-1");
+    }
+
+    #[test]
+    fn partition_candidates_folds_absent_to_exit_three() {
+        let outcome = tracker::FetchOutcome {
+            found: vec![found_pair("PP-1")],
+            absent: vec![ExternalId::new("PP-9".to_owned())],
+            indeterminate: Vec::new(),
+        };
+
+        let failures =
+            partition_candidates(outcome).expect_err("an absent token fails");
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].exit_code(), exit_codes::RESOLVE_NOT_FOUND);
+        assert!(failures[0].message().contains("PP-9"));
+    }
+
+    #[test]
+    fn partition_candidates_folds_indeterminate_to_exit_seventy() {
+        let outcome = tracker::FetchOutcome {
+            found: Vec::new(),
+            absent: Vec::new(),
+            indeterminate: vec![ExternalId::new("PP-7".to_owned())],
+        };
+
+        let failures = partition_candidates(outcome)
+            .expect_err("an indeterminate token fails");
+
+        assert_eq!(failures[0].exit_code(), exit_codes::RETRYABLE);
+    }
+
+    #[test]
+    fn a_mixed_absent_and_indeterminate_batch_exits_three_by_rank() {
+        let outcome = tracker::FetchOutcome {
+            found: Vec::new(),
+            absent: vec![ExternalId::new("PP-9".to_owned())],
+            indeterminate: vec![ExternalId::new("PP-7".to_owned())],
+        };
+
+        let failures =
+            partition_candidates(outcome).expect_err("the mixed batch fails");
+
+        assert_eq!(
+            highest_precedence_code(&failures),
+            exit_codes::RESOLVE_NOT_FOUND,
+            "absent (3) dominates indeterminate (70) by rank, not order"
+        );
+    }
+
+    #[test]
+    fn a_whole_call_fetch_all_error_folds_to_indeterminate_exit_seventy() {
+        let failures = super::confirm_remote_candidates(
+            &FetchFailingTracker,
+            &[ExternalId::new("PP-9".to_owned())],
+        )
+        .expect_err("a pre-flight fetch_all failure aborts");
+
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].exit_code(), exit_codes::RETRYABLE);
+    }
+
+    #[test]
+    fn a_push_only_remote_only_candidate_aborts_before_the_tracker() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let corpus = vec![target_item(dir.path(), "0002", Some("PP-787"))];
+        let resolver = |_token: &str| RunOutcome::NotFound("nope".to_owned());
+
+        let outcome = build_selection(
+            &corpus,
+            &["PP-999".to_owned()],
+            SyncDirection::PushOnly,
+            &resolver,
+        );
+
+        assert!(
+            outcome.is_err(),
+            "a remote-only target under --push-only aborts before any tracker \
+             contact"
         );
     }
 
@@ -1052,8 +1322,13 @@ mod tests {
         let corpus = vec![target_item(dir.path(), "0002", None)];
         let resolver = |_token: &str| RunOutcome::Invalid("unused".to_owned());
 
-        let selected = build_selection(&corpus, &[], &resolver)
-            .expect("no targets is a whole-corpus run");
+        let selected = build_selection(
+            &corpus,
+            &[],
+            SyncDirection::Bidirectional,
+            &resolver,
+        )
+        .expect("no targets is a whole-corpus run");
 
         assert!(matches!(selected.scope, Scope::All));
         assert!(selected.items.is_empty());
@@ -1394,6 +1669,391 @@ mod tests {
         assert!(
             !conflicts.join("0002.md").exists(),
             "no dossier is written when the ignore cannot be guaranteed"
+        );
+    }
+
+    // --- run_sync end-to-end over a stub tracker registry -------------------
+    //
+    // `accelerator-work` is bin-only, so these in-crate tests are the only seam
+    // that can exercise the post-credential `fetch_all` gate without live
+    // Linear/Jira. `run_sync` returns an opaque `ExitCode`, so they assert the
+    // observable effects — files written or not, the fetch_all call made or not
+    // — while the exit-code chain is proven by the pure-logic tests above.
+
+    use std::rc::Rc;
+
+    use tracker::RemoteIssue;
+    use tracker::RemoteTracker;
+    use tracker_test_support::Call;
+    use tracker_test_support::RecordingTracker;
+
+    use crate::cli::SyncArgs;
+    use crate::tracker_registry::SelectionError;
+    use crate::tracker_registry::TrackerRegistry;
+
+    /// A tracker whose `fetch_all` fails pre-flight — the whole-call `Err` path
+    /// `RecordingTracker` cannot produce. Only `fetch_all` is ever called on it.
+    struct FetchFailingTracker;
+
+    impl RemoteTracker for FetchFailingTracker {
+        fn fetch_all(
+            &self,
+            _ids: &[ExternalId],
+        ) -> Result<tracker::FetchOutcome, TrackerError> {
+            Err(TrackerError::Retryable {
+                detail: "unresolvable pre-flight".to_owned(),
+            })
+        }
+
+        fn create(
+            &self,
+            _title: &str,
+            _body: &str,
+            _kind: &str,
+        ) -> Result<ExternalId, TrackerError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn update(
+            &self,
+            _id: &ExternalId,
+            _title: &str,
+            _body: &str,
+        ) -> Result<(), TrackerError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn show(&self, _id: &ExternalId) -> Result<RemoteIssue, TrackerError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn search(
+            &self,
+            _scope: &tracker::SearchScope,
+        ) -> Result<tracker::Discovery, TrackerError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn resolve_scope(
+            &self,
+            _scope: &tracker::SearchScope,
+        ) -> Result<tracker::SearchScope, tracker::ScopeError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn preview_create(
+            &self,
+            _kind: &str,
+        ) -> Result<tracker::CreatePreview, TrackerError> {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+
+        fn validate_update(
+            &self,
+            _id: &ExternalId,
+            _title: &str,
+            _body: &str,
+        ) -> tracker::ValidationOutcome {
+            unimplemented!("not exercised by the fetch_all failure path")
+        }
+    }
+
+    /// Shares one `RecordingTracker` between the registry (which hands the
+    /// engine a `Box<dyn RemoteTracker>`) and the test (which inspects the call
+    /// log afterwards), since the box is moved into `run_sync`.
+    struct SharedTracker(Rc<RecordingTracker>);
+
+    impl RemoteTracker for SharedTracker {
+        fn create(
+            &self,
+            title: &str,
+            body: &str,
+            kind: &str,
+        ) -> Result<ExternalId, TrackerError> {
+            self.0.create(title, body, kind)
+        }
+
+        fn update(
+            &self,
+            id: &ExternalId,
+            title: &str,
+            body: &str,
+        ) -> Result<(), TrackerError> {
+            self.0.update(id, title, body)
+        }
+
+        fn show(&self, id: &ExternalId) -> Result<RemoteIssue, TrackerError> {
+            self.0.show(id)
+        }
+
+        fn fetch_all(
+            &self,
+            ids: &[ExternalId],
+        ) -> Result<tracker::FetchOutcome, TrackerError> {
+            self.0.fetch_all(ids)
+        }
+
+        fn search(
+            &self,
+            scope: &tracker::SearchScope,
+        ) -> Result<tracker::Discovery, TrackerError> {
+            self.0.search(scope)
+        }
+
+        fn resolve_scope(
+            &self,
+            scope: &tracker::SearchScope,
+        ) -> Result<tracker::SearchScope, tracker::ScopeError> {
+            self.0.resolve_scope(scope)
+        }
+
+        fn preview_create(
+            &self,
+            kind: &str,
+        ) -> Result<tracker::CreatePreview, TrackerError> {
+            self.0.preview_create(kind)
+        }
+
+        fn validate_update(
+            &self,
+            id: &ExternalId,
+            title: &str,
+            body: &str,
+        ) -> tracker::ValidationOutcome {
+            self.0.validate_update(id, title, body)
+        }
+    }
+
+    struct StubRegistry(Rc<RecordingTracker>);
+
+    impl TrackerRegistry for StubRegistry {
+        fn resolve(
+            &self,
+            _name: &str,
+        ) -> Result<Box<dyn RemoteTracker>, SelectionError> {
+            Ok(Box::new(SharedTracker(Rc::clone(&self.0))))
+        }
+    }
+
+    fn sync_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .status()
+                .expect("git invocation");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.name", "Test User"]);
+        git(&["config", "user.email", "test@example.com"]);
+        std::fs::create_dir_all(dir.path().join("meta/work")).expect("mkdir");
+        std::fs::create_dir_all(dir.path().join(".accelerator"))
+            .expect("mkdir");
+        // A configured integration's state directory already exists; the
+        // baseline write into it (unchanged by this feature) needs its parent
+        // present, exactly as a full-sync discovery import does.
+        std::fs::create_dir_all(
+            dir.path().join(".accelerator/state/integrations/jira"),
+        )
+        .expect("mkdir integration state");
+        std::fs::write(
+            dir.path().join(".accelerator/config.md"),
+            "---\nwork:\n  integration: jira\n---\n",
+        )
+        .expect("write config");
+        dir
+    }
+
+    fn work_file(dir: &Path, id: &str, external: Option<&str>) {
+        let external_line = external
+            .map(|value| format!("external_id: \"{value}\"\n"))
+            .unwrap_or_default();
+        std::fs::write(
+            dir.join(format!("meta/work/{id}-title.md")),
+            format!("---\nid: \"{id}\"\n{external_line}---\n\nBody\n"),
+        )
+        .expect("write work item");
+    }
+
+    fn sync_args(targets: Vec<String>) -> SyncArgs {
+        SyncArgs {
+            push_only: false,
+            pull_only: false,
+            preview: false,
+            resolutions: Vec::new(),
+            per_item_reads: false,
+            max_pulls: 25,
+            max_pushes: 25,
+            targets,
+        }
+    }
+
+    fn drive_sync(dir: &Path, tracker: &Rc<RecordingTracker>, args: &SyncArgs) {
+        let composed = config_adapters::compose(
+            dir,
+            config_adapters::LegacyPolicy::Reject,
+        )
+        .expect("compose the test config");
+        let registry = StubRegistry(Rc::clone(tracker));
+        let _ = super::run_sync(dir, &composed.service, args, &registry);
+    }
+
+    fn issue(body: &str) -> RemoteIssue {
+        RemoteIssue {
+            updated: tracker::RemoteTimestamp::Reported(
+                "2026-01-01T00:00:00Z".to_owned(),
+            ),
+            body: body.to_owned(),
+        }
+    }
+
+    fn new_work_files(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir.join("meta/work"))
+            .expect("read work dir")
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.extension().and_then(std::ffi::OsStr::to_str) == Some("md")
+            })
+            .map(|path| {
+                path.file_name().unwrap().to_string_lossy().into_owned()
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Whether any `fetch_all` the run made named `id`. The candidate-
+    /// confirmation gate reads the raw `--target` token, so a bare local id
+    /// appearing here means the gate ran; the engine's reconcile read only ever
+    /// names an item's `external_id`, never its local id.
+    fn fetch_all_contains(tracker: &RecordingTracker, id: &str) -> bool {
+        tracker.calls().iter().any(|call| {
+            matches!(call, Call::FetchAll { ids }
+                if ids.iter().any(|candidate| candidate.as_str() == id))
+        })
+    }
+
+    #[test]
+    fn a_remote_only_target_is_pulled_into_a_new_local_file() {
+        let dir = sync_repo();
+        let tracker = Rc::new(RecordingTracker::holding(vec![(
+            ExternalId::new("PP-999".to_owned()),
+            issue("Imported\nRemote body"),
+        )]));
+
+        drive_sync(dir.path(), &tracker, &sync_args(vec!["PP-999".to_owned()]));
+
+        assert_eq!(
+            new_work_files(dir.path()).len(),
+            1,
+            "a remote-only target creates one new local file"
+        );
+        assert!(
+            fetch_all_contains(&tracker, "PP-999"),
+            "the candidate is confirmed through fetch_all"
+        );
+    }
+
+    #[test]
+    fn a_locally_resolvable_target_makes_no_fetch_all_call() {
+        let dir = sync_repo();
+        work_file(dir.path(), "0001", Some("PP-1"));
+        let tracker = Rc::new(RecordingTracker::holding(vec![(
+            ExternalId::new("PP-1".to_owned()),
+            issue("Local\nRemote body"),
+        )]));
+
+        drive_sync(dir.path(), &tracker, &sync_args(vec!["0001".to_owned()]));
+
+        assert!(
+            !fetch_all_contains(&tracker, "0001"),
+            "a locally-resolvable target names no remote candidate, so the \
+             confirmation gate issues no fetch_all for its token"
+        );
+    }
+
+    #[test]
+    fn a_mixed_found_and_absent_batch_writes_no_local_file() {
+        let dir = sync_repo();
+        let tracker = Rc::new(RecordingTracker::holding(vec![(
+            ExternalId::new("PP-999".to_owned()),
+            issue("Found\nRemote body"),
+        )]));
+
+        drive_sync(
+            dir.path(),
+            &tracker,
+            &sync_args(vec!["PP-999".to_owned(), "PP-404".to_owned()]),
+        );
+
+        assert!(
+            new_work_files(dir.path()).is_empty(),
+            "an absent token aborts the whole run before any write, so the \
+             found target is not pulled either"
+        );
+    }
+
+    #[test]
+    fn a_previewed_remote_only_target_writes_nothing_yet_confirms_it() {
+        let dir = sync_repo();
+        let tracker = Rc::new(RecordingTracker::holding(vec![(
+            ExternalId::new("PP-999".to_owned()),
+            issue("Preview\nRemote body"),
+        )]));
+        let mut args = sync_args(vec!["PP-999".to_owned()]);
+        args.preview = true;
+
+        drive_sync(dir.path(), &tracker, &args);
+
+        assert!(
+            new_work_files(dir.path()).is_empty(),
+            "a previewed pull writes no file"
+        );
+        assert!(
+            fetch_all_contains(&tracker, "PP-999"),
+            "preview still confirms the candidate through fetch_all"
+        );
+    }
+
+    #[test]
+    fn a_mixed_local_and_remote_only_run_excludes_the_non_targeted_item() {
+        let dir = sync_repo();
+        work_file(dir.path(), "0001", Some("PP-1"));
+        work_file(dir.path(), "0002", Some("PP-2"));
+        let non_targeted = dir.path().join("meta/work/0002-title.md");
+        let before = std::fs::read_to_string(&non_targeted).expect("read 0002");
+        let tracker = Rc::new(RecordingTracker::holding(vec![
+            (
+                ExternalId::new("PP-1".to_owned()),
+                issue("One\nRemote body"),
+            ),
+            (
+                ExternalId::new("PP-999".to_owned()),
+                issue("New\nRemote body"),
+            ),
+        ]));
+
+        drive_sync(
+            dir.path(),
+            &tracker,
+            &sync_args(vec!["0001".to_owned(), "PP-999".to_owned()]),
+        );
+
+        assert_eq!(
+            new_work_files(dir.path()).len(),
+            3,
+            "the two seeded files plus one pulled file for PP-999"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&non_targeted).expect("read 0002"),
+            before,
+            "the non-targeted item is left byte-identical"
+        );
+        assert!(
+            !fetch_all_contains(&tracker, "PP-2"),
+            "the non-targeted item's remote is never read"
         );
     }
 }

--- a/cli/work-cli/src/sync.rs
+++ b/cli/work-cli/src/sync.rs
@@ -1939,6 +1939,18 @@ mod tests {
         names
     }
 
+    fn only_created_author(dir: &Path) -> String {
+        let files = new_work_files(dir);
+        let name = files.first().expect("one created file");
+        let content = std::fs::read_to_string(dir.join("meta/work").join(name))
+            .expect("read created file");
+        content
+            .lines()
+            .find_map(|line| line.strip_prefix("author: "))
+            .map(|value| value.trim_matches('"').to_owned())
+            .expect("author frontmatter")
+    }
+
     /// Whether any `fetch_all` the run made named `id`. The candidate-
     /// confirmation gate reads the raw `--target` token, so a bare local id
     /// appearing here means the gate ran; the engine's reconcile read only ever
@@ -1969,6 +1981,12 @@ mod tests {
             baseline_written(dir.path()),
             "the create-from-remote completes through its baseline write, even \
              on a never-synced integration whose state dir does not yet exist"
+        );
+        assert_eq!(
+            only_created_author(dir.path()),
+            "Test User",
+            "the imported file is authored with the synced repository's own \
+             identity, not the ambient process identity"
         );
         assert!(
             fetch_all_contains(&tracker, "PP-999"),

--- a/cli/work-cli/src/sync_author.rs
+++ b/cli/work-cli/src/sync_author.rs
@@ -23,7 +23,7 @@ use tracker::ExternalId;
 use work::create::resolve_author;
 use work::create::CreateInputs;
 use work::create::TypedLinkage;
-use work_adapters::author::VcsBackedIdentityProbe;
+use work_adapters::author::RepositoryIdentityProbe;
 use work_adapters::sync::create::AuthoredLocal;
 use work_adapters::sync::create::DiscoveredIssue;
 use work_adapters::sync::create::LocalAuthor;
@@ -121,7 +121,8 @@ impl LocalAuthor for ConfiguredLocalAuthor<'_> {
         )
         .map_err(failed)?;
         let author =
-            resolve_author(None, &VcsBackedIdentityProbe).map_err(failed)?;
+            resolve_author(None, &RepositoryIdentityProbe::new(&self.root))
+                .map_err(failed)?;
 
         let inputs = CreateInputs {
             id: &id,

--- a/cli/work-cli/tests/cli_sync_targets.rs
+++ b/cli/work-cli/tests/cli_sync_targets.rs
@@ -83,21 +83,23 @@ fn baseline_exists(dir: &Path) -> bool {
 }
 
 #[test]
-fn a_no_match_target_exits_three_before_the_credential_check(
+fn a_bare_remote_only_target_reaches_the_credential_phase(
 ) -> Result<(), TestError> {
     let repo = scratch_repo()?;
     work_item(repo.path(), "0001", Some("PP-1"))?;
+    // A token with no local match is now a remote candidate, so it is no longer
+    // an exit-3 resolution abort: it reaches the tracker phase, where the
+    // (unconfigured) jira credentials abort with 74 before any fetch_all.
     let output = run(repo.path(), &["--target", "9999"])?;
     assert_eq!(
         output.status.code(),
-        Some(3),
-        "a no-match target aborts before the tracker credential check (74)"
+        Some(74),
+        "a remote-only target passes resolution and reaches the credential \
+         check, rather than aborting with a resolution code"
     );
-    let stderr = String::from_utf8(output.stderr)?;
-    assert!(stderr.contains("9999"), "{stderr}");
     assert!(
         !baseline_exists(repo.path()),
-        "the abort writes no baseline"
+        "the credential abort writes no baseline"
     );
     Ok(())
 }
@@ -139,24 +141,52 @@ fn an_empty_target_token_is_a_usage_error() -> Result<(), TestError> {
 }
 
 #[test]
-fn a_no_match_and_an_out_of_dir_path_exit_six_naming_both(
+fn an_unmanaged_and_an_out_of_dir_path_exit_six_naming_both(
 ) -> Result<(), TestError> {
     let repo = scratch_repo()?;
     work_item(repo.path(), "0001", Some("PP-1"))?;
     fs::write(repo.path().join("meta/outside.md"), "---\nid: \"x\"\n---\n")?;
+    fs::write(repo.path().join("meta/work/notes.md"), "not a work item\n")?;
     let output = run(
         repo.path(),
-        &["--target", "9999", "--target", "meta/outside.md"],
+        &[
+            "--target",
+            "meta/work/notes.md",
+            "--target",
+            "meta/outside.md",
+        ],
     )?;
     assert_eq!(
         output.status.code(),
         Some(6),
-        "the out-of-directory code outranks the no-match code"
+        "the out-of-directory code outranks the unmanaged not-found code"
     );
     let stderr = String::from_utf8(output.stderr)?;
-    assert!(stderr.contains("9999"), "{stderr}");
+    assert!(stderr.contains("notes.md"), "{stderr}");
     assert!(stderr.contains("meta/outside.md"), "{stderr}");
     assert!(!baseline_exists(repo.path()));
+    Ok(())
+}
+
+#[test]
+fn a_push_only_remote_only_target_exits_two_naming_the_token(
+) -> Result<(), TestError> {
+    let repo = scratch_repo()?;
+    work_item(repo.path(), "0001", Some("PP-1"))?;
+    // A remote-only target under --push-only is contradictory: it aborts as a
+    // usage error before any tracker contact, so no fetch_all is issued.
+    let output = run(repo.path(), &["--push-only", "--target", "PP-999"])?;
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a remote-only target cannot be pulled under --push-only"
+    );
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("PP-999"), "{stderr}");
+    assert!(
+        !baseline_exists(repo.path()),
+        "the usage abort writes no baseline"
+    );
     Ok(())
 }
 

--- a/cli/work-cli/tests/cli_sync_targets.rs
+++ b/cli/work-cli/tests/cli_sync_targets.rs
@@ -161,6 +161,31 @@ fn a_no_match_and_an_out_of_dir_path_exit_six_naming_both(
 }
 
 #[test]
+fn a_local_local_collision_exits_two_naming_both_files() -> Result<(), TestError>
+{
+    let repo = scratch_repo()?;
+    // File A carries local id 0001 and no external_id; file B records 0001 as
+    // its external_id, so targeting "0001" is a genuine local/local collision.
+    work_item(repo.path(), "0001", None)?;
+    work_item(repo.path(), "0002", Some("0001"))?;
+    let output = run(repo.path(), &["--target", "0001"])?;
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a local/local collision is a usage error, decided from the corpus \
+         with no remote call"
+    );
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("0001-title.md"), "names file A: {stderr}");
+    assert!(stderr.contains("0002-title.md"), "names file B: {stderr}");
+    assert!(
+        !baseline_exists(repo.path()),
+        "the abort writes no baseline"
+    );
+    Ok(())
+}
+
+#[test]
 fn a_valid_target_resolves_then_reaches_the_credential_check(
 ) -> Result<(), TestError> {
     let repo = scratch_repo()?;

--- a/cli/work-cli/tests/cli_sync_targets.rs
+++ b/cli/work-cli/tests/cli_sync_targets.rs
@@ -87,9 +87,9 @@ fn a_bare_remote_only_target_reaches_the_credential_phase(
 ) -> Result<(), TestError> {
     let repo = scratch_repo()?;
     work_item(repo.path(), "0001", Some("PP-1"))?;
-    // A token with no local match is now a remote candidate, so it is no longer
-    // an exit-3 resolution abort: it reaches the tracker phase, where the
-    // (unconfigured) jira credentials abort with 74 before any fetch_all.
+    // A token with no local match is a remote candidate, not an exit-3
+    // resolution abort, so it reaches the tracker phase, where the unconfigured
+    // jira credentials abort with 74 before any fetch_all.
     let output = run(repo.path(), &["--target", "9999"])?;
     assert_eq!(
         output.status.code(),

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,13 +8,14 @@
       "name": "accelerator-docs-site",
       "version": "0.0.0",
       "dependencies": {
-        "@astrojs/starlight": "^0.41.3",
-        "astro": "^7.1.3",
-        "astro-rehype-relative-markdown-links": "^0.19.0",
+        "@astrojs/markdown-remark": "^7.3.1",
+        "@astrojs/starlight": "^0.42.0",
+        "astro": "^7.3.2",
+        "astro-rehype-relative-markdown-links": "^0.19.2",
         "playwright": "^1.0.0",
         "rehype-mermaid": "^3.0.0",
-        "starlight-image-zoom": "^0.14.0",
-        "starlight-links-validator": "^0.24.0"
+        "starlight-image-zoom": "^0.16.0",
+        "starlight-links-validator": "^0.26.0"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -31,29 +32,29 @@
       }
     },
     "node_modules/@astrojs/compiler-binding": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
-      "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.4.0.tgz",
+      "integrity": "sha512-x2RjDUuWfwLNtc3mjAdSRInwqh/rqbLar9cm/5FOMbHvmYZB7yfKewzSclAxWjIZsypJDXv1lhaP2WG+P8TK3g==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@astrojs/compiler-binding-darwin-arm64": "0.3.1",
-        "@astrojs/compiler-binding-darwin-x64": "0.3.1",
-        "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
-        "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
-        "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
-        "@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
-        "@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
-        "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
-        "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
+        "@astrojs/compiler-binding-darwin-arm64": "0.4.0",
+        "@astrojs/compiler-binding-darwin-x64": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.4.0",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.4.0",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.4.0",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.4.0"
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-arm64": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
-      "integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-ZVUwHundaQyFNjE6uoa0usaC0WOCitDCLS/4mdb4rOiJXwVUuKJBMxI5WMzXLWmamsXtK/Z//ifLXvV5Yeh4Hw==",
       "cpu": [
         "arm64"
       ],
@@ -67,9 +68,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-x64": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
-      "integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-FI6G8AY8u6fR1SI/QRR5yGMwtvZwP34CDmZpZ5HwJGa50UM1VISTLhqkhV4a476pmgd25X1Aur2dqw6hUnrlKA==",
       "cpu": [
         "x64"
       ],
@@ -83,9 +84,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
-      "integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-lB9gLFJK7m82EnjaU8nlRBEfcwGNeHidW3sSjODTUjMNaoewVuUz9fwwdY5M4jiSXIqWLH3yl6TX8FTDKA74Sw==",
       "cpu": [
         "arm64"
       ],
@@ -99,9 +100,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
-      "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
       "cpu": [
         "arm64"
       ],
@@ -115,9 +116,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
-      "integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-tQKolMxoJ/+0AmLWm1PmJ/i+z3i10ZU1bNuVjEDulCf48azEMtUNjTZgHJ5MPtpYRNc7dlETr8QujUfduzoC7Q==",
       "cpu": [
         "x64"
       ],
@@ -131,9 +132,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
-      "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
       "cpu": [
         "x64"
       ],
@@ -147,25 +148,25 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
-      "integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.4.0.tgz",
+      "integrity": "sha512-m/phuH3x3PREvv1OnkM44NoPh4MatUadix1fB1u5SvMLCyDTUZykDJbKnWf1cjnYmHdlB8HcjTjl6JrCqAIXcw==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@napi-rs/wasm-runtime": "^1.2.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
-      "integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.4.0.tgz",
+      "integrity": "sha512-B9zYf3okEY83kM8gydlpH2BHP00w4ifxPqlYlWrgTwuD6wnkrJDCwBlgy1q31cERjCJRXN1lrE2VmkLvFjv/6g==",
       "cpu": [
         "arm64"
       ],
@@ -179,9 +180,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
-      "integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-zB0Nrv0dGc0zZWPGDRmmETTPhDRqyZjAjk+gWMlVrJX5U89obpB3VUUE1ZiHxOCN5LQojeLK6O8L/dnoHolvNQ==",
       "cpu": [
         "x64"
       ],
@@ -195,26 +196,26 @@
       }
     },
     "node_modules/@astrojs/compiler-rs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
-      "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.4.0.tgz",
+      "integrity": "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-binding": "0.3.1"
+        "@astrojs/compiler-binding": "0.4.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
-      "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
+      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
         "@types/mdast": "^4.0.4",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "picomatch": "^4.0.4",
         "retext-smartypants": "^6.2.0",
         "shiki": "^4.0.2",
@@ -223,15 +224,19 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
-      "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.3.1.tgz",
+      "integrity": "sha512-QCjsjZQl0+Cgb91+T3Ip9hyUe1r5aLm4udi584rML9YO3syupbAYE+jWpAxYg+z4lFLNUugPrylFxZ+8qFTClg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
+        "@mdx-js/mdx": "^3.1.1",
+        "acorn": "^8.16.0",
+        "estree-util-visit": "^2.0.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
+        "hast-util-to-html": "^9.0.5",
         "hast-util-to-text": "^4.0.2",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
@@ -240,6 +245,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
+        "source-map": "^0.7.6",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -248,48 +254,37 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
-      "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.1.tgz",
+      "integrity": "sha512-EniHbFNa6SQHDih7JnpPos3NWXO6hdt4raBcOosfGmlfc3gP9CI/sESA3VOf1PgJZ7SFfewlZW9Livn0JugEZg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "satteri": "^0.9.1"
+        "satteri": "^0.10.3"
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
-      "integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-8.0.1.tgz",
+      "integrity": "sha512-VKodp/f3+XE6L0950K+ZOAolY47vdt0R78Ao+L2RdJ1hfAdYffL7IEjc/MsoyuS7CPVvCsd5/I3RP0ZyAIewdQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/markdown-remark": "7.2.1",
-        "@mdx-js/mdx": "^3.1.1",
-        "acorn": "^8.16.0",
-        "es-module-lexer": "^2.0.0",
-        "estree-util-visit": "^2.0.0",
-        "hast-util-to-html": "^9.0.5",
-        "piccolore": "^0.1.3",
-        "rehype-raw": "^7.0.0",
-        "remark-gfm": "^4.0.1",
-        "remark-smartypants": "^3.0.2",
-        "source-map": "^0.7.6",
-        "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3"
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.1",
+        "es-module-lexer": "^2.0.0"
       },
       "engines": {
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-satteri": "^0.3.1",
-        "astro": "^7.0.0"
+        "@astrojs/markdown-remark": "^7.3.0",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "astro": "^7.2.6"
       },
       "peerDependenciesMeta": {
-        "@astrojs/markdown-satteri": {
+        "@astrojs/markdown-remark": {
           "optional": true
         }
       }
@@ -318,44 +313,43 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.41.3.tgz",
-      "integrity": "sha512-8xsG6UpK581TJmtOc7/pnxHKEbP16rV06VLWaVa7FOyE/VEwnaHOsLtL+miifCEfuiuv0Wn+j8u3JSluRQesMQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.42.0.tgz",
+      "integrity": "sha512-EVsGnyGJ6rRNwGRZFYmGABo0qTQ55F7OSmfSL0VK+5lsqD+u6GWcB8tFqXETcUvP8kyn90W+QBLSL2aer9jNJQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-satteri": "^0.3.2",
-        "@astrojs/mdx": "^7.0.0",
-        "@astrojs/sitemap": "^3.7.2",
+        "@astrojs/markdown-satteri": "^0.4.0",
+        "@astrojs/mdx": "^8.0.0",
+        "@astrojs/sitemap": "^3.7.3",
         "@pagefind/default-ui": "^1.3.0",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/js-yaml": "^4.0.9",
         "@types/mdast": "^4.0.4",
         "astro-expressive-code": "^0.44.0",
         "bcp-47": "^2.1.0",
-        "hast-util-from-html": "^2.0.3",
+        "hast-util-format": "^1.1.0",
         "hast-util-select": "^6.0.4",
+        "hast-util-to-html": "^9.0.5",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
         "i18next": "^26.0.7",
         "js-yaml": "^4.1.1",
         "klona": "^2.0.6",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.2.3",
         "mdast-util-directive": "^3.1.0",
         "mdast-util-to-markdown": "^2.1.2",
         "mdast-util-to-string": "^4.0.0",
         "pagefind": "^1.5.2",
-        "rehype": "^13.0.2",
-        "rehype-format": "^5.0.1",
         "remark-directive": "^4.0.0",
-        "satteri": "^0.9.1",
+        "satteri": "^0.10.3",
         "ultrahtml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
         "vfile": "^6.0.3"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "^7.2.0",
-        "astro": "^7.0.2"
+        "@astrojs/markdown-remark": "^7.3.0",
+        "astro": "^7.2.10"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -431,9 +425,9 @@
       "license": "MIT"
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
       "cpu": [
         "arm64"
       ],
@@ -444,9 +438,9 @@
       ]
     },
     "node_modules/@bruits/satteri-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
       "cpu": [
         "x64"
       ],
@@ -457,9 +451,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
-      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
       "cpu": [
         "arm64"
       ],
@@ -470,9 +464,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
-      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
       ],
@@ -483,9 +477,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
-      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
       "cpu": [
         "x64"
       ],
@@ -496,9 +490,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
-      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
       ],
@@ -509,9 +503,9 @@
       ]
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
-      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
       "cpu": [
         "wasm32"
       ],
@@ -520,7 +514,7 @@
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@napi-rs/wasm-runtime": "^1.2.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -548,9 +542,9 @@
       }
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
-      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
       "cpu": [
         "arm64"
       ],
@@ -561,9 +555,9 @@
       ]
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
-      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
       "cpu": [
         "x64"
       ],
@@ -641,9 +635,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1158,9 +1152,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -1176,13 +1170,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1198,20 +1192,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1221,9 +1215,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1237,9 +1231,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1253,9 +1247,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -1269,9 +1263,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1285,9 +1279,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1301,9 +1295,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1317,9 +1311,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1333,9 +1327,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1349,9 +1343,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1365,9 +1359,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1381,9 +1375,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1399,13 +1393,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1421,13 +1415,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1443,13 +1437,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1465,13 +1459,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1487,13 +1481,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1509,13 +1503,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1531,13 +1525,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1553,17 +1547,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1573,16 +1567,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1592,9 +1586,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1611,9 +1605,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1630,9 +1624,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -1649,9 +1643,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "license": "MIT"
     },
     "node_modules/@mdx-js/mdx": {
@@ -1701,21 +1695,24 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -2097,34 +2094,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "license": "MIT"
-    },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/@shikijs/core": {
@@ -2619,9 +2588,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2732,19 +2701,18 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.3.tgz",
-      "integrity": "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.2.tgz",
+      "integrity": "sha512-ysTcdpGP61XZpHoMRYC/CK19DQ94qkBvzXMtXEo0gEqPNkmOU/Tv++CtWmzaI4nF2Ck8RXFdiWvdlTWa2oOr9w==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-rs": "^0.3.1",
-        "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/markdown-satteri": "0.3.4",
+        "@astrojs/compiler-rs": "^0.4.0",
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.1",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.3.0",
         "am-i-vibing": "^0.4.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
@@ -2753,19 +2721,20 @@
         "common-ancestor-path": "^2.0.0",
         "cookie": "^2.0.1",
         "devalue": "^5.8.1",
-        "diff": "^8.0.3",
+        "diff": "^9.0.0",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.28.0",
+        "find-proc": "0.1.0",
         "flattie": "^1.1.1",
         "fontace": "~0.4.1",
         "get-tsconfig": "5.0.0-beta.4",
         "github-slugger": "^2.0.0",
         "html-escaper": "3.0.3",
         "http-cache-semantics": "^4.2.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "jsonc-parser": "^3.3.1",
-        "magic-string": "^0.30.21",
+        "magic-string": "^1.0.0",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
         "neotraverse": "^1.0.1",
@@ -2783,13 +2752,13 @@
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.4",
+        "unifont": "~0.7.5",
         "unstorage": "^1.17.5",
         "vite": "^8.0.13",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -2804,10 +2773,10 @@
         "url": "https://opencollective.com/astrodotbuild"
       },
       "optionalDependencies": {
-        "sharp": "^0.34.0 || ^0.35.0"
+        "sharp": "^0.35.4"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.1"
+        "@astrojs/markdown-remark": "^7.3.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -2829,9 +2798,9 @@
       }
     },
     "node_modules/astro-rehype-relative-markdown-links": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/astro-rehype-relative-markdown-links/-/astro-rehype-relative-markdown-links-0.19.0.tgz",
-      "integrity": "sha512-JgalnGkY5Azx08gX7rLRPjhgbUVaApt4QYQvDataEcRd/ZNoP6UmIQxdm9+ccH6SDMl8opcrQNwCO0C+bd4o2Q==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/astro-rehype-relative-markdown-links/-/astro-rehype-relative-markdown-links-0.19.2.tgz",
+      "integrity": "sha512-+BrDDofT8LWYDkUuCH0DOD1fhmZI2IDZhg9aQYK4kitg5RXmlfOFniR1rEqa4RQQ+FC+ZI36Szt8aGmmzCM7KQ==",
       "license": "MIT",
       "dependencies": {
         "catch-unknown": "^2.0.0",
@@ -2844,13 +2813,22 @@
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "astro": ">=2 <7"
+        "astro": ">=2 <8"
       }
     },
     "node_modules/astro-rehype-relative-markdown-links/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/astro/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -3077,16 +3055,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -3122,9 +3100,9 @@
       }
     },
     "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -3781,9 +3759,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4065,9 +4043,9 @@
       }
     },
     "node_modules/estree-util-scope": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
-      "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.1.tgz",
+      "integrity": "sha512-B0np3dcdxqILX5e9nEi5/Fr4K7gL4oYFVPV1zRa2e9wRCbQoZZNWOZFYyoInvXUPJXBXjss+QXlWLJChDEHDkA==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -4193,6 +4171,15 @@
         }
       }
     },
+    "node_modules/find-proc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/find-proc/-/find-proc-0.1.0.tgz",
+      "integrity": "sha512-OaOpEYv2PiQ7SQ5LIrl+deA1XaWcxEjnpM6VuWXTUvn+teIXxeFTLDmu18/zDQpFmHN4o3oDBX+BT0AGwEhemg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -4283,9 +4270,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4925,9 +4912,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -5272,9 +5259,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6563,9 +6550,9 @@
       }
     },
     "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-parser": {
@@ -6987,22 +6974,6 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
-    "node_modules/rehype": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
-      "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "rehype-parse": "^9.0.0",
-        "rehype-stringify": "^10.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-expressive-code": {
       "version": "0.44.1",
       "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
@@ -7010,20 +6981,6 @@
       "license": "MIT",
       "dependencies": {
         "expressive-code": "^0.44.1"
-      }
-    },
-    "node_modules/rehype-format": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
-      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-format": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-mermaid": {
@@ -7052,21 +7009,6 @@
         "playwright": {
           "optional": true
         }
-      }
-    },
-    "node_modules/rehype-parse": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
-      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-raw": {
@@ -7196,9 +7138,9 @@
       }
     },
     "node_modules/remark-smartypants": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
-      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.3.tgz",
+      "integrity": "sha512-gCaK+ndZ0hYezlqFegHFCVh2CQemsi0Npdh1qVM9bxlUFknjkbP6VmojWhddOCrbK0PbbacmYLWfTULRiT1eWA==",
       "license": "MIT",
       "dependencies": {
         "retext": "^9.0.0",
@@ -7359,32 +7301,32 @@
       "license": "MIT"
     },
     "node_modules/satteri": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
-      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/mdast": "^4.0.4",
         "@types/unist": "^3.0.3"
       },
       "optionalDependencies": {
-        "@bruits/satteri-darwin-arm64": "0.9.5",
-        "@bruits/satteri-darwin-x64": "0.9.5",
-        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
-        "@bruits/satteri-linux-arm64-musl": "0.9.5",
-        "@bruits/satteri-linux-x64-gnu": "0.9.5",
-        "@bruits/satteri-linux-x64-musl": "0.9.5",
-        "@bruits/satteri-wasm32-wasi": "0.9.5",
-        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
-        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -7416,9 +7358,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7433,31 +7375,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -7510,9 +7452,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -7556,13 +7498,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/starlight-image-zoom": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/starlight-image-zoom/-/starlight-image-zoom-0.14.2.tgz",
-      "integrity": "sha512-YBvE724gFMiVjObGtXmfIDi3zAxVBsvGukeRXOiWLNnESFOBZFfO9DpC/reHohrCxFrO+5ot0XR8EimbE0LpsA==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/starlight-image-zoom/-/starlight-image-zoom-0.16.0.tgz",
+      "integrity": "sha512-N/mZ1Jwu+1JRQ9MqJjdj69UXiVpfDd3k6i78ZIuht1aZGceVC0wOcqCPASZ6VNmUoELlMXLz9n0xtAyBIfmA8A==",
       "license": "MIT",
       "dependencies": {
         "mdast-util-mdx-jsx": "^3.2.0",
         "rehype-raw": "^7.0.0",
+        "satteri": "^0.10.3",
         "unist-util-visit": "^5.1.0",
         "unist-util-visit-parents": "^6.0.2"
       },
@@ -7570,15 +7513,16 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.38.0"
+        "@astrojs/starlight": ">=0.42.0"
       }
     },
     "node_modules/starlight-links-validator": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.24.1.tgz",
-      "integrity": "sha512-nATZ0xMLYnmO1YDBGEy9PdjF/WxhbKR7/gQo0dFs5UELcorKLPXcNLM62xbqII7g0AF7/D9wSzD4qSwIGTu8sw==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.26.0.tgz",
+      "integrity": "sha512-b3JlzP5bczSDMQp10ST/Gldd6RNzcwpWfTrszzGPcqnuav2W31+MjyX92IXH+VCcG2pG9G1qyDcEcNuMRYi2ig==",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/markdown-satteri": "^0.4.0",
         "@types/picomatch": "^4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
@@ -7586,6 +7530,7 @@
         "mdast-util-mdx-jsx": "^3.2.0",
         "mdast-util-to-hast": "^13.2.1",
         "picomatch": "^4.0.3",
+        "satteri": "^0.10.3",
         "terminal-link": "^5.0.0",
         "unist-util-visit": "^5.1.0",
         "yaml": "^2.8.3"
@@ -7594,8 +7539,8 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.38.0",
-        "astro": ">=6.0.0"
+        "@astrojs/starlight": ">=0.42.0",
+        "astro": ">=7.2.10"
       }
     },
     "node_modules/starlight-links-validator/node_modules/is-absolute-url": {
@@ -7692,18 +7637,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"
@@ -7835,6 +7780,15 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -7861,14 +7815,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
-        "ofetch": "^1.5.1",
-        "ohash": "^2.0.11"
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
       }
     },
     "node_modules/unist-util-find-after": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -9,17 +9,23 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.41.3",
-    "astro": "^7.1.3",
-    "astro-rehype-relative-markdown-links": "^0.19.0",
+    "@astrojs/markdown-remark": "^7.3.1",
+    "@astrojs/starlight": "^0.42.0",
+    "astro": "^7.3.2",
+    "astro-rehype-relative-markdown-links": "^0.19.2",
     "playwright": "^1.0.0",
     "rehype-mermaid": "^3.0.0",
-    "starlight-image-zoom": "^0.14.0",
-    "starlight-links-validator": "^0.24.0"
+    "starlight-image-zoom": "^0.16.0",
+    "starlight-links-validator": "^0.26.0"
   },
   "overrides": {
     "astro-rehype-relative-markdown-links": {
       "astro": "$astro"
+    },
+    "svgo": "^4.1.0",
+    "js-yaml": "^4.3.2",
+    "gray-matter": {
+      "js-yaml": "^3.15.2"
     }
   }
 }

--- a/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -557,31 +557,36 @@ overstated count.
 
 #### Automated Verification
 
-- [ ] `partition_candidates` returns `found` for an all-found outcome and folds
+- [x] `partition_candidates` returns `found` for an all-found outcome and folds
       `absent`→3 / `indeterminate`→70, with a batch carrying both exiting 3:
-      `cargo test -p work-cli partition_candidates`
-- [ ] Driven through `run_sync` with a stub `TrackerRegistry`, a remote-only
-      `PP-999` (stub `found`) is pulled and reconciled: `cargo test -p work-cli remote_only_target`
-- [ ] A mixed `found`+`absent` batch aborts exit 3 naming the absent token, zero
-      writes, found not pulled: `cargo test -p work-cli mixed_targets`
-- [ ] An all-success batch mixing a local-id target, a path target, and a
+      `cargo test -p accelerator-work partition_candidates`
+- [x] Driven through `run_sync` with a stub `TrackerRegistry`, a remote-only
+      `PP-999` (stub `found`) is pulled and reconciled: `cargo test -p accelerator-work remote_only`
+- [x] A mixed `found`+`absent` batch aborts exit 3 naming the absent token, zero
+      writes, found not pulled: `cargo test -p accelerator-work mixed_found` (zero-write
+      asserted through `run_sync`; the exit-3 chain by `partition_candidates`)
+- [x] An all-success batch mixing a local-id target, a path target, and a
       remote-only `found` id reconciles the local files, creates the remote-only
-      one, and writes no non-targeted item (AC7): `cargo test -p work-cli`
-- [ ] A whole-call `fetch_all` `Err` for an unembeddable id exits 2 (usage), not
-      70: `cargo test -p work-cli`
-- [ ] Two spellings of one remote-only issue (`PP-999`, `pp-999`) yield a single
-      pull, not two files: `cargo test -p work-cli`
-- [ ] `--push-only --target <remote-only>` exits 2 naming the token, with no
-      `fetch_all` call: `cargo test -p work-cli`
-- [ ] A locally-resolvable token makes no remote call, asserted by a recording
-      stub whose `fetch_all` count is zero: `cargo test -p work-cli`
-- [ ] `--preview --target PP-999` shows the would-create, writes nothing, counts
-      against `--max-pulls`: `cargo test -p work-cli`
-- [ ] A bare remote-only token now reaches the credential/tracker phase (the
-      inverted `a_no_match_target_exits_three_before_the_credential_check`):
-      `cargo test -p work-cli`
-- [ ] An untargeted full sync report and write set are unchanged: `cargo test -p work-cli`
-- [ ] Read-only aggregate clean: `mise run check`
+      one, and writes no non-targeted item (AC7): `cargo test -p accelerator-work mixed_local_and_remote`
+- [~] A whole-call `fetch_all` `Err` **maps to exit 70 (retryable)**, not the
+      plan's three-way split — `TrackerError` carries no discriminant to separate
+      an unembeddable-id from a transient fault, and a credential fault is already
+      caught at `registry.resolve` (74). Per an explicit user decision; covered by
+      `a_whole_call_fetch_all_error_folds_to_indeterminate_exit_seventy`.
+- [x] Two spellings of one remote-only issue (`PP-999`, `pp-999`) yield a single
+      pull, not two files: `cargo test -p accelerator-work two_spellings`
+- [x] `--push-only --target <remote-only>` exits 2 naming the token, with no
+      `fetch_all` call: `cargo test -p accelerator-work push_only_remote_only`
+- [x] A locally-resolvable token makes no candidate `fetch_all` call, asserted by
+      a recording stub: `cargo test -p accelerator-work locally_resolvable`
+- [x] `--preview --target PP-999` shows the would-create, writes nothing, and the
+      pull counts against `--max-pulls` (bound covered by the phase-2 preview test):
+      `cargo test -p accelerator-work previewed_remote_only`
+- [x] A bare remote-only token now reaches the credential/tracker phase (the
+      inverted `a_bare_remote_only_target_reaches_the_credential_phase`):
+      `cargo test -p accelerator-work bare_remote_only`
+- [x] An untargeted full sync report and write set are unchanged: `cargo test -p accelerator-work`
+- [x] Read-only aggregate clean: `mise run check`
 
 #### Manual Verification
 

--- a/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -254,17 +254,17 @@ test that demands the change.
 
 #### Automated Verification
 
-- [ ] The rewritten `a_local_id_wins_...` test asserts exit 2 naming both files,
+- [x] The rewritten `a_local_id_wins_...` test asserts exit 2 naming both files,
       zero writes: `cargo test -p work-cli collision`
-- [ ] An own-`external_id` token reconciles with no note: `cargo test -p work-cli`
-- [ ] The suppressed-line test is gone and the suite compiles without
+- [x] An own-`external_id` token reconciles with no note: `cargo test -p work-cli`
+- [x] The suppressed-line test is gone and the suite compiles without
       `Suppressed`: `cargo test -p work-cli`
-- [ ] Workspace lint and format clean: `mise run cli:check`
-- [ ] Read-only aggregate clean: `mise run check`
+- [x] Workspace lint and format clean: `mise run cli:check`
+- [x] Read-only aggregate clean: `mise run check`
 
 #### Manual Verification
 
-- [ ] The `sync-work-items` skill prose reads coherently with no dangling
+- [x] The `sync-work-items` skill prose reads coherently with no dangling
       reference to a suppressed-remote note, and states the own-`external_id`
       reconcile case.
 

--- a/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -368,39 +368,39 @@ the three existing work-adapters test sites (`sync_run.rs:342`, `sync_run.rs:480
 
 #### Automated Verification
 
-- [ ] A non-empty `pull_ids` with a stub `show` creates the file, counts as a
+- [x] A non-empty `pull_ids` with a stub `show` creates the file, counts as a
       pull, and applies it: `cargo test -p work-adapters targeted_pull`
-- [ ] An empty `pull_ids` still emits `SkippedTargeted`, proving the phase's
+- [x] An empty `pull_ids` still emits `SkippedTargeted`, proving the phase's
       output is unchanged for a reconcile-only targeted run: `cargo test -p work-adapters`
-- [ ] Exceeding `--max-pulls` refuses the whole run with zero writes (no partial
+- [x] Exceeding `--max-pulls` refuses the whole run with zero writes (no partial
       creation): `cargo test -p work-adapters`
-- [ ] Preview reports `CreateFromRemote`/`NotApplied` with zero writes: `cargo test -p work-adapters`
-- [ ] A candidate `found` by the gate but whose `show` returns `Retryable`
+- [x] Preview reports `CreateFromRemote`/`NotApplied` with zero writes: `cargo test -p work-adapters`
+- [x] A candidate `found` by the gate but whose `show` returns `Retryable`
       reports a `Failed` create, leaves earlier creates intact with valid
       baselines, and re-runs cleanly: `cargo test -p work-adapters`
-- [ ] A `pull_ids` entry whose canonical key already binds a corpus file is
+- [x] A `pull_ids` entry whose canonical key already binds a corpus file is
       filtered out — no second `author_from_remote` call, no extra write:
       `cargo test -p work-adapters`
-- [ ] A run mixing resolved `items` and a remote-only `pull_id`, over a corpus
+- [x] A run mixing resolved `items` and a remote-only `pull_id`, over a corpus
       that also holds a non-targeted item, writes exactly the two targeted items
       and nothing else (AC7): `cargo test -p work-adapters`
-- [ ] Of two `pull_ids` where one `show` fails, the pull tally and item rows
+- [x] Of two `pull_ids` where one `show` fails, the pull tally and item rows
       report one success, not two: `cargo test -p work-adapters`
-- [ ] A create whose baseline write fails after the file is authored recovers on
+- [x] A create whose baseline write fails after the file is authored recovers on
       re-run via the file's `external_id` with no duplicate pull: `cargo test -p work-adapters`
-- [ ] The same stub issue imported via discovery and via `pull_ids` authors an
+- [x] The same stub issue imported via discovery and via `pull_ids` authors an
       identical id, filename, and baseline entry (AC2 parity): `cargo test -p work-adapters`
-- [ ] `discovery_line` emits `#\tdiscovery\ttargeted-pull\t<N>` for
+- [x] `discovery_line` emits `#\tdiscovery\ttargeted-pull\t<N>` for
       `TargetedPull { attempted: N }` (extend `render_report_emits_each_discovery_status_line`):
       `cargo test -p work-adapters`
-- [ ] A second run with the id now local reconciles via the ordinary arm and the
+- [x] A second run with the id now local reconciles via the ordinary arm and the
       watermark has advanced: `cargo test -p work-adapters`
-- [ ] The `All` path is unchanged (existing full-sync tests pass): `cargo test -p work-adapters`
-- [ ] Workspace lint and format clean: `mise run cli:check`
+- [x] The `All` path is unchanged (existing full-sync tests pass): `cargo test -p work-adapters`
+- [x] Workspace lint and format clean: `mise run cli:check`
 
 #### Manual Verification
 
-- [ ] None — this phase is engine-internal and fully covered by tests.
+- [x] None — this phase is engine-internal and fully covered by tests.
 
 ---
 

--- a/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -1,0 +1,667 @@
+---
+type: "plan"
+id: "2026-09-08-0285-targeted-pull-of-remote-only-work-items"
+title: "Targeted Pull of Remote-Only Work Items and Resolution Normalisation Implementation Plan"
+date: "2026-09-08T20:35:43+00:00"
+author: "Toby Clemson"
+producer: "create-plan"
+status: "ready"
+work_item_id: "work-item:0285"
+parent: "work-item:0285"
+derived_from: ["codebase-research:2026-09-08-0285-targeted-pull-of-remote-only-work-items"]
+tags: ["work", "sync", "targeting", "pull"]
+revision: "9c49306cdec8d222b253eac36d05cc769592f064"
+repository: "accelerator"
+last_updated: "2026-09-08T21:50:31+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Targeted Pull of Remote-Only Work Items and Resolution Normalisation Implementation Plan
+
+## Overview
+
+Extend `work sync --target <id|external-id|path>` so a token with no local file
+is looked up on the remote tracker and, if it exists there, pulled into a new
+local file and reconciled. The same change redefines targeted resolution: the
+genuine local/local collision becomes a hard usage error (exit 2), and the
+suppressed-remote note is retired because every dual-shape token now resolves to
+exactly one deterministic outcome.
+
+The three behaviours ship together because they are one function. All of
+`resolve_targets` (`cli/work-cli/src/sync.rs:456`) decides them, and introducing
+remote lookup is precisely what forces the collision and ordinary-synced-item
+arms to be redefined.
+
+## Current State Analysis
+
+`resolve_targets` resolves every `--target` token against the local corpus only,
+through a filesystem-pure `resolver` closure. The tracker is resolved *after*
+selection completes (`sync.rs:699`), so resolution today has no network access —
+a deliberate invariant from 0257 that keeps target validation
+credential-independent (`sync.rs:654-655`).
+
+Three arms of the token loop carry the behaviour this plan changes:
+
+- **No-local-match** (`sync.rs:514-527`) — a token that resolves to neither a
+  local file nor a single `external_id` entry pushes `NoMatch` → exit 3, with
+  the message "untracked remote issues are imported only by a full (untargeted)
+  sync". This is the abort the plan inverts.
+- **Collision** (`sync.rs:484-492` via `suppressed_remote` at `438-449`) — a
+  token that resolves locally to file A *and* keys a different file B's
+  `external_id` records a non-fatal `Suppressed` note and lets A win.
+- **Ordinary synced item** (same `Some(item)` arm) — a token equal to its own
+  file's `external_id` finds no *different* file, so `suppressed_remote` returns
+  `None` and it already reconciles with no note. This arm needs no logic change;
+  the requirement here is satisfied once the collision arm stops emitting notes.
+
+The engine reuse target is clean. `create_from_remote` (`apply.rs:270`) takes
+only an `&ExternalId`, drives `tracker.show → author_from_remote → baseline`
+with `local_synced_at = run_start_epoch`, and bypasses discovery. The single
+`discovery_suppressed()` branch (`run.rs:786`) forces the targeted `untracked`
+set empty; that one branch simultaneously governs pull accounting
+(`run.rs:822`), the preview loop (`run.rs:886`), and the apply loop
+(`run.rs:929`). A targeted pull is a non-empty, targeted `untracked` set at that
+branch — not a discovery search.
+
+### Key Discoveries
+
+- **`show` cannot report absence** (`cli/tracker/src/lib.rs:415-425`, verified).
+  A non-resolving id is `TrackerError::Retryable`, indistinguishable from a
+  transient fault. Only `fetch_all([id])`, whose `absent` partition is provable
+  (`lib.rs:221-247`, verified), yields a clean exit 3.
+- **Resolution accumulates all failures and aborts before the engine**
+  (`sync.rs:539`, `build_selection` at `594-606`). One bad `--target` aborts the
+  whole selection with zero writes. Extending absence into this accumulator
+  preserves that all-or-nothing property across a mixed batch.
+- **The ordinary-synced-item arm already reconciles silently** (`sync.rs:447`,
+  the `item.id != local_match.id` guard). No logic change; deletion of the
+  `Suppressed` machinery is the whole of the requirement.
+- **`create_from_remote` produces a byte-identical file to a discovery import.**
+  Id and filename allocation live in `author_from_remote`
+  (`cli/work-cli/src/sync_author.rs:97-159`); both create paths route through it,
+  satisfying the allocation-parity criterion by construction.
+- **`ItemSelection::Targeted` is a single lever** (`run.rs:98-141`). It gates
+  discovery, preview imports, apply imports, and document-watermark advance from
+  one enum. A targeted pull extends `Targeted` to carry confirmed remote-only
+  ids rather than forcing `untracked` empty.
+
+## Desired End State
+
+`work sync --target PP-999`, where `PP-999` exists remotely but not locally,
+creates a new local file for `PP-999`, populates it from the remote issue,
+reconciles it, and advances its watermark — no exit-3 abort. A second run does
+not re-pull it. The pull counts against `--max-pulls` and shows under
+`--preview` with zero writes.
+
+Resolution is deterministic per token (the rows this item changes; the unchanged
+0257 malformed/unmanaged/ambiguous/outside-dir cases still map to their existing
+codes and take precedence per `2 > 6 > 3 > 70`):
+
+```text
+token resolves to a single local file A ......... reconcile A, no note
+  (by path, by A's local id, or by A's own external_id)
+token is A's local id AND a different file B's
+  external_id ................................... exit 2, name A and B, no remote call
+token has no local match, present remotely ...... pull-create and reconcile
+token has no local match, present, --push-only .. exit 2, name the token, no remote call
+token has no local match, provably absent ....... exit 3, name the token
+token has no local match, indeterminate ......... exit 70 (retryable)
+```
+
+A confirmed-present target is fetched a second time by `show` inside
+`create_from_remote`; if the issue is deleted in that window `show` reports a
+retryable failure (it cannot report absence), so the create surfaces as a
+per-item `Failed` row with a non-zero exit, never a silent success. Under
+`--preview` every "pull-create" row is a would-create with zero writes.
+
+Verify by the acceptance criteria in `meta/work/0285-...md:92-127`, the extended
+tests in `cli/work-cli/tests/cli_sync_targets.rs`, and new engine tests in
+`cli/work-adapters`.
+
+## What We're NOT Doing
+
+- **No `search`/discovery for a targeted pull.** The existence gate is
+  `fetch_all([candidates])` (by-id, scoped); `discover_untracked` stays gated off
+  under `Targeted`.
+- **No new id-allocation scheme.** A targeted pull routes through the existing
+  `author_from_remote` path unchanged.
+- **No change to the full (untargeted) sync.** The `ItemSelection::All` path,
+  its report, its write set, and per-item watermark semantics stay
+  byte-identical.
+- **No change to standard conflict resolution** (conflict dossiers, dirty
+  guard). It applies unchanged once a targeted item is present locally.
+- **No retry loop around the tracker.** `indeterminate` maps to exit 70 and the
+  operator re-runs; the engine does not poll.
+
+## Implementation Approach
+
+Resolution stays filesystem-pure; the remote probe is a *separate* pre-flight
+step in `run_sync` after the tracker is resolved, so a locally-resolvable
+failure (collision, usage, outside-dir) still aborts credential-free. A
+no-local-match token is no longer a failure — it becomes a *remote candidate*
+carried out of `resolve_targets`, de-duplicated by `canonical_external_key` so
+two spellings of one issue never yield two pulls. A remote-only candidate under
+`--push-only` is contradictory and aborts as a usage error (exit 2) before any
+tracker contact.
+
+Exit-code precedence stays single-sourced. `absent` and `indeterminate` become
+`TargetResolutionFailure` variants carrying their own `exit_code`, so the
+`2 > 6 > 3 > 70` chain lives in one `rank` function even though it is evaluated
+at two sequenced moments (local failures before credentials, remote failures
+after). Within one `fetch_all` batch `absent` (3) therefore dominates
+`indeterminate` (70) by rank, not by iteration order.
+
+Once credentials resolve, a single `fetch_all(candidates)` partitions the
+candidates through a pure function over its `FetchOutcome`: `absent` folds into
+the failure accumulator (exit 3), `indeterminate` maps to exit 70, `found`
+becomes the confirmed pull set threaded into the engine. The all-or-nothing
+zero-write property holds at this gate: any `absent` or `indeterminate` aborts
+before a write. The subsequent per-id create loop is not transactional — a
+mid-batch `create_from_remote` failure leaves earlier creates written (each with
+a valid baseline) and is recoverable idempotently on re-run.
+
+The engine change is a capability, not a behaviour switch:
+`ItemSelection::Targeted` gains a `pull_ids` slice injected at the discovery
+branch as the `untracked` set, so `create_from_remote`, preview, accounting, and
+apply run exactly as they do for a discovery import. The discovery status stays
+`SkippedTargeted` while `pull_ids` is empty and becomes `TargetedPull` only when
+a pull actually occurs, so an existing reconcile-only targeted run emits the same
+report line as before. The CLI passes an empty slice until Phase 3 populates it,
+keeping Phase 2 free of CLI-visible behaviour change.
+
+## Phase 1: Local/local collision becomes a usage error
+
+### Overview
+
+Turn the different-file collision into an exit-2 `TargetResolutionFailure`
+naming both files, and delete the `Suppressed` machinery. The ordinary synced
+item already reconciles silently, so this phase adds no reconciliation logic —
+it hardens one arm and removes dead code and its report line. No remote contact.
+
+### Changes Required
+
+#### 1. Collision failure variant and detection
+
+**File**: `cli/work-cli/src/sync.rs`
+**Changes**: Add a `LocalCollision` variant (exit 2) and build it from the
+different-file match. Replace the `Suppressed`-pushing branch. Rename
+`suppressed_remote` to a name that reads as collision detection and have it
+return the colliding file, not just its key.
+
+```rust
+enum TargetResolutionFailure {
+    Malformed(String),
+    NoMatch(String),
+    Unmanaged(String),
+    OutsideWorkDir(String),
+    AmbiguousLocal(String),
+    AmbiguousExternal(String),
+    LocalCollision(String),
+}
+```
+
+`LocalCollision` maps to `exit_codes::USAGE` in `exit_code`. In the `Some(item)`
+arm, when a different local file claims the token, push
+`TargetResolutionFailure::LocalCollision` with a message that labels each file's
+role and carries both files' **paths** — the token is file A's local id and file
+B's `external_id` — and says to re-run with the path of the intended file. The
+renamed collision detector already returns the colliding file, so both paths are
+in hand; the operator can copy one straight into the re-run without guessing
+which side matched by which key.
+
+#### 2. Delete the suppressed-remote machinery
+
+**File**: `cli/work-cli/src/sync.rs`
+**Changes**: Remove `struct Suppressed`, `ResolvedTargets.suppressed`,
+`SelectedTargets.suppressed`, `suppression_line`, and `render_report`'s
+`suppressed` parameter and its emission loop. `resolve_targets` returns only
+matched items.
+
+#### 3. Skill rendering
+
+**File**: `skills/work/sync-work-items/SKILL.md`
+**Changes** (anchored by sentence, since line numbers drift as the file is
+edited): rewrite the whole **suppressed-note sentence** ("…the remote match is
+reported as suppressed.") to state both outcomes explicitly — a token equal to a
+single file's own `external_id` reconciles silently with no note, and a token
+that is one file's id and a *different* file's `external_id` is an exit-2
+collision. Add the collision to the **exit-2 entry** naming both files. Delete
+the **suppressed-remote note rendering** in the Step 5 translation block *and*
+rewrite the **render-region lead-in** so it no longer references a
+suppressed-remote note.
+
+Phase boundary: Phase 1 owns every sentence touching the suppressed note; Phase 3
+owns the whole **discovery-suppression sentence** ("Naming any target suppresses
+untracked-remote discovery…"). Neither phase edits a sentence the other owns, so
+the split never bisects a sentence.
+
+#### 4. Invert the tests the collision change reverses
+
+**File**: `cli/work-cli/src/sync.rs` (unit tests),
+`cli/work-cli/tests/cli_sync_targets.rs`
+**Changes**: The red step rewrites `a_local_id_wins_and_records_the_remote_match_as_suppressed`
+to assert exit 2 naming both files (its scenario is exactly the new collision)
+and renames it to describe the new behaviour, e.g.
+`a_local_local_collision_is_a_usage_error_naming_both_files`, so the name no
+longer asserts the opposite of the body. It deletes
+`the_suppression_line_collapses_record_breaking_whitespace` and updates every
+`render_report(&report, &[])` call site to the new signature. The suite must not
+merely gain a `collision` test — the contradictory existing test is the failing
+test that demands the change.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] The rewritten `a_local_id_wins_...` test asserts exit 2 naming both files,
+      zero writes: `cargo test -p work-cli collision`
+- [ ] An own-`external_id` token reconciles with no note: `cargo test -p work-cli`
+- [ ] The suppressed-line test is gone and the suite compiles without
+      `Suppressed`: `cargo test -p work-cli`
+- [ ] Workspace lint and format clean: `mise run cli:check`
+- [ ] Read-only aggregate clean: `mise run check`
+
+#### Manual Verification
+
+- [ ] The `sync-work-items` skill prose reads coherently with no dangling
+      reference to a suppressed-remote note, and states the own-`external_id`
+      reconcile case.
+
+---
+
+## Phase 2: Engine carries and imports targeted pull ids
+
+### Overview
+
+Teach the engine's `ItemSelection::Targeted` to carry a set of confirmed
+remote-only ids and import them through `create_from_remote`, folding them into
+pull accounting, preview, apply, and the watermark exactly as a discovery import
+folds in. The CLI passes an empty set, so this phase changes no CLI-visible
+behaviour and is mergeable on its own.
+
+### Changes Required
+
+#### 1. Selection carries pull ids
+
+**File**: `cli/work-adapters/src/sync/run.rs`
+**Changes**: Extend the `Targeted` variant. `reconciled()` keeps its meaning
+(`pull_ids` are not reconciled items). Update the `ItemSelection` doc comment to
+describe `pull_ids` as a third set — remote-only ids in neither `corpus` nor the
+reconciled set — so the "single lever" framing still reads honestly, and state
+its precondition: an id already bound to a local file must not appear here (the
+engine enforces this, see §2).
+
+```rust
+pub enum ItemSelection<'a> {
+    All,
+    Targeted {
+        items: &'a [LocalItem],
+        pull_ids: &'a [ExternalId],
+    },
+}
+```
+
+#### 2. Inject the pull ids at the discovery branch
+
+**File**: `cli/work-adapters/src/sync/run.rs`
+**Changes**: At the discovery branch (`run.rs:786`), return the selection's
+`pull_ids` — **filtered against the corpus's canonical `external_id` set**,
+reusing the existing `corpus_carries` predicate — as the `untracked` set, plus a
+targeted discovery status. Filtering here, at the injection point beside
+`corpus_carries` and mirroring `discover_untracked`'s own filter, makes
+`Targeted { pull_ids }` safe by construction for any caller rather than trusting
+each caller to pre-filter (the CLI's `fetch_all` result still de-dupes upstream,
+but the engine no longer depends on it for the double-binding guarantee).
+
+Add a `DiscoveryStatus::TargetedPull { attempted }` variant, emitted **only**
+when the filtered set is non-empty; otherwise keep `SkippedTargeted`, so an
+existing reconcile-only targeted run emits the same discovery line as before and
+this phase changes no observable output. Add the matching arm to `discovery_line`
+in the same phase (its `DiscoveryStatus` match is exhaustive, so Phase 2 does not
+compile — and its `cli:check` criterion does not pass — without it), emitting the
+TSV `#\tdiscovery\ttargeted-pull\t<attempted>`. Rename `discovery_suppressed()`
+to `discovery_search_suppressed()`: the predicate suppresses the untracked
+*search*, not a by-id targeted pull.
+
+```rust
+let (untracked, discovery) = match &request.selection {
+    ItemSelection::Targeted { pull_ids, .. } => {
+        let confirmed: Vec<_> =
+            pull_ids.iter().filter(|id| !corpus_carries(request.corpus, id)).cloned().collect();
+        if confirmed.is_empty() {
+            (Vec::new(), DiscoveryStatus::SkippedTargeted)
+        } else {
+            let attempted = confirmed.len();
+            (confirmed, DiscoveryStatus::TargetedPull { attempted })
+        }
+    }
+    _ if matches!(request.direction, SyncDirection::PushOnly) => {
+        (Vec::new(), DiscoveryStatus::SkippedPushOnly)
+    }
+    _ => discover_this_run(request)?,
+};
+```
+
+The confirmed ids flow through `pulls = plan.pull_count() + untracked.len()`
+(`run.rs:822`), the preview loop (`run.rs:886`), and the apply loop
+(`run.rs:929`) with no further change. `attempted` names what it holds — the
+count gated in, not the count applied. The discovery line reports `attempted`;
+the *applied* result is conveyed by the per-item `CreateFromRemote` outcome rows
+and the pull tally, which report any `create_from_remote` failure as `Failed`.
+The two never disagree because the discovery line never claims imports —
+"requested/would import N", never "imported N" (see Phase 3 §4).
+
+#### 3. Migrate every `ItemSelection::Targeted` construction site
+
+**Files**: `cli/work-cli/src/sync.rs`, `cli/work-adapters/tests/sync_run.rs`,
+`cli/work-adapters/tests/sync_create.rs`
+**Changes**: Changing `Targeted` from a tuple to a struct variant is a breaking
+signature change to a `pub enum`, so every construction site must migrate or the
+crate will not build. The CLI's `Scope::Targeted` arm (`sync.rs:757`) constructs
+`Targeted { items: &selected.items, pull_ids: &[] }` (no behaviour change yet);
+the three existing work-adapters test sites (`sync_run.rs:342`, `sync_run.rs:480`,
+`sync_create.rs:275`) migrate to the struct form too. Regenerate the
+`cargo-public-api` snapshot for the variant-shape change.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] A non-empty `pull_ids` with a stub `show` creates the file, counts as a
+      pull, and applies it: `cargo test -p work-adapters targeted_pull`
+- [ ] An empty `pull_ids` still emits `SkippedTargeted`, proving the phase's
+      output is unchanged for a reconcile-only targeted run: `cargo test -p work-adapters`
+- [ ] Exceeding `--max-pulls` refuses the whole run with zero writes (no partial
+      creation): `cargo test -p work-adapters`
+- [ ] Preview reports `CreateFromRemote`/`NotApplied` with zero writes: `cargo test -p work-adapters`
+- [ ] A candidate `found` by the gate but whose `show` returns `Retryable`
+      reports a `Failed` create, leaves earlier creates intact with valid
+      baselines, and re-runs cleanly: `cargo test -p work-adapters`
+- [ ] A `pull_ids` entry whose canonical key already binds a corpus file is
+      filtered out — no second `author_from_remote` call, no extra write:
+      `cargo test -p work-adapters`
+- [ ] A run mixing resolved `items` and a remote-only `pull_id`, over a corpus
+      that also holds a non-targeted item, writes exactly the two targeted items
+      and nothing else (AC7): `cargo test -p work-adapters`
+- [ ] Of two `pull_ids` where one `show` fails, the pull tally and item rows
+      report one success, not two: `cargo test -p work-adapters`
+- [ ] A create whose baseline write fails after the file is authored recovers on
+      re-run via the file's `external_id` with no duplicate pull: `cargo test -p work-adapters`
+- [ ] The same stub issue imported via discovery and via `pull_ids` authors an
+      identical id, filename, and baseline entry (AC2 parity): `cargo test -p work-adapters`
+- [ ] `discovery_line` emits `#\tdiscovery\ttargeted-pull\t<N>` for
+      `TargetedPull { attempted: N }` (extend `render_report_emits_each_discovery_status_line`):
+      `cargo test -p work-adapters`
+- [ ] A second run with the id now local reconciles via the ordinary arm and the
+      watermark has advanced: `cargo test -p work-adapters`
+- [ ] The `All` path is unchanged (existing full-sync tests pass): `cargo test -p work-adapters`
+- [ ] Workspace lint and format clean: `mise run cli:check`
+
+#### Manual Verification
+
+- [ ] None — this phase is engine-internal and fully covered by tests.
+
+---
+
+## Phase 3: Resolve remote-only targets and gate them with `fetch_all`
+
+### Overview
+
+Stop failing the no-local-match arm; collect the token as a remote candidate.
+After credentials resolve, gate the candidates through one
+`fetch_all(candidates)`: `absent` aborts exit 3 (all-or-nothing, naming every
+absent token), `indeterminate` aborts exit 70, `found` becomes the `pull_ids`
+threaded into the engine's `Targeted` selection. Wire the skill rendering for
+the pull-create and the narrowed exit 3.
+
+### Changes Required
+
+#### 1. Resolution collects remote candidates
+
+**File**: `cli/work-cli/src/sync.rs`
+**Changes**: In the no-local-match arm (`sync.rs:519-527`), the `None | Some([])`
+case no longer pushes `NoMatch`; it records the token as a remote candidate.
+`ResolvedTargets` carries `remote_candidates: Vec<ExternalId>` alongside `items`,
+de-duplicated by `canonical_external_key` so two spellings of one issue produce
+one candidate. Under a `--push-only` direction a remote-only candidate is
+contradictory: push a named `PushOnlyRemoteOnly(String)` variant (exit 2) in
+`build_selection`, before any tracker contact, with a message stating the
+contradiction and the remedy — e.g. "'PP-999' has no local file and --push-only
+cannot pull a remote-only item; drop --push-only to import it." The `Some(_)`
+ambiguous-external case stays exit 2. Collision, usage, and outside-dir failures
+still abort before the tracker call.
+
+Add three variants to `TargetResolutionFailure`: `PushOnlyRemoteOnly(String)`
+(exit 2), `Absent(String)` (exit 3), and `Indeterminate(String)` (exit 70), so
+the push-only and `fetch_all` outcomes map through the same `exit_code` + `rank`
+function as the local failures. Each variant carries a user-facing message
+naming its offender, honouring the `message()` invariant the other variants
+hold. Extend `rank` to give four distinct values ordering `USAGE` >
+`OUTSIDE_WORKDIR` > `RESOLVE_NOT_FOUND` > `RETRYABLE`, so a batch carrying both
+`absent` and `indeterminate` exits 3, not 70, by rank rather than the tie-broken
+iteration order `max_by_key` would otherwise use. Because
+`TargetResolutionFailure` now spans pre-credential (local, push-only) and
+post-credential (`absent`, `indeterminate`) failures, add a doc line
+distinguishing the two so the credential-free invariant stays discoverable from
+the type.
+
+#### 2. `fetch_all` gate in `run_sync`
+
+**File**: `cli/work-cli/src/sync.rs`
+**Changes**: After `registry.resolve(&integration)` (`sync.rs:699`), if
+`remote_candidates` is non-empty call `tracker.fetch_all(&remote_candidates)` and
+pass its `FetchOutcome` to a pure `partition_candidates` function that returns
+either the confirmed `found` ids or a `Vec<TargetResolutionFailure>`:
+
+`FetchOutcome::found` pairs each id with the stamp the bulk read returned
+(`Vec<(ExternalId, RemoteTimestamp)>`); the stamps are intentionally discarded
+because `create_from_remote` re-reads each issue's body via `show`. `absent` and
+`indeterminate` are `Vec<ExternalId>`, mapped to a failure carrying a per-token
+message, not a bare id:
+
+```rust
+fn partition_candidates(
+    outcome: FetchOutcome,
+) -> Result<Vec<ExternalId>, Vec<TargetResolutionFailure>> {
+    let absent = outcome.absent.into_iter().map(|id| {
+        TargetResolutionFailure::Absent(format!("no local file nor remote issue for '{id}'"))
+    });
+    let indeterminate = outcome.indeterminate.into_iter().map(|id| {
+        TargetResolutionFailure::Indeterminate(format!("remote read for '{id}' was indeterminate; re-run when the tracker is reachable"))
+    });
+    let failures: Vec<_> = absent.chain(indeterminate).collect();
+    if failures.is_empty() {
+        Ok(outcome.found.into_iter().map(|(id, _)| id).collect())
+    } else {
+        Err(failures)
+    }
+}
+```
+
+A whole-call `Err` from `fetch_all` is not automatically retryable: per the
+tracker contract it fires only on a pre-flight fault — unresolvable credentials
+or an id the client cannot safely embed in its query, neither fixable by a
+re-run. Inspect the error class: route an unembeddable-id fault to a usage error
+(exit 2) naming the token, a credential fault to the existing `UNCONFIGURED`
+(74), and only a genuinely transient pre-flight fault to `Indeterminate` (70).
+The failures fold into the same accumulator and `rank` function as the local
+failures, so precedence `USAGE (2) > OUTSIDE_WORKDIR (6) > RESOLVE_NOT_FOUND (3)
+> RETRYABLE (70)` holds across the whole run from one authority: a batch mixing
+`absent` and `indeterminate` exits 3, and a run carrying both a local failure and
+a remote-absent token still exits on the local code, credential-free, because
+the local failures short-circuit before the tracker call. Extracting the
+partition keeps it unit-testable without a `TrackerRegistry`; wrap the whole
+resolve → `fetch_all` → partition → confirmed-ids sequence in one named helper so
+`run_sync` gains a single call rather than an inlined block.
+
+#### 3. Thread confirmed ids into the engine
+
+**File**: `cli/work-cli/src/sync.rs`
+**Changes**: Build `ItemSelection::Targeted { items: &selected.items, pull_ids:
+&found }` from the `fetch_all` result. The double-binding guard lives in the
+engine (Phase 2 §2), so the CLI passes `found` through unfiltered; the upstream
+`canonical_external_key` de-dup of `remote_candidates` still prevents two
+spellings becoming two candidates. The engine filter is defensive against
+canonicalisation divergence between resolution and the corpus: if it ever drops a
+`found` id (the id is already locally bound yet resolution did not match it), that
+id is neither pulled nor reconciled — a silent no-op for a named target. Assert
+the two canonicalisations are identical, and if the filter can fire, emit a
+diagnostic naming the dropped id rather than discarding it silently. The
+`render_report` targeted-pull line and `discovery_line` render the `TargetedPull`
+status.
+
+#### 4. Skill rendering
+
+**File**: `skills/work/sync-work-items/SKILL.md`
+**Changes**: Rewrite the whole **discovery-suppression sentence** ("Naming any
+target suppresses untracked-remote discovery…") — a targeted pull now reaches a
+remote-only item by id and pulls it. Reconcile every exit-code surface, not just
+the first one an author notices, so all copies stay consistent (referenced by
+content, since line numbers drift):
+
+- **Step 1 exit-code list, exit-3 entry**: narrow to "no local file *nor* remote
+  issue".
+- **Step 1 precedence line**: change `2 > 6 > 3` to `2 > 6 > 3 > 70`.
+- **Step 1 exit-code list**: add exit 70 (`RETRYABLE`) for an indeterminate
+  remote read, with recovery guidance matching the other entries' pattern
+  ("re-run once the tracker is reachable"); add the `--push-only` remote-only
+  target as an exit-2 usage error.
+- **Step 2 target-abort summary**: narrow its exit-3 description and add the
+  exit-70 case, matching Step 1. Note that a *targeted* exit-70 (indeterminate
+  remote read during resolution) aborts before any write, distinguishing it from
+  the engine-level exit-70 that can follow partial writes — so the operator knows
+  whether a re-run is a clean retry or a resume.
+- **Step 2 discovery-line enumeration** (ran / skipped-push-only /
+  skipped-targeted / failed): add the new `targeted-pull` state.
+- **Exit-3 recovery text**: cover the "reachable tracker required to classify a
+  typo" shift — a bare typo run offline surfaces as exit 70 (unreachable) or
+  exit 74 (unconfigured), not exit 3.
+- **Step 1 `--preview` change-class list**: add `targeted-pull` so the
+  previewability of the headline behaviour is discoverable.
+
+Admit a targeted `create-from-remote` into `pulled-untracked:`. Pin the emitted
+discovery TSV shape — `#\tdiscovery\ttargeted-pull\t<N>`, where N is the
+`attempted` count — and add the matching Step 5 translation entry. The
+suppressed-remote Step 5 entry is already removed by Phase 1 §3; this phase only
+references it as gone. The discovery line renders "Targeted pull: would import N
+remote-only item(s)" under `--preview` and "Targeted pull: requested N
+remote-only item(s)" on apply — it reports the *requested* count and never claims
+"imported", because the actual imports are the `pulled-untracked:` rows (one per
+created item). A partial-failure run therefore shows "requested N" above a
+`pulled-untracked:` list of the M ≤ N that succeeded, with the failures in their
+own item rows — two honest numbers for two distinct concepts, never one
+overstated count.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `partition_candidates` returns `found` for an all-found outcome and folds
+      `absent`→3 / `indeterminate`→70, with a batch carrying both exiting 3:
+      `cargo test -p work-cli partition_candidates`
+- [ ] Driven through `run_sync` with a stub `TrackerRegistry`, a remote-only
+      `PP-999` (stub `found`) is pulled and reconciled: `cargo test -p work-cli remote_only_target`
+- [ ] A mixed `found`+`absent` batch aborts exit 3 naming the absent token, zero
+      writes, found not pulled: `cargo test -p work-cli mixed_targets`
+- [ ] An all-success batch mixing a local-id target, a path target, and a
+      remote-only `found` id reconciles the local files, creates the remote-only
+      one, and writes no non-targeted item (AC7): `cargo test -p work-cli`
+- [ ] A whole-call `fetch_all` `Err` for an unembeddable id exits 2 (usage), not
+      70: `cargo test -p work-cli`
+- [ ] Two spellings of one remote-only issue (`PP-999`, `pp-999`) yield a single
+      pull, not two files: `cargo test -p work-cli`
+- [ ] `--push-only --target <remote-only>` exits 2 naming the token, with no
+      `fetch_all` call: `cargo test -p work-cli`
+- [ ] A locally-resolvable token makes no remote call, asserted by a recording
+      stub whose `fetch_all` count is zero: `cargo test -p work-cli`
+- [ ] `--preview --target PP-999` shows the would-create, writes nothing, counts
+      against `--max-pulls`: `cargo test -p work-cli`
+- [ ] A bare remote-only token now reaches the credential/tracker phase (the
+      inverted `a_no_match_target_exits_three_before_the_credential_check`):
+      `cargo test -p work-cli`
+- [ ] An untargeted full sync report and write set are unchanged: `cargo test -p work-cli`
+- [ ] Read-only aggregate clean: `mise run check`
+
+#### Manual Verification
+
+- [ ] `work sync --target <a real remote-only key>` against a live Linear
+      integration creates and reconciles the local file, and a second run does
+      not re-pull it.
+- [ ] `work sync --target <a typo'd key>` reports exit 3 naming the token with
+      zero writes.
+- [ ] The `sync-work-items` skill renders the pull-create and the narrowed exit
+      codes with human phrasing, no raw TSV leaking.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Resolution (work-cli)**: collision → exit 2 naming both files with each role
+  labelled; own-`external_id` token reconciles with no note; no-local-match token
+  becomes a candidate; duplicate spellings collapse to one candidate; a
+  remote-only candidate under `--push-only` → exit 2 with no tracker call;
+  ambiguous-external stays exit 2.
+- **`partition_candidates` (work-cli, pure)**: `found` → pull ids (id projected
+  from the `(id, stamp)` pair); `absent` → exit 3; `indeterminate` → exit 70; a
+  mixed `absent`+`indeterminate` outcome exits 3 by rank; an unembeddable-id
+  whole-call `Err` → exit 2; precedence `2 > 6 > 3 > 70` across mixed local and
+  remote failures. Tested directly on a constructed `FetchOutcome`, no tracker.
+- **Engine (work-adapters)**: `pull_ids` create-from-remote counts as a pull,
+  refuses the whole run when over `--max-pulls`, previews with zero writes,
+  advances the watermark; a `found`-then-`show`-`Retryable` create reports
+  `Failed` and leaves earlier creates recoverable; a baseline-write failure after
+  authoring recovers on re-run; a `pull_id` already bound in the corpus is
+  filtered out (no duplicate author); the same stub issue via discovery and via
+  `pull_ids` authors an identical id/filename/baseline (AC2 parity); of two
+  `pull_ids` where one create fails the tally reports one success; a run mixing
+  resolved `items` and a `pull_id` writes exactly the targeted union (AC7); a
+  re-run reconciles via the ordinary arm; an empty `pull_ids` emits
+  `SkippedTargeted`; `discovery_line` emits the pinned `targeted-pull` TSV; the
+  `All` path is unchanged.
+
+### Integration Tests
+
+The subprocess harness in `cli/work-cli/tests/cli_sync_targets.rs` is bin-only
+and cannot inject a stub tracker, so it covers only the credential-independent
+assertions it can actually make: a collision exits 2, a `--push-only`
+remote-only target exits 2, and local resolution aborts before the credential
+check. The remote-gate behaviour — a remote-only pull, a mixed-batch abort, and a
+preview — is driven in-crate through `run_sync` with a stub `TrackerRegistry`
+(and a recording stub for the no-remote-call assertion), which is the only seam
+that can exercise the post-credential gate without live Linear/Jira.
+
+### Manual Testing Steps
+
+1. `work sync --target <remote-only key>` against Linear; confirm the new local
+   file, its taxonomy, and reconciliation.
+2. Re-run the same target; confirm no re-pull and an advanced `local_synced_at`.
+3. `work sync --target <typo'd key>`; confirm exit 3, zero writes.
+4. `work sync --target <a local id> --target <a different file's external_id
+   that is that local id>`; confirm exit 2 naming both files.
+
+## Performance Considerations
+
+One extra by-id `fetch_all` round-trip per run that names a remote-only target,
+on top of the `show` inside `create_from_remote`. `fetch_all` batches every
+candidate into a single call, so the cost is one round-trip regardless of the
+number of remote-only targets. A run naming only locally-resolvable targets
+makes no additional remote call.
+
+## Migration Notes
+
+None. The baseline schema is unchanged; a targeted pull writes the same `Entry`
+shape as a discovery import.
+
+## References
+
+- Original work item: `meta/work/0285-targeted-pull-of-remote-only-work-items.md`
+- Research: `meta/research/codebase/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md`
+- Predecessor plan: `meta/plans/2026-09-06-0257-sync-specific-work-items.md`
+- Resolution: `cli/work-cli/src/sync.rs:456` (`resolve_targets`)
+- Reuse target: `cli/work-adapters/src/sync/apply.rs:270` (`create_from_remote`)
+- Injection point: `cli/work-adapters/src/sync/run.rs:786` (`discovery_suppressed`)
+- Tracker contract: `cli/tracker/src/lib.rs:413-454` (`show`, `fetch_all`)
+- Skill: `skills/work/sync-work-items/SKILL.md:78-101,268-296`

--- a/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -5,7 +5,7 @@ title: "Targeted Pull of Remote-Only Work Items and Resolution Normalisation Imp
 date: "2026-09-08T20:35:43+00:00"
 author: "Toby Clemson"
 producer: "create-plan"
-status: "ready"
+status: "done"
 work_item_id: "work-item:0285"
 parent: "work-item:0285"
 derived_from: ["codebase-research:2026-09-08-0285-targeted-pull-of-remote-only-work-items"]

--- a/meta/prs/109-description.md
+++ b/meta/prs/109-description.md
@@ -1,0 +1,98 @@
+---
+type: "pr-description"
+id: "109"
+title: "[0285] Targeted pull of remote-only work items and resolution normalisation"
+date: "2026-09-09T10:17:35+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0285"
+parent: "work-item:0285"
+relates_to: ["work-item:0257"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/109"
+pr_number: 109
+tags: ["work", "sync", "targeting", "pull", "tracker"]
+revision: "f397be3a7254074199a45928abe242f86288fa47"
+repository: "accelerator"
+last_updated: "2026-09-09T10:17:35+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0285] Targeted pull of remote-only work items and resolution normalisation
+
+## Summary
+
+`work sync --target <token>` now pulls a work item that exists only on the
+remote tracker: a token with no local file is looked up by id and, if present,
+created locally and reconciled — where it previously aborted with exit 3. The
+same change makes targeted resolution deterministic per token, turning the
+genuine local/local collision into a hard usage error and retiring the
+suppressed-remote note.
+
+## Changes
+
+- **Remote-only pull.** A no-local-match `--target` token becomes a remote
+  candidate rather than an abort. After credentials resolve, one
+  `fetch_all(candidates)` gate partitions them: `found` ids are imported through
+  the existing `create_from_remote` path, `absent` aborts exit 3 naming every
+  absent token, `indeterminate` aborts exit 70.
+- **Local/local collision is exit 2.** A token that is one file's local id and a
+  *different* file's `external_id` now aborts as a usage error naming both files,
+  decided from the local corpus with no remote call. The `Suppressed` machinery
+  and its report line are removed; a token equal to a single file's own
+  `external_id` reconciles silently.
+- **Engine carries pull ids.** `ItemSelection::Targeted` gains a `pull_ids`
+  slice, filtered against the corpus's canonical `external_id` set at the
+  discovery branch and injected as the untracked set, so preview, pull
+  accounting, and the watermark fold a targeted pull in exactly as a discovery
+  import. A new `DiscoveryStatus::TargetedPull { attempted }` is emitted only for
+  a non-empty set; an empty set keeps `SkippedTargeted`, leaving a reconcile-only
+  targeted run's output unchanged.
+- **Single-sourced exit precedence.** `absent`, `indeterminate`, and the
+  `--push-only` remote-only contradiction join the local failures in one `rank`
+  function, so precedence `2 > 6 > 3 > 70` holds from one authority across the
+  pre-credential and post-credential gates. Locally-resolvable aborts stay
+  credential-free.
+- **State-directory fix.** On a never-synced integration the state directory did
+  not exist, and the atomic-write containment check canonicalises it as the
+  trusted root — so the first baseline write authored the file but failed to
+  record its baseline. `run_sync` now creates the directory up-front.
+- **Skill and docs.** `sync-work-items` is rewritten for the pull-create, the
+  narrowed exit 3, exit 70, the `--push-only` remote-only usage error, and the
+  `targeted-pull` discovery line. The work item, plan, and a `pass` validation
+  report are included.
+
+## Context
+
+- Work item: `meta/work/0285-targeted-pull-of-remote-only-work-items.md`
+- Plan: `meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md`
+- Validation: `meta/validations/2026-09-08-0285-targeted-pull-of-remote-only-work-items-validation.md`
+- Builds on the `--target` targeting introduced by work item 0257 (PR #107).
+
+## Testing
+
+- [x] Read-only aggregate clean: `mise run check` (exit 0)
+- [x] Resolution, gate, and skill suite green: `cargo test -p accelerator-work`
+- [x] Engine suite green: `cargo test -p work-adapters`
+- [ ] Live remote-only pull against Linear creates and reconciles the file, and
+      a second run does not re-pull it (manual — no stub for the live tracker)
+- [ ] A typo'd `--target` reports exit 3 with zero writes against a live tracker
+      (manual)
+
+## Notes for Reviewers
+
+- **Deliberate deviation from the plan.** A whole-call `fetch_all` `Err` maps to
+  exit 70 (retryable) rather than the plan's three-way split: `TrackerError`
+  carries no discriminant to separate an unembeddable-id from a transient fault,
+  and a credential fault is already caught at `registry.resolve` (74). Recorded
+  in the plan and covered by
+  `a_whole_call_fetch_all_error_folds_to_indeterminate_exit_seventy`.
+- **No live-tracker coverage in the suite.** The post-credential gate is
+  exercised only through `run_sync` with a stub `TrackerRegistry` — the
+  subprocess harness cannot inject one — so the two manual steps above are the
+  sole check against real Linear/Jira. Focus there before merge.
+- **Non-transactional per-id create loop.** A mid-batch `create_from_remote`
+  failure leaves earlier creates written with valid baselines and is recoverable
+  idempotently on re-run; the gate itself is all-or-nothing (any `absent` or
+  `indeterminate` aborts before a write).

--- a/meta/research/codebase/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/research/codebase/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md
@@ -1,0 +1,337 @@
+---
+type: "codebase-research"
+id: "2026-09-08-0285-targeted-pull-of-remote-only-work-items"
+title: "Research: Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+date: "2026-09-08T19:37:42+00:00"
+author: "Toby Clemson"
+producer: "research-codebase"
+status: "complete"
+work_item_id: "0285"
+parent: "work-item:0285"
+relates_to: ["codebase-research:2026-09-06-0257-sync-specific-work-items"]
+topic: "Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+tags: ["research", "codebase", "work-sync", "targeting", "resolve-targets", "tracker", "create-from-remote"]
+revision: "818197a2b8f174a92092b8b52236043fcc19ed91"
+repository: "accelerator"
+last_updated: "2026-09-08T19:37:42+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Research: Targeted Pull of Remote-Only Work Items and Resolution Normalisation
+
+**Date**: 2026-09-08 19:37 UTC
+**Author**: Toby Clemson
+**Git Commit**: 818197a2b8f174a92092b8b52236043fcc19ed91
+**Branch**: HEAD (working copy, no bookmark)
+**Repository**: accelerator
+
+## Research Question
+
+Research the codebase for work item 0285 — extend `work sync --target` to pull a
+remote-only work item that has no local file, and normalise the targeted
+local/remote resolution and collision behaviour that 0257 left local-only. Find
+the exact code paths the three target changes touch: (a) the no-local-match arm
+must fetch by id and pull; (b) the genuine local/local collision must become an
+exit-2 hard error; (c) the ordinary synced item must reconcile with no warning.
+
+## Summary
+
+The change is well-supported by existing machinery but pivots on **three
+architectural facts**, one of which contradicts an acceptance criterion.
+
+1. **All three target branches live in one function** — `resolve_targets`
+   (`cli/work-cli/src/sync.rs:456`). Its no-local-match arm (`sync.rs:519-527`)
+   emits `NoMatch` → exit 3; its `suppressed_remote` arm (`sync.rs:482-494`,
+   `438-449`) records the local/local collision as a non-fatal note and lets
+   local win; the ordinary synced item already falls through the same
+   `Some(item)` arm with no warning. 0285 rewrites the first two and reconciles
+   the third.
+
+2. **The tracker is not available during resolution.** `resolve_targets` takes
+   only the local corpus and a filesystem `resolver` closure; the tracker is
+   resolved *after* selection completes (`sync.rs:699`). Threading a remote
+   lookup into resolution is the central plumbing task — the no-local-match arm
+   has no network access today.
+
+3. **A targeted pull can reuse `create_from_remote` untouched**
+   (`cli/work-adapters/src/sync/apply.rs:270`). It already takes only an
+   `&ExternalId`, drives `tracker.show` → `author_from_remote` → baseline with
+   `local_synced_at = run_start_epoch`, and bypasses discovery. The single
+   `discovery_suppressed()` branch at `run.rs:786-787` is what strips targeted
+   imports from pull accounting, preview, and apply in one place; a targeted
+   pull must inject a non-empty `untracked` set there.
+
+⚠️ **A `show` on a non-resolving id is a `TrackerError::Retryable`, not an
+absence signal** (`cli/tracker/src/lib.rs:413-425`). The trait explicitly says
+absence is established with `fetch_all`, not `show`. Acceptance criterion
+"matches neither a local file nor a remote issue → exit 3" (work item lines
+108-109) is therefore **not achievable through `show` alone** — a genuinely
+absent remote id and a transient network fault are indistinguishable, and both
+map to exit **70 (RETRYABLE)** through an engine run, never exit 3. This is the
+one design decision the plan must resolve up front. See Open Questions.
+
+## Detailed Findings
+
+### Crate layout
+
+The sync surface spans four crates with a clean division of labour, governed by
+ADR-0045 (skills-vs-CLI) and ADR-0044 (`external_id` identity):
+
+| Crate | Path | Responsibility |
+|---|---|---|
+| `work-cli` | `cli/work-cli/src/` | argv→flags, target resolution, exit codes, TSV report render |
+| `work-adapters` | `cli/work-adapters/src/sync/` | engine: run orchestration, per-item apply, create, discovery, baseline |
+| `work` | `cli/work/src/sync/` | pure domain: plan/classify/decide, push precondition |
+| `tracker` + `linear-client` | `cli/tracker/`, `cli/linear-client/` | remote port trait + Linear implementation |
+
+Exits 2 and 3 originate **pre-flight in `work-cli`**, before the engine runs;
+they are not `RunError` variants (`sync.rs:407-418`, `694-697`). Engine-phase
+failures map to a different band (70/71 tracker, 4 unresolved, 5 refused).
+
+### Target resolution — the three branches (`cli/work-cli/src/sync.rs`)
+
+`resolve_targets` (`sync.rs:456-550`) resolves each `--target` token against the
+local corpus only:
+
+```rust
+fn resolve_targets(
+    corpus: &[LocalItem],
+    targets: &[String],
+    resolver: &dyn Fn(&str) -> RunOutcome,
+) -> Result<ResolvedTargets, Vec<TargetResolutionFailure>>
+```
+
+It builds `external_id_index` once (`sync.rs:420-433`, a
+`BTreeMap<String, Vec<&LocalItem>>` keyed by `canonical_external_key` —
+whitespace-stripped, ASCII-upper-cased), then dispatches per token on
+`resolver(token)`. Three branches matter:
+
+- ❌ **(a) No-local-match arm** (`sync.rs:514-527`). When the resolver returns
+  `NotFound`/`Invalid` and the external-id index has no entry, it pushes
+  `TargetResolutionFailure::NoMatch` → exit 3, with the message "untracked
+  remote issues are imported only by a full (untargeted) sync". This is the
+  arm 0285(a) inverts to a remote `show` + pull.
+- ❌ **(b) Collision arm** (`sync.rs:482-494` + `suppressed_remote` at
+  `438-449`). When a token resolves locally to `item` and the same token also
+  keys a *different* file's `external_id` (`item.id != local_match.id`), it
+  records a `Suppressed` note and lets local win — a non-fatal
+  `#\ttarget\tsuppressed\t…` report line. 0285(b) turns this into a
+  `TargetResolutionFailure` → exit 2 naming both files.
+- ✅ **(c) Ordinary synced item** (same `Some(item)` arm). The
+  `item.id != local_match.id` guard (`sync.rs:447`) already excludes the item
+  from warning about itself, so the `id == external_id` case emits no note
+  today. What is missing is remote reconciliation — never triggered because the
+  tracker is absent from resolution.
+
+Relevant types: `RunOutcome` (`resolve.rs:25-31`), `LocalItem`
+(`fetch.rs:26-30`), `TargetResolutionFailure` (`sync.rs:385-393`), `Suppressed`
+(`sync.rs:366-374`), `ResolvedTargets` (`sync.rs:376-380`). Exit mapping at
+`sync.rs:407-417`; precedence `USAGE > OUTSIDE_WORKDIR > NOT_FOUND` at
+`sync.rs:566-577`.
+
+⚠️ **The tracker is nowhere in resolution.** The `resolver` closure is
+`crate::resolve::resolve_with` — filesystem-only, no network (`resolve.rs:92-132`).
+The tracker is resolved by `registry.resolve(&integration)` only after
+`build_selection` returns (`sync.rs:699-716`), deliberately so target validation
+precedes the credential check (`sync.rs:654-655`). To fetch a remote-only token,
+0285 must thread the tracker (or a lookup port) into `resolve_targets`.
+
+### Create-from-remote — the reusable pull path (`cli/work-adapters/src/sync/`)
+
+`create_from_remote` (`apply.rs:270-309`) is the clean reuse target:
+
+```rust
+pub fn create_from_remote(
+    &mut self,
+    external_id: &ExternalId,
+    author: &dyn LocalAuthor,
+) -> Result<String, ApplyError>
+```
+
+It fetches `tracker.show(external_id)` (`apply.rs:275`), authors the local file
+via `author.author_from_remote(&DiscoveredIssue { external_id, issue })`
+(`apply.rs:283`), hashes what was written, then writes the baseline `Entry` with
+`local_synced_at: self.run_start_epoch` (`apply.rs:297-307`). It takes only an
+`&ExternalId` — no marker, no `corpus_carries` — so a targeted by-id pull routes
+through it unchanged, bypassing `discover_untracked` entirely.
+
+Id and filename allocation live inside `ConfiguredLocalAuthor::author_from_remote`
+(`cli/work-cli/src/sync_author.rs:97-159`): a create lock
+(`.accelerator-work-create.lockdir`), `allocate_id` (scan-highest-then-increment
+over on-disk filenames, `create.rs:183-200`), `slugify` → `{id}-{slug}.md`, and
+`exclusive_write` (refuses to clobber). Imported taxonomy is fixed:
+`kind=task`, `priority=medium`, `status=ready`, `producer=sync-work-items`,
+`external_id=Some(remote key)` (`sync_author.rs:36-39`, `126-145`). A targeted
+pull-create therefore produces a byte-identical file to a discovery import
+(acceptance criterion lines 95-97 satisfied by construction).
+
+The `corpus_carries` double-binding guard (`push_precondition.rs:66-95`) is a
+create-**from-local** concern only — it guards the crash window between an
+`external_id` write-back and marker delete. It reads `request.corpus` (the whole
+set) regardless of selection, so a narrowed targeted run still judges what the
+whole corpus carries (`run.rs:914-919`).
+
+### Run orchestration — where the pull plugs in (`cli/work-adapters/src/sync/run.rs`)
+
+The pull bound is computed in `prepare_run` before any write:
+
+```rust
+let pulls = plan.pull_count() + untracked.len();          // run.rs:822
+if pulls > request.max_pulls || pushes > request.max_pushes {
+    return Err(RunError::Refused { ... });                 // run.rs:824-832
+}
+```
+
+`untracked.len()` folds create-from-remote imports into the pull dimension
+(`run.rs:819-821`); `RunError::Refused` breaks out `new_local_files` /
+`new_remote_issues` for the operator message (exit 5, `sync.rs:812-828`).
+
+⚠️ **One branch gates everything targeted.** `discovery_suppressed()`
+(`run.rs:138-141`) is true for `ItemSelection::Targeted`, and `prepare_run`
+short-circuits `untracked` to empty at `run.rs:786-787` before scope resolution.
+That single branch simultaneously removes targeted imports from pull accounting
+(`run.rs:822`), the preview loop (`run.rs:886-892`), and the apply loop
+(`run.rs:929-940`). For 0285, a targeted pull-create must produce a **non-empty,
+targeted `untracked` set** at that branch — not a discovery search — so it flows
+through accounting, preview (zero writes, `Action::CreateFromRemote` /
+`NotApplied`), and apply unchanged.
+
+The full-sync (untargeted) write set is structurally the same code path: for
+`ItemSelection::All`, `reconciled() == corpus`, and the only two selection-keyed
+branches (`discovery_suppressed()` and `advance_document`, `run.rs:232`) both
+take their original `All` value. This is what keeps an untargeted run
+byte-identical (acceptance criterion lines 125-127) — provided the targeted
+injection does not perturb the `All` path.
+
+### Tracker port — `show` semantics (`cli/tracker/src/lib.rs`, `cli/linear-client/src/client.rs`)
+
+`RemoteTracker::show` (`lib.rs:430`): `fn show(&self, id: &ExternalId) -> Result<RemoteIssue, TrackerError>`.
+Linear implements it as a single by-id GraphQL query
+`issue(id: $id) { id identifier title updatedAt description }`
+(`client.rs:55-60`, `515-553`, `617`). `RemoteIssue { updated, body }`
+(`lib.rs:107-132`) is exactly the type `author_from_remote` consumes, so a
+`show` result feeds the create path identically to discovery.
+
+⚠️ **Absence is not discoverable through `show`** (`lib.rs:413-425`): "a
+`RemoteIssue` or an error are the only outcomes"; a non-resolving id is a
+`TrackerError::Retryable` (a read mutates nothing, so never `Terminal`). The
+contract directs callers to establish absence with `fetch_all`
+(`lib.rs:451`, `FetchOutcome`). Through a sync run, a retryable failure becomes
+`ItemOutcome::Failed` → exit **70 RETRYABLE** (`sync.rs:240-268`,
+`exit_codes.rs:69-75`), never exit 3.
+
+The config key `work.integration` selects the implementation in
+`ConfiguredTrackers::resolve` (`tracker_registry.rs:155-189`): `linear` →
+`LinearClient`, `jira` → `JiraClient`, `trello`/`github-issues` → `NotAvailable`,
+`""` → `Unset`.
+
+### Skill rendering (`skills/work/sync-work-items/SKILL.md`)
+
+The skill is prose-only — no formatter module; it consumes the engine's stdout
+TSV report as authoritative and re-expresses it. Four passages must change:
+
+- **Line 84-86** — "a targeted pull reaches only items already tracked locally"
+  becomes factually wrong; rewrite to say a remote-only target is fetched by id
+  and pulled.
+- **Line 91-92** — narrow exit 3 from "no local id, path, or external_id" to
+  "no local file **nor** remote issue".
+- **Line 274 / 291-296** — admit a *targeted* create-from-remote into the
+  `pulled-untracked:` group and preview, counted against `--max-pulls`.
+- **Line 82-85 / 95-98 / 287-289** — remove the non-fatal "Suppressed remote
+  match" note; the ordinary synced item reconciles silently, and the genuine
+  local/local collision becomes an exit-2 usage error naming both files.
+
+## Code References
+
+- `cli/work-cli/src/sync.rs:456-550` — `resolve_targets`, the three target branches
+- `cli/work-cli/src/sync.rs:438-449` — `suppressed_remote`, the collision detector (→ exit 2)
+- `cli/work-cli/src/sync.rs:514-527` — no-local-match arm (`NoMatch` → exit 3), the (a) inversion point
+- `cli/work-cli/src/sync.rs:420-433` — `external_id_index` construction and keying
+- `cli/work-cli/src/sync.rs:699-716` — tracker resolved *after* selection (the plumbing gap)
+- `cli/work-cli/src/sync.rs:755-758` — `Scope` → `ItemSelection` bridge
+- `cli/work-cli/src/sync.rs:198-238` — `render_report` TSV serialiser
+- `cli/work-cli/src/sync.rs:240-268` — `exit_code_for_report` (engine-phase codes)
+- `cli/work-cli/src/exit_codes.rs:55-75` — code taxonomy (USAGE=2, RESOLVE_NOT_FOUND=3, 70/71 tracker)
+- `cli/work-adapters/src/sync/apply.rs:270-309` — `create_from_remote` (reusable pull path)
+- `cli/work-adapters/src/sync/apply.rs:297-307` — baseline `Entry` with `local_synced_at` watermark
+- `cli/work-adapters/src/sync/run.rs:786-787` — `discovery_suppressed()` gate (the single injection point)
+- `cli/work-adapters/src/sync/run.rs:822-832` — pull accounting and `--max-pulls` refusal
+- `cli/work-adapters/src/sync/run.rs:883-908` — preview branch (zero-write would-create rows)
+- `cli/work-adapters/src/sync/run.rs:929-940` — apply-mode `create_from_remote` call site
+- `cli/work-cli/src/sync_author.rs:97-159` — `author_from_remote` (id/filename allocation, taxonomy)
+- `cli/work/src/sync/push_precondition.rs:66-95` — `corpus_carries` double-binding guard
+- `cli/tracker/src/lib.rs:413-430` — `show` contract (absence not discoverable)
+- `cli/tracker/src/lib.rs:451` — `fetch_all` / `FetchOutcome` (the absence-capable read)
+- `cli/linear-client/src/client.rs:55-60,515-553,617` — Linear `show` by-id query
+- `cli/work-cli/tests/cli_sync_targets.rs` — targeted-sync exit-code tests to extend
+- `skills/work/sync-work-items/SKILL.md:82-98,274,287-296` — rendering to revise
+
+## Architecture Insights
+
+- **Resolution is filesystem-pure by design.** 0257 deliberately kept the
+  tracker out of `resolve_targets` so target validation is credential-independent
+  and runs before any network contact (`sync.rs:654-655`). 0285 breaks that
+  invariant intentionally; the plan should decide whether the remote lookup lives
+  *in* resolution (enabling a pre-flight exit 3) or *after* it in the engine
+  (pushing remote-absent to exit 70). This choice drives the exit-code semantics.
+- **`ItemSelection::Targeted` is a single lever.** It gates discovery, preview
+  imports, apply imports, and document-watermark advance from one enum. A
+  targeted pull must extend `Targeted` to carry a set of confirmed remote-only
+  ids for import, rather than always forcing `untracked = empty`.
+- **The create path is already id-driven, not discovery-driven.**
+  `create_from_remote(&ExternalId, …)` means the plan needs a way to inject an
+  explicit id list, not to re-run `search`. This aligns with 0285's "by-id fetch,
+  no search" assumption (work item lines 154-156).
+- **Two exit-code bands, two phases.** Codes 2/3/6 are resolution-phase
+  (`work-cli`, pre-engine); 70/71/4/5 are engine-phase. Which phase performs the
+  remote lookup determines which band a remote-absent target lands in.
+
+## Historical Context
+
+- `meta/research/codebase/2026-09-06-0257-sync-specific-work-items.md` — the
+  closest prior art; analyses `resolve_targets`, `create_from_remote`,
+  `external_id_index` as built by 0257 (the code 0285 extends).
+- `meta/plans/2026-09-06-0257-sync-specific-work-items.md` — 0257's plan; the
+  exit-3 abort, discovery suppression, and pull-bound accounting 0285 modifies
+  all originate here.
+- `meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md`
+  — discovery suppression and targeted-vs-discovery gating on Linear.
+- `meta/research/codebase/2026-08-11-0204-remote-tracker-port.md` — the tracker
+  port surface, including `show` by-id fetch semantics.
+- `meta/decisions/ADR-0044-remote-work-item-identity-in-external-id.md` —
+  `external_id` as remote identity; the basis for resolution and collision keys.
+- `meta/decisions/ADR-0045-skills-vs-cli-division-of-labour.md` — why resolution
+  and exit codes live in the CLI, not the skill.
+- `meta/work/0146-work-item-sync-enhancements.md` — parent epic; `0229` (pull
+  scope) and `0255` (chunk merge) touch the same engine path (work item lines
+  146-150).
+
+## Related Research
+
+- `meta/research/codebase/2026-09-06-0257-sync-specific-work-items.md` (direct predecessor)
+- `meta/research/codebase/2026-08-30-0220-untracked-remote-discovery-never-runs-on-linear.md`
+- `meta/research/codebase/2026-08-18-0213-conversational-conflict-resolution-flow.md`
+- `meta/research/codebase/2026-08-12-0194-tracker-crate-and-remote-sync-engine.md`
+
+## Open Questions
+
+- ❓ **Exit 3 for a remote-absent target is not reachable via `show`.**
+  Acceptance criterion (lines 108-109) requires "neither local nor remote → exit
+  3", but `show` cannot distinguish an absent id from a transient fault — both
+  are `TrackerError::Retryable`. Resolve one of: (i) use `fetch_all([id])`
+  (`lib.rs:451`), which reports absence, to gate the pull and produce a clean
+  exit 3; or (ii) accept remote-absent → exit 70 and amend the criterion. Option
+  (i) is the only path that honours the criterion as written. This is the
+  headline decision for the plan.
+- ❓ **Where does the remote lookup run — resolution or engine?** A pre-flight
+  exit 3 requires threading the tracker into `resolve_targets` (breaking the
+  credential-independence invariant, `sync.rs:654-655`). An engine-phase lookup
+  keeps resolution pure but pushes remote-absent into the 70 band. The two are
+  coupled to the question above.
+- ❓ **Watermark on re-run.** Acceptance criterion (lines 119-121) requires a
+  completed targeted pull to advance `local_synced_at` and not re-pull. The
+  baseline `Entry` is written on create (`apply.rs:297-307`), so re-run
+  classification should treat it as synced — confirm the second-run path with
+  the item now local resolves via the ordinary synced-item arm (c), not the pull
+  arm.

--- a/meta/reviews/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items-review-1.md
+++ b/meta/reviews/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items-review-1.md
@@ -1,0 +1,841 @@
+---
+type: "plan-review"
+id: "2026-09-08-0285-targeted-pull-of-remote-only-work-items-review-1"
+title: "Plan Review: Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+date: "2026-09-08T20:57:03+00:00"
+author: "Toby Clemson"
+producer: "review-plan"
+status: "complete"
+target: "plan:2026-09-08-0285-targeted-pull-of-remote-only-work-items"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["correctness", "architecture", "code-quality", "test-coverage", "compatibility", "safety", "usability", "documentation"]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-09-08T21:50:31+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Targeted Pull of Remote-Only Work Items and Resolution Normalisation
+
+**Verdict:** REVISE
+
+The plan is unusually well-reasoned: it preserves the credential-free
+resolution invariant by keeping the remote probe a separate imperative-shell
+pre-flight, reuses `create_from_remote`/`author_from_remote` for allocation
+parity by construction, extends `ItemSelection::Targeted` as a capability rather
+than a behaviour switch, and correctly grounds absence on `fetch_all`'s provable
+partition instead of `show`. Two structural issues nonetheless block approval:
+the `SkippedTargeted` → `TargetedPull { imported: 0 }` swap falsifies Phase 2's
+"no CLI-visible change" claim and cannot compile without touching the renderer
+it defers, and the four-way exit-code precedence spans two mechanisms whose tie
+between `absent` (3) and `indeterminate` (70) is unresolved. Alongside these,
+the test strategy targets a harness that provably cannot stub the tracker, and
+the skill-rendering change set omits several stale duplicate locations.
+
+### Cross-Cutting Themes
+
+- **`SkippedTargeted` → `TargetedPull { imported: 0 }` breaks Phase 2's
+  independence** (flagged by: architecture, code-quality, correctness,
+  compatibility, documentation) — Phase 2 maps every `Targeted` run to
+  `TargetedPull { imported: pull_ids.len() }`. With the CLI passing an empty
+  slice, an existing reconcile-only targeted run now emits
+  `TargetedPull { imported: 0 }` instead of `#\tdiscovery\tskipped\ttargeted`.
+  `DiscoveryStatus` is matched exhaustively by `discovery_line`, so the phase
+  cannot compile without updating the renderer — contradicting "changes no
+  CLI-visible behaviour and is mergeable on its own", and stranding
+  `SkippedTargeted` as dead code with a now-false doc comment.
+
+- **Exit-code precedence and all-offenders accumulation split across two sites**
+  (flagged by: correctness, architecture, code-quality, compatibility) — Today
+  `TargetResolutionFailure::exit_code` + `highest_precedence_code` are the single
+  owners. Phase 3 adds a second precedence path in `run_sync` for the `fetch_all`
+  outcome. `highest_precedence_code` ranks both `RESOLVE_NOT_FOUND` (3) and
+  `RETRYABLE` (70) at the same weight, so a batch carrying both `absent` and
+  `indeterminate` could exit 70 (retry forever) instead of the intended 3, by
+  iteration order.
+
+- **The `fetch_all` gate is untestable as placed** (flagged by: test-coverage,
+  code-quality) — The gate sits inline in the already-`too_many_lines` `run_sync`,
+  after `registry.resolve`. The proposed integration tests target the bin-only
+  subprocess harness in `cli_sync_targets.rs`, which cannot inject a stub
+  tracker, so `--target PP-999` fails at the credential check before reaching any
+  pull, mixed-abort, or preview behaviour the plan wants to assert.
+
+- **Existing tests encode the behaviour the plan reverses** (flagged by:
+  test-coverage) — Phase 1 inverts `a_local_id_wins_and_records_the_remote_match_as_suppressed`
+  and Phase 3 inverts `a_no_match_target_exits_three_before_the_credential_check`,
+  but the plan only "adds" a collision test and "narrows" exit 3. The red step is
+  understated: these tests must be rewritten/deleted or the suite asserts stale
+  behaviour (or won't compile once `Suppressed` is gone).
+
+- **Skill-rendering change set is incomplete** (flagged by: documentation,
+  usability) — Exit codes are documented in `SKILL.md` in several further places
+  the change set omits: the Step 1 precedence line (must become `2 > 6 > 3 > 70`),
+  the Step 2 target-abort summary (lines 153-156), and the suppressed-note
+  lead-in sentence (281-283). Phase 1 and Phase 3 also both cite line 84 for
+  different edits.
+
+### Tradeoff Analysis
+
+- **Fail-safe refuse-all vs the AC's "at most N created"**: The reused engine
+  path refuses the whole run with zero writes when `pulls > max_pulls`
+  (`RunError::Refused`), but work item AC #9 reads "at most N are created and the
+  remainder are reported as bounded", implying partial creation. Refuse-all is
+  the safer choice (no partial blast radius, consistent with 0257).
+  Recommendation: adopt refuse-all and reword AC #9 so no future change
+  reinterprets it as a per-item budget.
+
+- **One exit-code owner vs the resolution-pure/probe-separate split**: The
+  architecture and code-quality lenses want a single `exit_code` + precedence
+  function; the plan's design deliberately evaluates local failures before
+  credentials and remote failures after. These are reconcilable: keep one
+  ranking function (extend it with `Absent`/`Indeterminate` variants) invoked at
+  two sequenced moments, rather than duplicating the precedence logic inline.
+
+### Findings
+
+#### Critical
+
+- None.
+
+#### Major
+
+- 🟡 **Architecture / Code Quality / Correctness / Compatibility**: `TargetedPull { imported: 0 }` replaces `SkippedTargeted` for all targeted runs, contradicting "no CLI-visible change"
+  **Location**: Phase 2 §2 (Inject the pull ids at the discovery branch)
+  Every `Targeted` run now emits `TargetedPull { imported: pull_ids.len() }`. With Phase 2's empty slice, a reconcile-only targeted run emits `imported: 0` rather than `skipped targeted`, changing the report TSV that `discovery_line` and `SKILL.md` consume. The enum is matched exhaustively, so the phase cannot compile without the renderer change it defers to Phase 3, and `SkippedTargeted` becomes dead code with a false doc comment.
+
+- 🟡 **Correctness / Compatibility**: Combined `absent` + `indeterminate` `fetch_all` outcome has an unresolved precedence tie
+  **Location**: Phase 3 §2 (`fetch_all` gate); Implementation Approach
+  A single `fetch_all` batch can return both a non-empty `absent` and a non-empty `indeterminate`. The gate lists `absent → 3` and `indeterminate → 70` as separate arms without stating which wins, and `highest_precedence_code` ranks both at the same weight, so `max_by_key` breaks the tie by iteration order — a batch could exit 70 (retryable, re-run forever) instead of 3.
+
+- 🟡 **Correctness**: Duplicate remote candidates canonicalising to one remote issue create two local files
+  **Location**: Phase 3 §1 (Resolution collects remote candidates)
+  Two no-local-match tokens for the same underlying issue (e.g. `--target PP-999 --target pp-999`) are each collected without canonical de-dup. `create_from_remote` runs once per candidate and is not wrapped by the `corpus_carries` double-binding guard, so a canonically-duplicated target authors two local files bound to one remote issue — the exact double-binding the work item's Technical Notes require the guard to prevent.
+
+- 🟡 **Compatibility**: `--push-only --target <remote-only>` would perform a pull
+  **Location**: Phase 2 §2 (match ordering)
+  The `Targeted` arm precedes the `PushOnly` guard, so injected `pull_ids` become the `untracked` set even on a push-only run. Once Phase 3 populates `pull_ids` from `fetch_all` without gating on direction, a push-only targeted run authors a new local file — violating the direction contract that push-only never pulls.
+
+- 🟡 **Code Quality / Architecture / Compatibility**: Exit-code precedence and all-offenders accumulation split across two sites
+  **Location**: Phase 3 §2 (`fetch_all` gate); Implementation Approach
+  The precedence `2 > 6 > 3 > 70` and the "name every offender" property, each single-sourced today, are split: remote-absent tokens accumulate in a second accumulator inside `run_sync`, and precedence is enforced partly by `highest_precedence_code` and partly by control-flow sequencing. A future change must be made consistently in two implicitly-related places.
+
+- 🟡 **Test Coverage**: `fetch_all` gate placed where no test can reach it
+  **Location**: Testing Strategy (Integration Tests); Phase 3 §2
+  The subprocess harness is bin-only and cannot stub the tracker, and the gate sits after `registry.resolve`, so the planned remote-only pull, mixed-batch abort, and preview tests are unreachable without live credentials. The highest-risk new behaviour would be manual-only.
+
+- 🟡 **Test Coverage**: Plan inverts existing tests but only describes "adding"
+  **Location**: Phase 1 §1-2; Phase 3 §1
+  `a_local_id_wins_and_records_the_remote_match_as_suppressed` and `a_no_match_target_exits_three_before_the_credential_check` assert the behaviour this plan reverses. The plan says "add a collision test" and "narrow exit 3" but never lists these (plus `the_suppression_line_...` and every `render_report(&report, &[])` call site) as rewrites/deletions — the TDD red step is understated.
+
+- 🟡 **Documentation / Usability**: Skill-rendering change set omits stale duplicate locations
+  **Location**: Phase 1 §3; Phase 3 §4
+  Exit codes are documented again at the Step 1 precedence line (100-101, still `2 > 6 > 3`), the Step 2 target-abort summary (153-156, no exit-70 case), and the suppressed-note lead-in (281-283, orphaned once the bullet is deleted). Phase 1 and Phase 3 also cite overlapping edits on line 84.
+
+- 🟡 **Usability**: "imported N remote-only item(s)" misleads under `--preview`
+  **Location**: Phase 2 §2 / Phase 3 §4 (`TargetedPull` rendering)
+  The rendered line and field name use past-tense `imported`, but under `--preview` nothing is written. The existing discovery line uses neutral `found=N` to stay preview-safe; an operator running `--preview --target PP-999` would read "imported 1" and believe a write occurred.
+
+#### Minor
+
+- 🔵 **Architecture / Code Quality**: `discovery_suppressed()` name and `ItemSelection` doc become misleading once `Targeted` imports
+  **Location**: Phase 2 §2 injection point
+  After the change, discovery is not suppressed but substituted by a by-id pull; the predicate named for suppression becomes the hook that performs imports, and the doc comment ("a narrowed set can never re-import") no longer holds. Rename (e.g. `discovery_search_suppressed`) and correct the doc.
+
+- 🔵 **Correctness**: `imported` count reflects attempted, not successfully applied, pulls
+  **Location**: Phase 2 §2 / Phase 3 §4
+  `TargetedPull { imported: pull_ids.len() }` is computed before the apply loop; if a `create_from_remote` fails mid-run the item reports `Failed` yet the summary still says `imported N`, disagreeing with the per-item rows.
+
+- 🔵 **Correctness / Safety / Test Coverage**: `--max-pulls` "at most N created" (AC) vs refuse-all (engine)
+  **Location**: Phase 2 Success Criteria; work item AC #9
+  The engine refuses the whole run with zero writes when exceeded; AC #9 implies partial creation up to N. The planned test asserts refuse-all, so it would not confirm the AC as written. Reconcile the wording (see Tradeoff Analysis).
+
+- 🔵 **Correctness / Safety / Test Coverage**: `found`-then-`show`-fails path unspecified and untested
+  **Location**: Desired End State (resolution table); Phase 3 gate
+  Presence is established by `fetch_all`, but the body is fetched by a later `show` inside `create_from_remote`. `show` cannot report absence, so an issue deleted in the window fails indefinitely as a per-item error. "Present remotely → pull-create" is not an absolute guarantee; the path needs an engine test and a documented expectation.
+
+- 🔵 **Safety**: "All-or-nothing" holds at the gate, not across the apply loop
+  **Location**: Implementation Approach; Phase 3 §2
+  The pre-flight gate aborts before any write, but the create loop applies each `create_from_remote` sequentially and continues past a failure, so a mid-batch failure leaves earlier files written (recoverable, idempotent on re-run). Scope the wording to the gate and add a test proving a clean recoverable state.
+
+- 🔵 **Safety / Usability**: A typo'd remote-only target is no longer diagnosable offline
+  **Location**: Phase 3 §1-2; Desired End State exit table
+  Under 0257 a no-local-match token exited 3 credential-free; now it defers to the gate. Offline, a bare typo surfaces as exit 70 (retryable) or exit 74 (unconfigured) rather than exit 3, and the skill's exit-3 recovery text ("offer /list-work-items") no longer fully fits. Note the shift and update the recovery guidance.
+
+- 🔵 **Usability**: Collision message should label each file's role
+  **Location**: Phase 1 §1 (Collision failure variant)
+  Naming two paths plus "pick one" leaves the operator guessing why the token is ambiguous. The message should say the token is A's local id and B's `external_id`, so the operator can choose the right path to re-run with.
+
+- 🔵 **Documentation**: Phase 1 prose rewrite should state the own-`external_id` reconcile case
+  **Location**: Phase 1 §3 (`--target` prose)
+  The rewrite addresses only the collision case; it should also positively state that a token equal to a single file's own `external_id` reconciles silently (the "reconcile A, no note" row), the common now-changed path.
+
+- 🔵 **Documentation**: Resolution table omits exit 6 and the ambiguous exit-2 cases
+  **Location**: Desired End State (lines 99-107)
+  The table reads as an exhaustive per-token spec but omits outside-workdir (6) and malformed/ambiguous (2), which appear in the `2 > 6 > 3 > 70` precedence. Add the rows or annotate the table as covering only the outcomes this item changes.
+
+#### Suggestions
+
+- 🔵 **Architecture**: Targeted pull bypasses `discover_untracked`'s corpus dedup
+  **Location**: Implementation Approach / Phase 2 injection
+  Full sync filters discovered ids against the corpus by `canonical_external_key`; the targeted pull injects `pull_ids` directly, skipping that filter and relying on a cross-module invariant. Defend it at the injection point by filtering `pull_ids` against the corpus's canonical `external_id` set (reusing the same predicate).
+
+- 🔵 **Code Quality**: Plan snippet comments risk verbatim transcription
+  **Location**: Phase 2 §2 / Phase 3 §2 (illustrative snippets)
+  `// existing discover_untracked path, unchanged` and the four-line partition legend would violate the project's very-low comment tolerance if carried into production. Treat them as plan-only annotation and express the distinctions through named arms/functions.
+
+- 🔵 **Usability / Documentation**: Emitted TSV shape for `TargetedPull` is not pinned
+  **Location**: Phase 3 §4 (skill rendering)
+  The plan gives the human phrasing but not the exact `#\tdiscovery\t…` token the skill's Step 5 table must match. If the table cannot match it, the raw TSV leaks. Pin the emitted shape and add the matching translation entry.
+
+- 🔵 **Test Coverage**: "No remote call" assertion needs a recording stub
+  **Location**: Testing Strategy (Unit Tests)
+  Proving a locally-resolvable token makes no remote call requires a spy stub counting `fetch_all` invocations; the plan states the assertion without the infrastructure. Specify a recording stub and assert a zero count.
+
+### Strengths
+
+- ✅ Preserves the deliberate credential-independence invariant from 0257 by
+  keeping `resolve_targets` filesystem-pure and moving the remote probe into a
+  separate pre-flight in `run_sync` after credentials resolve — a clean
+  functional-core / imperative-shell split.
+- ✅ Reuses `create_from_remote` → `author_from_remote`, achieving id, filename,
+  and baseline allocation parity with a discovery import by construction rather
+  than a parallel scheme, and folds into the existing pull accounting, preview,
+  and apply loops.
+- ✅ Correctly grounds absence on `fetch_all`'s provable `absent` partition
+  rather than `show` (which cannot distinguish a deleted issue from a transient
+  fault), and maps `indeterminate`/transport failure to retryable exit 70.
+- ✅ Extends `ItemSelection::Targeted` from a tuple to a struct variant carrying
+  `pull_ids` — an open-closed extension that adds capability without rewriting
+  the selection model.
+- ✅ Preserves the untargeted `All` path structurally (the discover branch,
+  `reconciled()` over the whole corpus, and the document-watermark advance gated
+  on `ItemSelection::All`), so the byte-identical full-sync requirement holds by
+  construction.
+- ✅ New local files are authored through an exclusive `LocalAuthor` write, so an
+  id/filename collision surfaces as an error rather than silently clobbering an
+  existing file; the `--max-pulls` bound refuses the whole run before any write
+  in both preview and apply; and re-run idempotence is sound via the baseline
+  `local_synced_at` written at creation.
+- ✅ Deleting the whole `Suppressed` machinery (rather than repurposing it) and
+  renaming `suppressed_remote` to return the colliding file are genuine
+  readability/DDD improvements.
+- ✅ Phased delivery with genuinely separable concerns, each with named automated
+  checks paired to manual verification, and an explicit mixed-failure precedence
+  contract.
+
+### Recommended Changes
+
+1. **Resolve the `SkippedTargeted`/`TargetedPull` swap explicitly** (addresses:
+   the swap theme, "imported under preview", dead-doc findings) — Either retain
+   `SkippedTargeted` for the `imported == 0` case and emit `TargetedPull` only
+   when a pull occurs, or move the `discovery_line` + skill rendering into Phase 2
+   and drop the "no CLI-visible behaviour change" claim. Make the rendered line
+   preview-aware ("would import N" under `--preview`) and rename the field if it
+   overstates applied work.
+
+2. **Pin the exit-code precedence in one ranking function** (addresses: the
+   precedence-split theme, the absent/indeterminate tie) — Model `absent` and
+   `indeterminate` as `TargetResolutionFailure`-style variants carrying their own
+   `exit_code`, so `absent` (3) provably dominates `indeterminate` (70) within one
+   `fetch_all` batch and the `2 > 6 > 3 > 70` chain lives in one place, even
+   though evaluated at two sequenced moments. Add a test for a batch carrying both.
+
+3. **De-duplicate and guard the pull candidates** (addresses: double-binding) —
+   De-dup `remote_candidates` by `canonical_external_key` before the gate, and
+   filter confirmed `pull_ids` against the corpus's canonical `external_id` set at
+   the injection point, mirroring the double-binding guard the work item requires.
+
+4. **Gate the pull on a pull-capable direction** (addresses: push-only pulls) —
+   Collect/inject `pull_ids` only for a direction that pulls, so
+   `--push-only --target <remote-only>` is a no-op or usage error, not a create.
+
+5. **Relocate and extract the test seam** (addresses: gate untestability,
+   inverted existing tests) — Extract the candidate partition/precedence into a
+   pure function over a `FetchOutcome`, drive the wiring via `run_sync` with a
+   stub `TrackerRegistry`, and reserve the subprocess harness for
+   credential-independent assertions. List the existing tests to invert/delete as
+   the Phase 1/Phase 3 red step, and add cases for `found`-then-`show`-fails and a
+   mixed absent+indeterminate batch.
+
+6. **Complete the skill-rendering change set** (addresses: skill doc theme) — Add
+   the Step 1 precedence line (100-101), the Step 2 target-abort summary
+   (153-156), and the suppressed-note lead-in (281-283) to the change set;
+   correct the overlapping Phase 1/Phase 3 citation on line 84; state the
+   own-`external_id` reconcile case in the `--target` prose; and pin the emitted
+   `TargetedPull` TSV shape with a matching Step 5 translation entry.
+
+7. **Reconcile `--max-pulls` semantics** (addresses: refuse-all vs AC) — Adopt
+   refuse-the-whole-run (fail-safe, zero writes) and reword AC #9 and the success
+   criteria so no future reviewer reinterprets it as a partial-create budget.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Correctness
+
+**Summary**: The plan is logically well-structured and correctly identifies the
+key invariants it must preserve (filesystem-pure resolution before credentials,
+all-or-nothing target resolution, provable absence via `fetch_all` rather than
+`show`, and reuse of the `create_from_remote` import path). The main correctness
+gaps are under-specified branch behaviour when a single `fetch_all` outcome
+carries more than one partition class, an unaddressed duplicate-candidate path
+that can double-bind one remote issue to two local files, and a Phase 2
+discovery-status change that contradicts its own "no CLI-visible change" claim.
+None are fatal, but each would produce a wrong result on an input the acceptance
+criteria imply.
+
+**Strengths**:
+- Correctly grounds absence on `fetch_all`'s provable `absent` partition rather
+  than `show` (whose Retryable error cannot distinguish a deleted issue from a
+  transient fault), citing the verified tracker contract at lib.rs:413-454.
+- Preserves the all-or-nothing zero-write property by keeping local-resolvable
+  failures aborting in `build_selection` before any tracker contact.
+- Reuses `create_from_remote` so id/filename/baseline allocation is
+  byte-identical to a discovery import.
+- Correctly reasons that the ordinary-synced-item arm already reconciles
+  silently, so a re-run of a pulled item resolves through the local external_id
+  index with no re-pull.
+
+**Findings**:
+- 🟡 major (medium) — **Combined absent + indeterminate `fetch_all` outcome has
+  under-specified precedence and ties in the rank function** (Phase 3 §2). A
+  single `fetch_all` call can return non-empty `absent` AND `indeterminate`
+  simultaneously. The gate lists them as separate arms without stating which
+  wins, and `highest_precedence_code` ranks both `RESOLVE_NOT_FOUND` (3) and
+  `RETRYABLE` (70) at the same `else => 1` weight (sync.rs:566-577), so
+  `max_by_key` breaks the tie by iteration order. A mixed batch could exit 70
+  instead of 3, or be order-dependent. Specify absent-first precedence and extend
+  the `rank` closure to rank `RESOLVE_NOT_FOUND` above `RETRYABLE`.
+- 🔴 major (medium) — **Duplicate remote candidates that canonicalise to one
+  remote issue create two local files** (Phase 3 §1). Two distinct tokens with no
+  local match but the same underlying remote issue are each collected without
+  canonical de-dup. `resolve_targets` de-dupes matched local items by id
+  (sync.rs:543-548) but adds no equivalent for candidates, and `create_from_remote`
+  is not guarded by `corpus_carries` (that guard only wraps `apply_local_create`,
+  run.rs:914-919). The work item explicitly requires the double-binding guard to
+  extend to a newly-created targeted item. De-dup by `canonical_external_key`
+  before the gate and confirm absence from `request.corpus` before authoring.
+- 🟡 major (high) — **Replacing `SkippedTargeted` with `TargetedPull{imported:0}`
+  changes reporting for existing reconcile-only targeted runs** (Phase 2 §2).
+  With Phase 2's empty `pull_ids`, an existing targeted reconcile now emits
+  `TargetedPull { imported: 0 }` instead of `SkippedTargeted`, changing the
+  rendered discovery line (sync.rs:181-196) and breaking existing assertions that
+  expect `#\tdiscovery\tskipped\ttargeted`. The phase is not the behaviour-neutral,
+  independently-mergeable change it claims. Keep `SkippedTargeted` for the empty
+  case, or acknowledge and update the affected assertions in Phase 2.
+- 🔵 minor (medium) — **Refuse-all `--max-pulls` may not satisfy the "at most N
+  created" AC** (Phase 2 / work item AC #9). The reused engine path refuses the
+  whole run before any write (`RunError::Refused`, run.rs:824-833) — zero, not up
+  to N. Confirm the intended semantics; if refuse-all is correct, reword the AC.
+- 🔵 minor (medium) — **`imported` count reflects attempted, not applied, pulls**
+  (Phase 2 §2 / Phase 3 §4). Computed in `prepare_run` before the apply loop; a
+  mid-run `create_from_remote` failure reports the item `Failed` yet the count
+  still says imported N. Name the field to reflect the attempted count or derive
+  it from applied outcomes.
+- 🔵 suggestion (low) — **A `fetch_all`-confirmed "found" target can still fail at
+  `create_from_remote`'s `show`** (Desired End State / Phase 3 gate). Presence is
+  established by `fetch_all`; the body is fetched by a later `show` (apply.rs:270).
+  A deleted-after-confirmation issue fails indefinitely as a per-item error. Note
+  that a confirmed-found target may still fail at `show` and is reported as a
+  per-item retryable failure.
+
+### Architecture
+
+**Summary**: The plan is structurally sound and shows strong architectural
+discipline: it preserves the credential-free resolution invariant by keeping the
+remote probe a separate imperative-shell pre-flight, reuses the
+create-from-remote/author-from-remote path for allocation parity, and extends
+`ItemSelection::Targeted` as a capability (carried `pull_ids`) rather than a
+behaviour switch. The main concerns are (1) the report/discovery-status contract
+changing in a way that contradicts Phase 2's "no CLI-visible change" claim, and
+(2) exit-code precedence and the load-bearing "no-double-import" invariant now
+being split across two decision sites, weakening single-source-of-truth cohesion.
+
+**Strengths**:
+- Preserves the deliberate credential-independence invariant from 0257 — a clean
+  functional-core / imperative-shell separation.
+- Reuses `create_from_remote` → `author_from_remote`, achieving allocation parity
+  by construction and folding into existing accounting, preview, and apply loops.
+- Extends `ItemSelection::Targeted` from a tuple to a struct variant — an
+  open-closed extension that keeps `reconciled() ⊆ corpus` intact.
+- Phased delivery with genuinely separable concerns and an explicit precedence
+  contract for mixed-failure exit codes.
+
+**Findings**:
+- 🟡 major (medium) — **`TargetedPull` discovery status replaces `SkippedTargeted`
+  for all targeted runs, contradicting the "no CLI-visible change" claim** (Phase
+  2 §2). Because the CLI passes an empty slice, an existing targeted-local run
+  emits `TargetedPull { imported: 0 }` instead of `#\tdiscovery\tskipped\ttargeted`
+  — a change to the engine→CLI→skill report contract. Either retain
+  `SkippedTargeted` for the empty case, or move the discovery-line and skill
+  rendering into Phase 2 and drop the claim.
+- 🔵 minor (medium) — **Exit-code precedence and all-or-nothing failure
+  accumulation split across two sites** (Phase 3 §1-2). Phase 3 introduces a
+  second, parallel failure-collection-and-precedence path in `run_sync`,
+  reproducing "name every offender, all-or-nothing" outside the resolution
+  accumulator. Model remote outcomes as additional `TargetResolutionFailure`-style
+  variants so one authoritative `exit_code` + precedence function remains.
+- 🔵 minor (medium) — **`discovery_suppressed()` name and `ItemSelection`
+  invariant no longer match behaviour once `Targeted` imports** (Phase 2 injection
+  point). The predicate named "suppressed" becomes the gate that performs imports;
+  the documented "a narrowed set can never re-import" no longer holds. Update the
+  doc and consider `discovery_search_suppressed()`.
+- 🔵 suggestion (medium) — **Targeted pull bypasses `discover_untracked`'s corpus
+  dedup, relying on an implicit cross-module invariant** (Implementation Approach
+  / Phase 2). Full sync filters discovered ids by `canonical_external_key`; the
+  targeted pull injects `pull_ids` directly, skipping that filter. Defend the
+  invariant at the injection point by reusing the same predicate.
+
+### Code Quality
+
+**Summary**: The plan is unusually well-reasoned and expressed in rich domain
+language, with careful attention to reusing existing paths and phasing the change
+so each step is independently mergeable. The main maintainability risks are a
+now-stale `DiscoveryStatus` variant the plan never retires, a
+`discovery_suppressed()` abstraction whose name and doc become misleading once
+`Targeted` carries pull ids, and the fragmentation of two previously-single-source
+invariants (exit-code precedence and all-offenders accumulation) across two code
+sites. A couple of testability and comment-hygiene points round out the concerns.
+
+**Strengths**:
+- Renaming `suppressed_remote` to a collision-detection name that returns the
+  colliding file is a genuine readability/DDD improvement.
+- Deleting the whole `Suppressed` machinery rather than repurposing it is the
+  right call — it removes a concept the domain no longer has.
+- Keeps resolution filesystem-pure and isolates the remote probe as a separate
+  pre-flight, preserving credential-independence.
+- Threads `pull_ids` through the existing `ItemSelection::Targeted` lever rather
+  than a parallel discovery path.
+
+**Findings**:
+- 🔴 major (high) — **Stale `SkippedTargeted` variant plus an unnoticed report-line
+  change** (Phase 2 §2). After the change `SkippedTargeted` (its production site,
+  its `discovery_line` arm at sync.rs:189, its doc comment) is unreachable dead
+  code with a factually-wrong comment, and a fully-local targeted run emits
+  "targeted pull imported 0" — a visible report change contradicting the
+  mergeable-in-isolation claim. Decide explicitly: remove `SkippedTargeted` (and
+  its arm and tests) in Phase 2, or keep it for `imported == 0` and branch.
+- 🟡 major (medium) — **Two single-sourced invariants split by Phase 3**
+  (Implementation Approach / Phase 3 §2). Exit-code precedence
+  (`exit_code` + `highest_precedence_code`) and "one run names all offenders" (the
+  single `failures` accumulator) are both split — remote-absent tokens accumulate
+  in a second accumulator, and precedence is enforced partly by control-flow.
+  Fold remote outcomes into the same vocabulary/accumulator (e.g. `Absent`,
+  `Indeterminate` variants).
+- 🔵 minor (medium) — **`discovery_suppressed()` misnomer** (Phase 2 §1 / Phase 3
+  §2). Discovery is not suppressed, it is substituted by a targeted by-id pull;
+  the plan even injects pull ids "at the `discovery_suppressed()` branch",
+  entrenching the misnomer. Rename to reflect substitution and update the docs.
+- 🔵 minor (medium) — **`fetch_all` gate placed inline in an already-oversized
+  `run_sync`** (Phase 3 §2 / Testing Strategy). The partition/print/precedence
+  logic is inline in a `#[allow(clippy::too_many_lines)]` function reachable only
+  through a full `TrackerRegistry`, making the intended unit assertions hard to
+  reach. Extract a pure function over a `FetchOutcome`.
+- 🔵 suggestion (low) — **Plan snippets carry explanatory comments** (Phase 2 §2 /
+  Phase 3 §2). `// existing discover_untracked path, unchanged` and the partition
+  legend risk verbatim transcription into production, which the project forbids.
+  Treat them as plan-only annotation.
+
+### Test Coverage
+
+**Summary**: The plan has a phase-by-phase testing structure with named automated
+checks and clear happy/edge partitions, and Phase 2's engine-level coverage is
+genuinely strong because it reuses the existing create-from-remote path. However,
+it does not reckon with how Phase 3 breaks and inverts existing tests,
+mis-locates its integration tests in a bin-only subprocess harness that provably
+cannot stub the tracker, and leaves the full `run_sync` wiring seam and a real
+two-tier-read error path without automated coverage.
+
+**Strengths**:
+- Each phase pairs named automated verification with manual verification, and
+  Phase 2 is structured to be fully test-covered at the engine level.
+- The Testing Strategy enumerates meaningful partitions of the new remote gate,
+  not only the happy path.
+- Calls out a negative-behaviour assertion ("a locally-resolvable token makes no
+  remote call") and asserts all-or-nothing/zero-write invariants.
+- Reusing `author_from_remote`/`create_from_remote` legitimately shrinks the
+  surface a targeted-pull test must re-verify.
+
+**Findings**:
+- 🔴 major (high) — **Phase 3 inverts an existing subprocess test the plan never
+  updates** (Phase 3 §1 / Testing Strategy).
+  `a_no_match_target_exits_three_before_the_credential_check`
+  (cli_sync_targets.rs:85) asserts exit 3 before the credential check; under
+  Phase 3 a no-local-match token passes resolution and reaches `registry.resolve`
+  (exit 74 with no credentials), and the `fetch_all` exit-3 now sits behind the
+  credential check. Rewrite the test and file header, and add an in-crate
+  `run_sync` test for the post-credential `absent` → exit-3 path.
+- 🟡 major (high) — **Integration tests placed in a harness that cannot stub the
+  tracker** (Testing Strategy). The harness is bin-only, and the gate lives after
+  `registry.resolve`, so `--target PP-999` fails at the credential check, never
+  reaching the stubbed pull/mixed-abort/preview behaviour. Relocate to in-crate
+  tests calling `run_sync` with a stub `TrackerRegistry`.
+- 🟡 major (high) — **Existing suppressed-remote tests encode the reversed
+  behaviour; plan only "adds"** (Phase 1 §1-2).
+  `a_local_id_wins_and_records_the_remote_match_as_suppressed` (sync.rs:906)
+  asserts the opposite of the new exit-2 collision, and
+  `the_suppression_line_collapses_record_breaking_whitespace` plus every
+  `render_report(&report, &[])` call site depend on deleted machinery. List the
+  exact tests to invert/delete as the red step.
+- 🟡 major (medium) — **No testable seam for the `fetch_all` gate** (Phase 3 §2 /
+  Success Criteria). The partition, precedence, and id-threading are inline in the
+  oversized `run_sync`; the planned checks presuppose a way to drive the gate the
+  plan never provides. Extract a pure function over `FetchOutcome` and cover the
+  wiring with a stub-registry `run_sync` test.
+- 🔵 minor (medium) — **Untested error path: `fetch_all` "found" then `show` fails
+  during create** (Phase 2/3 create path). A two-tier read; an issue deleted
+  between reads yields `Failed` (Retryable → exit 70). Add an engine test where
+  the stub returns `found` from `fetch_all` but `Retryable` from `show`.
+- 🔵 minor (medium) — **No coverage for a single batch yielding both `absent` and
+  `indeterminate`** (Desired End State / Phase 3). Precedence `3 > 70` is asserted
+  in prose but not by a test. Add a case where the stub carries both.
+- 🔵 minor (medium) — **Planned `--max-pulls` test asserts refuse-all, but the AC
+  describes "at most N created"** (Phase 2 / work item AC). Reconcile the AC with
+  the refuse-all engine behaviour and assert whichever is intended.
+- 🔵 suggestion (low) — **The "no remote call" assertion needs a recording stub**
+  (Testing Strategy). Specify a stub that records `fetch_all` calls and assert the
+  count is zero for a fully local-resolvable run.
+
+### Compatibility
+
+**Summary**: The plan is contract-aware in the right places: it routes the
+existence check through `fetch_all` (provable `absent`) rather than `show`, and
+preserves the untargeted `All` path structurally so the full-sync report and
+write set stay byte-identical. Two contract seams are underspecified: the
+discovery report line for existing no-pull targeted runs changes shape (breaking
+the skill's `SkippedTargeted` renderer) and undermines the Phase 2 "no CLI-visible
+change" claim, and injecting `pull_ids` at a branch that precedes the push-only
+guard would make `--push-only --target <remote-only>` perform a pull. The
+exit-code precedence also spans two mechanisms whose composition is not pinned.
+
+**Strengths**:
+- Honours the `RemoteTracker` trait contract: `fetch_all` for the existence gate
+  because `show` cannot distinguish absence (lib.rs:413-425), mapping
+  `indeterminate`/whole-call `Err` to retryable 70 (lib.rs:213-249, 439-454).
+- The untargeted `All` path is preserved structurally — the `All` arm falls
+  through to the unchanged discover branch, `reconciled()` returns the whole
+  corpus, and the document-watermark advance still gates on `ItemSelection::All`.
+- Reusing `create_from_remote` (apply.rs:270) preserves allocation parity.
+
+**Findings**:
+- 🔴 major (high) — **`TargetedPull` replaces `SkippedTargeted`; a non-`non_exhaustive`
+  public enum is matched exhaustively by `discovery_line`** (Phase 2). Phase 2
+  cannot compile without also updating the renderer (sync.rs:181-196), and the
+  `SkippedTargeted` renderer in SKILL.md:285 would no longer match any run —
+  contradicting the phase-independence guarantee. Retain `SkippedTargeted` for
+  `imported == 0` or move the rendering update into Phase 2.
+- 🟡 major (medium) — **Match ordering: push-only + targeted remote-only would
+  pull** (Phase 2, match ordering). The `Targeted` arm precedes the `PushOnly`
+  guard, so `pull_ids` drive `create_from_remote` even on a push-only run. Gate
+  the candidate collection/injection on a pull-capable direction.
+- 🔵 minor (medium) — **Four-way precedence spans two disconnected mechanisms**
+  (Phase 3 §2 / Implementation Approach). The accumulator/`highest_precedence_code`
+  runs before credentials and ranks only 2 and 6; the `fetch_all` gate producing 3
+  and 70 runs after. How `absent` (3) reliably dominates `indeterminate` (70) in
+  one batch is asserted, not mechanised. Check `absent` before `indeterminate` and
+  state the two tiers are composable, adding 70 to the skill's precedence table.
+
+### Safety
+
+**Summary**: This plan extends targeted sync to create new local files from
+remote data, and handles the core safety concerns well: it gates existence on
+`fetch_all`'s provable `absent` partition (never on `show`), maps the
+indeterminate case to a retryable exit, folds pull-creates into the existing
+pre-write `--max-pulls` bound that refuses the whole run before any write, and
+keeps local resolution failures credential-free ahead of the tracker call. The
+main residual risks are language rather than mechanism: the plan repeatedly
+claims "all-or-nothing" for a mixed batch, but that holds only at the pre-flight
+gate — the per-id create loop is not transactional. The remaining observations
+are minor and low-blast-radius given the target is version-controlled Markdown.
+
+**Strengths**:
+- The existence gate uses `fetch_all`, whose `absent` partition is provably
+  complete, and routes `indeterminate`/transport failure to exit 70 — avoiding
+  the "infer absence from a truncated fetch" hazard (lib.rs:221-247).
+- Pull-creates fold into `pulls = plan.pull_count() + untracked.len()`
+  (run.rs:822-833), which refuses the whole run with zero writes before apply, in
+  both preview and apply modes.
+- The `--preview` path returns before the apply block (run.rs:883-908), emitting
+  report rows without calling `create_from_remote` — no `show`, no writes.
+- New files are authored through an exclusive `LocalAuthor` write (apply.rs:263-289),
+  so a collision errors rather than clobbering.
+- Local failures are resolved credential-free before the tracker call
+  (precedence 2 > 6 > 3 > 70), preserving the 0257 credential-independence
+  invariant.
+- Idempotence is sound: `create_from_remote` writes the baseline with
+  `local_synced_at = run_start_epoch`, and `advance_document` stays false for
+  targeted runs (run.rs:232), so a second run reconciles via the ordinary arm.
+
+**Findings**:
+- 🔴 minor (high) — **"All-or-nothing" holds at the gate, not across the apply
+  loop** (Implementation Approach / Phase 3 §2). Once the `found` set enters the
+  engine, the create loop (run.rs:929-940) applies each `create_from_remote`
+  sequentially and continues past a failure, so a mid-batch failure leaves earlier
+  files committed (recoverable, idempotent on re-run). Scope the wording to the
+  gate and add a test proving a cleanly recoverable state.
+- 🔵 minor (medium) — **Refuse-whole-run bound is safer than the AC's "at most N
+  created" — reconcile them** (Phase 2 / AC #9). Reuses `RunError::Refused`
+  (run.rs:824), refusing the entire run with zero writes; AC #9 implies partial
+  creation. State the refuse-all bound explicitly and annotate AC #9.
+- 🔵 minor (medium) — **TOCTOU gap between `fetch_all` found and
+  `create_from_remote` show** (Phase 3 §2-3). An id proven `found` is re-fetched
+  by `show` (apply.rs:275), which can never report absence; a deleted-in-the-window
+  issue returns Retryable indefinitely. Confirm and test that this surfaces as a
+  non-zero exit with an explicit per-id failure line and never advances a
+  watermark.
+- 🔵 minor (medium) — **A typo'd remote-only target is no longer diagnosable
+  offline** (Phase 3 §1 / Desired End State). A bare typo now requires a reachable
+  tracker to classify; offline it surfaces as exit 70 rather than exit 3. Note the
+  change in the skill and steer the exit-70 message toward both "unreachable" and
+  "check the key".
+
+### Usability
+
+**Summary**: The plan is unusually disciplined about operator experience: it
+fixes the collision message to name both files, preserves `--preview` zero-write
+semantics, keeps the all-or-nothing batch abort, and explicitly demands no raw
+TSV leak in manual verification. The main gaps are documentation-surface
+consistency in the skill (a second exit-code block is left un-updated), a
+report-line word ("imported") that misleads under `--preview`, and an unremarked
+shift in the operator's mental model for exit 3, which now depends on tracker
+reachability.
+
+**Strengths**:
+- The collision error names both files and how to disambiguate, turning a silent
+  local-wins note into an actionable exit-2 error.
+- Exit 70 (RETRYABLE) is reused for the indeterminate remote read, consistent
+  with its existing meaning, and added to the skill's abort table.
+- The `--preview` affordance is preserved end-to-end: a would-create with zero
+  writes that still counts against `--max-pulls`.
+- Manual verification explicitly checks human phrasing with no raw TSV leaking,
+  and the all-or-nothing batch abort names every absent token.
+
+**Findings**:
+- 🟡 major (medium) — **Second exit-code block in the skill (Step 2, lines
+  144-157) is left un-updated** (Phase 1 §3 / Phase 3 §4). Step 2 (153-156)
+  describes exit 3 as "no match", omits the new exit-70 case, and is not in any
+  change item — contradicting the Step 1 block. Add it to the Phase 3 skill
+  changes.
+- 🟡 major (medium) — **"imported N remote-only item(s)" misleads under
+  `--preview`** (Phase 2 §2 / Phase 3 §4). Past-tense `imported` / field
+  `imported`, but under `--preview` nothing is written; the existing line uses
+  neutral `found=N`. Make the phrasing preview-aware.
+- 🔵 minor (medium) — **Collision message should identify which file is the
+  id-match vs the external_id-match** (Phase 1 §1). Two bare paths plus "pick one"
+  leaves the operator guessing. Label each file's role.
+- 🔵 minor (medium) — **Exit 3 for a mistyped remote key now requires working
+  credentials — unremarked mental-model shift** (Implementation Approach / Phase 3
+  §2). With missing credentials the operator gets exit 74, and the skill's exit-3
+  guidance no longer fully fits. Update the recovery text.
+- 🔵 suggestion (low) — **Wire (TSV) format of the new `TargetedPull` status is
+  not specified for the skill to translate** (Phase 3 §4). If the Step 5
+  translation table cannot match the emitted token, raw TSV leaks. Pin the emitted
+  shape and add the matching entry.
+
+### Documentation
+
+**Summary**: The plan documents the new resolution model clearly through a
+deterministic five-case table in Desired End State, and gives concrete SKILL.md
+line anchors for each rewrite. However, the exit-code documentation is not fully
+reconciled across the skill's several duplicate locations: the Step 1 precedence
+summary and the Step 2 target-abort summary are left stale, the suppressed-remote
+lead-in sentence is orphaned, and the now-superseded "skipped targeted" discovery
+rendering is never removed. Several Phase 1/Phase 3 line citations are also
+imprecise and overlap on the same sentence.
+
+**Strengths**:
+- The Desired End State resolution table (99-107) documents the new per-token
+  behaviour deterministically across all five outcomes.
+- Each SKILL.md rewrite is anchored to concrete line ranges.
+- Phase 1's Manual Verification explicitly checks for no dangling suppressed-note
+  reference.
+- Exit-code precedence and internal assignments are stated consistently across
+  Overview, Desired End State, and both phases.
+
+**Findings**:
+- 🟡 major (high) — **Exit 70 not added to the Step 1 precedence (100-101) and
+  Step 2 (153-156) blocks** (Phase 3 §4). Step 1 reads "2 > 6 > 3" and must become
+  "2 > 6 > 3 > 70"; Step 2 lists only "3, 6, or 2" with no exit-70 case. Neither
+  is in the change set.
+- 🟡 major (high) — **Suppressed-remote lead-in sentence (281-283) orphaned**
+  (Phase 1 §3). The lead-in ("...or a suppressed-remote note, render them...")
+  references a rendering deleted at 287-289 but is not in the change set. Add it so
+  the sentence is rewritten when the bullet is removed.
+- 🟡 major (high) — **Overlapping line citations Phase 1 vs Phase 3** (Phase 1 §3
+  vs Phase 3 §4). Phase 1 cites 81-83 but the "suppressed" sentence spans 82-84;
+  Phase 3 separately claims 84-86. The two phases misattribute overlapping edits
+  on line 84. Correct the citations or note Phase 3 must re-base after Phase 1.
+- 🟡 major (medium) — **`TargetedPull` vs "skipped targeted" dead documentation**
+  (Phase 2 §2 / Phase 3 §4). The Step 5 bullet at 285-286 ("Discovery skipped:
+  targeted run over N item(s)") and the Step 2 narrative at line 138 are left
+  untouched. Clarify whether "skipped targeted" survives for `imported == 0`; list
+  the updates either way.
+- 🔵 minor (medium) — **Phase 1 prose rewrite addresses only the collision case**
+  (Phase 1 §3). It should also state that a token equal to a single file's own
+  `external_id` reconciles silently.
+- 🔵 minor (low) — **Resolution table omits exit-6 and ambiguous exit-2 cases**
+  (Desired End State, 99-107). The table reads as exhaustive but omits codes that
+  appear in the precedence chain. Add the rows or annotate the table's scope.
+
+## Re-Review (Pass 2) — 2026-09-08
+
+**Verdict:** REVISE
+
+All eight lenses ran again against the revised plan. Every finding from the
+initial review is resolved — the structural blockers are gone. The verdict stays
+REVISE only because the edits introduced a cluster of implementation-precision
+findings, none structural: a count field that carries the wrong quantity, a code
+sketch that does not type-check, a deferred renderer arm that breaks Phase 2's
+compile, a guard placed one layer from where it protects, and test gaps for
+newly-added branches. Several are naturally resolved during TDD; four are
+design-level and worth a focused second edit.
+
+### Previously Identified Issues
+
+- 🟡 **Architecture/Code Quality/Correctness/Compatibility**: `SkippedTargeted` →
+  `TargetedPull{0}` swap — **Resolved**. `TargetedPull` is now emitted only when
+  `pull_ids` is non-empty; an empty slice keeps `SkippedTargeted`, so a
+  reconcile-only run is byte-identical.
+- 🟡 **Correctness/Architecture/Code Quality/Compatibility**: Exit-code precedence
+  split + absent/indeterminate tie — **Resolved**. `Absent`/`Indeterminate` are
+  now `TargetResolutionFailure` variants through one `rank` function; `rank` is
+  extended so 3 beats 70.
+- 🟡 **Correctness**: Duplicate candidates double-bind — **Resolved** (dedup by
+  `canonical_external_key` + corpus filter), though the filter placement drew a
+  new finding (see below).
+- 🟡 **Compatibility**: `--push-only` + remote-only pulls — **Resolved**. Now an
+  exit-2 usage error before any tracker call.
+- 🟡 **Test Coverage**: gate untestable / existing tests inverted / no seam —
+  **Resolved**. The subprocess harness is scoped to credential-independent
+  assertions; the gate is a pure `partition_candidates`; existing tests are
+  listed for inversion. (Test coverage confirms the in-crate seam is genuinely
+  supported by existing `RecordingTracker`/`RecordingAuthor`/`Spy`.)
+- 🟡 **Documentation/Usability**: incomplete skill change set — **Resolved**. All
+  exit-code surfaces, the orphaned lead-in, the citations, and the pinned TSV
+  shape are now enumerated (residual line-reference precision noted below).
+- 🔵 **Safety**: "all-or-nothing" scoping, TOCTOU, refuse-all — **Resolved** and
+  explicitly documented; `--max-pulls` AC reworded in the work item.
+- 🔵 Minor/suggestion items (discovery_suppressed rename, preview wording, exit-3
+  offline shift, own-`external_id` prose) — **Resolved**.
+
+### New Issues Introduced
+
+#### Major
+
+- 🟡 **Count is attempted, not applied** (code-quality, architecture,
+  compatibility, usability, correctness, test-coverage, documentation) — The most
+  cross-cutting new issue. `DiscoveryStatus::TargetedPull { imported }` carries
+  `pull_ids.len()` (attempted) and drives the TSV `#\tdiscovery\ttargeted-pull\t<N>`,
+  while the human line is told to derive N from applied outcomes. On a
+  partial-failure run the two diverge and overstate success; under `--preview`
+  there are no applied outcomes at all. The field name `imported` compounds it.
+  Fix: single-source the count (carry the applied count, or drop N from the TSV),
+  rename the field to `attempted`, and state the skill's N source per mode.
+- 🟡 **`partition_candidates` does not type-check** (code-quality, compatibility,
+  correctness) — `FetchOutcome::found` is `Vec<(ExternalId, RemoteTimestamp)>`,
+  not `Vec<ExternalId>`; the sketch returns it directly, and maps bare ids into
+  `Absent(String)`/`Indeterminate(String)` which must carry a user-facing message
+  per the `message()` invariant. Fix: project the id out of the pair and build a
+  message per token.
+- 🟡 **Phase 2 will not compile** (correctness) — Adding
+  `DiscoveryStatus::TargetedPull` makes `discovery_line`'s exhaustive match
+  non-exhaustive, yet `mise run cli:check` is a Phase 2 criterion and the renderer
+  arm is deferred to Phase 3. Fix: add the `discovery_line` arm in Phase 2 (a
+  provisional TSV line Phase 3 finalises).
+- 🟡 **Double-binding filter placed at the CLI caller, not the engine boundary**
+  (architecture; untested per test-coverage) — The filter sits in work-cli, but
+  the engine trusts `pull_ids` verbatim at the injection branch beside its own
+  `corpus_carries` closure. A second caller could reintroduce double-authoring.
+  Fix: apply the corpus filter inside the engine so `Targeted { pull_ids }` is
+  safe by construction, and cover it with a test.
+- 🟡 **Whole-call `fetch_all` `Err` → exit 70 misclassifies** (compatibility;
+  safety concurs) — Per the tracker contract, `fetch_all` errors only on a
+  pre-flight fault (unresolvable credentials, an unembeddable id) — permanently
+  unfixable by retry. Mapping to RETRYABLE (70) tells the operator to re-run when
+  re-running cannot help. Fix: route an unembeddable-id/credential fault to a
+  usage/unconfigured code, or document why it is deliberately retryable.
+- 🟡 **Test gaps for new behaviour** (test-coverage) — No test for the AC7
+  all-success mixed batch (local + path + remote-only in one run, asserting the
+  write set is exactly the targeted union), the double-binding filter, or the
+  partial-failure count.
+- 🟡 **Skill line references and the phase-boundary sentence split are inaccurate**
+  (documentation) — The suppressed-note and discovery-suppression sentences do not
+  sit at the cited lines, and the 84/85 split cuts one sentence in half. Fix:
+  reference by sentence content, not line number, and assign each whole sentence
+  to one phase.
+- 🟡 **Step 2 discovery enumeration not updated** (documentation) — The skill's
+  Step 2 lists the discovery states (ran/skipped-push-only/skipped-targeted/failed)
+  but the change set never adds the new `targeted-pull` state to it.
+
+#### Minor
+
+- 🔵 **`ItemSelection::Targeted` has three test construction sites** beyond the CLI
+  (compatibility, high) — `sync_run.rs:342,480` and `sync_create.rs:275` use the
+  tuple form and must migrate in Phase 2, or Phase 2 will not build. Consider
+  whether `cargo-public-api` needs regenerating.
+- 🔵 **Push-only and collision messages under-specified** (usability) — The
+  push-only error should state the contradiction and remedy; the collision message
+  should carry actual file paths (not ids) for the path-based recovery.
+- 🔵 **`--preview` change-class list missing targeted-pull** (usability) — Step 1's
+  enumeration of previewable actions does not add the new targeted pull-create.
+- 🔵 **exit-70 recovery text and write-semantics** (documentation, usability) — The
+  new exit-70 skill entry omits recovery guidance, and a targeted exit-70 (aborts
+  before any write) is not distinguished from the engine-level exit-70 (may follow
+  partial writes).
+- 🔵 **Rewritten collision test keeps the old name** (code-quality) — rename
+  `a_local_id_wins_..._as_suppressed` to describe the new exit-2 behaviour.
+- 🔵 **Confirmed target silently dropped by the corpus filter** (correctness) — if
+  the defensive filter ever fires, the named target is neither pulled nor
+  reconciled with no signal; route it to reconcile or emit a diagnostic.
+- 🔵 **Baseline-write partial state untested** (safety) — a create whose baseline
+  write fails after the file is authored is a distinct partial state; add a
+  recovery test.
+- 🔵 **AC2 allocation parity has no comparison test** (test-coverage) — assert a
+  discovery import and a targeted pull of the same stub issue author identical
+  id/filename/baseline.
+
+#### Not a defect
+
+- ⚪ **Desired End State precedence note** (flagged by documentation as still
+  `2 > 6 > 3`) — false positive. Plan line 99 already reads `2 > 6 > 3 > 70`; the
+  `2 > 6 > 3` the lens saw is the SKILL.md copy the plan (line 445) correctly
+  instructs changing.
+
+### Assessment
+
+The plan is now structurally sound: the resolution model, the phase decomposition,
+the exit-code single-sourcing, and the test seam are all sensible, and every
+original finding is resolved. The new findings are precision issues — four
+design-level ones worth fixing in the plan text (single-source the count; move the
+double-binding filter into the engine; correct the `fetch_all` `Err` mapping; add
+the Phase 2 `discovery_line` arm and enumerate the enum construction sites), and a
+tail of mechanical ones (pseudocode types, skill line references, test-name and
+Step 2 enumeration) that a careful implementer resolves during TDD. A focused
+second edit on the design-level four would carry this to APPROVE.
+
+### Verdict Update (2026-09-08) — APPROVE
+
+A second edit round applied **every** Pass-2 finding to the plan, not only the
+design-level four: the count is single-sourced on an `attempted` field with the
+discovery line reporting "requested/would import N" (never "imported"); the
+double-binding filter moved into the engine at the injection branch; the
+`fetch_all` whole-call `Err` is split by fault class (exit 2 / 74 / 70); the
+Phase 2 `discovery_line` arm and the three enum construction sites are enumerated;
+`partition_candidates` type-checks; the `PushOnlyRemoteOnly` variant is named; the
+skill edits are anchored by sentence with the Step 2 enumeration, exit-70 recovery
+text, and `--preview` class added; and tests were added for the engine filter,
+AC7, AC2 parity, the partial-failure count, the baseline-write state, and the
+`Err`-class. The one documentation "major" was a false positive.
+
+This verdict was set by the reviewer after applying those fixes; it was **not**
+produced by a third automated lens pass. The plan is approved and marked ready
+for implementation.
+
+---
+*Re-review generated by /accelerator:review-plan*

--- a/meta/reviews/work/0285-targeted-pull-of-remote-only-work-items-review-1.md
+++ b/meta/reviews/work/0285-targeted-pull-of-remote-only-work-items-review-1.md
@@ -1,0 +1,569 @@
+---
+type: "work-item-review"
+id: "0285-targeted-pull-of-remote-only-work-items-review-1"
+title: "Work Item Review: Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+date: "2026-09-08T18:47:27+00:00"
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
+target: "work-item:0285"
+work_item_id: "0285"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
+review_number: 1
+review_pass: 2
+tags: []
+last_updated: "2026-09-08T19:24:23+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Work Item Review: Targeted Pull of Remote-Only Work Items and Resolution Normalisation
+
+**Verdict:** REVISE
+
+The work item is structurally complete, well-scoped, and unusually precise on
+exit codes and the two collision cases — completeness found nothing, and scope
+confirms a single coherent increment correctly parented under epic 0146. It
+falls short of APPROVE on two axes: several behaviours the Requirements and
+Technical Notes name (report/skill rendering, watermark advance for the new
+item, live `--max-pulls` bounding) have no acceptance criterion, and the work
+item silently drops dependency detail its predecessor 0257 chose to make
+visible. A surface contradiction between the local-precedence rule and the
+collision-abort rule compounds the risk.
+
+### Cross-Cutting Themes
+
+- **Parity regression against predecessor 0257** (flagged by: dependency,
+  testability) — 0257 explicitly captured the external tracker coupling, an
+  integration watch-out against siblings 0229/0255, a watermark/resumability
+  criterion, and a `--max-pulls` criterion. 0285 extends the same engine but
+  carries none of these forward, despite adding a new remote path. This is the
+  dominant theme and accounts for four of the six major/minor findings.
+- **Local-vs-remote resolution precedence** (flagged by: clarity, scope) — the
+  resolution normalisation is the work item's second capability; clarity finds
+  its two precedence rules read as contradictory, and scope asks whether the
+  normalisation is a separable deliverable or a necessary consequence of the
+  pull.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Testability**: 'reconciled or created appropriately' is tautological
+  **Location**: Acceptance Criteria
+  The mixed-targets criterion uses 'appropriately', which has no defined
+  pass/fail outcome — any behaviour could be argued to satisfy it, adding no
+  verification value beyond the per-shape criteria it summarises.
+
+- 🟡 **Testability**: Report-line and skill-rendering change has no acceptance
+  criterion
+  **Location**: Requirements
+  Requirements mandate updating the report lines and `sync-work-items` skill
+  rendering for the pull-create and the exit-2 collision, but no criterion
+  specifies the expected output for either — the visible result of the two
+  central new behaviours is unverifiable.
+
+- 🟡 **Clarity**: Local-precedence rule appears to contradict the
+  collision-abort rule
+  **Location**: Requirements
+  The fourth Requirement says a local match 'wins and selects that local item'
+  unconditionally; the sixth says a token that is one file's id and a *different*
+  file's `external_id` must abort (exit 2). The precedence rule does not carve
+  out the collision exception, so the two read as conflicting.
+
+- 🟡 **Dependency**: External tracker coupling absent from Dependencies
+  **Location**: Dependencies
+  The work item adds a new by-id `tracker.show(external_id)` fetch — remote
+  contact where today's code aborts without it — yet Dependencies records only
+  'Blocked by: none' / 'Blocks: none' and never names the remote tracker
+  (Linear). Predecessor 0257 captured this external coupling explicitly.
+
+- 🟡 **Dependency**: 0257 mischaracterised as a non-blocker
+  **Location**: Dependencies
+  Dependencies states 'Blocked by: none (0257 is in review)', but 0285 directly
+  extends 0257's unmerged code — the exit-3 abort it inverts, the
+  `resolve_targets` arm it modifies, the discovery suppression, the pull-bound
+  accounting. This is a hard upstream ordering gate, not 'none'.
+
+- 🟡 **Testability**: Watermark advance for a targeted pull-create is not
+  verified
+  **Location**: Acceptance Criteria
+  Requirements and Technical Notes require the per-item watermark
+  (`local_synced_at`) to extend to a newly-created targeted item, but no
+  criterion verifies that a re-run does not re-pull it. 0257 had an explicit
+  baseline-advance / resumability criterion; 0285 has none for the new item.
+
+#### Minor
+
+- 🔵 **Dependency**: Integration watch-out not carried forward
+  **Location**: Dependencies
+  0285 modifies the shared engine pull/discovery path that 0257 flagged as an
+  integration watch-out against siblings 0229 (pull scope) and 0255 (chunk
+  merge); 0285 carries no equivalent note, risking merge conflicts discovered at
+  implementation rather than planning time.
+
+- 🔵 **Testability**: `--max-pulls` bounding only verified under `--preview`
+  **Location**: Acceptance Criteria
+  AC3 asserts the pull count only under `--preview` (a zero-write path). No
+  criterion verifies bounding in a real writing run when pull-creates exceed
+  `--max-pulls`, leaving the safety-relevant blast-radius guarantee untested for
+  the live path.
+
+- 🔵 **Clarity**: Relationship between `--preview` and `--dry-run` undefined
+  **Location**: Requirements
+  The third Requirement writes '`--preview`/`--dry-run`' as if interchangeable,
+  but never states whether they are one aliased flag or two. `--dry-run` appears
+  once; every criterion and 0257 use only `--preview`.
+
+- 🔵 **Clarity**: 'Missed in the definition' conflicts with Summary's
+  'explicitly scoped out'
+  **Location**: Context
+  The Summary frames the 0257 gap as 'explicitly — and wrongly — scoped out' (a
+  deliberate decision); the Context says it 'was missed in the definition' (an
+  accident). The mixed framing affects how the reader reads 0257's other scope
+  decisions.
+
+#### Suggestions
+
+- 🔵 **Scope**: Title and Summary name two capabilities
+  **Location**: Summary
+  The pull of a remote-only item (new feature) and 'resolution normalisation' (a
+  behavioural change to shipped 0257 semantics) could in principle ship or roll
+  back independently. The work item argues persuasively they share the same
+  `resolve_targets` decision — if so, state explicitly that the normalisation is
+  a necessary consequence, not a separable second deliverable.
+
+- 🔵 **Testability**: 'via the same path as a discovery import' leans on
+  implementation
+  **Location**: Acceptance Criteria
+  AC1 references an internal code path rather than an observable outcome; the
+  verifiable part is carried by AC2's field-equivalence comparison. Reword AC1 to
+  the observable result and let AC2 carry the equivalence claim.
+
+- 🔵 **Clarity**: 'corpus'/'local corpus' introduced without definition
+  **Location**: Context
+  0285 uses 'local corpus' where 0257 says 'work directory' / 'local work items'.
+  The term is inferable but the vocabulary shift could momentarily suggest a
+  distinct concept. Define on first use or reuse 0257's phrasing.
+
+### Strengths
+
+- ✅ Every expected section is present and substantively populated; frontmatter
+  is valid with a recognised kind, status, priority, and parent/relates_to
+  linkage consistent with 0257 and epic 0146.
+- ✅ The two collision cases are defined with precise, mutually exclusive
+  criteria, and exit-code semantics (exit 2 usage error, exit 3
+  `RESOLVE_NOT_FOUND`) are used consistently across Context, Requirements, and
+  Acceptance Criteria.
+- ✅ Most acceptance criteria state outcomes as observable system states — file
+  created, nothing written, counts against `--max-pulls`, byte-identical
+  full-sync report — with concrete tokens (`PP-999`) and a testable 'no remote
+  call' constraint (AC5).
+- ✅ Deliberately reuses existing mechanisms (`create_from_remote`, the
+  discovery-import id allocation, pull-bound accounting, standard conflict
+  resolution) rather than inventing parallel machinery, keeping it a single
+  coherent increment confined to one engine.
+
+### Recommended Changes
+
+1. **Add acceptance criteria for the unverified behaviours** (addresses:
+   Report-line and skill-rendering change has no acceptance criterion; Watermark
+   advance not verified; `--max-pulls` bounding only verified under `--preview`)
+   Add criteria pinning: the report line(s) for a targeted pull-create and the
+   exit-2 collision (mirroring how 0257 pinned the discovery line to 'skipped');
+   that a re-run after a pull-create does not re-pull and its watermark has
+   advanced; and that pull-creates exceeding `--max-pulls N` in a real run cap at
+   N with the remainder reported as bounded.
+
+2. **Resolve the local-precedence / collision-abort contradiction** (addresses:
+   Local-precedence rule appears to contradict the collision-abort rule)
+   Qualify the fourth Requirement so 'a local-id match wins' explicitly excludes
+   the local/local collision defined in the sixth Requirement, or cross-reference
+   the collision rule as an exception.
+
+3. **Restore the dependency detail 0257 carried** (addresses: External tracker
+   coupling absent; 0257 mischaracterised as a non-blocker; Integration watch-out
+   not carried forward)
+   Add an 'External' line naming the remote tracker (Linear via
+   `work.integration`) and the new by-id pull path's reachability dependency;
+   record 0257 as 'Blocked by: 0257 until merged'; and carry forward the
+   integration watch-out against 0229 and 0255 on the shared pull/discovery path.
+
+4. **Replace the tautological mixed-targets criterion** (addresses: 'reconciled
+   or created appropriately' is tautological)
+   State the concrete disposition per shape — local-id/path tokens reconcile
+   their existing local file, remote-only ids create-and-reconcile a new local
+   file, no non-targeted item is written.
+
+5. **Tidy the minor clarity and framing issues** (addresses: `--preview` /
+   `--dry-run` undefined; 'Missed' vs 'explicitly scoped out'; 'corpus'
+   undefined; two-capability framing; AC1 phrasing)
+   State whether `--dry-run` is an alias for `--preview` or drop it; pick one
+   framing for the 0257 gap; define or replace 'local corpus'; state in the
+   Summary that the normalisation is a necessary consequence of the pull; and
+   reword AC1 to an observable outcome.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: Work item 0285 is unusually precise: it names concrete exit codes,
+distinguishes the two collision cases with sharp definitions, and reuses domain
+vocabulary consistently with its predecessor 0257. The main clarity risk is a
+surface-level contradiction between the local-precedence requirement and the
+collision requirement, plus a couple of minor undefined-term and framing issues.
+Actors and outcomes are mostly clear, stated as observable states (file created,
+exit 2/3, zero writes).
+
+**Strengths**:
+- The two collision cases are defined with precise, mutually exclusive criteria
+  — 'a token that resolves to the local file carrying the matching external_id'
+  (reconcile normally) versus 'a token that is one local file's id and
+  simultaneously a *different* local file's external_id' (abort exit 2) — leaving
+  little room for misinterpretation.
+- Exit-code semantics (exit 2 usage error for local/local collision, exit 3
+  RESOLVE_NOT_FOUND for no match) are used consistently across Context,
+  Requirements, and Acceptance Criteria.
+- Acceptance Criteria state outcomes as observable system states (file created,
+  nothing written, counts against --max-pulls, byte-identical full-sync report)
+  rather than vague desired properties.
+- Domain terms carried over from 0257 (token, external_id, blast-radius,
+  discovery suppression) are used consistently, so a reader of the predecessor
+  faces no vocabulary drift on those terms.
+
+**Findings**:
+- 🟡 major (confidence: medium) — **Local-precedence rule appears to contradict
+  the collision-abort rule** (Requirements). The fourth Requirement states a
+  target with a local match 'wins and selects that local item', phrased
+  unconditionally. The sixth Requirement then says that when a token is one local
+  file's id and *also* a different local file's external_id — a case that does
+  have a local-id match — the run must instead abort as a usage error (exit 2). A
+  reader following the fourth bullet would select and reconcile the local-id
+  item; the sixth bullet says do not, abort. Impact: an implementer or reviewer
+  cannot tell from the Requirements alone whether the local-id match is honoured
+  or the run aborts in the collision case. Suggestion: qualify the fourth
+  Requirement so 'a local-id match wins' explicitly excludes the local/local
+  collision case, or cross-reference the collision rule as an exception.
+- 🔵 minor (confidence: medium) — **Relationship between --preview and --dry-run
+  left undefined** (Requirements). The third Requirement writes
+  '`--preview`/`--dry-run`' as though interchangeable, but never states whether
+  these are two names for one flag or two distinct flags. Every criterion and
+  0257 use only `--preview`; `--dry-run` appears once without explanation.
+  Suggestion: state explicitly whether `--dry-run` is an alias or a separate
+  flag, or drop it.
+- 🔵 minor (confidence: medium) — **'Missed in the definition' conflicts with
+  Summary's 'explicitly scoped out'** (Context). The Summary frames the omission
+  as a deliberate exclusion ('explicitly — and wrongly — scoped out'); the
+  Context frames it as an oversight ('missed in the definition'). The mixed
+  framing affects how confidently the reader trusts 0257's other scope decisions.
+  Suggestion: pick one framing and use it in both Summary and Context.
+- 🔵 suggestion (confidence: low) — **'Corpus'/'local corpus' introduced without
+  definition** (Context). 0285 uses 'local corpus' where 0257 says 'work
+  directory' / 'local work items'. The meaning is inferable, but the vocabulary
+  shift could momentarily suggest a distinct concept. Suggestion: define on first
+  use or reuse 0257's phrasing.
+
+### Completeness
+
+**Summary**: Work item 0285 is a structurally complete story: every expected
+section (Summary, Context, Requirements, Acceptance Criteria, Open Questions,
+Dependencies, Assumptions, Technical Notes, Drafting Notes, References) is
+present and substantively populated. It carries the kind-appropriate content a
+story demands — an identified actor (an engineer maintaining work items
+locally), a Context that explains why the work is needed, and eight specific
+Given/When/Then acceptance criteria. Frontmatter is valid with a recognised
+kind, status, priority, and parent linkage.
+
+**Strengths**:
+- Summary follows a clear user-story form (as-a / I-want / so-that) and states
+  precisely what is being built — a targeted pull of remote-only items plus
+  resolution normalisation.
+- Context explains the motivation concretely: it traces the gap 0257 scoped out
+  and the wrong 'suppressed remote match' framing, giving a reader the forces
+  behind the work without follow-up.
+- Acceptance Criteria section is dense and specific — eight Given/When/Then
+  bullets covering the happy path, preview/bounds, collision, not-found, mixed
+  targets, and full-sync regression.
+- Requirements are detailed and actionable, each tied to a concrete behaviour
+  (by-id fetch, create-from-remote reuse, exit codes), and Assumptions plus
+  Dependencies are explicitly populated rather than left blank.
+- Frontmatter integrity is sound: kind (story), status (draft), priority, parent
+  (0146), and relates_to (0257) are all present and consistent with the
+  referenced predecessor and epic.
+
+**Findings**: None.
+
+### Dependency
+
+**Summary**: 0285 is a story that directly extends the targeted-sync feature
+delivered by 0257, reusing its resolution, discovery-suppression, and
+create-from-remote machinery, and it introduces a new by-id remote fetch
+(`tracker.show`) that widens remote contact. The most significant dependency
+gaps are the external tracker (Linear) coupling — captured explicitly by
+predecessor 0257 but entirely absent from 0285's Dependencies despite a new
+remote path — and the framing of 0257 as a non-blocker while 0285 cannot start
+until 0257's code lands. Downstream Blocks are plausibly none, but the
+same-engine integration watch-out 0257 flagged against 0229/0255 is not carried
+forward.
+
+**Strengths**:
+- The predecessor coupling to 0257 is visible via the `relates_to` frontmatter,
+  the References section, and repeated narrative acknowledgement, so the lineage
+  is not hidden.
+- The `tracker.show(external_id)` behavioural assumption is explicitly captured
+  in Assumptions, naming the remote operation the targeted pull relies on.
+- Blocks is reasoned about ('none identified') rather than left blank, and the
+  full-sync preservation requirement bounds the change's reach.
+
+**Findings**:
+- 🟡 major (confidence: medium) — **External tracker coupling absent from
+  Dependencies** (Dependencies). The work item introduces a new remote
+  interaction — a by-id `tracker.show(external_id)` fetch to pull a remote-only
+  issue where today's code aborts without contacting the remote — yet the
+  Dependencies section records only 'Blocked by: none' and 'Blocks: none' and
+  never names the remote tracker (Linear) as a coupling. Predecessor 0257
+  explicitly captured this: 'External: the Linear tracker (via
+  `work.integration`)… every… `external_id` lookup depends on the Linear API
+  being reachable.' Impact: a targeted pull's success now depends on the remote
+  tracker being reachable and on `tracker.show` resolving a single issue by id;
+  omitting this hides a runtime dependency the equivalent predecessor made
+  visible. Suggestion: add an 'External' line naming the remote tracker and the
+  new by-id pull path's reachability dependency, mirroring 0257.
+- 🟡 major (confidence: medium) — **0257 mischaracterised as a non-blocker**
+  (Dependencies). Dependencies states 'Blocked by: none (0257 is in review)', but
+  0285 directly extends 0257's just-shipped code — the exit-3 abort it inverts,
+  the `resolve_targets` arm it modifies, the discovery suppression under
+  `ItemSelection::Targeted`, and the pull-bound accounting all originate in 0257.
+  This is a hard upstream ordering constraint: 0285 cannot begin until 0257 is
+  merged, not merely 'in review'. Impact: characterising a strict predecessor as
+  a non-blocker understates a real scheduling gate — if 0257 slips or changes in
+  review, 0285's requirements are invalidated. Suggestion: record 0257 as an
+  explicit upstream blocker ('Blocked by: 0257 until merged').
+- 🔵 minor (confidence: medium) — **Integration watch-out not carried forward**
+  (Dependencies). 0285 modifies the shared engine pull/discovery path (discovery
+  suppression under `Targeted`, `resolve_targets`, pull-count accounting in
+  `run.rs`), which is exactly the path 0257 flagged as an integration watch-out:
+  '0229 (pull scope) and 0255 (chunk merge) touch the same engine pull/discovery
+  path… whichever lands second should expect to integrate against the other's
+  changes.' 0285 carries no equivalent note. Impact: two concurrent siblings
+  touching the same code region create a merge coupling that, left unrecorded,
+  risks conflicts at implementation time. Suggestion: carry forward 0257's
+  integration watch-out.
+
+### Scope
+
+**Summary**: Work item 0285 is a well-bounded story that extends 0257's targeted
+sync so a named remote-only item can be pulled, and reuses existing mechanisms
+(create_from_remote, pull-bound accounting, standard conflict resolution) rather
+than inventing new machinery — keeping it a single-team, single-increment unit
+correctly parented under epic 0146. The one scope signal is that the title and
+Summary explicitly name two capabilities — the remote-only pull and a
+resolution/collision-semantics normalisation — though the work item makes a
+defensible case that the second is a direct consequence of the first, since both
+live in the same resolve_targets local-vs-remote decision. Sizing,
+service-boundary confinement, and epic fit are all appropriate.
+
+**Strengths**:
+- Clear in-scope/out-of-scope boundaries: the targeted pull is scoped to a
+  direct by-id fetch that never triggers full untracked-discovery, and full-sync
+  report/write-set/watermark behaviour is explicitly preserved unchanged.
+- Deliberately reuses existing paths (create_from_remote, the discovery-import id
+  allocation, pull-bound accounting, standard conflict resolution) so the story
+  adds no parallel mechanism and stays a single coherent increment.
+- Correctly parented under epic 0146 as a sibling of 0257 that directly extends
+  the targeted-sync feature — a coherent decomposition rather than a grab-bag
+  addition.
+- Confined to one engine (the work-cli sync resolution path) with no
+  cross-service or cross-team ownership split; the remote tracker is an inherited
+  external dependency, not new orchestration.
+
+**Findings**:
+- 🔵 suggestion (confidence: medium) — **Title and Summary name two
+  capabilities** (Summary). The title and Summary name two capabilities — pulling
+  a remote-only work item (the new feature) and 'resolution normalisation', which
+  reworks the collision semantics from 0257's local-wins-with-warning into a hard
+  exit-2 usage error and removes the suppressed-remote-match warning for ordinary
+  synced items. The second is a behavioural change to already-shipped 0257
+  behaviour that could, in principle, ship or roll back independently. Impact:
+  bundling a new capability with a change to existing behaviour can blur what a
+  reviewer signs off on and complicate rollback if only one half proves
+  problematic. Suggestion: confirm the coupling is intentional — the work item
+  argues persuasively that introducing remote lookup is exactly what forces the
+  local-vs-remote decision to be redefined; if that shared-decision framing
+  holds, keep them together but state explicitly in the Summary that the
+  normalisation is a necessary consequence of the pull, not a separable second
+  deliverable; otherwise consider splitting the collision-semantics change into
+  its own item.
+
+### Testability
+
+**Summary**: The acceptance criteria for 0285 are largely strong from a
+verification standpoint: most are framed as Given/When/Then with concrete exit
+codes (2, 3), named example tokens (`PP-999`), explicit write-set assertions
+('nothing written', 'zero writes'), a testable 'no remote call' constraint, and
+a byte-identical comparison for full-sync preservation. Weaknesses cluster in one
+vague criterion ('reconciled or created appropriately') and in gaps where
+Requirements/Technical Notes describe behaviours (report/skill rendering,
+watermark advance for the new item, real-run pull bounding) that no criterion
+pins down.
+
+**Strengths**:
+- Most criteria specify an exact exit code and write-set outcome (exit 2 naming A
+  and B with nothing written; exit 3 naming the token with zero writes), giving
+  unambiguous pass/fail procedures.
+- AC5's 'determined from the local corpus with no remote call' is a concrete,
+  verifiable constraint (spy on the tracker) rather than a vague behavioural
+  statement.
+- AC2 makes the otherwise implementation-flavoured 'same path as a discovery
+  import' testable by requiring the local id, filename, and baseline entry to
+  match a full-sync discovery import for the same issue.
+- AC8 uses a 'byte-identical to before this change' regression comparison for
+  full-sync preservation — an objectively decidable check.
+
+**Findings**:
+- 🟡 major (confidence: high) — **'reconciled or created appropriately' is
+  tautological** (Acceptance Criteria). The mixed-targets criterion uses
+  'appropriately', which has no defined pass/fail outcome — any behaviour could
+  be argued to satisfy it. Impact: a verifier cannot conclusively confirm the
+  mixed-target run behaved correctly; the criterion adds no value beyond the
+  per-shape criteria it summarises. Suggestion: replace 'appropriately' with the
+  concrete expected disposition per shape.
+- 🟡 major (confidence: high) — **Report-line and skill-rendering change has no
+  acceptance criterion** (Requirements). The Requirements state 'Update the
+  report lines and the `sync-work-items` skill rendering for the targeted
+  pull-create and the revised collision semantics', but no criterion specifies
+  the expected report/rendering output for either the pull-create or the exit-2
+  collision. Impact: the visible output of the two central new behaviours is
+  unverifiable, so this requirement could ship unmet. Suggestion: add a criterion
+  asserting the specific report line(s) for a pull-create and for the exit-2
+  collision, mirroring how 0257 pinned the discovery line to 'skipped'.
+- 🟡 major (confidence: medium) — **Watermark advance for a targeted pull-create
+  is not verified** (Acceptance Criteria). The Requirements and Technical Notes
+  require the per-item watermark (`local_synced_at`) to extend to a newly-created
+  targeted item, but no criterion verifies that a re-run after a targeted
+  pull-create does not re-pull it (0257 had an explicit 'baseline has advanced' /
+  'resumes without re-pushing' criterion; 0285 has none for the new item).
+  Impact: resumability and baseline correctness for the new pull path has no
+  test, so regressions (re-pulling on every run) would pass acceptance.
+  Suggestion: add 'Given a completed targeted pull-create of PP-999, when sync
+  runs again, then PP-999 is not re-pulled and its baseline/watermark has
+  advanced.'
+- 🔵 minor (confidence: medium) — **--max-pulls bounding only verified under
+  --preview** (Acceptance Criteria). The requirement 'Count a targeted
+  pull-create as a pull for blast-radius bounds (`--max-pulls`)' is only exercised
+  by AC3, which asserts the count under `--preview` (a zero-write path). No
+  criterion verifies bounding behaviour in a real (writing) run when targeted
+  pull-creates exceed `--max-pulls`. Impact: the safety-relevant enforcement of
+  the pull bound during actual writes is untested. Suggestion: add 'Given more
+  targeted pull-creates than `--max-pulls N` allows, when sync runs, then at most
+  N are created and the remainder are reported as bounded', matching 0257.
+- 🔵 suggestion (confidence: low) — **'via the same path as a discovery import'
+  phrasing leans on implementation** (Acceptance Criteria). AC1 describes the
+  outcome as 'a local file is created from the remote issue via the same path as
+  a discovery import', which references an internal code path rather than an
+  observable outcome; the verifiable part is carried by AC2's field-equivalence
+  comparison. Impact: on its own AC1 is only partly checkable, though AC2 largely
+  compensates. Suggestion: reword AC1's outcome to the observable result and let
+  AC2 carry the equivalence claim.
+
+## Re-Review (Pass 2) — 2026-09-08
+
+**Verdict:** COMMENT
+
+Re-ran clarity, dependency, scope, and testability against the edited work item
+(completeness had no findings and was not re-run). All six major findings from
+pass 1 are resolved, along with every minor and suggestion. One new major
+surfaced in clarity — the reconcile-vs-collision discriminator, the item's core
+distinction, is worded inconsistently between Requirement 5 and AC4 — plus a
+cluster of minor refinements on the newly-added criteria and relationship graph.
+With one major and no criticals, the verdict drops from REVISE to COMMENT: the
+work item is acceptable, and the remaining major is worth a quick pass.
+
+### Previously Identified Issues
+
+- 🟡 **Testability**: 'reconciled or created appropriately' is tautological —
+  Resolved (mixed-targets AC now states per-shape dispositions)
+- 🟡 **Testability**: Report-line and skill-rendering change has no acceptance
+  criterion — Partially resolved (criterion added; exact expected text still
+  open — see new minor)
+- 🟡 **Clarity**: Local-precedence rule contradicts the collision-abort rule —
+  Resolved (fourth Requirement carves out the collision exception)
+- 🟡 **Dependency**: External tracker coupling absent from Dependencies —
+  Resolved (External line names Linear via `work.integration`)
+- 🟡 **Dependency**: 0257 mischaracterised as a non-blocker — Resolved, but
+  over-corrected (0257 is already `done`/merged — see new minor)
+- 🟡 **Testability**: Watermark advance not verified — Resolved (re-run
+  baseline/watermark criterion added)
+- 🔵 **Dependency**: Integration watch-out not carried forward — Resolved in
+  prose (relationship-graph gap remains — see new minor)
+- 🔵 **Testability**: `--max-pulls` bounding only verified under `--preview` —
+  Resolved (live bounding criterion added)
+- 🔵 **Clarity**: `--preview` / `--dry-run` relationship undefined — Resolved
+  (`--dry-run` dropped)
+- 🔵 **Clarity**: 'missed' vs 'explicitly scoped out' — Resolved (single
+  deliberate-but-wrong framing)
+- 🔵 **Scope**: Title and Summary name two capabilities — Resolved (Summary
+  states the normalisation is a necessary consequence)
+- 🔵 **Testability**: AC1 leans on implementation phrasing — Resolved (reworded
+  to observable outcome)
+- 🔵 **Clarity**: 'corpus' introduced without definition — Resolved (defined
+  inline on first use)
+
+### New Issues Introduced
+
+- 🟡 **Clarity** (Requirements / Acceptance Criteria): the ordinary-synced
+  reconcile case is characterised two ways — Requirement 5 as 'a token that
+  resolves to the local file carrying the matching `external_id`', AC4 as 'local
+  file A whose own `external_id` equals the token'. Read against AC5's collision
+  wording, it is unclear whether the no-warning path triggers on any
+  `external_id` match or only on a same-file id-and-`external_id` self-match. This
+  is the exact discriminator between silent reconcile and exit-2 abort.
+- 🔵 **Clarity** (Requirements): the condition deciding whether the remote is
+  consulted is phrased three ways ('no local file', 'a path or local-id match
+  wins', 'no local counterpart'); the 'local-id match wins' clause omits an
+  `external_id` match, which also produces a local file and must suppress the
+  remote lookup.
+- 🔵 **Dependency** (Frontmatter: relates_to): the Integration watch-out names
+  0229 and 0255 in prose, but `relates_to` lists only `work-item:0257`, so the
+  concurrent code-path coupling is invisible to graph-traversing tooling.
+- 🔵 **Dependency** (Dependencies): 'Blocked by: 0257 until merged' is stale —
+  0257 is `status: done` and merged via PR #107, so the blocker is satisfied.
+- 🔵 **Testability** (AC3): the preview 'counts against `--max-pulls`' outcome has
+  no observable artefact, since preview writes nothing and names no bound.
+- 🔵 **Testability** (AC8): the report-line/rendering criterion names no concrete
+  expected text, so implementations could diverge and both claim to pass.
+- 🔵 **Scope / Testability / Clarity** (low): pin the collision-change coupling
+  explicitly; assert created-item field content; split compound criteria; name
+  the 'both arms' antecedent.
+
+### Assessment
+
+The work item is now materially stronger and acceptable for planning. The single
+remaining major — the reconcile-vs-collision discriminator wording — is worth
+resolving before implementation, since it defines the item's central behavioural
+branch; it needs a small semantic confirmation rather than a structural change.
+The minor items (stale 0257 blocker, `relates_to` graph, AC3/AC8 concreteness)
+are quick, unambiguous tidy-ups.
+
+## Approval — 2026-09-08
+
+**Verdict:** APPROVE
+
+After pass 2, the reconcile-vs-collision discriminator (the one remaining major)
+was aligned across Requirement 4, Requirement 5, and AC4 to the requester's
+stated intent: a token reconciles when it resolves to a single local file — by
+local id, its own `external_id`, or both — with exit-2 reserved for a token that
+is one file's id and a *different* file's `external_id`. The stale 0257 blocker
+and the `relates_to` graph gap were corrected. The work item is approved for
+planning; the remaining suggestions (AC3/AC8 concreteness, created-item field
+assertion, splitting compound criteria) are optional polish and non-blocking.
+

--- a/meta/validations/2026-09-08-0285-targeted-pull-of-remote-only-work-items-validation.md
+++ b/meta/validations/2026-09-08-0285-targeted-pull-of-remote-only-work-items-validation.md
@@ -1,0 +1,80 @@
+---
+type: "plan-validation"
+id: "2026-09-08-0285-targeted-pull-of-remote-only-work-items-validation"
+title: "Validation Report: Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+date: "2026-09-09T08:06:15+00:00"
+author: "Toby Clemson"
+producer: "validate-plan"
+status: "complete"
+result: "pass"
+parent: "plan:2026-09-08-0285-targeted-pull-of-remote-only-work-items"
+target: "plan:2026-09-08-0285-targeted-pull-of-remote-only-work-items"
+tags: ["work", "sync", "targeting", "pull"]
+last_updated: "2026-09-09T08:06:15+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Targeted Pull of Remote-Only Work Items and Resolution Normalisation
+
+### Implementation Status
+
+✓ Phase 1: Local/local collision becomes a usage error — fully implemented
+✓ Phase 2: Engine carries and imports targeted pull ids — fully implemented
+✓ Phase 3: Resolve remote-only targets and gate them with `fetch_all` — fully implemented (one accepted deviation, marked `[~]` in the plan)
+
+The three phases ship across four commits — `rpymnquy` (Phase 1), `rzmpkyku`
+(Phase 2), `uvvknrqs` (Phase 3), and a follow-up `stmsvvsz` fixing a discovered
+never-synced-integration gap. The change set touches exactly the files the plan
+names: `cli/work-cli/src/sync.rs`, `cli/work-adapters/src/sync/run.rs`, the two
+adapter test files, `cli/work-cli/tests/cli_sync_targets.rs`, and
+`skills/work/sync-work-items/SKILL.md`.
+
+### Automated Verification Results
+
+✓ Read-only aggregate clean: `mise run check` (exit 0)
+✓ `work-cli` suite green: `cargo test -p accelerator-work` (all binaries, 0 failed)
+✓ `work-adapters` suite green: `cargo test -p work-adapters` (0 failed)
+
+Every automated success-criterion command resolves to a test that exists and
+passes. The plan's Phase 1–2 criteria name `cargo test -p work-cli`; the crate
+publishes as `accelerator-work`, so those invocations run under that `-p` name.
+Phase 3 criteria already use `-p accelerator-work`.
+
+### Code Review Findings
+
+#### Matches Plan:
+
+- **Phase 1 collision → exit 2.** `a_local_local_collision_is_a_usage_error_naming_both_files` (`sync.rs:1023`) asserts a single `LocalCollision` failure, `exit_code() == USAGE`, and both `0001.md` and `0002.md` named. `an_own_external_id_token_reconciles_with_no_collision` covers the silent-reconcile arm.
+- **`Suppressed` machinery deleted.** No `struct Suppressed`, no `suppression_line`, no `suppressed` parameter survive; grep across `sync.rs` and the target tests is clean. The suppressed-line test is gone.
+- **Phase 2 `ItemSelection::Targeted { items, pull_ids }`.** The struct variant, the corpus filter at the injection branch (`run.rs:777`), and `DiscoveryStatus::TargetedPull { attempted }` emitted only for a non-empty confirmed set are all present. `discovery_search_suppressed` renamed from `discovery_suppressed`.
+- **Phase 2 engine tests.** All eleven named behaviours have a test: create-and-count, over-`--max-pulls` refusal, preview zero-write, `show`-failure-reports-`Failed`, corpus-filter dedup, AC7 mixed union, one-of-two-fails tally, baseline-write recovery, discovery/pull authoring parity, re-run reconcile + watermark, empty-set `SkippedTargeted`.
+- **Phase 3 resolution + gate.** `partition_candidates` (`sync.rs:649`), `push_only_remote_only` (exit 2, `sync.rs:636`), two-spellings dedup, `absent`→3 / `indeterminate`→70 with mixed-batch precedence, and the `run_sync`-driven remote-only pull are all covered.
+- **Skill prose reconciled.** The suppressed-note sentences are gone; the discovery-suppression sentence now describes id-reachable targeted pull; precedence reads `2 > 6 > 3 > 70` (`SKILL.md:115`); exit 70 and the push-only remote-only exit-2 case are documented; `targeted-pull` appears in the preview change-class list and the discovery-line enumeration.
+
+#### Deviations from Plan:
+
+- **`[~]` whole-call `fetch_all` `Err` maps to exit 70, not a three-way split.** The plan's Phase 3 §2 proposed routing an unembeddable-id fault to exit 2 and a credential fault to 74. `TrackerError` carries no discriminant to separate these, and a credential fault is already caught at `registry.resolve` (74). Implemented as a single fold to `Indeterminate` (70) per an explicit user decision recorded in the plan; covered by `a_whole_call_fetch_all_error_folds_to_indeterminate_exit_seventy`. Accepted, not a gap.
+- **`discovery_line` lives in `work-cli`, not `work-adapters`.** The plan's Phase 2 §2 placed the `targeted-pull` TSV arm in the engine and its test under `cargo test -p work-adapters`. The rendering (`sync.rs:181`) and the assertion (`render_report_emits_each_discovery_status_line`, `sync.rs:1490`, checking `#\tdiscovery\ttargeted-pull\t2`) sit in `accelerator-work`. Behaviour and coverage are identical; only the crate boundary differs.
+
+#### Potential Issues:
+
+- **Follow-up fix `stmsvvsz` addresses a gap the plan did not anticipate.** On a never-synced integration the state directory does not exist, and the atomic-write containment check canonicalises it as the trusted root, so the first baseline write from a targeted pull would fail. The fix `create_dir_all`s the directory up-front and `baseline_written` guards the create-through-baseline path. The single explanatory comment records the containment-canonicalisation invariant — the allowed comment category, not a what-comment.
+- **No live-tracker coverage in the automated suite.** The post-credential gate is exercised only through `run_sync` with a stub `TrackerRegistry`, by design (the subprocess harness cannot inject a stub). The Phase 3 manual steps remain the only check against real Linear/Jira.
+
+### Manual Testing Required:
+
+1. Live remote-only pull (Phase 3 manual):
+  - [ ] `work sync --target <a real remote-only key>` against Linear creates and reconciles the local file; a second run does not re-pull it.
+  - [ ] `work sync --target <a typo'd key>` reports exit 3 naming the token with zero writes.
+
+2. Skill rendering:
+  - [ ] The `sync-work-items` skill renders the pull-create and the narrowed exit codes with human phrasing, no raw TSV leaking.
+
+3. Collision (Phase 1 manual, credential-free):
+  - [ ] `work sync --target <a local id> --target <a different file's external_id equal to that id>` exits 2 naming both files.
+
+### Recommendations:
+
+- Run the three live-tracker manual steps before merge; they are the only coverage of the real `fetch_all` round-trip and the `show` re-read inside `create_from_remote`.
+- Consider correcting the plan's `-p work-cli` criterion crate name to `-p accelerator-work` if the plan is kept as a living reference; immaterial to the shipped code.

--- a/meta/work/0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/work/0285-targeted-pull-of-remote-only-work-items.md
@@ -1,0 +1,197 @@
+---
+type: "work-item"
+id: "0285"
+title: "Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
+date: "2026-09-08T17:43:59+00:00"
+author: "Toby Clemson"
+producer: "create-work-item"
+status: "ready"
+kind: "story"
+priority: "medium"
+parent: "work-item:0146"
+relates_to: ["work-item:0257", "work-item:0229", "work-item:0255"]
+tags: ["work", "sync", "targeting", "pull"]
+last_updated: "2026-09-08T20:57:03+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# 0285: Targeted Pull of Remote-Only Work Items and Resolution Normalisation
+
+**Kind**: Story
+**Status**: Ready
+**Priority**: Medium
+**Author**: Toby Clemson
+
+## Summary
+
+As an engineer maintaining work items locally, I want `work sync --target` to
+pull a named work item that does not yet exist locally, so that I can import a
+specific remote issue without running a full untargeted sync. This closes a gap
+0257 explicitly — and wrongly — scoped out, and normalises the targeted
+local/remote resolution and collision behaviour that gap forced. The
+normalisation is not a separable second deliverable: introducing remote lookup
+is exactly what forces the local-vs-remote resolution decision to be redefined,
+so both arms share the same `resolve_targets` logic and ship together.
+
+## Context
+
+0257 added `work sync --target <id|external-id|path>` but resolved every target
+against the local corpus only — the local corpus being all tracked work items
+under the work directory. A remote id with no local counterpart aborts with
+`RESOLVE_NOT_FOUND` (exit 3), and untracked discovery is suppressed whenever any
+target is named. Pulling a remote-only item was the original point of targeting,
+yet 0257 deliberately narrowed away from it and marked it out of scope — a wrong
+call this item corrects. A remote-only issue can therefore only be imported by a
+full sync today, which defeats the point of targeting a single item.
+
+The same local-only resolution produced a dual-shape "suppressed remote match"
+warning whenever a token both resolved as a local id and matched some
+`external_id`. That framing is wrong for the ordinary synced item, where the
+local file and the remote issue are one logical item carrying the same key — that
+case should reconcile normally. A signal is warranted only for a genuine
+collision, and that collision is reliably decidable only when both sides are in
+the local corpus.
+
+## Requirements
+
+- Extend `work sync --target <remote-id>` so a token with no local file is looked
+  up on the remote tracker by id and, if present, pulled into a new local file
+  and reconciled — the inverse of today's exit-3 abort. The lookup is a direct
+  by-id fetch, scoped to the named target; it never triggers the full
+  untracked-discovery search.
+- Route a targeted pull through the existing create-from-remote path, so the
+  pulled item's local id, filename, and baseline entry are allocated identically
+  to a full-sync discovery import (`external_id` set to the remote key). No new
+  allocation scheme.
+- Count a targeted pull-create as a pull for blast-radius bounds (`--max-pulls`),
+  and show it under `--preview` with zero writes, exactly as an untracked import
+  is today.
+- Resolve each target against the local corpus first: a token that resolves to a
+  single local file — by path, by local id, or by that file's own `external_id`
+  — wins and selects that local item, except the local/local collision defined
+  below, which aborts rather than selecting; consult the remote only for a token
+  with no local match of any of those kinds.
+- Reconcile the ordinary synced item — a token that resolves to a single local
+  file, whether as that file's local id, its own `external_id`, or both (the
+  `id == external_id` case) — under standard conflict resolution, with no
+  collision warning.
+- Detect the genuine local/local collision deterministically from the corpus — a
+  token that is one local file's id and simultaneously a *different* local file's
+  `external_id` — and abort it as a usage error (exit 2), naming both files and
+  how to disambiguate. Never probe the remote for a locally-resolvable token.
+- Keep `RESOLVE_NOT_FOUND` (exit 3) for a token that matches neither a local file
+  nor a remote issue.
+- Update the report lines and the `sync-work-items` skill rendering for the
+  targeted pull-create and the revised collision semantics. Preserve full-sync
+  behaviour, its report, its write set, and the per-item watermark semantics
+  unchanged.
+
+## Acceptance Criteria
+
+- [ ] Given a remote issue `PP-999` with no local counterpart, when I run
+      `work sync --target PP-999`, then a new local file is created for PP-999,
+      populated from the remote issue, and reconciled, with no exit-3 abort.
+- [ ] Given that pulled item, when it is created, then its local id, filename,
+      and baseline entry match what a full-sync discovery import produces for the
+      same issue.
+- [ ] Given `--preview --target PP-999`, when I run it, then the would-create is
+      shown, nothing is written, and the create counts against `--max-pulls`.
+- [ ] Given a token that resolves to a single local file A — as A's local id, A's
+      own `external_id`, or both — with no *different* file claiming the token,
+      when I target it, then A reconciles under standard conflict resolution with
+      no collision warning.
+- [ ] Given a token that is local file A's id and a *different* local file B's
+      `external_id`, when I target it, then the run aborts as a usage error
+      (exit 2) naming A and B, determined from the local corpus with no remote
+      call, and writes nothing.
+- [ ] Given a token matching neither a local file nor a remote issue, when I
+      target it, then the run aborts (exit 3) naming the token, with zero writes.
+- [ ] Given several `--target`s mixing local ids, paths, and remote-only ids,
+      when I run the sync, then local-id and path tokens reconcile their existing
+      local file, remote-only ids create-and-reconcile a new local file, no
+      non-targeted item is written, and discovery beyond the named set stays
+      suppressed.
+- [ ] Given a targeted pull-create of `PP-999` and, separately, a local/local
+      collision, when each run finishes, then the report line and the
+      `sync-work-items` skill rendering name the pull-create as a created pull and
+      the collision as an exit-2 usage error identifying both files.
+- [ ] Given a completed targeted pull-create of `PP-999`, when I run sync again,
+      then `PP-999` is not re-pulled and its baseline/watermark
+      (`local_synced_at`) has advanced.
+- [ ] Given more targeted pull-creates than `--max-pulls N` allows, when I run
+      the sync, then the whole run is refused with zero creates (fail-safe, no
+      partial blast radius) and the bound breach is reported.
+- [ ] Given no `--target`, when I run a full sync, then its report and item write
+      set are byte-identical to before this change.
+
+## Open Questions
+
+- None outstanding — the drafting questions were resolved into the requirements
+  above.
+
+## Dependencies
+
+- Blocked by: none. This item extends 0257's code directly — the exit-3 abort it
+  inverts, the `resolve_targets` arm it modifies, the discovery suppression under
+  `ItemSelection::Targeted`, and the pull-bound accounting all originate in 0257
+  — but 0257 is already done (merged via PR #107), so that prerequisite has
+  landed and no open blocker remains.
+- Blocks: none identified.
+- External: the remote tracker (Linear via `work.integration`). The new by-id
+  `tracker.show(external_id)` pull path adds remote contact where today's code
+  aborts without it, so a targeted pull now depends on the tracker being
+  reachable and on `show` resolving a single issue by id — inherited from the
+  full sync, mirroring 0257's external-dependency entry.
+- Integration watch-out: 0285 modifies the shared engine pull/discovery path
+  (discovery suppression, `resolve_targets`, pull-count accounting in `run.rs`) —
+  the same path 0257 flagged for 0229 (pull scope) and 0255 (chunk merge). No
+  delivery ordering is required, but whichever lands second should integrate
+  against the other's changes rather than assuming disjoint code.
+
+## Assumptions
+
+- `tracker.show(external_id)` resolves a single issue by id, so a targeted pull
+  needs no `search`; the by-id fetch keeps remote contact scoped to the named
+  targets.
+- Standard conflict resolution (conflict dossiers, dirty guard) applies unchanged
+  once a targeted item is present locally.
+
+## Technical Notes
+
+- A remote-only pull can reuse `create_from_remote` (`apply.rs:270`), which
+  already does `tracker.show(external_id)` then `author.author_from_remote(...)`
+  to allocate the local file and baseline entry.
+- `resolve_targets` (`cli/work-cli/src/sync.rs`) builds `external_id_index` over
+  the local corpus; extend its no-local-match arm to attempt a remote `show`
+  (targeted pull) rather than always returning `NoMatch`.
+- Discovery stays gated off under `ItemSelection::Targeted`
+  (`discovery_suppressed()`); the targeted pull uses by-id `show`, not
+  `discover_untracked`.
+- The collision signal derives entirely from the local `external_id_index`
+  (`item.id != local_match.id`); make it exit 2 rather than a suppressed note.
+- Pull-bound accounting already treats imports as pulls
+  (`pulls = plan.pull_count() + untracked.len()`, `run.rs:822`); a targeted
+  pull-create feeds the same count.
+- The `corpus_carries` double-binding guard and the per-item watermark
+  (`local_synced_at`) must extend to a newly-created targeted item.
+
+## Drafting Notes
+
+- Interpreted "same ID in both places" as the ordinary synced item (a local file
+  whose `external_id` matches the token); confirmed with the requester.
+- Chose a hard usage error (exit 2) for the genuine local/local collision over
+  0257's local-wins-with-warning, per an explicit decision — safer than silently
+  syncing one side.
+- Resolved the id-allocation, preview/bounds, and exit-code questions into
+  requirements by reusing the existing discovery-import path rather than
+  inventing new mechanisms.
+- Scoped as a story under epic 0146 (Work Item Synchronisation Enhancements), the
+  same parent as 0257, since it directly extends 0257's targeted-sync feature.
+
+## References
+
+- Predecessor: `meta/work/0257-sync-specific-work-items.md`,
+  `meta/plans/2026-09-06-0257-sync-specific-work-items.md`
+- Parent epic: `meta/work/0146-work-item-sync-enhancements.md`
+- Skill: `skills/work/sync-work-items/SKILL.md`

--- a/meta/work/0285-targeted-pull-of-remote-only-work-items.md
+++ b/meta/work/0285-targeted-pull-of-remote-only-work-items.md
@@ -5,13 +5,13 @@ title: "Targeted Pull of Remote-Only Work Items and Resolution Normalisation"
 date: "2026-09-08T17:43:59+00:00"
 author: "Toby Clemson"
 producer: "create-work-item"
-status: "ready"
+status: "done"
 kind: "story"
 priority: "medium"
 parent: "work-item:0146"
 relates_to: ["work-item:0257", "work-item:0229", "work-item:0255"]
 tags: ["work", "sync", "targeting", "pull"]
-last_updated: "2026-09-08T20:57:03+00:00"
+last_updated: "2026-09-09T11:52:35+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 ---

--- a/skills/work/sync-work-items/SKILL.md
+++ b/skills/work/sync-work-items/SKILL.md
@@ -68,7 +68,8 @@ Translate the user's arguments into `accelerator work sync`'s flags:
   **mutually exclusive**; passing both makes `work sync` exit **2** (usage) —
   surface that and stop. Omitting both means **bidirectional** (the default).
 - `--preview` — report the full set of intended changes (push, pull, conflict,
-  create-from-local, untracked-pull) **without** any local write or remote
+  create-from-local, untracked-pull, targeted-pull) **without** any local write
+  or remote
   mutation, and **without** touching the baseline. Combinable with a directional
   flag.
 - `--max-pulls N` / `--max-pushes N` — the blast-radius bounds (default **25**
@@ -83,26 +84,36 @@ Translate the user's arguments into `accelerator work sync`'s flags:
   `external_id` (the `id == external_id` case) — reconciles it silently, with
   **no note**. A token that is one file's local id **and** a *different* file's
   `external_id` is a genuine local/local collision and is an **exit-2** usage
-  error naming both files, not a silent win. Naming any target **suppresses
-  untracked-remote discovery**, so a targeted pull reaches only items already
-  tracked locally. Per-item behaviour is otherwise identical to a full sync.
+  error naming both files, not a silent win. A token with **no** local match is
+  looked up on the remote tracker by id: present, it is **pulled** into a new
+  local file and reconciled; provably absent, it is an exit-3 abort. Naming a
+  target still **suppresses the untracked-remote *search*** — a targeted pull
+  reaches a remote-only item by its named id, never by discovery. Per-item
+  behaviour is otherwise identical to a full sync.
 
   A target that fails to resolve aborts the run before any side effect, naming
   every offender, with zero writes. The abort exit codes and their recovery:
 
-  - **3** (`RESOLVE_NOT_FOUND`) — a token matched no local id, path, or
-    `external_id`. Offer `/list-work-items` to find the right value.
+  - **3** (`RESOLVE_NOT_FOUND`) — a token matched no local file *nor* a remote
+    issue. Note this now needs a reachable tracker to classify: a typo run
+    offline surfaces as exit 70 (unreachable) or 74 (unconfigured), not 3.
+    Offer `/list-work-items` to find the right value.
   - **6** (`RESOLVE_OUTSIDE_WORKDIR`) — a path outside the work directory. Offer
     `/list-work-items`.
   - **2** (`USAGE`) — a malformed token (empty or blank), an **ambiguous
-    match**, or a **local/local collision** (the token is one file's local id
-    and a *different* file's `external_id`). For an ambiguous match, mirror the
-    sibling resolve callers: list the candidates and ask the user to re-run with
-    a full id or a path. For a collision, the error names both files; re-run
-    with the path of the file you intended.
+    match**, a **local/local collision** (the token is one file's local id and a
+    *different* file's `external_id`), or a **remote-only target under
+    `--push-only`** (which cannot pull it; drop `--push-only` to import it). For
+    an ambiguous match, mirror the sibling resolve callers: list the candidates
+    and ask the user to re-run with a full id or a path. For a collision, the
+    error names both files; re-run with the path of the file you intended.
+  - **70** (`RETRYABLE`) — the remote lookup for a named target was
+    indeterminate (the tracker was unreachable). Re-run once the tracker is
+    reachable; a *targeted* exit-70 aborts before any write, so the re-run is a
+    clean retry, not a resume.
 
   When several classes coexist the run returns the highest-precedence code (2 >
-  6 > 3), but every offender is still named on stderr.
+  6 > 3 > 70), but every offender is still named on stderr.
 
 Example: `/sync-work-items --push-only --preview` previews only the
 local→remote pushes. `/sync-work-items --target 0257` reconciles only item
@@ -139,25 +150,32 @@ over-budget discovery is a refusal with guidance (exit 5), and an unset or
 unresolvable key is a pre-flight refusal (exit 74), neither a silent flood nor a
 silent skip. The report carries a `#\tdiscovery\t…` line saying whether the
 search **ran** (`found=N`), was **skipped** because the run was push-only, was
-**skipped** because the run named explicit `--target`s
-(`#\tdiscovery\tskipped\ttargeted`), or **failed** transiently — so a completed
-search that found nothing is never mistaken for a skip.
+**skipped** because the run named explicit `--target`s with nothing to pull by
+id (`#\tdiscovery\tskipped\ttargeted`), pulled **N** remote-only targets by id
+(`#\tdiscovery\ttargeted-pull\tN`, where N is the *requested* count), or
+**failed** transiently — so a completed search that found nothing is never
+mistaken for a skip.
 
 **The stdout report is authoritative.** Read it for `unresolved` lines
 regardless of exit code — a `71` run may also carry conflicts. Exit codes: `0`
 clean; `4` items await a human (unresolved conflicts, skipped-dirty pulls,
 remote-absent or indeterminate items); `5` refused (would exceed
 `--max-pulls`/`--max-pushes`, zero writes); `70` a read failed, a discovery
-search failed transiently, or every per-item failure was retryable; `71` a
-per-item failure was terminal (a whole-item update is idempotent, so the hazard
-is response uncertainty — never auto-retried); `72` tracker recognised but no
-client built; `73` `work.integration` unset or unrecognised; `74` wired but a
-run cannot proceed on its config — missing/refused credentials, or a
-non-push-only run whose discovery scope names no valid target (nothing sent;
-set the key or run `--push-only`). A `--target` that fails to resolve aborts
-before any side effect with `3` (no match), `6` (path outside the work
-directory), or `2` (malformed or ambiguous token) — see the target-abort codes
-under Step 1. Under `--preview` no baseline mutation occurs and every planned
+search failed transiently, a named target's remote lookup was indeterminate, or
+every per-item failure was retryable; `71` a per-item failure was terminal (a
+whole-item update is idempotent, so the hazard is response uncertainty — never
+auto-retried); `72` tracker recognised but no client built; `73`
+`work.integration` unset or unrecognised; `74` wired but a run cannot proceed on
+its config — missing/refused credentials, or a non-push-only run whose discovery
+scope names no valid target (nothing sent; set the key or run `--push-only`). A
+`--target` that fails to resolve aborts before any side effect with `3` (no
+local file *nor* remote issue), `6` (path outside the work directory), `2`
+(malformed, ambiguous, collision, or a remote-only target under `--push-only`),
+or `70` (a named target's remote lookup was indeterminate) — see the
+target-abort codes under Step 1. A *targeted* exit-70 aborts before any write,
+distinguishing it from an engine-level exit-70 that can follow partial writes,
+so the operator knows whether a re-run is a clean retry or a resume. Under
+`--preview` no baseline mutation occurs and every planned
 push carries a locally-validated payload check.
 
 ## Step 3: Conflict resolution (bidirectional only)
@@ -274,7 +292,8 @@ the engine's report:
 pushed:                <ids>
 pulled:                <ids>
 pushed-unsynced:       <ids>   (new external_id written back)
-pulled-untracked:      <ids>   (remote key → new local id)
+pulled-untracked:      <ids>   (remote key → new local id; includes a
+                                 targeted create-from-remote)
 conflicts-skipped:     <ids>
 overrides:             OVERRIDE <id> (<external_id>): pushed local→remote
 needs-retry:           <ids>
@@ -288,6 +307,13 @@ unchanged — do not reinterpret:
 
 - Targeted discovery (`#\tdiscovery\tskipped\ttargeted`): "Discovery skipped:
   targeted run over N item(s)".
+- Targeted pull (`#\tdiscovery\ttargeted-pull\tN`): "Targeted pull: requested N
+  remote-only item(s)" on apply, or "Targeted pull: would import N remote-only
+  item(s)" under `--preview`. N is the *requested* count — never "imported N".
+  The actual imports are the `pulled-untracked:` rows (one per created item), so
+  a partial-failure run shows "requested N" above a `pulled-untracked:` list of
+  the M ≤ N that succeeded, with the failures in their own item rows: two honest
+  numbers for two distinct concepts, never one overstated count.
 
 Under `--preview`, present the same plan (every push carrying its
 locally-validated payload check) and report every pull instead of writing it;

--- a/skills/work/sync-work-items/SKILL.md
+++ b/skills/work/sync-work-items/SKILL.md
@@ -78,12 +78,14 @@ Translate the user's arguments into `accelerator work sync`'s flags:
   reported conflict; repeatable. Used by the conflict loop below.
 - `--target <id|external-id|path>` — reconcile only the named work item(s);
   repeatable. A target may be a local id (`0257`), a remote tracker key /
-  `external_id` (`PP-787`), or a file path. On a token that is both a valid
-  local-id shape and a match for some `external_id`, the **local-id
-  interpretation wins** and the remote match is reported as suppressed. Naming
-  any target **suppresses untracked-remote discovery**, so a targeted pull
-  reaches only items already tracked locally. Per-item behaviour is otherwise
-  identical to a full sync.
+  `external_id` (`PP-787`), or a file path. A token that resolves to a single
+  local file — by path, by that file's local id, or by that file's own
+  `external_id` (the `id == external_id` case) — reconciles it silently, with
+  **no note**. A token that is one file's local id **and** a *different* file's
+  `external_id` is a genuine local/local collision and is an **exit-2** usage
+  error naming both files, not a silent win. Naming any target **suppresses
+  untracked-remote discovery**, so a targeted pull reaches only items already
+  tracked locally. Per-item behaviour is otherwise identical to a full sync.
 
   A target that fails to resolve aborts the run before any side effect, naming
   every offender, with zero writes. The abort exit codes and their recovery:
@@ -92,10 +94,12 @@ Translate the user's arguments into `accelerator work sync`'s flags:
     `external_id`. Offer `/list-work-items` to find the right value.
   - **6** (`RESOLVE_OUTSIDE_WORKDIR`) — a path outside the work directory. Offer
     `/list-work-items`.
-  - **2** (`USAGE`) — a malformed token (empty or blank) **or an ambiguous
-    match**. For an ambiguous match, mirror the sibling resolve callers: list
-    the candidates and ask the user to re-run with a full id or a path, rather
-    than treating it as a flat "malformed invocation".
+  - **2** (`USAGE`) — a malformed token (empty or blank), an **ambiguous
+    match**, or a **local/local collision** (the token is one file's local id
+    and a *different* file's `external_id`). For an ambiguous match, mirror the
+    sibling resolve callers: list the candidates and ask the user to re-run with
+    a full id or a path. For a collision, the error names both files; re-run
+    with the path of the file you intended.
 
   When several classes coexist the run returns the highest-precedence code (2 >
   6 > 3), but every offender is still named on stderr.
@@ -278,15 +282,12 @@ remote-absent:         <ids>
 unsynced (not pushed): <ids>   (declined)
 ```
 
-When the report carries the targeted discovery line or a suppressed-remote note,
-render them with exact human phrasing so the machine TSV tokens never leak
-verbatim, passing both through unchanged — do not reinterpret:
+When the report carries the targeted discovery line, render it with exact human
+phrasing so the machine TSV token never leaks verbatim, passing it through
+unchanged — do not reinterpret:
 
 - Targeted discovery (`#\tdiscovery\tskipped\ttargeted`): "Discovery skipped:
   targeted run over N item(s)".
-- Suppressed remote match (`#\ttarget\tsuppressed\t<token>\tlocal=<id>\tremote=<key>`):
-  "Suppressed remote match: <token> resolved to local <id>; remote <key>
-  ignored".
 
 Under `--preview`, present the same plan (every push carrying its
 locally-validated payload check) and report every pull instead of writing it;


### PR DESCRIPTION

# [0285] Targeted pull of remote-only work items and resolution normalisation

## Summary

`work sync --target <token>` now pulls a work item that exists only on the
remote tracker: a token with no local file is looked up by id and, if present,
created locally and reconciled — where it previously aborted with exit 3. The
same change makes targeted resolution deterministic per token, turning the
genuine local/local collision into a hard usage error and retiring the
suppressed-remote note.

## Changes

- **Remote-only pull.** A no-local-match `--target` token becomes a remote
  candidate rather than an abort. After credentials resolve, one
  `fetch_all(candidates)` gate partitions them: `found` ids are imported through
  the existing `create_from_remote` path, `absent` aborts exit 3 naming every
  absent token, `indeterminate` aborts exit 70.
- **Local/local collision is exit 2.** A token that is one file's local id and a
  *different* file's `external_id` now aborts as a usage error naming both files,
  decided from the local corpus with no remote call. The `Suppressed` machinery
  and its report line are removed; a token equal to a single file's own
  `external_id` reconciles silently.
- **Engine carries pull ids.** `ItemSelection::Targeted` gains a `pull_ids`
  slice, filtered against the corpus's canonical `external_id` set at the
  discovery branch and injected as the untracked set, so preview, pull
  accounting, and the watermark fold a targeted pull in exactly as a discovery
  import. A new `DiscoveryStatus::TargetedPull { attempted }` is emitted only for
  a non-empty set; an empty set keeps `SkippedTargeted`, leaving a reconcile-only
  targeted run's output unchanged.
- **Single-sourced exit precedence.** `absent`, `indeterminate`, and the
  `--push-only` remote-only contradiction join the local failures in one `rank`
  function, so precedence `2 > 6 > 3 > 70` holds from one authority across the
  pre-credential and post-credential gates. Locally-resolvable aborts stay
  credential-free.
- **State-directory fix.** On a never-synced integration the state directory did
  not exist, and the atomic-write containment check canonicalises it as the
  trusted root — so the first baseline write authored the file but failed to
  record its baseline. `run_sync` now creates the directory up-front.
- **Skill and docs.** `sync-work-items` is rewritten for the pull-create, the
  narrowed exit 3, exit 70, the `--push-only` remote-only usage error, and the
  `targeted-pull` discovery line. The work item, plan, and a `pass` validation
  report are included.

## Context

- Work item: `meta/work/0285-targeted-pull-of-remote-only-work-items.md`
- Plan: `meta/plans/2026-09-08-0285-targeted-pull-of-remote-only-work-items.md`
- Validation: `meta/validations/2026-09-08-0285-targeted-pull-of-remote-only-work-items-validation.md`
- Builds on the `--target` targeting introduced by work item 0257 (PR #107).

## Testing

- [x] Read-only aggregate clean: `mise run check` (exit 0)
- [x] Resolution, gate, and skill suite green: `cargo test -p accelerator-work`
- [x] Engine suite green: `cargo test -p work-adapters`
- [ ] Live remote-only pull against Linear creates and reconciles the file, and
      a second run does not re-pull it (manual — no stub for the live tracker)
- [ ] A typo'd `--target` reports exit 3 with zero writes against a live tracker
      (manual)

## Notes for Reviewers

- **Deliberate deviation from the plan.** A whole-call `fetch_all` `Err` maps to
  exit 70 (retryable) rather than the plan's three-way split: `TrackerError`
  carries no discriminant to separate an unembeddable-id from a transient fault,
  and a credential fault is already caught at `registry.resolve` (74). Recorded
  in the plan and covered by
  `a_whole_call_fetch_all_error_folds_to_indeterminate_exit_seventy`.
- **No live-tracker coverage in the suite.** The post-credential gate is
  exercised only through `run_sync` with a stub `TrackerRegistry` — the
  subprocess harness cannot inject one — so the two manual steps above are the
  sole check against real Linear/Jira. Focus there before merge.
- **Non-transactional per-id create loop.** A mid-batch `create_from_remote`
  failure leaves earlier creates written with valid baselines and is recoverable
  idempotently on re-run; the gate itself is all-or-nothing (any `absent` or
  `indeterminate` aborts before a write).
