### PR TITLE
[0184] Refuse template resolution on a wrong plugin root

### DIFF
--- a/cli/config-adapters/src/store.rs
+++ b/cli/config-adapters/src/store.rs
@@ -397,8 +397,7 @@ impl ReadTemplate for FileConfigStore {
                 warning,
             )?));
         }
-        let plugin = self.require_plugin_root()?;
-        let default = plugin.join("templates").join(format!("{name}.md"));
+        let default = self.plugin_template_path(name)?;
         if default.is_file() {
             return Ok(Some(self.resolved(
                 TemplateSource::PluginDefault,
@@ -489,10 +488,7 @@ impl FileConfigStore {
     }
 
     fn plugin_template_path(&self, name: &str) -> Result<PathBuf, ConfigError> {
-        Ok(self
-            .require_plugin_root()?
-            .join("templates")
-            .join(format!("{name}.md")))
+        Ok(self.require_templates_dir()?.join(format!("{name}.md")))
     }
 }
 
@@ -825,7 +821,8 @@ mod tests {
 
     use config::{
         ConfigAccess, ConfigError, ConfigService, Key, Level, Node,
-        ReadConfigLevel, ReadContent, ReadTemplate, Scalar, WriteConfigLevel,
+        ReadConfigLevel, ReadContent, ReadTemplate, Scalar, TemplateOverride,
+        TemplateSource, WriteConfigLevel,
     };
     use tempfile::TempDir;
 
@@ -1483,6 +1480,99 @@ mod tests {
         assert!(matches!(
             store.template_names(),
             Err(ConfigError::Io { .. })
+        ));
+        Ok(())
+    }
+
+    /// A plugin root carrying a `templates/` directory with the named default.
+    fn plugin_with_templates(names: &[&str]) -> Result<TempDir, TestError> {
+        let plugin = tempdir()?;
+        let templates = plugin.path().join("templates");
+        fs::create_dir_all(&templates)?;
+        for name in names {
+            fs::write(templates.join(format!("{name}.md")), "# default\n")?;
+        }
+        Ok(plugin)
+    }
+
+    #[test]
+    fn resolve_template_refuses_a_wrong_root_with_no_override(
+    ) -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.resolve_template("demo", None, ".accelerator/templates"),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_template_resolves_a_user_override_against_a_wrong_root(
+    ) -> Result<(), TestError> {
+        let root = tempdir()?;
+        let overrides = root.path().join(".accelerator/templates");
+        fs::create_dir_all(&overrides)?;
+        fs::write(overrides.join("demo.md"), "# Mine\n")?;
+        let plugin = tempdir()?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        let resolved = store
+            .resolve_template("demo", None, ".accelerator/templates")?
+            .ok_or("expected the user override to resolve")?;
+        assert!(matches!(resolved.source, TemplateSource::UserOverride));
+        assert_eq!(resolved.content, "# Mine\n");
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_template_reports_not_found_for_a_missing_default(
+    ) -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = plugin_with_templates(&["demo"])?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(store
+            .resolve_template("nonesuch", None, ".accelerator/templates")?
+            .is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn plugin_default_reports_not_found_for_a_missing_default(
+    ) -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = plugin_with_templates(&["demo"])?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(store.plugin_default("nonesuch")?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn plugin_default_refuses_a_wrong_root() -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.plugin_default("demo"),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn eject_refuses_a_wrong_root() -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.eject("demo", ".accelerator/templates", false, false),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
         ));
         Ok(())
     }

--- a/cli/config-adapters/src/store.rs
+++ b/cli/config-adapters/src/store.rs
@@ -1484,7 +1484,6 @@ mod tests {
         Ok(())
     }
 
-    /// A plugin root carrying a `templates/` directory with the named default.
     fn plugin_with_templates(names: &[&str]) -> Result<TempDir, TestError> {
         let plugin = tempdir()?;
         let templates = plugin.path().join("templates");

--- a/cli/config-adapters/src/store.rs
+++ b/cli/config-adapters/src/store.rs
@@ -410,10 +410,9 @@ impl ReadTemplate for FileConfigStore {
     }
 
     fn template_names(&self) -> Result<Vec<String>, ConfigError> {
-        let plugin = self.require_plugin_root()?;
-        let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
-            return Ok(Vec::new());
-        };
+        let templates = self.require_templates_dir()?;
+        let entries =
+            fs::read_dir(&templates).map_err(|e| io_error(&templates, &e))?;
         let mut files: Vec<String> = entries
             .filter_map(Result::ok)
             .map(|entry| entry.file_name().to_string_lossy().into_owned())
@@ -461,6 +460,32 @@ impl FileConfigStore {
             content,
             warning,
         })
+    }
+
+    /// The installation's `templates/` directory. A root whose `templates/`
+    /// is absent or not a directory — or a root that is itself a file — is not
+    /// an installation and refuses with `PluginRootNotAnInstallation`, resting
+    /// on the invariant that every installation ships `templates/`. A genuine
+    /// unreadable fault surfaces as the degradable `Io`.
+    fn require_templates_dir(&self) -> Result<PathBuf, ConfigError> {
+        let root = self.require_plugin_root()?;
+        let templates = root.join("templates");
+        let not_an_installation = || ConfigError::PluginRootNotAnInstallation {
+            path: display(root),
+        };
+        match fs::metadata(&templates) {
+            Ok(metadata) if metadata.is_dir() => Ok(templates),
+            Ok(_) => Err(not_an_installation()),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::NotFound | ErrorKind::NotADirectory
+                ) =>
+            {
+                Err(not_an_installation())
+            }
+            Err(error) => Err(io_error(&templates, &error)),
+        }
     }
 
     fn plugin_template_path(&self, name: &str) -> Result<PathBuf, ConfigError> {
@@ -800,7 +825,7 @@ mod tests {
 
     use config::{
         ConfigAccess, ConfigError, ConfigService, Key, Level, Node,
-        ReadConfigLevel, ReadContent, Scalar, WriteConfigLevel,
+        ReadConfigLevel, ReadContent, ReadTemplate, Scalar, WriteConfigLevel,
     };
     use tempfile::TempDir;
 
@@ -1395,6 +1420,68 @@ mod tests {
         let store = FileConfigStore::at(&root);
         assert!(matches!(
             store.skill_context("demo"),
+            Err(ConfigError::Io { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn template_names_refuses_a_root_without_a_templates_dir(
+    ) -> Result<(), TestError> {
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.template_names(),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn template_names_refuses_when_templates_is_a_file() -> Result<(), TestError>
+    {
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        fs::write(plugin.path().join("templates"), "not a dir")?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.template_names(),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn template_names_refuses_when_the_root_is_a_file() -> Result<(), TestError>
+    {
+        let root = tempdir()?;
+        let holder = tempdir()?;
+        let plugin_file = holder.path().join("not-a-dir");
+        fs::write(&plugin_file, "")?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin_file));
+        assert!(matches!(
+            store.template_names(),
+            Err(ConfigError::PluginRootNotAnInstallation { .. })
+        ));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn template_names_reports_io_on_an_unreadable_templates(
+    ) -> Result<(), TestError> {
+        use std::os::unix::fs::symlink;
+        let root = tempdir()?;
+        let plugin = tempdir()?;
+        symlink("templates", plugin.path().join("templates"))?;
+        let store = FileConfigStore::at(root.path())
+            .with_plugin_root(Some(plugin.path().to_path_buf()));
+        assert!(matches!(
+            store.template_names(),
             Err(ConfigError::Io { .. })
         ));
         Ok(())

--- a/cli/config/src/error.rs
+++ b/cli/config/src/error.rs
@@ -64,6 +64,9 @@ pub enum ConfigError {
     },
     LegacyLayout,
     PluginRootUnavailable,
+    PluginRootNotAnInstallation {
+        path: String,
+    },
 }
 
 impl ConfigError {
@@ -75,7 +78,9 @@ impl ConfigError {
     #[must_use]
     pub const fn is_refusal(&self) -> bool {
         match self {
-            Self::Invalid { .. } | Self::PluginRootUnavailable => true,
+            Self::Invalid { .. }
+            | Self::PluginRootUnavailable
+            | Self::PluginRootNotAnInstallation { .. } => true,
             Self::NotFound { .. }
             | Self::PathConflict { .. }
             | Self::MalformedFrontmatter { .. }
@@ -133,6 +138,12 @@ impl Display for ConfigError {
                 "the plugin installation root is unknown: set \
                  ACCELERATOR_PLUGIN_ROOT, or invoke accelerator through \
                  bin/accelerator, which derives it"
+            ),
+            Self::PluginRootNotAnInstallation { path } => write!(
+                formatter,
+                "the plugin root '{path}' is not an Accelerator \
+                 installation (no templates/ directory); check \
+                 ACCELERATOR_PLUGIN_ROOT"
             ),
         }
     }
@@ -253,8 +264,23 @@ mod tests {
     }
 
     #[test]
+    fn plugin_root_not_an_installation_names_the_path_and_variable() {
+        let rendered = ConfigError::PluginRootNotAnInstallation {
+            path: "/tmp/not-a-plugin".to_owned(),
+        }
+        .to_string();
+        assert!(rendered.contains("/tmp/not-a-plugin"));
+        assert!(rendered.contains("ACCELERATOR_PLUGIN_ROOT"));
+        assert!(!rendered.contains("unknown"));
+    }
+
+    #[test]
     fn a_missing_plugin_root_is_a_refusal_and_a_read_failure_is_not() {
         assert!(ConfigError::PluginRootUnavailable.is_refusal());
+        assert!(ConfigError::PluginRootNotAnInstallation {
+            path: "/tmp/not-a-plugin".to_owned(),
+        }
+        .is_refusal());
         assert!(!ConfigError::LegacyLayout.is_refusal());
         assert!(!ConfigError::Io {
             path: ".accelerator/config.md".to_owned(),

--- a/cli/config/tests/fixtures/public-api.txt
+++ b/cli/config/tests/fixtures/public-api.txt
@@ -37,6 +37,8 @@ pub config::error::ConfigError::PathConflict
 pub config::error::ConfigError::PathConflict::at: alloc::string::String
 pub config::error::ConfigError::PathConflict::existing: config::error::Existing
 pub config::error::ConfigError::PathConflict::key: config::key::Key
+pub config::error::ConfigError::PluginRootNotAnInstallation
+pub config::error::ConfigError::PluginRootNotAnInstallation::path: alloc::string::String
 pub config::error::ConfigError::PluginRootUnavailable
 pub config::error::ConfigError::UnsafePath
 pub config::error::ConfigError::UnsafePath::path: alloc::string::String
@@ -317,6 +319,8 @@ pub config::ConfigError::PathConflict
 pub config::ConfigError::PathConflict::at: alloc::string::String
 pub config::ConfigError::PathConflict::existing: config::error::Existing
 pub config::ConfigError::PathConflict::key: config::key::Key
+pub config::ConfigError::PluginRootNotAnInstallation
+pub config::ConfigError::PluginRootNotAnInstallation::path: alloc::string::String
 pub config::ConfigError::PluginRootUnavailable
 pub config::ConfigError::UnsafePath
 pub config::ConfigError::UnsafePath::path: alloc::string::String

--- a/cli/launcher/tests/config_read.rs
+++ b/cli/launcher/tests/config_read.rs
@@ -1287,6 +1287,30 @@ fn assert_refuses_without_a_plugin_root(output: &Output) {
     assert_names_the_plugin_root(output);
 }
 
+/// The wrong-root refusal signature: non-zero, empty stdout, and a diagnostic
+/// naming the offending root, its not-an-installation cause, and the variable.
+fn assert_refuses_as_not_an_installation(output: &Output, root: &Path) {
+    assert_ne!(code(output), 0);
+    assert!(
+        output.stdout.is_empty(),
+        "stdout was not empty: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "stderr does not name the variable: {stderr}"
+    );
+    assert!(
+        stderr.contains(&root.display().to_string()),
+        "stderr does not name the offending root: {stderr}"
+    );
+    assert!(
+        stderr.contains("not an Accelerator installation"),
+        "stderr does not name the not-an-installation cause: {stderr}"
+    );
+}
+
 #[test]
 fn templates_list_with_no_plugin_root_is_a_named_refusal_not_an_empty_table(
 ) -> TestResult {
@@ -1367,12 +1391,10 @@ fn a_user_override_still_resolves_with_no_plugin_root() -> TestResult {
     Ok(())
 }
 
-/// A root that is set but is not an installation still succeeds-with-nothing:
-/// `template_names` swallows the failed `read_dir`. Deliberate residue, tracked
-/// as its own work item rather than folded in here.
+/// AC9, the inverse of AC1: a root that is set but ships no `templates/` is not
+/// an installation, so enumeration refuses rather than rendering an empty table.
 #[test]
-fn a_root_without_a_templates_directory_still_renders_an_empty_table(
-) -> TestResult {
+fn a_root_without_a_templates_directory_refuses_to_list() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
     let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
     let output = run_with_plugin_root(
@@ -1380,11 +1402,133 @@ fn a_root_without_a_templates_directory_still_renders_an_empty_table(
         bare.path().as_os_str(),
         &["config", "templates", "list"],
     )?;
-    assert_eq!(
-        output.stdout,
-        b"| Template | Source | Path |\n|----------|--------|------|\n"
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    Ok(())
+}
+
+/// The dedicated variant's payoff: the wrong-root diagnostic names the offending
+/// path and differs from the absent-root diagnostic, which names neither.
+#[test]
+fn a_wrong_root_diagnostic_differs_from_the_absent_root_diagnostic(
+) -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let wrong = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    let absent = run_in(&fixture.root, &["config", "templates", "list"])?;
+
+    assert_ne!(code(&wrong), 0);
+    assert_ne!(code(&absent), 0);
+    let wrong_stderr = String::from_utf8_lossy(&wrong.stderr);
+    let absent_stderr = String::from_utf8_lossy(&absent.stderr);
+    assert_ne!(wrong_stderr, absent_stderr);
+    let root_path = bare.path().display().to_string();
+    assert!(
+        wrong_stderr.contains(&root_path),
+        "the wrong-root diagnostic does not name the root: {wrong_stderr}"
     );
+    assert!(
+        !absent_stderr.contains(&root_path),
+        "the absent-root diagnostic named the root: {absent_stderr}"
+    );
+    Ok(())
+}
+
+/// AC4: `eject --all` against a wrong root refuses and writes no override tree.
+#[test]
+fn templates_eject_all_against_a_wrong_root_refuses() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "eject", "--all"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    assert!(
+        !fixture.root.join(".accelerator/templates").exists(),
+        "eject --all created the override directory against a wrong root"
+    );
+    Ok(())
+}
+
+/// AC8-revised: a `templates` that is a file is a structural wrong-root shape and
+/// fails closed as not-an-installation, not as a genuine I/O fault.
+#[test]
+fn a_wrong_root_with_a_templates_file_refuses() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    fs::write(bare.path().join("templates"), "not a dir")?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    Ok(())
+}
+
+/// A plugin root that is itself a regular file refuses naming the root.
+#[test]
+fn a_root_that_is_a_file_refuses() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let holder = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let root_file = holder.path().join("not-a-dir");
+    fs::write(&root_file, "")?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        root_file.as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, &root_file);
+    Ok(())
+}
+
+/// AC8-revised, the `Io` arm: a genuine unreadable fault stays a degradable
+/// `Io` diagnostic distinct from the structural refusal — it does not name the
+/// variable.
+#[cfg(unix)]
+#[test]
+fn a_genuine_io_fault_is_not_the_refusal() -> TestResult {
+    use std::os::unix::fs::symlink;
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    symlink("templates", bare.path().join("templates"))?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    assert_ne!(code(&output), 0);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("I/O error"),
+        "stderr does not name the I/O fault: {stderr}"
+    );
+    assert!(
+        !stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "a genuine I/O fault named the variable: {stderr}"
+    );
+    Ok(())
+}
+
+/// AC11: a root-independent family succeeds under a wrong root, and `--fail-safe`
+/// forces the proof that it genuinely succeeded rather than degraded to empty.
+#[test]
+fn a_root_independent_family_still_succeeds_against_a_wrong_root() -> TestResult
+{
+    let workspace = workspace("summary")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &workspace,
+        bare.path().as_os_str(),
+        &["config", "paths", "--fail-safe"],
+    )?;
     assert_eq!(code(&output), 0);
+    assert!(!output.stdout.is_empty(), "config paths printed nothing");
     Ok(())
 }
 

--- a/cli/launcher/tests/config_read.rs
+++ b/cli/launcher/tests/config_read.rs
@@ -1391,8 +1391,6 @@ fn a_user_override_still_resolves_with_no_plugin_root() -> TestResult {
     Ok(())
 }
 
-/// AC9, the inverse of AC1: a root that is set but ships no `templates/` is not
-/// an installation, so enumeration refuses rather than rendering an empty table.
 #[test]
 fn a_root_without_a_templates_directory_refuses_to_list() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1406,8 +1404,6 @@ fn a_root_without_a_templates_directory_refuses_to_list() -> TestResult {
     Ok(())
 }
 
-/// The dedicated variant's payoff: the wrong-root diagnostic names the offending
-/// path and differs from the absent-root diagnostic, which names neither.
 #[test]
 fn a_wrong_root_diagnostic_differs_from_the_absent_root_diagnostic(
 ) -> TestResult {
@@ -1437,7 +1433,6 @@ fn a_wrong_root_diagnostic_differs_from_the_absent_root_diagnostic(
     Ok(())
 }
 
-/// AC4: `eject --all` against a wrong root refuses and writes no override tree.
 #[test]
 fn templates_eject_all_against_a_wrong_root_refuses() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1455,8 +1450,6 @@ fn templates_eject_all_against_a_wrong_root_refuses() -> TestResult {
     Ok(())
 }
 
-/// AC8-revised: a `templates` that is a file is a structural wrong-root shape and
-/// fails closed as not-an-installation, not as a genuine I/O fault.
 #[test]
 fn a_wrong_root_with_a_templates_file_refuses() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1471,7 +1464,6 @@ fn a_wrong_root_with_a_templates_file_refuses() -> TestResult {
     Ok(())
 }
 
-/// A plugin root that is itself a regular file refuses naming the root.
 #[test]
 fn a_root_that_is_a_file_refuses() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1487,9 +1479,6 @@ fn a_root_that_is_a_file_refuses() -> TestResult {
     Ok(())
 }
 
-/// AC8-revised, the `Io` arm: a genuine unreadable fault stays a degradable
-/// `Io` diagnostic distinct from the structural refusal — it does not name the
-/// variable.
 #[cfg(unix)]
 #[test]
 fn a_genuine_io_fault_is_not_the_refusal() -> TestResult {
@@ -1515,8 +1504,8 @@ fn a_genuine_io_fault_is_not_the_refusal() -> TestResult {
     Ok(())
 }
 
-/// AC11: a root-independent family succeeds under a wrong root, and `--fail-safe`
-/// forces the proof that it genuinely succeeded rather than degraded to empty.
+/// `--fail-safe` is deliberate: it forces the proof that the family genuinely
+/// succeeded rather than degraded to exit-0 empty output.
 #[test]
 fn a_root_independent_family_still_succeeds_against_a_wrong_root() -> TestResult
 {
@@ -1532,7 +1521,6 @@ fn a_root_independent_family_still_succeeds_against_a_wrong_root() -> TestResult
     Ok(())
 }
 
-/// AC2: `template <name>` against a wrong root with no override refuses.
 #[test]
 fn template_against_a_wrong_root_refuses() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1546,8 +1534,6 @@ fn template_against_a_wrong_root_refuses() -> TestResult {
     Ok(())
 }
 
-/// AC7: a valid installation missing one template reports a template-not-found
-/// naming the template, not the plugin root.
 #[test]
 fn template_not_found_names_the_template_not_the_plugin_root() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1564,8 +1550,6 @@ fn template_not_found_names_the_template_not_the_plugin_root() -> TestResult {
     Ok(())
 }
 
-/// AC3: `templates eject <name>` against a wrong root refuses as
-/// not-an-installation rather than degrading to a `NoDefault` outcome.
 #[test]
 fn eject_against_a_wrong_root_refuses() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1579,8 +1563,6 @@ fn eject_against_a_wrong_root_refuses() -> TestResult {
     Ok(())
 }
 
-/// AC5: `templates diff` and `reset` against a wrong root each refuse as
-/// not-an-installation.
 #[test]
 fn diff_and_reset_against_a_wrong_root_refuse() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
@@ -1599,8 +1581,8 @@ fn diff_and_reset_against_a_wrong_root_refuse() -> TestResult {
     Ok(())
 }
 
-/// AC10: a resolving user override renders at exit 0 under a wrong root, since
-/// the override tiers precede the plugin-default check.
+/// A resolving user override renders under a wrong root because the override
+/// tiers are checked before the plugin-default tier reaches the root.
 #[test]
 fn a_user_override_resolves_against_a_wrong_root() -> TestResult {
     let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;

--- a/cli/launcher/tests/config_read.rs
+++ b/cli/launcher/tests/config_read.rs
@@ -1532,6 +1532,94 @@ fn a_root_independent_family_still_succeeds_against_a_wrong_root() -> TestResult
     Ok(())
 }
 
+/// AC2: `template <name>` against a wrong root with no override refuses.
+#[test]
+fn template_against_a_wrong_root_refuses() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "template", "demo"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    Ok(())
+}
+
+/// AC7: a valid installation missing one template reports a template-not-found
+/// naming the template, not the plugin root.
+#[test]
+fn template_not_found_names_the_template_not_the_plugin_root() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let output =
+        run_with_plugin(&fixture.root, &["config", "template", "nonesuch"])?;
+    assert_ne!(code(&output), 0);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not found"), "{stderr}");
+    assert!(stderr.contains("nonesuch"), "{stderr}");
+    assert!(
+        !stderr.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "the not-found diagnostic named the plugin root: {stderr}"
+    );
+    Ok(())
+}
+
+/// AC3: `templates eject <name>` against a wrong root refuses as
+/// not-an-installation rather than degrading to a `NoDefault` outcome.
+#[test]
+fn eject_against_a_wrong_root_refuses() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "eject", "demo"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    Ok(())
+}
+
+/// AC5: `templates diff` and `reset` against a wrong root each refuse as
+/// not-an-installation.
+#[test]
+fn diff_and_reset_against_a_wrong_root_refuse() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    for args in [
+        vec!["config", "templates", "diff", "demo"],
+        vec!["config", "templates", "reset", "demo"],
+    ] {
+        let output = run_with_plugin_root(
+            &fixture.root,
+            bare.path().as_os_str(),
+            &args,
+        )?;
+        assert_refuses_as_not_an_installation(&output, bare.path());
+    }
+    Ok(())
+}
+
+/// AC10: a resolving user override renders at exit 0 under a wrong root, since
+/// the override tiers precede the plugin-default check.
+#[test]
+fn a_user_override_resolves_against_a_wrong_root() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    fs::create_dir_all(fixture.root.join(".accelerator/templates"))?;
+    fs::write(
+        fixture.root.join(".accelerator/templates/demo.md"),
+        "# Mine\n",
+    )?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "template", "demo"],
+    )?;
+    assert_eq!(output.stdout, b"```markdown\n# Mine\n```\n");
+    assert_eq!(code(&output), 0);
+    Ok(())
+}
+
 #[test]
 fn the_root_independent_families_still_succeed_with_no_plugin_root(
 ) -> TestResult {

--- a/cli/visualiser/server/tests/compose_contract.rs
+++ b/cli/visualiser/server/tests/compose_contract.rs
@@ -201,3 +201,34 @@ fn an_empty_plugin_root_refuses_to_compose() {
         "the error does not name the variable: {error}"
     );
 }
+
+/// A present-but-wrong plugin root — a real directory carrying no `templates/` —
+/// refuses to compose rather than resolving an empty template set, naming the
+/// offending root and its not-an-installation cause.
+#[test]
+fn a_wrong_plugin_root_refuses_to_compose() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_project(tmp.path());
+    let bare = tempfile::tempdir().unwrap();
+    let error = load(Params {
+        cwd: tmp.path().to_path_buf(),
+        plugin_root: bare.path().to_path_buf(),
+        owner_pid: 0,
+        owner_start_time: None,
+        host: "127.0.0.1".to_string(),
+    })
+    .expect_err("a wrong plugin root composed a config");
+    let message = error.to_string();
+    assert!(
+        message.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "the error does not name the variable: {error}"
+    );
+    assert!(
+        message.contains("not an Accelerator installation"),
+        "the error does not name the wrong-root cause: {error}"
+    );
+    assert!(
+        message.contains(&bare.path().display().to_string()),
+        "the error does not name the offending root: {error}"
+    );
+}

--- a/cli/visualiser/server/tests/compose_contract.rs
+++ b/cli/visualiser/server/tests/compose_contract.rs
@@ -202,9 +202,8 @@ fn an_empty_plugin_root_refuses_to_compose() {
     );
 }
 
-/// A present-but-wrong plugin root — a real directory carrying no `templates/` —
-/// refuses to compose rather than resolving an empty template set, naming the
-/// offending root and its not-an-installation cause.
+/// A present-but-wrong plugin root — a real directory with no `templates/` —
+/// refuses at the compose boundary rather than resolving an empty template set.
 #[test]
 fn a_wrong_plugin_root_refuses_to_compose() {
     let tmp = tempfile::tempdir().unwrap();

--- a/cli/visualiser/server/tests/shutdown.rs
+++ b/cli/visualiser/server/tests/shutdown.rs
@@ -4,11 +4,14 @@ use std::time::Duration;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
 
-/// Seed a minimal Model-1 project and return its visualiser state dir.
+/// Seed a minimal Model-1 project and return its visualiser state dir. The
+/// project doubles as the plugin root, so it must carry a `templates/`
+/// directory for compose to accept it as an installation.
 fn seed_project(project: &Path) -> PathBuf {
     std::fs::create_dir_all(project.join(".accelerator")).unwrap();
     std::fs::write(project.join(".accelerator/config.md"), "---\n---\n")
         .unwrap();
+    std::fs::create_dir_all(project.join("templates")).unwrap();
     project.join(".accelerator/tmp/visualiser")
 }
 

--- a/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
@@ -554,16 +554,16 @@ first, per the module idiom):
 
 #### Automated Verification
 
-- [ ] Store unit tests pass: `cargo test -p config-adapters`
-- [ ] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
-- [ ] Format + lint clean: `mise run cli:check`
+- [x] Store unit tests pass: `cargo test -p config-adapters`
+- [x] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
+- [x] Format + lint clean: `mise run cli:check`
 
 #### Manual Verification
 
-- [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config template plan`
+- [x] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config template plan`
       refuses naming the root path and `ACCELERATOR_PLUGIN_ROOT`, distinct from the
       absent-root message.
-- [ ] Against the real plugin root, `config template not-a-real-template` still
+- [x] Against the real plugin root, `config template not-a-real-template` still
       reports a template-not-found naming the template, with no mention of the
       plugin root.
 

--- a/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
@@ -623,13 +623,15 @@ fn a_wrong_plugin_root_refuses_to_compose() {
 
 #### Automated Verification
 
-- [ ] Compose contract tests pass: `cargo test -p accelerator-visualiser --test compose_contract`
-- [ ] Format + lint clean: `mise run cli:check`
-- [ ] Full local CI mirror is green: `mise run` (AC12)
+- [x] Compose contract tests pass: `cargo test -p accelerator-visualiser --test compose_contract`
+- [x] Format + lint clean: `mise run cli:check`
+- [ ] Full local CI mirror is green: `mise run` (AC12) — every lane green except
+      the pre-existing `docs:audit:check`, which fails on unrelated `docs-site/`
+      npm advisories (js-yaml, sharp, smol-toml, svgo); out of scope here.
 
 #### Manual Verification
 
-- [ ] Building the server against a wrong root fails composition rather than
+- [x] Building the server against a wrong root fails composition rather than
       serving an empty template set (the boundary test is the durable evidence;
       `run_serve` guards the env var before compose, so the running server does
       not reach this diagnostic on the absent-var path).

--- a/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
@@ -1,0 +1,707 @@
+---
+type: "plan"
+id: "2026-09-09-0184-template-resolution-wrong-plugin-root"
+title: "Template Resolution Wrong-Root Refusal Implementation Plan"
+date: "2026-09-09T07:15:11+00:00"
+author: "Toby Clemson"
+producer: "create-plan"
+status: "ready"
+work_item_id: "work-item:0184"
+parent: "work-item:0184"
+derived_from: ["codebase-research:2026-09-08-0184-template-resolution-wrong-plugin-root"]
+tags: ["cli", "config", "templates", "plugin-root", "visualiser"]
+revision: "48a9f5347c558bb678beff1be719c6d99d661b82"
+repository: "accelerator"
+last_updated: "2026-09-09T16:29:30+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# Template Resolution Wrong-Root Refusal Implementation Plan
+
+## Overview
+
+Extend 0182's *absent*-root refusal to the *wrong*-root case — a present plugin
+root that carries no `templates/` directory, so it is not an Accelerator
+installation — across the three plugin-root template accessors in
+`FileConfigStore`. Today those accessors pass the `require_plugin_root` gate on a
+wrong root (it is `Some(path)`) and fall through their own filesystem checks into
+a silent empty answer or a false template-not-found. After this change every
+structural wrong-root shape — no `templates/`, a `templates` that is a file, or a
+root that is itself a file — makes all six template commands and the visualiser
+compose path refuse with a dedicated `ConfigError::PluginRootNotAnInstallation`
+diagnostic that names the offending root and the invalid `templates/` layout (and
+`ACCELERATOR_PLUGIN_ROOT`), while a genuine missing template inside a valid
+installation, resolving user overrides, and the root-independent config families
+all keep working unchanged. A distinct
+variant — rather than reusing `PluginRootUnavailable`, whose message says the root
+is *unknown* and to *set* the variable — is what lets the wrong-root diagnostic
+tell a developer who already set the variable that their root simply is not an
+installation, and name which path.
+
+## Current State Analysis
+
+`require_plugin_root` (`cli/config-adapters/src/store.rs:73`) is the only gate
+raising `ConfigError::PluginRootUnavailable`, and it fires solely on an *absent*
+root. A present-but-wrong root reaches each accessor's own check:
+
+| Accessor | Site | Wrong-root behaviour today |
+|----------|------|----------------------------|
+| `template_names` | `store.rs:412` | `let Ok(entries) = read_dir(..) else { Ok(Vec::new()) }` swallows every error |
+| `resolve_template` plugin-default tier | `store.rs:400` | `<name>.md` not a file → `Ok(None)` (names no template) |
+| `plugin_template_path` | `store.rs:466` | builds the path, tests nothing |
+| `plugin_default` | `store.rs:436` | routes through `plugin_template_path`, then `is_file()` → `Ok(None)` |
+| `eject` | `store.rs:483` | routes through `plugin_template_path`, then `is_file()` → `EjectOutcome::NoDefault` |
+
+Each maps to an observable command, all exiting **1** today (a refusal becomes
+`kernel::Error::Failed` → `ExitCode::FAILURE`; a wrong root instead degrades the
+diagnosis). `PluginRootNotAnInstallation` maps through the same `From<ConfigError>`
+arm, so the new refusal also exits **1**:
+
+| Command | Store site | Wrong-root outcome today |
+|---------|------------|--------------------------|
+| `config templates list` | `template_names` | empty table, exit 0 |
+| `config templates eject --all` | `eject_all` → `template_names` | ejects nothing, exit 0 |
+| `config template <name>` | `resolve_template` tier | `Ok(None)` → not-found |
+| `config templates eject <name>` | `eject` → `plugin_template_path` | `EjectOutcome::NoDefault` |
+| `config templates diff` / `reset <name>` | `plugin_default` → `plugin_template_path` | `Ok(None)` → unknown-template |
+| visualiser compose | `resolve_templates` → `template_names` | empty template set |
+
+`template_names` is also consumed by the visualiser server compose path:
+`resolve_templates` loops `store.template_names()?` (`cli/visualiser/server/src/compose.rs:157`)
+and `ComposeError::Config(#[from] ConfigError)` (`compose.rs:20`) re-emits the
+wrapped message verbatim through `#[error("configuration error: {0}")]`.
+
+## Desired End State
+
+On a structural wrong root (no `templates/`, `templates` a file, or a root that is
+a file), every template command and the compose path refuses:
+
+- `config templates list`, `template <name>` (no resolving override), `eject`,
+  `eject --all`, `diff`, `reset` each exit non-zero with the
+  `PluginRootNotAnInstallation` diagnostic — naming the offending root, the
+  invalid `templates/` layout, and `ACCELERATOR_PLUGIN_ROOT` — even under
+  `--fail-safe`.
+- `compose::load` returns `Err(ComposeError)` whose message names the offending
+  root and `ACCELERATOR_PLUGIN_ROOT` rather than composing an empty template set.
+
+The distinctions that must survive:
+
+- The wrong-root message **differs** from the absent-root message: it names the
+  offending path and states the root is not an installation, rather than saying
+  the root is *unknown* and to *set* the variable.
+- A valid installation missing one `<name>.md` still reports a template-not-found
+  naming `<name>`, **not** the plugin root.
+- A resolving user override for `<name>` still renders at exit 0 under a wrong
+  root (the override tiers precede the plugin-default check).
+- Root-independent families (`config paths`, `config summary`, …) still exit 0
+  with their normal non-empty output, **including under `--fail-safe`**.
+- A genuine *unreadable* fault (permission denied, filesystem loop) yields
+  `ConfigError::Io` naming the path, stays degradable, and does **not** name
+  `ACCELERATOR_PLUGIN_ROOT` — the one wrong-root shape that does not fail closed,
+  because the root's validity is genuinely undeterminable.
+
+This refines the work item's **AC8**. As written, AC8 treats a `templates` path
+that is a file as the representative *genuine I/O fault* (→ `Io`); under this plan
+that shape is a structural refusal, and `Io` is reserved for a genuinely
+unreadable fault (permission, filesystem loop). AC8 and its trigger example should
+be updated in `meta/work/0184-…` to match, and a criterion added for the two extra
+structural shapes (`templates` a file, root a file) refusing — a work-item
+follow-up, not done in this plan.
+
+### Key Discoveries
+
+- `plugin_template_path` (`store.rs:466`) already returns `Result<PathBuf,
+  ConfigError>` and is the single choke both `plugin_default` (`:436`) and `eject`
+  (`:483`) route through — fixing it there fixes both callers at once.
+- The plugin-default check must sit **inside** each plugin-default step, after the
+  override tiers miss: `resolve_template` checks the config-path and user-override
+  tiers first (`store.rs:374-399`), and hoisting the root check above them would
+  refuse a resolving override. Pinned by `a_user_override_still_resolves_with_no_plugin_root`
+  (`cli/launcher/tests/config_read.rs:1356`).
+- The `NotFound`-vs-`Io` split to mirror already exists in `custom_lenses`
+  (`store.rs:296`) and `skill_names` (`store.rs:322`), constructing `Io` via the
+  `io_error` helper (`store.rs:729`). This item's divergence: `NotFound` maps to
+  `PluginRootNotAnInstallation`, not an empty list — resting on the
+  installation-ships-`templates/` invariant, not sibling parity.
+- `PluginRootUnavailable.is_refusal()` is `true` (`cli/config/src/error.rs:78`),
+  so `Failure::from` tags it `Failure::Refusal` (`cli.rs:424`) and `finish`'s
+  degrade arm — which matches `Failure::Read` only (`cli.rs:463`) — never absorbs
+  it. Behaviour is byte-identical with and without `--fail-safe`.
+  `PluginRootNotAnInstallation` is classified `is_refusal() == true` alongside it,
+  so it fails closed identically. `is_refusal` is exhaustive inside the config
+  crate (no wildcard, `error.rs:76-88`), so adding the variant does not compile
+  until it is classified — the classification cannot be defaulted by omission.
+- R3 needs **no production change**: the `?` at `compose.rs:157` already
+  propagates the refusal with its message intact. AC6 is a test, and it passes
+  only once R1 lands (today a wrong root composes successfully with an empty map).
+- The packaging invariant holds for the git-tag distribution model: 13 templates
+  are tracked under `templates/` and ride along with the checkout; nothing filters
+  them out of the release artifact.
+- Test scaffolding to reuse (`config_read.rs`): `run_with_plugin_root` (`:1226`,
+  sets the var to any root — the wrong-root invoker), `run_with_plugin` (`:1219`,
+  the committed valid fixture at `tests/fixtures/plugin/templates/{demo,other}.md`),
+  `run_in` (`:71`, strips the var), `assert_refuses_without_a_plugin_root`
+  (`:1280`), `assert_names_the_plugin_root` (`:1270`). The characterisation test
+  to replace is `a_root_without_a_templates_directory_still_renders_an_empty_table`
+  (`:1373`).
+
+## What We're NOT Doing
+
+- Detecting a mis-pointed root that happens to retain an unrelated `templates/`
+  directory — indistinguishable from a valid installation by this signal, out of
+  scope.
+- Touching `known_skill_names` (`store.rs:338`) — deliberately left tolerant by
+  0182; not a template accessor.
+- Changing the root-independent config families — they never read the plugin root
+  and must stay unaffected (R4).
+- The visualiser frontend's surface-level handling of the propagated
+  `ComposeError` — downstream of the server boundary, out of scope.
+- `cli/visualiser/server/src/templates.rs` (`TemplateResolver`) — a downstream
+  renderer of the already-composed map, its `plugin_root` display-only; not a
+  store consumer.
+- Consolidating the `<plugin-root>/templates` **layout** fact, which
+  `compose.rs:155` still reconstructs with `plugin_root.join("templates")` to build
+  each tier's absolute `plugin_default` path. The validity *gate* is centralised
+  (compose refuses via `store.template_names()?`); relocating the per-name path
+  construction behind a store accessor is a wider refactor of the compose tier
+  build, deliberately out of scope here. The residual duplication is a conscious
+  choice, not an oversight.
+- Generalising `require_templates_dir` into a resource-agnostic
+  `require_installation_root()` predicate. Only `templates/` presence is the
+  installation signal today and there is no second consumer; the helper stays
+  templates-specific (YAGNI) rather than speculatively abstracted.
+- Renaming the helper away from the `require_*` gate family. `require_templates_dir`
+  reads as a path accessor but can refuse; the name is kept for consistency with
+  `require_plugin_root` / `require_secure_personal_file`, and the doc comment
+  states the refusal.
+
+## Implementation Approach
+
+A dedicated error variant, `ConfigError::PluginRootNotAnInstallation { path }`,
+carries the wrong-root refusal, and one shared installation-detection helper —
+`require_templates_dir` — validates the `templates/` directory, raises that
+variant on any structurally-invalid `templates/`, and returns the directory's
+path; all three accessors call it. The helper probes with `fs::metadata` (a
+single `stat`), so the plugin-default sites pay one `stat` and `template_names`
+pays `stat` + `read_dir`; the structural shapes (missing, a file, root-is-a-file)
+are each explicit. The three phases are strictly ordered but each is
+independently mergeable and leaves the tree green. Every phase drives the store
+change from a failing test first: unit tests on `FileConfigStore` for the tight
+red-green loop, CLI integration tests in `config_read.rs` to pin the observable
+acceptance criteria, and a compose contract test for the server boundary.
+
+The new variant is added to `ConfigError` in `cli/config/src/error.rs` — a
+struct-like variant `PluginRootNotAnInstallation { path: String }`, a `Display`
+arm naming the path and the missing-`templates/` cause, and a `true` arm in
+`is_refusal` (which is exhaustive, so the classification is forced):
+
+```rust
+Self::PluginRootNotAnInstallation { path } => write!(
+    formatter,
+    "the plugin root '{path}' is not an Accelerator \
+     installation (no templates/ directory); check \
+     ACCELERATOR_PLUGIN_ROOT"
+),
+```
+
+The shared helper, added to a `FileConfigStore` impl block near
+`plugin_template_path`:
+
+```rust
+/// The installation's `templates/` directory. A root whose `templates/`
+/// is absent or not a directory — or a root that is itself a file — is
+/// not an installation and refuses with `PluginRootNotAnInstallation`,
+/// resting on the invariant that every installation ships `templates/`.
+/// A genuine unreadable fault surfaces as the degradable `Io`.
+fn require_templates_dir(&self) -> Result<PathBuf, ConfigError> {
+    let root = self.require_plugin_root()?;
+    let templates = root.join("templates");
+    let not_an_installation = || ConfigError::PluginRootNotAnInstallation {
+        path: display(root),
+    };
+    match fs::metadata(&templates) {
+        Ok(metadata) if metadata.is_dir() => Ok(templates),
+        Ok(_) => Err(not_an_installation()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::NotFound | ErrorKind::NotADirectory
+            ) =>
+        {
+            Err(not_an_installation())
+        }
+        Err(error) => Err(io_error(&templates, &error)),
+    }
+}
+```
+
+Every *structural* wrong-root shape refuses and fails closed under `--fail-safe`:
+`templates/` missing (`NotFound`), `templates` present but a file (`Ok(!is_dir)`),
+and a root that is itself a file (`NotADirectory` on the join). `Io` is reserved
+for a genuine *unreadable* fault — a permission error or a filesystem loop — where
+the root's validity is genuinely undeterminable; only that case stays degradable.
+`ErrorKind::NotADirectory` is stable on the pinned toolchain (Rust 1.90);
+`NotFound` and `NotADirectory` collapse to one refusal arm.
+
+## Phase 1: `template_names` refuses on a wrong root (R1)
+
+### Overview
+
+Introduce the `PluginRootNotAnInstallation` variant and `require_templates_dir`,
+and route `template_names` through the helper, so enumeration refuses on a wrong
+root instead of swallowing the failed `read_dir`. This alone fixes `config
+templates list` and `config templates eject --all`.
+
+### Changes Required
+
+#### 1. The error variant
+
+**File**: `cli/config/src/error.rs`
+**Changes**: Add the struct-like variant `PluginRootNotAnInstallation { path:
+String }` to `ConfigError`, its `Display` arm (above), and a `true` arm in
+`is_refusal` alongside `PluginRootUnavailable`. `is_refusal` is exhaustive, so the
+crate does not compile until the variant is classified.
+
+#### 2. The shared helper and `template_names`
+
+**File**: `cli/config-adapters/src/store.rs`
+**Changes**: Add `require_templates_dir` (above). Replace `template_names`' swallow
+with a call to it, then map any enumeration error to `Io`:
+
+```rust
+fn template_names(&self) -> Result<Vec<String>, ConfigError> {
+    let templates = self.require_templates_dir()?;
+    let entries = fs::read_dir(&templates)
+        .map_err(|e| io_error(&templates, &e))?;
+    let mut files: Vec<String> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| {
+            Path::new(name).extension().and_then(|e| e.to_str()) == Some("md")
+        })
+        .collect();
+    files.sort();
+    Ok(files
+        .into_iter()
+        .filter_map(|name| name.strip_suffix(".md").map(str::to_owned))
+        .collect())
+}
+```
+
+The `stat`-then-`read_dir` pair is a deliberate double probe. The helper
+establishes not-an-installation — a persistent condition — via `metadata`; a
+`read_dir` failure *after* a confirmed directory is a transient concurrent-mutation
+fault, so mapping every such error (including a racing `NotFound`) to `Io`
+(degradable) is correct: a directory that vanishes mid-enumeration degrades under
+`--fail-safe` rather than being misreported as not-an-installation.
+
+#### 3. Error-variant unit tests (red first)
+
+**File**: `cli/config/src/error.rs` (test module)
+**Changes**: Mirror `plugin_root_unavailable_names_the_variable_and_the_bootstrap`
+and the refusal-classification test for the new variant:
+
+- `plugin_root_not_an_installation_names_the_path_and_variable`: assert the
+  rendered message contains the path passed in and `ACCELERATOR_PLUGIN_ROOT`, and
+  does **not** contain "unknown".
+- Extend `a_missing_plugin_root_is_a_refusal_and_a_read_failure_is_not` to assert
+  `PluginRootNotAnInstallation { .. }.is_refusal()` is `true`.
+
+#### 4. Store unit tests (red first)
+
+**File**: `cli/config-adapters/src/store.rs` (test module; add `ReadTemplate` to
+the test imports)
+**Changes**: Drive the change from failing unit tests that build a store with a
+plugin root — a pattern not yet present in this crate. Bind the root `TempDir` to
+a local first (matching the module idiom), so it outlives the store:
+
+```rust
+#[test]
+fn template_names_refuses_a_root_without_a_templates_dir(
+) -> Result<(), TestError> {
+    let root = tempdir()?;
+    let plugin = tempdir()?;
+    let store = FileConfigStore::at(root.path())
+        .with_plugin_root(Some(plugin.path().to_path_buf()));
+    assert!(matches!(
+        store.template_names(),
+        Err(ConfigError::PluginRootNotAnInstallation { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn template_names_refuses_when_templates_is_a_file(
+) -> Result<(), TestError> {
+    let root = tempdir()?;
+    let plugin = tempdir()?;
+    fs::write(plugin.path().join("templates"), "not a dir")?;
+    let store = FileConfigStore::at(root.path())
+        .with_plugin_root(Some(plugin.path().to_path_buf()));
+    assert!(matches!(
+        store.template_names(),
+        Err(ConfigError::PluginRootNotAnInstallation { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn template_names_refuses_when_the_root_is_a_file(
+) -> Result<(), TestError> {
+    let root = tempdir()?;
+    let holder = tempdir()?;
+    let plugin_file = holder.path().join("not-a-dir");
+    fs::write(&plugin_file, "")?;
+    let store =
+        FileConfigStore::at(root.path()).with_plugin_root(Some(plugin_file));
+    assert!(matches!(
+        store.template_names(),
+        Err(ConfigError::PluginRootNotAnInstallation { .. })
+    ));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn template_names_reports_io_on_an_unreadable_templates(
+) -> Result<(), TestError> {
+    use std::os::unix::fs::symlink;
+    let root = tempdir()?;
+    let plugin = tempdir()?;
+    symlink("templates", plugin.path().join("templates"))?;
+    let store = FileConfigStore::at(root.path())
+        .with_plugin_root(Some(plugin.path().to_path_buf()));
+    assert!(matches!(
+        store.template_names(),
+        Err(ConfigError::Io { .. })
+    ));
+    Ok(())
+}
+```
+
+The two file shapes refuse: `templates` present as a file hits the `Ok(!is_dir)`
+arm, and a root that is itself a file makes `fs::metadata` fail `NotADirectory` —
+both structural, both `PluginRootNotAnInstallation`. The last test pins the
+genuine-fault `Io` arm with a self-referential `templates` symlink, whose
+`fs::metadata` fails `FilesystemLoop` (neither `NotFound` nor `NotADirectory`) —
+Unix-only, but with no permission fault and no root guard.
+
+#### 5. CLI integration tests (the acceptance pins)
+
+**File**: `cli/launcher/tests/config_read.rs`
+**Changes**:
+
+Add an assertion helper `assert_refuses_as_not_an_installation(&output, root)`
+next to `assert_refuses_without_a_plugin_root`: non-zero exit, empty stdout,
+stderr contains `ACCELERATOR_PLUGIN_ROOT`, contains the wrong root's path, and
+contains "not an Accelerator installation". The wrong-root command tests below use
+it, pinning the new message rather than only the presence of the variable name.
+
+- **Replace** `a_root_without_a_templates_directory_still_renders_an_empty_table`
+  (`:1373`) with its inverse (AC9 = inverse of AC1). Write the inverse test and
+  observe it fail against the unmodified `template_names` **before** replacing the
+  swallow, keeping the red step verifiable:
+
+```rust
+#[test]
+fn a_root_without_a_templates_directory_refuses_to_list() -> TestResult {
+    let fixture = Fixture::new()?.team("---\npaths:\n  work: x\n---\n")?;
+    let bare = tempfile::Builder::new().prefix("config-read-").tempdir()?;
+    let output = run_with_plugin_root(
+        &fixture.root,
+        bare.path().as_os_str(),
+        &["config", "templates", "list"],
+    )?;
+    assert_refuses_as_not_an_installation(&output, bare.path());
+    Ok(())
+}
+```
+
+- **Add** `a_wrong_root_diagnostic_differs_from_the_absent_root_diagnostic`:
+  capture `config templates list` stderr under a wrong root (via
+  `run_with_plugin_root`) and under an absent root (via `run_in`), assert both
+  refuse, and assert the two stderr strings differ and only the wrong-root one
+  contains the bare root's path. Pins the distinction the dedicated variant buys.
+- **Add** `templates_eject_all_against_a_wrong_root_refuses` (AC4): a wrong root,
+  `config templates eject --all` refuses and creates no override directory.
+- **Add** `a_wrong_root_with_a_templates_file_refuses` (AC8-revised): seed
+  `templates` as a file, `config templates list` refuses via
+  `assert_refuses_as_not_an_installation` — a structural shape now fails closed.
+- **Add** `a_root_that_is_a_file_refuses`: point `ACCELERATOR_PLUGIN_ROOT` at a
+  regular file, `config templates list` refuses naming the root.
+  Environment-independent, no root guard.
+- **Add** `a_genuine_io_fault_is_not_the_refusal` (AC8-revised, the `Io` arm):
+  Unix-only, create a self-referential `templates` symlink so `fs::metadata` fails
+  `FilesystemLoop`, run `config templates list`, assert non-zero exit and stderr
+  contains `I/O error` but **not** `ACCELERATOR_PLUGIN_ROOT`. Pins that a genuine
+  unreadable fault stays `Io` (degradable), distinct from the structural refusal.
+- **Add** `a_root_independent_family_still_succeeds_against_a_wrong_root` (AC11):
+  a wrong root, `config paths --fail-safe` exits 0 **and** prints non-empty
+  stdout. The `--fail-safe` flag is the point: it forces the assertion to prove
+  the family genuinely succeeded rather than degraded to exit-0 empty output.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Error-variant unit tests pass: `cargo test -p config`
+- [ ] Store unit tests pass: `cargo test -p config-adapters`
+- [ ] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
+- [ ] Format + lint clean: `mise run cli:check`
+
+#### Manual Verification
+
+- [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config templates list`
+      exits non-zero and prints a diagnostic naming the root path, stating it is
+      not an Accelerator installation, and naming `ACCELERATOR_PLUGIN_ROOT`.
+- [ ] The same against `config templates eject --all` refuses and writes nothing.
+
+---
+
+## Phase 2: Plugin-default resolution refuses on a wrong root (R2)
+
+### Overview
+
+Route `plugin_template_path` through the helper and have `resolve_template`'s
+plugin-default tier build its candidate via `plugin_template_path` rather than
+rejoining the path inline. `plugin_template_path` then becomes the single choke
+for all four of `config template <name>`, `eject <name>`, `diff <name>`, and
+`reset <name>` (the last two via `plugin_default`, which already routes through
+it), eliminating the duplicated path-building while preserving the genuine
+template-not-found for a valid installation missing one file.
+
+### Changes Required
+
+#### 1. `resolve_template` plugin-default tier and `plugin_template_path`
+
+**File**: `cli/config-adapters/src/store.rs`
+**Changes**: Route `plugin_template_path` (`:466`) through the helper:
+
+```rust
+fn plugin_template_path(&self, name: &str) -> Result<PathBuf, ConfigError> {
+    Ok(self.require_templates_dir()?.join(format!("{name}.md")))
+}
+```
+
+In `resolve_template`, replace the inline tier (`:400-401`) so it builds its
+candidate via `plugin_template_path` — inheriting the root check ahead of the
+`is_file()` fall-through and sharing the one path-building site:
+
+```rust
+let default = self.plugin_template_path(name)?;
+if default.is_file() {
+    return Ok(Some(self.resolved(
+        TemplateSource::PluginDefault,
+        &default,
+        warning,
+    )?));
+}
+Ok(None)
+```
+
+The eject handlers pre-compute `template_view::available_or_none(..)`, which
+swallows `template_names()` via `unwrap_or_default()`; that tolerance stays safe
+only because every command is dominated by a `?` on `plugin_default`,
+`template_names`, or `plugin_template_path` that surfaces the refusal before the
+swallowed value is observable. A future caller of `available()` not preceded by
+such a `?` would re-mask a wrong-root refusal — the invariant to preserve.
+
+#### 2. Store unit tests (red first)
+
+**File**: `cli/config-adapters/src/store.rs` (test module; add `TemplateOverride`
+to the test imports)
+**Changes**: Cover, with a plugin root (binding each root `TempDir` to a local
+first, per the module idiom):
+
+- `resolve_template` under a wrong root, no override →
+  `Err(PluginRootNotAnInstallation { .. })`.
+- `resolve_template` under a wrong root **with** a user override for `<name>`,
+  seeding `<store-root>/.accelerator/templates/<name>.md` first (so the
+  `UserOverride` tier reads real content) → `Ok(Some(..))` with
+  `TemplateSource::UserOverride`. This pins the hoisting crux — the root check sits
+  *inside* the plugin-default tier, after the override tiers — at the fast store
+  layer, not only at the CLI layer (AC10).
+- `resolve_template` under a valid fixture root missing `<name>.md`, no override →
+  `Ok(None)` (the genuine not-found preserved).
+- `plugin_default` under a valid fixture root missing `<name>.md` → `Ok(None)`.
+  This pins the genuine-not-found for the diff/reset site specifically, distinct
+  from `resolve_template`'s tier — so a mutation conflating not-an-installation
+  with a missing file at `plugin_default` cannot pass while AC5/AC7 stay green.
+- `plugin_default` and `eject` under a wrong root →
+  `Err(PluginRootNotAnInstallation { .. })`.
+
+#### 3. CLI integration tests (the acceptance pins)
+
+**File**: `cli/launcher/tests/config_read.rs`
+**Changes**:
+
+- **Add** `template_against_a_wrong_root_refuses` (AC2): wrong root, no override,
+  `config template demo` refuses via `assert_refuses_as_not_an_installation`.
+- **Add** `template_not_found_names_the_template_not_the_plugin_root` (AC7):
+  `run_with_plugin` (valid fixture), `config template nonesuch`, assert non-zero,
+  stderr contains `not found` and `nonesuch`, and does **not** contain
+  `ACCELERATOR_PLUGIN_ROOT`.
+- **Add** `eject_against_a_wrong_root_refuses` (AC3): wrong root,
+  `config templates eject demo` refuses as not-an-installation (not `NoDefault`).
+- **Add** `diff_and_reset_against_a_wrong_root_refuse` (AC5): wrong root,
+  `config templates diff demo` and `reset demo` each refuse as not-an-installation.
+- **Add** `a_user_override_resolves_against_a_wrong_root` (AC10): seed
+  `.accelerator/templates/demo.md`, invoke via `run_with_plugin_root` with a bare
+  root, assert exit 0 and the override's rendered content.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Store unit tests pass: `cargo test -p config-adapters`
+- [ ] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
+- [ ] Format + lint clean: `mise run cli:check`
+
+#### Manual Verification
+
+- [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config template plan`
+      refuses naming the root path and `ACCELERATOR_PLUGIN_ROOT`, distinct from the
+      absent-root message.
+- [ ] Against the real plugin root, `config template not-a-real-template` still
+      reports a template-not-found naming the template, with no mention of the
+      plugin root.
+
+---
+
+## Phase 3: Compose path surfaces the refusal (R3)
+
+### Overview
+
+Confirm the wrong-root refusal reaches the visualiser server boundary intact and
+pin it with a compose contract test. No production change: the `?` at
+`compose.rs:157` already propagates `PluginRootNotAnInstallation` into
+`ComposeError`, and this test passes only because Phase 1 made `template_names`
+refuse. Because the new message drops the launcher-only `bin/accelerator`
+remediation, the server-side error no longer contradicts `run_serve`'s own prior
+`ACCELERATOR_PLUGIN_ROOT`-is-set check.
+
+### Changes Required
+
+#### 1. Compose contract test
+
+**File**: `cli/visualiser/server/tests/compose_contract.rs`
+**Changes**: Mirror `an_empty_plugin_root_refuses_to_compose` (`:187`), but pass a
+real temp directory without `templates/` as the plugin root:
+
+```rust
+#[test]
+fn a_wrong_plugin_root_refuses_to_compose() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_project(tmp.path());
+    let bare = tempfile::tempdir().unwrap();
+    let error = load(Params {
+        cwd: tmp.path().to_path_buf(),
+        plugin_root: bare.path().to_path_buf(),
+        owner_pid: 0,
+        owner_start_time: None,
+        host: "127.0.0.1".to_string(),
+    })
+    .expect_err("a wrong plugin root composed a config");
+    let message = error.to_string();
+    assert!(
+        message.contains("ACCELERATOR_PLUGIN_ROOT"),
+        "the error does not name the variable: {error}"
+    );
+    assert!(
+        message.contains("not an Accelerator installation"),
+        "the error does not name the wrong-root cause: {error}"
+    );
+    assert!(
+        message.contains(&bare.path().display().to_string()),
+        "the error does not name the offending root: {error}"
+    );
+}
+```
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Compose contract tests pass: `cargo test -p accelerator-visualiser --test compose_contract`
+- [ ] Format + lint clean: `mise run cli:check`
+- [ ] Full local CI mirror is green: `mise run` (AC12)
+
+#### Manual Verification
+
+- [ ] Building the server against a wrong root fails composition rather than
+      serving an empty template set (the boundary test is the durable evidence;
+      `run_serve` guards the env var before compose, so the running server does
+      not reach this diagnostic on the absent-var path).
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `ConfigError` in `error.rs`: the new variant's `Display` names the path and
+  `ACCELERATOR_PLUGIN_ROOT` (and not "unknown"), and its `is_refusal()` is `true`.
+- `FileConfigStore` with a plugin root — the new pattern for this crate — covering
+  `require_templates_dir`'s outcomes: present dir → path; the three structural
+  refusals (no `templates/`; `templates` a file; a root that is a file →
+  `NotADirectory`) → `PluginRootNotAnInstallation`; and a genuine unreadable fault
+  (a self-referential `templates` symlink → `FilesystemLoop`) → `Io`. Exercised
+  through `template_names`, `resolve_template`, `plugin_default`, and `eject`. The
+  structural triggers are environment-independent; the `Io` trigger is Unix-only
+  but needs no permission fault and no root guard.
+- The genuine-not-found path (`resolve_template` → `Ok(None)`) under a valid
+  fixture root missing one template, and the hoisting crux (wrong root + override →
+  `Ok(Some(UserOverride))`) at the fast store layer.
+
+### Integration Tests
+
+- CLI black-box runs in `config_read.rs` for each of the six commands on a wrong
+  root, plus the distinguishing cases (genuine not-found naming the template;
+  resolving override at exit 0; wrong-root message differs from absent-root and
+  names the path), the structural refusals (`templates` a file; the root a file),
+  the genuine-`Io` fault (self-referential symlink), and the
+  root-independent-family guard under `--fail-safe`.
+- The compose contract boundary test for the server consumer.
+
+### Manual Testing Steps
+
+1. `root=$(mktemp -d)` — a directory with no `templates/`.
+2. `ACCELERATOR_PLUGIN_ROOT=$root accelerator config templates list` — refuses,
+   names the root path and `ACCELERATOR_PLUGIN_ROOT`, exit non-zero.
+3. Repeat for `template <name>`, `templates eject <name>`, `eject --all`,
+   `diff <name>`, `reset <name>` — each refuses naming the root path.
+4. `ACCELERATOR_PLUGIN_ROOT=$root accelerator config paths --fail-safe` — exits 0
+   with normal non-empty output.
+5. Against the committed valid root, `config template <missing>` — reports a
+   template-not-found naming the template, not the plugin root.
+
+## Performance Considerations
+
+Negligible. The added cost is one `stat` per plugin-default lookup and one `stat`
+before `template_names`' existing `read_dir`, on cold, explicitly-invoked config
+paths (13 templates at most). No hot path is affected.
+
+## Migration Notes
+
+None. No data or on-disk layout changes. The behavioural change is a wrong root
+moving from a silent empty/not-found answer to a hard refusal — the intended
+fix — and it ships in the shared `config-adapters` library, so both the launcher
+and the visualiser server pick it up at the same plugin version, kept in lockstep
+by 0182's version-keyed cache.
+
+## References
+
+- Original work item: `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`
+- Related research: `meta/research/codebase/2026-09-08-0184-template-resolution-wrong-plugin-root.md`
+- Builds on: `meta/work/0182-cli-derives-plugin-root-from-own-location.md`,
+  `meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md` (Phase 5)
+- Store sites: `cli/config-adapters/src/store.rs:73,400,412,436,466,483,729`
+- Error taxonomy: `cli/config/src/error.rs` — variant list `:38-67`, `is_refusal`
+  `:76-88` (exhaustive), `Display` `:90-139`, `From<ConfigError>` `:143-147`, tests
+  `:149-283`. The new `PluginRootNotAnInstallation { path }` variant slots into
+  each.
+- Compose consumer: `cli/visualiser/server/src/compose.rs:20,157`; server env-var
+  guard `cli/visualiser/server/src/main.rs:68`
+- Test scaffolding: `cli/launcher/tests/config_read.rs:1219-1401`,
+  `cli/visualiser/server/tests/compose_contract.rs:187`

--- a/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
@@ -5,7 +5,7 @@ title: "Template Resolution Wrong-Root Refusal Implementation Plan"
 date: "2026-09-09T07:15:11+00:00"
 author: "Toby Clemson"
 producer: "create-plan"
-status: "ready"
+status: "done"
 work_item_id: "work-item:0184"
 parent: "work-item:0184"
 derived_from: ["codebase-research:2026-09-08-0184-template-resolution-wrong-plugin-root"]

--- a/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md
@@ -445,17 +445,17 @@ fn a_root_without_a_templates_directory_refuses_to_list() -> TestResult {
 
 #### Automated Verification
 
-- [ ] Error-variant unit tests pass: `cargo test -p config`
-- [ ] Store unit tests pass: `cargo test -p config-adapters`
-- [ ] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
-- [ ] Format + lint clean: `mise run cli:check`
+- [x] Error-variant unit tests pass: `cargo test -p config`
+- [x] Store unit tests pass: `cargo test -p config-adapters`
+- [x] Launcher integration tests pass: `cargo test -p accelerator --test config_read`
+- [x] Format + lint clean: `mise run cli:check`
 
 #### Manual Verification
 
-- [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config templates list`
+- [x] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config templates list`
       exits non-zero and prints a diagnostic naming the root path, stating it is
       not an Accelerator installation, and naming `ACCELERATOR_PLUGIN_ROOT`.
-- [ ] The same against `config templates eject --all` refuses and writes nothing.
+- [x] The same against `config templates eject --all` refuses and writes nothing.
 
 ---
 

--- a/meta/prs/111-description.md
+++ b/meta/prs/111-description.md
@@ -1,0 +1,91 @@
+---
+type: "pr-description"
+id: "111"
+title: "[0184] Refuse template resolution on a wrong plugin root"
+date: "2026-09-10T00:47:43+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0184"
+parent: "work-item:0184"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/111"
+pr_number: 111
+tags: ["cli", "config", "templates", "plugin-root", "visualiser"]
+revision: "6b66bc059057ecb330226b459ae7d9e2b65edd8e"
+repository: "accelerator"
+last_updated: "2026-09-10T00:47:43+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0184] Refuse template resolution on a wrong plugin root
+
+## Summary
+
+Extends 0182's *absent*-root refusal to the *wrong*-root case: a present
+plugin root that carries no `templates/` directory is not an Accelerator
+installation, so every template command and the visualiser compose path now
+refuse with a dedicated diagnostic instead of degrading to a silent empty
+answer or a false template-not-found. The refusal names the offending root,
+the invalid `templates/` layout, and `ACCELERATOR_PLUGIN_ROOT`, and fails
+closed even under `--fail-safe`.
+
+## Changes
+
+- **New error variant** — `ConfigError::PluginRootNotAnInstallation { path }`
+  (`cli/config/src/error.rs`), classified `is_refusal() == true` so it fails
+  closed identically to `PluginRootUnavailable`, with a message that names the
+  path and states the root is not an installation (distinct from the
+  absent-root "unknown, set the variable" message).
+- **Shared installation-detection helper** — `require_templates_dir`
+  (`cli/config-adapters/src/store.rs`) validates `templates/` with a single
+  `fs::metadata` probe and becomes the one choke point for `template_names`,
+  `plugin_template_path`, `plugin_default`, `eject`, and `resolve_template`'s
+  plugin-default tier.
+- **Structural shapes fail closed** — a missing `templates/`, a `templates`
+  that is a file, and a root that is itself a file all refuse; a genuinely
+  *unreadable* fault (permission, filesystem loop) stays the degradable `Io`
+  and does not name the variable.
+- **Preserved behaviour** — a resolving user override still renders at exit 0
+  under a wrong root (override tiers precede the plugin-default check), a valid
+  installation missing one template still reports a template-not-found naming
+  the template, and the root-independent config families are untouched.
+- **Compose boundary** — no production change; the existing `?` at
+  `compose.rs:157` propagates the refusal into `ComposeError`, pinned by a new
+  contract test.
+- **Fixtures** — regenerated the config `public-api.txt` for the new public
+  variant and seeded `templates/` in the shutdown-test plugin-root fixture,
+  which compose now correctly refuses without.
+
+## Context
+
+- Work item: `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`
+- Plan: `meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md`
+- Research: `meta/research/codebase/2026-09-08-0184-template-resolution-wrong-plugin-root.md`
+- Validation: `meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md`
+- Builds on 0182 (CLI derives plugin root from its own location).
+
+## Testing
+
+- [x] Error-crate unit tests — `cargo test -p config` (new variant Display + `is_refusal`)
+- [x] Store unit tests — `cargo test -p config-adapters` (10 new tests: three structural refusals, the `Io` arm, the override hoisting crux, genuine-not-found preservation)
+- [x] Launcher integration — `cargo test -p accelerator --test config_read` (152 passed, all six commands on a wrong root)
+- [x] Compose contract — `cargo test -p accelerator-visualiser --test compose_contract` (wrong root refuses to compose)
+- [x] Format + lint — `mise run cli:check` (rustfmt, clippy, store-duplication)
+- [ ] Full local CI mirror — `mise run` recorded green in the work item after the docs-site advisory rebase; not re-run in this validation session
+
+## Notes for Reviewers
+
+- **AC8 semantics moved.** The work item's AC8 originally treated a
+  `templates`-is-a-file root as the representative `Io` fault; this change
+  reclassifies that shape as a structural refusal and reserves `Io` for
+  genuinely unreadable faults. AC8 was revised and AC13 added for the two extra
+  structural shapes — both reflected in the work item.
+- **Deliberate residual duplication.** `compose.rs:155` still reconstructs
+  `plugin_root.join("templates")` to build each tier's absolute default path;
+  the validity gate is centralised, but relocating the per-name path
+  construction behind a store accessor is a wider compose-tier refactor left
+  out of scope. The `store-duplication` lint passes.
+- Worth focusing on: the ordering invariant that keeps a resolving override
+  ahead of the root check (`resolve_template`), and the `NotFound |
+  NotADirectory` collapse in `require_templates_dir`.

--- a/meta/research/codebase/2026-09-08-0184-template-resolution-wrong-plugin-root.md
+++ b/meta/research/codebase/2026-09-08-0184-template-resolution-wrong-plugin-root.md
@@ -1,0 +1,377 @@
+---
+type: "codebase-research"
+id: "2026-09-08-0184-template-resolution-wrong-plugin-root"
+title: "Research: Template resolution succeeds silently on a plugin root that is not an installation"
+date: "2026-09-08T22:44:28+00:00"
+author: "Toby Clemson"
+producer: "research-codebase"
+status: "complete"
+work_item_id: "0184"
+parent: "work-item:0184"
+topic: "Template resolution succeeds silently on a plugin root that is not an installation"
+tags: ["research", "codebase", "config", "templates", "plugin-root", "cli", "visualiser"]
+revision: "8da94dbf0ba9aa3ddaffb5823633a16cdec2189d"
+repository: "accelerator"
+last_updated: "2026-09-08T22:49:34+00:00"
+last_updated_by: "Toby Clemson"
+last_updated_note: "Added follow-up research settling the templates.rs scope gap (no gap: it is a downstream renderer of the composed map, not an independent store consumer; R3 correctly scoped to compose.rs)."
+schema_version: 1
+---
+
+# Research: Template resolution succeeds silently on a plugin root that is not an installation
+
+**Date**: 2026-09-08 22:44 UTC
+**Author**: Toby Clemson
+**Git Commit**: 8da94dbf0ba9aa3ddaffb5823633a16cdec2189d
+**Branch**: anonymous jj change `vnqrqyrt` (no bookmark, atop `main`)
+**Repository**: accelerator
+
+## Research Question
+
+Ground work item 0184 against live code: verify that the three plugin-root
+template accessors in `FileConfigStore` still succeed silently on a *wrong* root
+(present directory, no `templates/`), map every affected command and consumer to
+its store site, confirm the fix's precondition, and surface the test scaffolding
+a fix would build on.
+
+## Summary
+
+Every behavioural claim in 0184 holds against the current tree. The wrong-root
+case is real at all three accessors, the `require_plugin_root` gate fires only on
+an *absent* root, and the `ErrorKind::NotFound` split the fix must mirror already
+exists in the sibling accessors. The packaging precondition — a real installation
+always ships `templates/` — is **supported** inside this repo.
+
+Three findings sharpen or extend the item:
+
+- **Exit code is 1, not 2, for all six commands.** `PluginRootUnavailable`
+  converts to `kernel::Error::Failed` → `ExitCode::FAILURE` (exit 1). The ACs say
+  "non-zero", which exit 1 satisfies; exit 2 is reserved for the write commands'
+  own domain refusals (`EjectOutcome::Exists`, no-override diff/reset).
+- ✅ **No second visualiser consumer — R3 is correctly scoped.** Traced in the
+  follow-up below: `cli/visualiser/server/src/templates.rs` is a downstream
+  renderer of the already-composed `Config.templates` map, not a store consumer.
+  Its `plugin_root` is display-only; the single server enforcement point is
+  `store.template_names()?` at `compose.rs:157`, which R3/AC6 already cover.
+- ⚠️ **AC6's wrong-root compose test only works after R1 lands.** Today a
+  non-empty wrong root composes *successfully* with an empty template map; it
+  never errors. The existing `an_empty_plugin_root_refuses_to_compose` test
+  exercises the *absent* root via `PathBuf::new()`. A present-but-no-`templates/`
+  root reaches the refusal only once `template_names` maps `NotFound` →
+  `PluginRootUnavailable`, which the `?` at `compose.rs:157` then propagates with
+  no production change.
+
+## Detailed Findings
+
+### The three accessors and their current wrong-root behaviour (`cli/config-adapters/src/store.rs`)
+
+`require_plugin_root` (`store.rs:73-77`) is the sole gate raising
+`PluginRootUnavailable`, and it fires only when `self.plugin_root` is `None`. A
+present-but-wrong root is `Some(path)`; `as_deref()` yields `Some(&path)` and it
+returns `Ok(&path)` with no filesystem validation. `with_plugin_root`
+(`store.rs:64-69`) normalises an empty-string root to `None` via
+`.filter(|root| !root.as_os_str().is_empty())`, so `Some("")` collapses to the
+absent case.
+
+| Accessor | Site | Wrong-root behaviour today | Fix target |
+|----------|------|----------------------------|------------|
+| `template_names` | `store.rs:412` | `let Ok(entries) = read_dir(...) else { Ok(Vec::new()) }` swallows every error | R1 |
+| `resolve_template` plugin-default tier | `store.rs:400-408` | `<name>.md` not a file → `Ok(None)` (names no template) | R2 |
+| `plugin_template_path` | `store.rs:466-471` | tests nothing; only builds the path | R2 |
+| `plugin_default` | `store.rs:432-445` | `is_file()` at `:437` → `Ok(None)` at `:438` | R2 |
+| `eject` | `store.rs:475-532` | `is_file()` at `:484` → `EjectOutcome::NoDefault` | R2 |
+
+The `template_names` swallow is exactly as the item quotes, at `store.rs:414-416`:
+
+```rust
+let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
+    return Ok(Vec::new());
+};
+```
+
+It calls `require_plugin_root()?` first (`store.rs:413`), so an absent root
+short-circuits; once the root is present, a missing `templates/` (`NotFound`), a
+permission error, and a not-a-directory error all collapse identically to
+`Ok(Vec::new())`. The plugin-default tier of `resolve_template` builds its path
+**inline** (`store.rs:401`), not through `plugin_template_path`; `plugin_default`
+routes through `plugin_template_path` (`store.rs:436`). Both fall to `Ok(None)`
+via a `path.is_file()` check.
+
+Two distinct sites, near-identical names, as the item warns: `resolve_template`'s
+plugin-default tier (reached by `config template <name>`) and the `plugin_default`
+method (reached only by `diff`/`reset`).
+
+### The error machinery and the pattern to mirror (`cli/config/src/error.rs`)
+
+`ConfigError` is hand-written, not `thiserror` — a manual `Display`
+(`error.rs:90-139`) and a bare `impl std::error::Error`. `PluginRootUnavailable`
+is a unit variant (`error.rs:66`) whose message already names the variable and
+the bootstrap (`error.rs:131-136`):
+
+```text
+the plugin installation root is unknown: set ACCELERATOR_PLUGIN_ROOT, or invoke
+accelerator through bin/accelerator, which derives it
+```
+
+It is classified as a refusal (`error.rs:78`), so `--fail-safe` cannot absorb it.
+`ConfigError::Io { path, detail }` (`error.rs:52-55`, message `error.rs:112-114`)
+is **not** a refusal, so it can be degraded. The `Io` half of the fix is built via
+the `io_error` helper (`store.rs:729-734`).
+
+The three-way `ErrorKind::NotFound` split the R1 `Io` half must mirror already
+exists in `custom_lenses` (`store.rs:296-302`) and `skill_names`
+(`store.rs:322-328`), and in `read`/`write`/`ensure_line`/`ensure_inner_gitignore`:
+
+```rust
+let entries = match fs::read_dir(&dir) {
+    Ok(entries) => entries,
+    Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+    Err(error) => return Err(io_error(&dir, &error)),
+};
+```
+
+⚠️ **The R1 divergence.** The siblings map `NotFound` → empty list; R1 maps it →
+`PluginRootUnavailable`. That is a deliberate divergence resting on the
+Assumption, not parity — only the `Io` (non-`NotFound`) half matches the siblings.
+
+### CLI command surface, exit codes, and `--fail-safe`
+
+The command-to-site mapping in the item is verified exactly. Handlers live in
+`cli/launcher/src/config_command/inbound/cli.rs`; a two-layer dispatch maps clap
+`ConfigAction` → the hexagon's `Action` (`launch/mod.rs:33-163`) before reaching
+them.
+
+| Command | Handler | Store site | Confirmed |
+|---------|---------|------------|-----------|
+| `config templates list` | `cli.rs:260` | `template_names` (`store.rs:412`) | yes |
+| `config template <name>` | `cli.rs:238` | `resolve_template` tier (`store.rs:400`) — **not** `plugin_default` | yes |
+| `config templates eject <name>` | `cli.rs:507` | `eject` → `plugin_template_path` | yes |
+| `config templates eject --all` | `cli.rs:533,542` | `eject_all` → `template_names` | yes |
+| `config templates diff <name>` | `cli.rs:579` | `plugin_default` → `plugin_template_path` | yes |
+| `config templates reset <name>` | `cli.rs:602` | `plugin_default` → `plugin_template_path` | yes |
+| `config paths` | `cli.rs:311` | none — never reads the plugin root | yes |
+
+**Exit-code precision.** Every `ConfigError` becomes
+`kernel::Error::Failed(msg)` via `From<ConfigError>` (`error.rs:143-147`), never
+`kernel::Error::Refusal`. `main::report` (`main.rs:417-426`) maps `Refusal` →
+exit 2 and everything else → exit 1. So a `PluginRootUnavailable` from any of the
+six commands prints to stderr and exits **1**. The `assert_refuses_without_a_plugin_root`
+helper (`config_read.rs:1278-1288`) asserts non-zero + empty stdout + stderr names
+the variable — satisfied by exit 1.
+
+**`--fail-safe` (relevant to AC11).** The flag maps to `OnFailure::Degrade`
+(`launch/mod.rs:23-29`). In `finish` (`cli.rs:453-472`) the degrade arm matches
+**only** `Failure::Read`; a `Failure::Refusal` (which `PluginRootUnavailable`
+becomes, `cli.rs:422-430`) is never degraded. So under `--fail-safe` a genuinely
+failing degradable read *also* exits 0 — with empty stdout (scalar) or a
+`## … Unavailable` notice (block). That is why AC11 must assert exit 0 **and**
+non-empty real output; `the_root_independent_families_still_succeed_with_no_plugin_root`
+(`config_read.rs:1391-1401`) already does exactly this. `eject`/`diff`/`reset`
+carry no `--fail-safe` flag at all.
+
+### Visualiser compose path (`cli/visualiser/server/src/compose.rs`)
+
+`compose::load` calls `resolve_templates` (`compose.rs:55-61`), which loops
+`store.template_names()?` at `compose.rs:157`; the store there carries the plugin
+root (`compose.rs:42-44`). `ComposeError::Config(#[from] ConfigError)`
+(`compose.rs:19-25`) stores the whole `ConfigError` value and re-emits its message
+through `#[error("configuration error: {0}")]`, so a wrapped
+`PluginRootUnavailable` renders with `ACCELERATOR_PLUGIN_ROOT` **intact** — no
+flattening. R3's claim that the `?` propagation needs no production change is
+correct.
+
+The only production caller is `run_serve` (`main.rs:80-92`), which exits 2 on a
+compose error. It guards the env var *before* compose (`main.rs:68-71`), so the
+absent-var path prints a different message and never reaches `template_names`;
+the compose diagnostic is reachable through `main` only via the empty-string edge.
+AC6's clean boundary is therefore calling `compose::load(Params { plugin_root, .. })`
+directly, as the existing contract test does.
+
+### Second server template site, traced (`cli/visualiser/server/src/templates.rs`)
+
+✅ Not an independent consumer — see the follow-up section for the full trace.
+`TemplateResolver::build` (`templates.rs:117-122`) takes the already-composed
+`Config.templates: HashMap<String, TemplateTiers>` and renders it; it never calls
+the store's plugin-root accessors. Its `plugin_root` argument feeds only
+`display_path` (`templates.rs:90-104`) for `<plugin-root>`-prefix stripping. Per-tier
+file reads go through `load_via_driver` (`templates.rs:254-268`), which swallows a
+read failure into `present: false` — a correct rendering of a genuinely-absent
+tier file, not a root-validity signal. R3 stays scoped to `compose.rs`.
+
+### Test scaffolding
+
+All plugin-root behaviour is tested at the **CLI integration layer** in
+`cli/launcher/tests/config_read.rs` (black-box `Command` runs of the compiled
+binary via `env!("CARGO_BIN_EXE_accelerator")`), plus two unit tests on the error
+variant in `error.rs:248-268`. There are **no** `config-adapters` unit tests that
+build a `FileConfigStore` with a plugin root — every store unit test uses bare
+`FileConfigStore::at(dir)` with `plugin_root == None`.
+
+- **Characterisation test to replace (AC9)**:
+  `a_root_without_a_templates_directory_still_renders_an_empty_table`
+  (`config_read.rs:1373-1389`) — builds a `bare` temp dir with no `templates/`,
+  runs `templates list` via `run_with_plugin_root`, asserts the byte-exact header
+  table and exit 0. Its doc comment says "tracked as its own work item"; the
+  0182 plan is what names that item as **0184**.
+- **Property to preserve (R4)**:
+  `a_user_override_still_resolves_with_no_plugin_root` (`config_read.rs:1356-1368`)
+  — writes `.accelerator/templates/demo.md`, runs `config template demo` via
+  `run_in` (which strips `ACCELERATOR_PLUGIN_ROOT`), asserts the override resolves
+  at exit 0. Pins the plugin-default check at the *third* tier.
+- **The 0182 absent-root suite** (`config_read.rs:1244-1401`): the reusable
+  helpers `run_with_plugin_root` (`:1226`, sets the var to any `&OsStr` — the
+  invoker for a wrong root), `run_with_plugin` (`:1219`, the committed valid
+  fixture), `run_in` (`:71`, strips the var), `assert_names_the_plugin_root`
+  (`:1270`), and `assert_refuses_without_a_plugin_root` (`:1278`).
+- **Valid-installation fixture (AC7, AC10)**: committed at
+  `cli/launcher/tests/fixtures/plugin/templates/{demo,other}.md`, pointed at by
+  `run_with_plugin`. AC7 (present `templates/`, absent `<name>.md`) is already
+  the shape of `template_not_found_fails_closed_even_with_fail_safe`
+  (`config_read.rs:1446`). AC10 (wrong root + override) is a *new* composition of
+  the override setup with `run_with_plugin_root`.
+- **IO-fault triggers (AC8)**: the established idiom is `fs::create_dir(x)` where
+  a file is expected (`config_read.rs:648-703, 1639-1725`); AC8's inverse —
+  `fs::write(plugin.join("templates"), ...)` so `read_dir` fails with
+  `NotADirectory` (not `NotFound`, so it maps to `Io`) — is the mirror. The
+  `chmod` variant uses `PermissionsExt::from_mode` (`config_read.rs:1853`).
+- **Compose boundary (AC6)**: `an_empty_plugin_root_refuses_to_compose`
+  (`compose_contract.rs:187-203`) is the shape — `load(Params { plugin_root, .. })
+  .expect_err(..)` asserting the message contains `ACCELERATOR_PLUGIN_ROOT`. AC6
+  differs by passing a real temp dir without `templates/` instead of
+  `PathBuf::new()`, and depends on R1 landing.
+
+### Packaging precondition — supported
+
+The plugin ships as a **whole git checkout at a tag** (`marketplace.json:13-17`),
+not a curated package. The release tasks cross-compile and upload only the Rust
+binaries (`tasks/release.py:186-233`, `tasks/manifest.py:115-178`,
+`tasks/build.py`); nothing assembles a plugin-content package or selects/omits
+files. There is no `files` array in `plugin.json`, no `.claude-pluginignore`, and
+`.gitignore` does not exclude `templates/`. The 13 tracked `templates/*.md` ride
+along automatically. **Verdict: the in-repo assumption holds** — a real
+installation always ships `templates/`, so its absence is a reliable
+not-an-installation signal.
+
+## Code References
+
+- `cli/config-adapters/src/store.rs:73-77` — `require_plugin_root`, the absent-root-only gate
+- `cli/config-adapters/src/store.rs:412-430` — `template_names`, the `read_dir` swallow (R1)
+- `cli/config-adapters/src/store.rs:400-408` — `resolve_template` plugin-default tier (R2)
+- `cli/config-adapters/src/store.rs:432-471` — `plugin_default` + `plugin_template_path` (R2)
+- `cli/config-adapters/src/store.rs:475-532` — `eject` → `EjectOutcome::NoDefault`
+- `cli/config-adapters/src/store.rs:296-302, 322-328, 729-734` — the `NotFound`/`Io` split + `io_error` to mirror
+- `cli/config/src/error.rs:66,78,131-136` — `PluginRootUnavailable` variant, refusal classification, message
+- `cli/config/src/error.rs:143-147` — `From<ConfigError> for kernel::Error` (→ `Failed`, exit 1)
+- `cli/launcher/src/config_command/inbound/cli.rs:238,260,507,533,542,579,602` — the six command handlers
+- `cli/launcher/src/config_command/inbound/cli.rs:453-472` — `finish`, the `--fail-safe` degrade boundary
+- `cli/launcher/src/main.rs:417-426` — exit-code mapping (Refusal→2, else→1)
+- `cli/visualiser/server/src/compose.rs:19-25,55-61,157` — `ComposeError`, `resolve_templates`, the `?` forward
+- `cli/visualiser/server/src/templates.rs:90-104,117-122,254-268` — display-only `plugin_root`, driver-swallowing renderer (not a store consumer)
+- `cli/visualiser/server/src/server.rs:90-98,140` + `watcher.rs:372-419` + `api/templates.rs:20-31` — how the composed map reaches `TemplateResolver` and the API
+- `cli/launcher/tests/config_read.rs:1219-1401` — plugin-root helpers, the characterisation test, the absent-root suite
+- `cli/visualiser/server/tests/compose_contract.rs:187-203` — `an_empty_plugin_root_refuses_to_compose`
+- `cli/launcher/tests/fixtures/plugin/templates/{demo,other}.md` — committed valid-installation fixture
+- `templates/` — 13 tracked plugin-default templates (the shipped source)
+
+## Architecture Insights
+
+- **A single shared installation-detection helper is the natural fix shape.** The
+  item's decision is that detection lives in one "is this root an installation?"
+  helper validating `templates/` presence, called by all three accessors. It must
+  sit *inside* each plugin-default step, not hoisted: for `resolve_template` and
+  `plugin_default` the check runs only after the override tiers miss, or a wrong
+  root would pre-empt a resolving override (the R4 property). This bundling is why
+  the three accessors stay in one item.
+- **The genuine-not-found vs root-refusal distinction (AC2/AC5 vs AC7) is the
+  crux.** After R2, a plugin-default site must ask "does `templates/` exist?"
+  (absent → `PluginRootUnavailable`) *before* "is `<name>.md` a file?" (absent →
+  `Ok(None)`), so a valid installation missing one template still reports a
+  template-not-found naming `<name>`, not the plugin root.
+- **Refusal classification is load-bearing.** `PluginRootUnavailable.is_refusal()`
+  keeps behaviour byte-identical with and without `--fail-safe` and forces
+  fail-closed — the property 0182 established and 0184 extends to the wrong root.
+- **The store is shared across two binaries.** `config-adapters` ships in both the
+  launcher and the visualiser server; the fix changes both at once, and the
+  version-keyed plugin cache keeps them in lockstep (0182 inheritance).
+
+## Historical Context
+
+- `meta/work/0182-cli-derives-plugin-root-from-own-location.md` — introduced
+  `PluginRootUnavailable` and `require_plugin_root` for the *absent* root, and
+  Phase 5 §3 explicitly deferred the wrong-root case, raising it as 0184.
+- `meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md`
+  — Phase 5 §2 names `compose.rs:157` forwarding `template_names`' `ConfigError`
+  via `?` (the exact link R3 cites); §3 names the characterisation test as the
+  deferred residue. Its Implementation notes correct the plan body:
+  `plugin_template_path` shipped as `Result<PathBuf, ConfigError>` outright, and
+  `known_skill_names` was deliberately left tolerant (do not touch it here).
+- `meta/research/issues/2026-07-26-cli-requires-claude-plugin-root-env-var.md` —
+  the RCA on the plugin-root env-var contract underpinning the gate.
+- `meta/reviews/work/0184-...-review-1.md` — the review of this exact bug.
+
+## Related Research
+
+- `meta/research/codebase/2026-07-27-0182-plugin-root-self-location-implementation-surface.md`
+  — where the wrong root originates (bootstrap self-location).
+- `meta/research/codebase/2026-07-07-0178-config-crates-native-yaml-reader.md`
+  — the `config-adapters` / `FileConfigStore` implementation study.
+- `meta/research/codebase/2026-06-11-0096-templates-view-auto-discovery.md`
+  — template enumeration internals.
+- `meta/research/codebase/2026-03-29-template-management-subcommands.md`
+  — `resolve_template` / eject / diff / reset foundations.
+
+## Open Questions
+
+- ✅ **Resolved — is `templates.rs` a second wrong-root consumer?** No. Traced in
+  the follow-up section below: it is a downstream renderer of the composed
+  `Config.templates` map, its `plugin_root` is display-only, and the single server
+  enforcement point is `compose.rs:157`. R3 is correctly scoped.
+- ❓ **Does Claude Code's own plugin-install step ever filter files?** The in-repo
+  precondition is supported, but the external installer is not asserted anywhere
+  in this workspace. The item's Dependencies precondition ("confirm against the
+  release artifact's file list") is satisfied for the git-tag model; the residual
+  risk sits outside this repo.
+
+## Follow-up Research 2026-09-08 22:49 UTC — the `templates.rs` scope gap, settled
+
+**Verdict: no scope gap. R3/AC6 are correctly scoped to `compose.rs`.**
+`cli/visualiser/server/src/templates.rs` (`TemplateResolver`) is a downstream
+renderer of the already-composed `Config.templates` map, not an independent
+consumer of the store's plugin-root accessors. It needs no requirement of its own.
+
+The data flow, startup and reload:
+
+```text
+compose::load (main.rs:80, startup)
+  └─ resolve_templates (compose.rs:55-61)
+       └─ store.template_names()?   ← compose.rs:157   [single server enforcement point — R3/AC6]
+       → Config.templates: HashMap<name, TemplateTiers{ plugin_default: <abs path>, … }>
+                                   │
+      ┌────────────────────────────┴────────────────────────────┐
+ server.rs:90 TemplateResolver::build(&cfg.templates, …)   watcher.rs:412 rebuild from cloned map
+                                   │                        (cfg_templates, server.rs:140)
+                         api/templates.rs:20 → /api/templates[/:name]
+```
+
+Three facts settle it:
+
+- **`plugin_root` is display-only.** `TemplateResolver::build`
+  (`templates.rs:117-122`) passes `plugin_root` solely to `display_path`
+  (`templates.rs:90-104`), which strips it as a `<plugin-root>` UI prefix. It never
+  reads or validates the filesystem with it.
+- **Reads are keyed on pre-computed paths and swallow per-tier.** Each tier's
+  `plugin_default` is an absolute `PathBuf` resolved upstream by compose;
+  `load_via_driver` (`templates.rs:254-268`) reads it and maps `Err(_)` →
+  `(present: false, None, None)`. That swallow is the correct rendering of a
+  genuinely-absent tier file — the UI analogue of AC7 — and should stay.
+- **The watcher does not re-enumerate.** `TemplateChangeHandler::spawn`
+  (`watcher.rs:372-419`) captures the cloned `cfg_templates` map
+  (`Arc<HashMap<String, TemplateTiers>>`, from `server.rs:140`) and rebuilds
+  `TemplateResolver` from that fixed map on every FS change. It never calls
+  `store.template_names`.
+
+Consequence: once R1 makes `template_names` refuse on a wrong root,
+`compose::load` fails at startup (`main.rs:80` → exit 2) and `TemplateResolver` is
+never reached with a wrong-root config. There is no independent server path that
+re-enumerates the store and swallows, so R3's single-point coverage at
+`compose.rs:157` is complete.

--- a/meta/reviews/plans/2026-09-09-0184-template-resolution-wrong-plugin-root-review-1.md
+++ b/meta/reviews/plans/2026-09-09-0184-template-resolution-wrong-plugin-root-review-1.md
@@ -1,0 +1,659 @@
+---
+type: "plan-review"
+id: "2026-09-09-0184-template-resolution-wrong-plugin-root-review-1"
+title: "Plan Review: Template Resolution Wrong-Root Refusal Implementation Plan"
+date: "2026-09-09T08:03:18+00:00"
+author: "Toby Clemson"
+producer: "review-plan"
+status: "complete"
+target: "plan:2026-09-09-0184-template-resolution-wrong-plugin-root"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["architecture", "correctness", "code-quality", "test-coverage", "usability", "standards"]
+review_number: 1
+review_pass: 2
+tags: ["cli", "config", "templates", "plugin-root", "visualiser"]
+last_updated: "2026-09-09T16:29:30+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Plan Review: Template Resolution Wrong-Root Refusal Implementation Plan
+
+**Verdict:** COMMENT
+
+The plan is well-grounded and implementable: the correctness lens verified its
+central branching against the live `store.rs` and found the `require_templates_dir`
+match arms exhaustive, the tier ordering preserved, and the genuine-not-found
+`Ok(None)` intact across all three plugin-default sites; the test-coverage lens
+confirmed complete AC1–AC12 traceability across a well-balanced three-layer
+pyramid. The one finding that recurs across two lenses is that the fix routes the
+*wrong-root* case through the existing `PluginRootUnavailable` variant, whose
+message tells a developer who has already set `ACCELERATOR_PLUGIN_ROOT` to "set
+`ACCELERATOR_PLUGIN_ROOT`" and never names the offending path — undercutting the
+diagnostic-quality goal that is the entire point of the work item. It is
+acceptable as a scoped tradeoff, but the plan does not currently acknowledge it as
+one. Plan is acceptable but could be improved — see the major finding below.
+
+### Cross-Cutting Themes
+
+- **The reused `PluginRootUnavailable` diagnostic mis-describes a set-but-wrong
+  root** (flagged by: architecture, usability) — both lenses independently land on
+  the same defect from different angles. Architecture sees a taxonomy that
+  conflates two distinct domain conditions (absent root vs present-but-not-an-
+  installation) behind one variant whose `Display` says the root is "unknown";
+  usability sees a self-contradictory remediation ("set a variable you have set")
+  that omits the path a developer needs to diagnose. The ACs pass regardless
+  because they only assert the message *contains* the variable name.
+- **The `Io` "not a directory" branch is under-served** (flagged by:
+  test-coverage, usability, correctness) — the `templates`-is-a-file case attracts
+  three separate concerns: its arm and the `read_dir` `map_err` line are never
+  exercised (both AC8 tests hit the not-a-directory arm, not the genuine-fault
+  arm); its bare "I/O error" message gives the developer no thread back to the
+  plugin root; and a TOCTOU race between the helper's `stat` and the later
+  `read_dir` could misclassify a `NotFound` as `Io`.
+- **Detection is centralised but adjacent duplication is left in place** (flagged
+  by: architecture, code-quality) — the plan consolidates the *validity check* into
+  one helper, but the `<plugin-root>/templates` *layout fact* is still
+  reconstructed in `compose.rs`, and the `require_templates_dir()?.join("{name}.md")`
+  path-building plus is-file-then-resolve shape is duplicated between
+  `resolve_template`'s tier and `plugin_default`.
+
+### Tradeoff Analysis
+
+- **Diagnostic precision vs minimal surface**: The plan's minimal-surface instinct
+  — reuse `PluginRootUnavailable`, touch the single `plugin_template_path` choke,
+  add no new variant — is what keeps it small and low-risk, but it is also the
+  direct cause of the major finding. A dedicated `PluginRootNotAnInstallation
+  { path }` variant would resolve the mis-diagnosis at the cost of a new error
+  variant, a new message, and touching `error.rs`. Recommendation: take the
+  precision, because the work item exists specifically to improve this
+  diagnostic; if minimal surface wins instead, record the message wording as a
+  conscious, documented tradeoff and pin an AC that the wrong-root message differs
+  from the absent-root message.
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Architecture + Usability**: Wrong-root refusal reuses the absent-root
+  message, which mis-describes a set-but-wrong root
+  **Location**: Desired End State / Implementation Approach (`require_templates_dir`
+  returning `PluginRootUnavailable`)
+  The plan maps a present-but-invalid root onto `ConfigError::PluginRootUnavailable`,
+  whose message reads "the plugin installation root is unknown: set
+  `ACCELERATOR_PLUGIN_ROOT`, or invoke accelerator through `bin/accelerator`"
+  (`error.rs:131`). On a wrong root the root is *known* — the developer set it —
+  so the remediation is a no-op they have already done, the message names neither
+  the offending path nor the real cause (a missing `templates/`), and a developer
+  could reasonably read it as an env-passing bug. The ACs and
+  `assert_names_the_plugin_root` only assert the message *contains* the variable, a
+  weak proxy for actionability that this misleading text passes.
+
+#### Minor
+
+- 🔵 **Test Coverage**: Genuine-I/O-fault arm of `require_templates_dir` (and the
+  `read_dir` `map_err` in `template_names`) is never exercised
+  **Location**: Implementation Approach; Phase 1 §1–§3
+  The helper has four outcomes but the plan tests three. Both AC8 tests trigger the
+  fault by making `templates` a *file*, so `fs::metadata` succeeds and the
+  not-a-directory `Ok(_)` arm fires — the `Err(other) => io_error(..)` arm and the
+  new `read_dir(..).map_err(..)?` line (unreachable once metadata confirms a
+  directory) both stay green under any mutation.
+
+- 🔵 **Standards + Code Quality**: The `require_templates_dir` doc comment breaks
+  the 80-column limit and partly restates its own match arms
+  **Location**: Implementation Approach (the helper snippet)
+  The second doc line is 81 chars as written, ~85 once indented into the impl
+  block, breaking the repo-wide 80-col rule; rustfmt does not reflow doc comments
+  (`wrap_comments` off), so `mise run cli:check` will not catch it — the identical
+  silent gap recorded before. Separately, the comment's opening restates the name
+  and signature and its closing narrates the two `Io` arms verbatim; only the
+  invariant clause (why `NotFound` → `PluginRootUnavailable`) earns its place under
+  the project's comment rule. Trimming to the invariant clause fixes both.
+
+- 🔵 **Usability**: A `templates` path that is a file surfaces as a bare "I/O
+  error" with no pointer back to the plugin root
+  **Location**: Implementation Approach (`require_templates_dir` `Io` branch) /
+  Phase 1 AC8
+  Two near-identical misconfigurations — `templates/` missing vs `templates` being
+  a file — produce wildly divergent diagnostic classes (an installation refusal vs
+  "I/O error on '<root>/templates': not a directory"), and AC8 asserts the file
+  variant does *not* name the plugin root, leaving the developer no thread back to
+  their `ACCELERATOR_PLUGIN_ROOT` setting for what is a plugin-root problem.
+
+- 🔵 **Usability**: The visualiser compose error contradicts the server's own
+  "var is set" check and offers launcher-only remediation
+  **Location**: Phase 3: Compose path surfaces the refusal (R3)
+  `run_serve` first confirms `ACCELERATOR_PLUGIN_ROOT` *is* set (`main.rs:68`), then
+  the composed failure prints "…the plugin installation root is unknown: set
+  `ACCELERATOR_PLUGIN_ROOT`, or invoke accelerator through `bin/accelerator`". Within
+  one binary the developer is told the variable is set and then that it is unknown,
+  plus remediation ("`bin/accelerator`") that describes the launcher, not the server
+  they are running.
+
+- 🔵 **Test Coverage**: AC11 asserts non-empty output but never runs the
+  `--fail-safe` path its rationale targets
+  **Location**: Phase 1 §3 (`a_root_independent_family_still_succeeds_against_a_wrong_root`)
+  AC11's stated reason for demanding non-empty output is that the `config` family
+  carries `--fail-safe`, which degrades a failing read to exit-0 empty output — yet
+  the planned test runs `config paths` *without* the flag, so it never exercises the
+  degrade path the assertion is designed to distinguish from real success.
+
+- 🔵 **Architecture**: The `templates/` layout fact remains reconstructed in
+  `compose.rs`
+  **Location**: Phase 3: Compose path (relationship to `require_templates_dir`)
+  The helper centralises the `<plugin-root>/templates` path and its validity check
+  inside `FileConfigStore`, but the compose path independently rebuilds the same
+  layout with `plugin_root.join("templates")` (`compose.rs:155`) to populate each
+  `TemplateTiers.plugin_default`. The validity gate is centralised; the *location*
+  of `templates/` now lives in two crates, only one of which carries the invariant.
+
+- 🔵 **Standards**: Store unit-test snippets drop the root `TempDir` immediately
+  **Location**: Phase 1 §2 / Phase 2 §2 (store unit tests)
+  The snippets build `FileConfigStore::at(tempdir()?.path())`, letting the root
+  `TempDir` drop (and delete its directory) at the end of that statement — every
+  existing `store.rs` unit test binds the handle first (`let root = tempdir()?;`),
+  and the plan itself already does this for the *plugin* handle. It roots the store
+  at an already-deleted path and breaks the module's uniform idiom.
+
+- 🔵 **Correctness**: TOCTOU between the helper's `stat` and `template_names`'
+  `read_dir` can misclassify `NotFound` as `Io`
+  **Location**: Phase 1 §1 (the shared helper and `template_names`)
+  `template_names` stats `templates/` through the helper (mapping `NotFound` →
+  `PluginRootUnavailable`), then does a separate `read_dir` whose error arm maps
+  *every* failure — including `NotFound` — to `Io`. If `templates/` is removed
+  between the two calls, the racing `NotFound` becomes the degradable `Io` and,
+  under `--fail-safe`, exit-0 empty output — the exact mode this item closes.
+  Negligible window on a cold path, but inconsistent with the helper's own
+  classification.
+
+#### Suggestions
+
+- 🔵 **Code Quality**: Residual path-building duplication between
+  `resolve_template`'s tier and `plugin_template_path`
+  **Location**: Phase 2 §1
+  After Phase 2, `require_templates_dir()?.join(format!("{name}.md"))` and the
+  is-file-then-resolve shape exist in both `resolve_template`'s inline tier and
+  `plugin_default`/`plugin_template_path`, differing only in the `warning` argument.
+  Having the tier build its candidate via `self.plugin_template_path(name)?` would
+  keep the plugin-default path concept in one place; if the differing `warning`
+  makes full unification awkward, note the residual duplication as deliberate.
+
+- 🔵 **Test Coverage**: No fast store-unit test for the override-precedes-plugin-
+  default crux
+  **Location**: Phase 2 §2
+  The hoisting hazard (the root check must sit *inside* each plugin-default step) is
+  pinned only at the slow CLI layer (AC10). A `config-adapters` unit test that seeds
+  a user override under a wrong root and asserts `resolve_template` returns
+  `Ok(Some(UserOverride))` would catch a hoisting regression in seconds.
+
+- 🔵 **Test Coverage**: The AC9 characterisation-test swap can skip an observable
+  red
+  **Location**: Phase 1 §3
+  Replacing the passing characterisation test with its inverse in the same change as
+  the production edit means the new test's red state is only observed if the author
+  deliberately stages it first. Note in the phase that the inverse test is written
+  and seen failing against the unmodified `template_names` before the swallow is
+  replaced.
+
+- 🔵 **Architecture**: The helper is templates-specific despite the "is this an
+  installation?" framing
+  **Location**: Decisions / Implementation Approach
+  `require_templates_dir` hard-codes `join("templates")`, coupling the installation-
+  validity concept to one resource; a future plugin-root accessor for a different
+  family could not reuse it cleanly. YAGNI-bounded — factor a general
+  `require_installation_root()` only if a second consumer is anticipated; otherwise
+  reconcile the Decisions wording with the templates-specific name.
+
+- 🔵 **Standards**: The helper name reads as a path accessor but encodes an
+  installation-validity refusal
+  **Location**: Implementation Approach
+  `require_templates_dir` looks like a plain path accessor, yet a missing
+  `templates/` surfaces `PluginRootUnavailable` (a refusal naming
+  `ACCELERATOR_PLUGIN_ROOT`). Consistent with the `require_*` gate family, but a
+  name like `require_installed_templates_dir` would signal the refusal at the call
+  site. A judgement call — hence low confidence.
+
+### Strengths
+
+- ✅ The central branching is verified sound against live code: `require_templates_dir`'s
+  match arms are exhaustive (`Ok(is_dir)`→path, `Ok(_)`→`Io "not a directory"`,
+  `Err(NotFound)`→`PluginRootUnavailable`, `Err(other)`→`io_error`), and the
+  referenced free functions and imports already exist.
+- ✅ The root check is correctly placed *inside* each plugin-default tier, after the
+  config-path and user-override tiers, so a resolving override still renders at exit
+  0 under a wrong root (AC10) — the R4 invariant is preserved, not hoisted away.
+- ✅ Genuine template-not-found (`Ok(None)`) survives across all three plugin-default
+  paths, and routing the fix through the single `plugin_template_path` choke fixes
+  `template`, `eject`, `diff`, and `reset` from one edit without duplicating the
+  branch.
+- ✅ Complete AC1–AC12 traceability across a well-balanced test pyramid: fast
+  `config-adapters` store unit tests for the red-green loop, black-box `config_read.rs`
+  pins for the observable surface, and one compose contract test at the server
+  boundary — with the not-found/refusal split double-covered and mutation-resistant.
+- ✅ The behavioural change lands in the shared `config-adapters` library, so both
+  binaries and the compose consumer inherit it through existing `?` / `#[from]`
+  abstractions with no consumer modification, in lockstep via 0182's version-keyed
+  cache.
+- ✅ The change conforms closely to existing conventions: it reuses the
+  `ErrorKind::NotFound` split idiom and the `io_error` helper, names the gate in the
+  established `require_*` family, and encodes the careful absent-vs-wrong-root
+  distinction in its test names.
+- ✅ The refusal classification is load-bearing and correct: `PluginRootUnavailable.is_refusal()`
+  is `true`, so wrong-root refusals fail closed byte-identically with and without
+  `--fail-safe`, while the `Io` arm stays degradable — matching AC8.
+
+### Recommended Changes
+
+1. **Resolve the wrong-root diagnostic** (addresses: the major finding; the compose
+   contradiction and the bare-I/O usability minors). Either introduce a dedicated
+   `PluginRootNotAnInstallation { path }` variant whose message names the offending
+   directory and the missing-`templates/` cause (dropping the launcher-only
+   `bin/accelerator` remediation for the server path), or consciously keep
+   `PluginRootUnavailable` and record the message reuse as a documented tradeoff in
+   the plan. Whichever path is taken, add an AC asserting the wrong-root message
+   differs from the absent-root message and names the path.
+2. **Close the `Io`-arm coverage gap** (addresses: the genuine-I/O-fault minor).
+   Add one store-unit test that induces a real fault on a *present* `templates/`
+   directory (`chmod 0o000` with the non-root guard AC8 already prescribes) and
+   asserts `Err(ConfigError::Io { .. })`, pinning both the stat-error arm and the
+   `read_dir` `map_err`.
+3. **Strengthen AC11 to exercise the flagged path** (addresses: the AC11 minor).
+   Run `config paths --fail-safe` against a wrong root and assert exit 0 *and*
+   non-empty real output, so the degrade path AC11 reasons about is actually run.
+4. **Trim the helper doc comment to the invariant clause** (addresses: the merged
+   doc-comment minor). Keep only the "why `NotFound` → `PluginRootUnavailable`"
+   rationale; drop the signature restatement and the `Io`-arm narration, which also
+   brings every line under 80 columns.
+5. **Fix the store-unit-test `TempDir` idiom** (addresses: the `TempDir` minor).
+   Bind the root handle first (`let root = tempdir()?;`) before passing `.path()` to
+   `FileConfigStore::at`, matching the surrounding tests.
+6. **Decide the residual duplication explicitly** (addresses: the compose-layout and
+   path-building findings). Either derive the compose plugin-default paths and the
+   `resolve_template` tier from single-owner accessors, or note both as deliberate,
+   out-of-scope for this fix.
+
+---
+*Review generated by /accelerator:review-plan*
+
+## Per-Lens Results
+
+### Architecture
+
+**Summary**: The plan is structurally sound: it consolidates installation-detection
+into a single shared helper (`require_templates_dir`) called by all three
+plugin-root template accessors, places the check inside each plugin-default step so
+the tiered resolution architecture and resolving-override property survive, and
+lands the change in the shared `config-adapters` library so both binaries and the
+compose consumer inherit it through existing abstractions (`?`/`#[from]`) with no
+consumer modification. The one meaningful architectural concern is that it overloads
+the existing `PluginRootUnavailable` error variant — whose message asserts the root
+is 'unknown' — to model a semantically distinct condition (root present but not an
+installation), producing a diagnostic that mis-describes the very case this work
+exists to diagnose. Two lesser observations concern incomplete centralisation of the
+templates-dir location and the templates-specific coupling of a helper the design
+framed as a general 'is-this-an-installation?' predicate.
+
+**Strengths**:
+- Detection consolidated into one shared helper called by all three accessors —
+  good cohesion and a single source of truth for both the templates-dir location and
+  the installation-validity check, which is also the justification for keeping the
+  three accessors bundled.
+- The check is correctly placed *inside* each plugin-default step, preserving the
+  tiered resolution architecture and the resolving-override-under-wrong-root property
+  (AC10).
+- The behavioural change lives in the shared `config-adapters` library, so launcher,
+  the six CLI commands, and the visualiser server inherit it in lockstep; the server
+  picks it up through existing `?` propagation and `ComposeError::Config(#[from])`
+  with no production change — a clean open-closed extension.
+- Respects the pre-existing fail-closed-for-answers vs degrade-for-hints boundary,
+  and correctly leaves `known_skill_names` tolerant rather than sweeping it in.
+- Introducing unit-level `FileConfigStore`-with-plugin-root tests pushes plugin-root
+  behaviour below the slow black-box CLI layer.
+- Choosing to hard-refuse at server compose rather than serve an empty template set
+  is an appropriate fail-fast posture.
+
+**Findings**:
+- **major** (confidence: medium) — *Wrong-root case overloads a variant whose
+  message says the root is 'unknown'* — Implementation Approach / Current State
+  Analysis. Maps a present-but-invalid root onto `PluginRootUnavailable`, whose
+  `Display` (`error.rs:131`) says the root is "unknown" and tells the user to set a
+  variable they set; the server surfaces this even though `run_serve` already
+  confirmed the variable is set. The taxonomy conflates absent-root and
+  present-but-not-an-installation, and the ACs pass because they only require the
+  message to *name* the variable. Suggestion: a dedicated
+  `PluginRootNotAnInstallation { path }` variant, or an explicit documented tradeoff.
+- **minor** (confidence: medium) — *Templates-dir location remains split between the
+  store helper and `compose.rs`* — Phase 3. The validity gate is centralised, but
+  `compose.rs:155` independently rebuilds `plugin_root.join("templates")`; the layout
+  fact now lives in two crates. Suggestion: derive compose's plugin-default paths
+  from a store-exposed accessor, or note the residual duplication.
+- **suggestion** (confidence: low) — *Helper is templates-specific despite being
+  framed as a general installation predicate* — Decisions / Implementation Approach.
+  `require_templates_dir` hard-codes `join("templates")`; a future plugin-root
+  accessor for another family could not reuse it cleanly. YAGNI-bounded.
+
+### Correctness
+
+**Summary**: The plan's central branching logic is sound and complete:
+`require_templates_dir` exhaustively distinguishes `ErrorKind::NotFound`
+(→`PluginRootUnavailable`), a present-but-non-directory `templates` entry (→`Io`),
+and other I/O faults (→`Io`), and every plugin-default site preserves the `Ok(None)`
+genuine-not-found while routing the wrong-root refusal ahead of the `is_file()`
+fall-through. The tier ordering is correctly preserved — the root check sits inside
+each plugin-default step, after the config-path and user-override tiers — so a
+resolving override under a wrong root still renders. The one correctness wrinkle is a
+non-atomic double filesystem probe in `template_names` whose `read_dir` error arm
+maps every error to `Io`, diverging from the helper's `NotFound`→`PluginRootUnavailable`
+classification in a narrow TOCTOU window; practically negligible on this cold path.
+
+**Strengths**:
+- `require_templates_dir`'s match arms are exhaustive and each maps to the intended
+  variant; verified `display()`, `io_error()`, and the `ErrorKind` import already
+  exist.
+- The plugin-default root check is correctly placed inside the plugin-default tier
+  (after config-path and user-override tiers), so AC10 / the R4 invariant is
+  preserved.
+- Genuine template-not-found (`Ok(None)`) is preserved across all three
+  plugin-default paths.
+- Routing the fix through `plugin_template_path` (the single choke both
+  `plugin_default` and `eject` call) is a correct minimal-surface choice.
+- The refusal-vs-degradable classification is load-bearing and correct:
+  `is_refusal()` is `true`, so wrong-root refusals fail closed identically with and
+  without `--fail-safe`, while the `Io` arm stays degradable (AC8).
+- No concurrency correctness concern introduced: `FileConfigStore` is a
+  stateless-over-filesystem `Clone`; the watcher rebuilds from a cloned map without
+  re-enumerating.
+
+**Findings**:
+- **minor** (confidence: low) — *Non-atomic double probe in `template_names`* —
+  Phase 1 §1. The helper stats `templates/` (mapping `NotFound` →
+  `PluginRootUnavailable`), then a separate `read_dir` maps every failure — including
+  `NotFound` — to `Io`. A TOCTOU removal between the two calls degrades to exit-0
+  empty under `--fail-safe`. Suggestion: map the `read_dir` `NotFound` arm to
+  `PluginRootUnavailable` for consistency, or note the arm is helper-guaranteed
+  impossible.
+
+### Code Quality
+
+**Summary**: A clean, well-factored quality change: a single `require_templates_dir`
+helper consolidates installation detection across all three accessors, mirroring the
+existing `require_plugin_root` naming and error-raising convention, and it replaces a
+swallow-everything `let Ok(...) else { Ok(Vec::new()) }` with precise three-way error
+categorisation. Testability is strong — it introduces store-level unit tests that
+inject a plugin root through the existing `with_plugin_root` builder, and the phased
+structure keeps the tree green at each step. The only quality nits are a doc comment
+that partly restates its own match arms and a small residual path-building
+duplication left in place.
+
+**Strengths**:
+- The shared helper is a genuine DRY consolidation: one detection point called by all
+  three accessors, mirroring `require_plugin_root`'s `require_`-prefix convention and
+  returning the resolved path so callers never re-join the segment.
+- Error handling is a clear improvement — the previous swallow (collapsing `NotFound`,
+  permission, and not-a-directory faults identically) is replaced with distinct,
+  diagnosable outcomes.
+- `fs::metadata` is a well-chosen single detection primitive serving both the
+  enumerating and the path-building callers, avoiding an inline presence check
+  duplicated per site.
+- Testability is well-considered: injects a plugin root via the existing builder,
+  backs it with black-box CLI pins and a compose contract test, drives every store
+  change red-first.
+- The three-phase split is cohesive; each phase is independently mergeable and leaves
+  the tree green.
+
+**Findings**:
+- **minor** (confidence: high) — *Doc comment partly restates its own match arms* —
+  Implementation Approach. The invariant clause (why `NotFound` →
+  `PluginRootUnavailable`) is load-bearing and permitted, but the opening restates the
+  name and signature and the closing narrates the two `Io` arms verbatim; the file's
+  surrounding comments are terse and why-focused. Suggestion: trim to the invariant
+  clause.
+- **suggestion** (confidence: medium) — *Residual path-building duplication between
+  `resolve_template`'s tier and `plugin_template_path`* — Phase 2 §1. The
+  `require_templates_dir()?.join("{name}.md")` and is-file-then-resolve shape live in
+  two near-identical spots, differing only in `warning`. Suggestion: build the tier's
+  candidate via `plugin_template_path`, or note the duplication as deliberate.
+
+### Test Coverage
+
+**Summary**: The plan achieves complete AC-to-test traceability: all twelve criteria
+map onto a well-balanced three-layer pyramid — fast `config-adapters` store unit
+tests, black-box `config_read.rs` integration tests, and a single compose contract
+test. Coverage is strong on the crux distinctions (genuine-not-found vs refusal at
+both unit and CLI level, override-resolves-under-wrong-root, `NotFound` vs
+not-a-directory) and reuses established scaffolding faithfully. The residual gaps are
+narrow: one branch of the helper (a genuine I/O fault on a real `templates/`
+directory) is never exercised, and AC11's fail-safe rationale is asserted without
+running the flagged path.
+
+**Strengths**:
+- Complete AC1–AC12 mapping, with genuine-not-found (AC7) and IO-fault (AC8)
+  double-covered at both store-unit and CLI layers.
+- Balanced pyramid fitting the risk: red-green loop in fast unit tests, durable
+  acceptance pins as black-box runs, exactly one server contract test.
+- Mutation-resistant assertions on the crux split (stderr contains the template name
+  AND not the variable; "I/O error" present AND variable absent).
+- AC10 correctly recognised as a new composition distinct from the absent-root
+  property, asserting rendered override content, not merely exit 0.
+- The characterisation test is replaced in place by its inverse (AC9) rather than
+  deleted, preserving the site's visibility.
+
+**Findings**:
+- **minor** (confidence: high) — *Genuine-I/O-fault arm never exercised* —
+  Implementation Approach; Phase 1. Both AC8 tests make `templates` a file, so
+  `metadata` succeeds and the not-a-directory arm fires; the `Err(other) => io_error`
+  arm and the `read_dir` `map_err` line stay green under mutation. Suggestion: add a
+  `chmod 0o000` store-unit test on a present `templates/` with the non-root guard.
+- **minor** (confidence: medium) — *AC11 never runs the `--fail-safe` path* — Phase 1
+  §3. The test runs `config paths` without the flag, so the degrade path its
+  non-empty assertion targets is unverified. Suggestion: run `config paths
+  --fail-safe` and assert exit 0 AND non-empty output.
+- **suggestion** (confidence: low) — *No fast store-unit test for
+  override-precedes-plugin-default* — Phase 2 §2. The hoisting crux is pinned only at
+  the CLI layer (AC10). Suggestion: a `config-adapters` unit test seeding an override
+  under a wrong root asserting `Ok(Some(UserOverride))`.
+- **suggestion** (confidence: low) — *AC9 swap can skip an observable red* — Phase 1
+  §3. Replacing a passing test with its inverse alongside the production edit can be
+  authored to pass by construction. Suggestion: note the inverse test is seen failing
+  first.
+
+### Usability
+
+**Summary**: The change delivers a real DX win in shape — replacing a silent empty
+table / misleading template-not-found with a loud, non-zero refusal across all six
+commands and the compose path, while preserving the genuine-missing-template message
+and resolving overrides. But the entire stated value is diagnostic quality, and the
+plan reuses the absent-root message verbatim for the wrong-root case: it tells a
+developer who has *set* `ACCELERATOR_PLUGIN_ROOT` to a wrong path that the root 'is
+unknown: set `ACCELERATOR_PLUGIN_ROOT`' — advice that is a no-op and can be read as
+an env-passing bug, and it never names the offending path. The distinction the plan
+nails is wrong-root-vs-missing-template; the distinction it collapses is
+absent-root-vs-wrong-root, precisely the case being fixed.
+
+**Strengths**:
+- Turns a silent wrong answer into a loud, non-zero refusal — strictly more
+  discoverable, the right least-surprise default.
+- Preserves and message-distinguishes the genuine-missing-template case (AC7).
+- User overrides still resolve at exit 0 under a wrong root (AC10).
+- Root-independent families keep working with normal output (AC11) — no collateral
+  regression.
+- Behaviour is uniform across all six commands and the compose path, byte-identical
+  with/without `--fail-safe`.
+
+**Findings**:
+- **major** (confidence: high) — *Wrong-root refusal reuses the absent-root message*
+  — Desired End State / Implementation Approach. The `PluginRootUnavailable` message
+  ("unknown: set `ACCELERATOR_PLUGIN_ROOT`") is self-contradictory for a set-but-wrong
+  root, echoes no path, and could read as an env-passing bug; the ACs only assert the
+  message *contains* the variable. Suggestion: a distinct diagnostic naming the path
+  and the real cause, plus an AC that the wrong-root message differs and names the
+  path.
+- **minor** (confidence: medium) — *Compose error contradicts `run_serve`'s own
+  check and offers launcher-only remediation* — Phase 3. Within one binary the server
+  is told the variable is set (`main.rs:68`) then that it is unknown, with
+  `bin/accelerator` remediation that describes the launcher. Suggestion: a
+  server-standalone message without the launcher remediation.
+- **minor** (confidence: medium) — *A `templates` file is reported as a bare "I/O
+  error" with no pointer to the plugin root* — Implementation Approach `Io` branch /
+  Phase 1 AC8. Two near-identical misconfigurations diverge into an installation
+  refusal vs a bare "I/O error"; AC8 asserts the file variant does not name the root.
+  Suggestion: word the detail to name the plugin-root expectation.
+
+### Standards
+
+**Summary**: The plan conforms closely to the `config-adapters` error conventions: it
+reuses the `ErrorKind::NotFound` split idiom and the `io_error` helper, constructs
+`ConfigError::Io` inline (matching `to_config_error`/`read_within`) for the
+no-`std::io::Error`-in-hand 'not a directory' case, names the new gate in the existing
+`require_*` family, and correctly uses per-crate test-result aliases and
+absent-vs-wrong-root test vocabulary. The one genuine convention break is a doc-comment
+line that exceeds the repo-wide 80-column limit with no rustfmt safety net; a
+test-idiom deviation and a helper-naming nuance are minor. No API, web, or
+accessibility standards apply.
+
+**Strengths**:
+- Mirrors the `ErrorKind::NotFound` split idiom of `custom_lenses`/`skill_names`,
+  routing the non-`NotFound` branch through the shared `io_error` helper.
+- Constructs `ConfigError::Io { path, detail }` inline for the file case (no
+  `std::io::Error` in hand), consistent with `to_config_error`/`read_within`; the
+  terse lowercase 'not a directory' detail matches the 'not writable' style.
+- Names the gate `require_templates_dir`, following the `require_*` family.
+- Test names encode the absent-vs-wrong-root distinction, keeping the suites
+  discoverable and non-conflated.
+- The doc comment documents a genuinely non-obvious invariant, within the codebase's
+  comment carve-out.
+- Reuses the exact existing scaffolding and mirrors the
+  `an_empty_plugin_root_refuses_to_compose` contract-test shape.
+
+**Findings**:
+- **minor** (confidence: high) — *Doc-comment line breaks the 80-column convention
+  with no rustfmt net* — Implementation Approach / Phase 1 §1. The second doc line is
+  81 chars, ~85 indented; rustfmt does not reflow doc comments, so `cli:check` will
+  not catch it. The `read_dir` chain also reaches ~83 cols but rustfmt will reformat
+  that code line. Suggestion: rewrap the doc comment ≤80 and pre-break the `read_dir`
+  chain as rustfmt will.
+- **minor** (confidence: medium) — *Store unit-test snippets drop the root `TempDir`
+  immediately* — Phase 1 §2 / Phase 2 §2. `FileConfigStore::at(tempdir()?.path())`
+  lets the root `TempDir` drop; every existing test binds the handle first, as the
+  plan already does for the plugin handle. Suggestion: bind the root to a local first.
+- **suggestion** (confidence: low) — *Helper name reads as a path accessor but
+  encodes an installation-validity refusal* — Implementation Approach. `self.require_templates_dir()?`
+  does not signal that an `ACCELERATOR_PLUGIN_ROOT` refusal can surface. Suggestion:
+  `require_installed_templates_dir`, or lean on the doc comment. A judgement call.
+
+## Re-Review (Pass 2) — 2026-09-09
+
+**Verdict:** APPROVE
+
+All six lenses re-ran on the revised plan. The sole major and the great majority
+of minors are resolved; the re-review caught one new major (a genuine-fault test
+that could not build as described), now fixed in the plan along with two further
+test-coverage gaps. The remaining open items are conscious, documented tradeoffs.
+
+**Approved (2026-09-09):** after the fail-closed-on-all-structural-shapes decision
+was folded into the plan and the work item (0184) reconciled to match, the author
+marked this review APPROVE and moved the plan to `ready`. No open findings remain.
+The fail-closed refinement and the work-item edits were applied after this pass and
+were not themselves re-run through the lenses.
+
+### Previously Identified Issues
+
+- 🟡 **Architecture + Usability**: Wrong-root refusal reuses the absent-root
+  message — **Resolved**. The dedicated `PluginRootNotAnInstallation { path }`
+  variant is assessed as the correct taxonomy; the exhaustive `is_refusal` +
+  `#[non_exhaustive]` combination makes it fail-closed by construction, and the
+  message is verified actionable and self-contained.
+- 🔵 **Test Coverage**: Genuine-I/O-fault arm never exercised — **Resolved** (via
+  the new-major fix below): a root-that-is-a-file trigger pins the `io_error` arm
+  environment-independently at both store and CLI layers.
+- 🔵 **Standards + Code Quality**: Doc comment over-wide and restates its arms —
+  **Resolved**. Widths recomputed ≤80 at real indent; the comment is now judged
+  justified, and its opening clause was trimmed further this pass.
+- 🔵 **Usability**: Bare "I/O error" with no pointer to the plugin root —
+  **Partially resolved**. The `Io` detail now names the plugin-root expectation; the
+  file case still omits the env var by AC8's design (accepted asymmetry).
+- 🔵 **Usability**: Compose error contradicts `run_serve`'s own check —
+  **Resolved**. Verified: the message drops the launcher-only remediation, and
+  `bin/accelerator` exports the derived root into `ACCELERATOR_PLUGIN_ROOT`, so
+  "check `ACCELERATOR_PLUGIN_ROOT`" is the correct single lever on both paths.
+- 🔵 **Test Coverage**: AC11 never runs `--fail-safe` — **Resolved**. The test now
+  runs `config paths --fail-safe`.
+- 🔵 **Architecture**: `templates/` layout reconstructed in `compose.rs` —
+  **Resolved as accepted**. Recorded as a deliberate deferral; re-review confirms
+  reasonable (the gate is centralised; the duplicated path-building is unreachable
+  on a wrong root).
+- 🔵 **Standards**: Store unit-test snippets drop the root `TempDir` — **Resolved**.
+  Snippets bind `let root = tempdir()?;` first.
+- 🔵 **Correctness**: TOCTOU in the double probe — **Resolved**. Reasoning assessed
+  sound; a deliberate-decision note was added.
+- 🔵 **Code Quality**: Path-building duplication — **Resolved**. The tier now builds
+  via `plugin_template_path`; one choke for all four commands.
+- 🔵 **Test Coverage**: Fast override-hoisting test / AC9 observable red —
+  **Resolved**. Both added; this pass made the override test seed its fixture.
+- 🔵 **Architecture / Standards**: Helper generality and naming — **Resolved as
+  accepted**. Both recorded as deliberate decisions; standards confirms the name is
+  not a deviation given the documented refusal.
+
+### New Issues Introduced
+
+- 🟡 **Test Coverage** (major, medium): The `chmod 0o000` genuine-fault test rested
+  on a root-guard precedent that does not exist (no root-detection facility in the
+  launcher test crate; the existing `chmod` test has no guard) — **Fixed this
+  pass**. Replaced with an environment-independent root-is-a-file trigger
+  (`metadata` fails `ENOTDIR`, not `NotFound`) at the store and CLI layers.
+- 🔵 **Test Coverage** (minor, medium): The genuine-not-found invariant was pinned
+  only for the `resolve_template` tier, not the `plugin_default` (diff/reset) site —
+  **Fixed this pass**. Added a `plugin_default` valid-root-missing-name → `Ok(None)`
+  store test.
+- 🔵 **Test Coverage** (suggestion): The override crux store test did not seed the
+  override file — **Fixed this pass**. The bullet now seeds
+  `.accelerator/templates/<name>.md`.
+- 🔵 **Standards / Code Quality** (suggestions): `|error|` vs the dominant `|e|`
+  closure idiom, and a trimmable doc-comment opening — **Fixed this pass**.
+- 🔵 **Correctness** (suggestion, low): The eject handlers' `available_or_none()`
+  swallow is safe only because a `?` on the same helper dominates every caller —
+  **Fixed this pass**. Recorded as an explicit invariant in the plan.
+- 🔵 **Code Quality** (minor, medium): The structural "templates is a file" fault
+  renders under the "I/O error" label — **Accepted**. Consistent with the
+  established `Io` reuse (UTF-8 decode, cross-filesystem); the detail already names
+  the expectation. Usability raised the same wording nuance.
+- 🔵 **Architecture** (minor, medium): The packaging invariant is now encoded in the
+  error taxonomy, and the external-installer leg is unverified — **Accepted**.
+  Documented in the helper doc comment; a change to the distribution model is the
+  trigger to revisit.
+- 🔵 **Architecture** (minor, medium) — **Resolved by product decision**: the
+  file-not-directory case originally mapped to `Io` (degradable under
+  `--fail-safe`). The user chose to fail closed on all structural shapes, so the
+  plan now refuses on `templates`-is-a-file (`Ok(!is_dir)`) and root-is-a-file
+  (`NotADirectory`) as well as missing `templates/`, reserving `Io` for a genuinely
+  unreadable fault (permission, filesystem loop) — tested via a self-referential
+  `templates` symlink (`FilesystemLoop`), no root guard. This also resolves the
+  "I/O error label on a structural fault" (code-quality) and the "bare I/O error"
+  (usability) findings, since those shapes now refuse and name the root. It refines
+  the work item's **AC8**, flagged in the plan as a work-item follow-up.
+
+### Assessment
+
+The plan is in strong shape and ready for implementation. The dedicated-variant
+decision resolved the headline finding cleanly, and correctness verified — against
+live code — that it compiles, forces its own classification, and preserves the
+override ordering. The re-review's value was catching a flawed genuine-fault test
+before implementation; that and two adjacent coverage gaps are now fixed. The one
+item flagged for a product decision — the file-not-directory case degrading under
+`--fail-safe` — was decided in favour of failing closed on all structural shapes,
+so the plan now refuses on every definitely-wrong root and reserves `Io` for
+genuinely unreadable faults. The sole outstanding follow-up is a work-item edit:
+AC8 must be revised to match (its file trigger is now a refusal, and criteria added
+for the two extra structural shapes).
+
+⚠️ The fixes applied in this pass were not themselves re-run through an agent, so
+they are unverified by a further review.
+
+---
+*Re-review generated by /accelerator:review-plan*

--- a/meta/reviews/work/0184-template-enumeration-swallows-a-wrong-plugin-root-review-1.md
+++ b/meta/reviews/work/0184-template-enumeration-swallows-a-wrong-plugin-root-review-1.md
@@ -1,0 +1,667 @@
+---
+type: "work-item-review"
+id: "0184-template-enumeration-swallows-a-wrong-plugin-root-review-1"
+title: "Work Item Review: Template resolution succeeds silently on a plugin root that is not an installation"
+date: "2026-09-08T19:34:01+00:00"
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
+target: "work-item:0184"
+work_item_id: "0184"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
+review_number: 1
+review_pass: 4
+tags: []
+last_updated: "2026-09-08T22:25:16+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Work Item Review: Template resolution succeeds silently on a plugin root that is not an installation
+
+**Verdict:** REVISE
+
+For a low-priority bug, 0184 is unusually well-specified: it quotes the offending
+code, distinguishes the *unknown* root (`None`) from the *known-and-wrong* root
+(`Some(path)`), anchors every symbol with a `store.rs` file:line reference, and
+frames most acceptance criteria as observable CLI outcomes with an explicit
+contrast to today's behaviour. The verdict is driven by one issue seen through
+four lenses — the `eject` site is mandated in Requirements yet its intended
+behaviour is an unresolved Open Question and no acceptance criterion covers it —
+compounded by a "wrong root" referent that silently narrows between the Summary
+and the Requirements, and a "three" count that names two different sets. These
+are correctness-of-specification defects, not polish: an implementer cannot
+currently tell what "done" means for `eject`, nor whether the fix is meant to
+catch every non-installation root or only the no-`templates/` subset.
+
+### Cross-Cutting Themes
+
+- **The `eject` site is under-specified** (flagged by: clarity, completeness,
+  scope, testability) — Requirement 2 commits `eject` to raising
+  `PluginRootUnavailable` on a wrong root, while Open Question 2 says exactly that
+  is undecided. No acceptance criterion exercises `eject`, so one of the three
+  mandated change sites has neither a settled directive nor a pass/fail check.
+  This single unresolved decision is the dominant reason for the REVISE.
+- **"Wrong root" narrows between Summary and Requirements** (flagged by: clarity,
+  testability) — the Summary defines a wrong root as "present, but not an
+  Accelerator installation", but every requirement and criterion detects only the
+  narrower "root carries no `templates/` directory". A mis-pointed root that
+  happens to contain an unrelated `templates/` directory is a wrong root by the
+  Summary's wording yet is caught by nothing, so passing all criteria would not
+  confirm the stated intent.
+- **The load-bearing `templates/` assumption is prose-only** (flagged by:
+  completeness, dependency) — the entire `NotFound → PluginRootUnavailable`
+  mapping rests on "every installation ships a `templates/` directory", which the
+  item itself flags as needing confirmation against the release artifact, but that
+  check is not tracked as a precondition or acceptance step.
+
+### Findings
+
+#### Critical
+
+_None._
+
+#### Major
+
+- 🟡 **Clarity / Completeness / Testability / Scope**: `eject` site is mandated
+  but its behaviour is undecided and untested
+  **Location**: Requirements / Open Questions / Acceptance Criteria
+  Requirement 2 directs the fix at "all three sites — `resolve_template`'s
+  plugin-default tier, and `plugin_template_path`'s callers `plugin_default` and
+  `eject`", committing `eject` to refuse on a wrong root; Open Question 2 then
+  asks whether `eject` should refuse at all or whether `EjectOutcome::NoDefault`
+  is legitimate, "left open". No acceptance criterion exercises `eject`, so its
+  "done" is undefined and can be claimed either way. Resolve the question, then
+  either add a criterion pinning eject's wrong-root outcome or scope `eject` out
+  of Requirements until the decision lands.
+
+- 🟡 **Testability / Clarity**: Criteria verify "no `templates/` directory",
+  narrower than the Summary's "wrong root" intent
+  **Location**: Summary / Acceptance Criteria
+  Every criterion operationalises a wrong root as one lacking a `templates/`
+  directory (AC1 explicitly; AC2's "a wrong root" only refuses under that same
+  condition per the Assumption). A wrong root containing an unrelated
+  `templates/` directory — a plausible mis-pointed root — is covered by no
+  criterion and, by the design's own discriminator, would still succeed silently
+  as a template-not-found: the exact failure mode the item exists to close.
+  Either tighten the Summary to "a root lacking a `templates/` directory", or add
+  a criterion for a wrong root that retains a `templates/` directory.
+
+- 🟡 **Clarity**: "Three" refers to two different, only-partly-overlapping sets
+  **Location**: Summary / Requirements
+  The Summary names "three plugin-root template accessors" (`template_names`,
+  `resolve_template`'s tier, `plugin_template_path`); Requirement 2's "all three
+  sites" is a different triple (`resolve_template`'s tier, `plugin_default`,
+  `eject`) sharing only one member. A reader mapping "all three sites" onto the
+  Summary's "three accessors" will mis-scope the change. Use one consistent
+  vocabulary and state how many of each — accessors versus application sites —
+  there are.
+
+#### Minor
+
+- 🔵 **Scope**: Extended scope bundles two independently-deliverable fixes the
+  item itself flags as splittable
+  **Location**: Drafting Notes
+  The "Option B" enlargement added `resolve_template`/`plugin_template_path` to
+  the original `template_names`-only bug, and the Drafting Notes concede "a
+  reviewer may still prefer to split" that work out. The two slices
+  (`config templates list` versus `config template <name>`/eject) could each be
+  delivered and rolled back independently. Bundling is defensible given the shared
+  fix pattern, but the keep-or-split call should be deliberate, not implicit.
+
+- 🔵 **Testability**: AC3 relies on a relative message discriminator with no exit
+  code or substring pinned
+  **Location**: Acceptance Criteria
+  AC3 requires a present `templates/` directory lacking `<name>.md` to "still
+  yield a genuine template-not-found ... distinguishable from the message alone",
+  but names no command, pins no exit code, and asserts only that the two messages
+  differ. State the command (`config template <name>` with no resolving
+  override), the expected exit code, and a concrete substring the not-found
+  message must contain (and that the `ACCELERATOR_PLUGIN_ROOT` diagnostic is
+  absent).
+
+- 🔵 **Dependency / Completeness**: Load-bearing release-artefact assumption is
+  not tracked as a precondition
+  **Location**: Assumptions
+  The `NotFound → PluginRootUnavailable` mapping rests on "every Accelerator
+  installation ships a `templates/` directory", which the Assumption flags as
+  "worth confirming against the release artifact's file list before relying on
+  it" — but that confirmation lives only as prose, not as an Open Question, a
+  first verification step, or a Dependencies note. If an installation ever ships
+  without `templates/`, the mapping misdiagnoses a genuine installation. Promote
+  the check to a tracked precondition.
+
+#### Suggestions
+
+- 🔵 **Clarity**: Filename slug and title frame the scope differently
+  **Location**: Frontmatter: title
+  The slug `template-enumeration-swallows-a-wrong-plugin-root` ("enumeration"
+  points at `template_names` alone) is narrower than the title "Template
+  resolution succeeds silently ..." ("resolution" spans `resolve_template`). The
+  Drafting Notes record the scope extension that "motivated the title change", but
+  the narrower slug was kept. Align the two framings, or note the slug reflects
+  the original narrower framing.
+
+### Strengths
+
+- ✅ Every code symbol is anchored with a `store.rs` file:line reference in
+  Technical Notes, so specialised identifiers are resolvable rather than opaque.
+- ✅ The two root states are consistently distinguished — "unknown" (`None`) vs
+  "known and wrong" (`Some(path)`, passes `require_plugin_root`) — with the
+  mechanism spelled out.
+- ✅ All four bug-reproduction elements are present: input, action, expected
+  outcome, and the named actual outcomes per accessor (header-only table at
+  exit 0; `Ok(None)` rendered as a template-name "not found").
+- ✅ Requirements and criteria state concrete, observable outcomes (specific
+  `ConfigError` variants, non-zero exit, a diagnostic naming the greppable
+  literal `ACCELERATOR_PLUGIN_ROOT`), falsifiable in both directions.
+- ✅ The behaviour change is anchored at a named existing characterisation test
+  (`a_root_without_a_templates_directory_still_renders_an_empty_table`) replaced
+  by its inverse rather than deleted, recording the change at the same site.
+- ✅ The dependency on 0182 is named with its correct `done` status and the
+  reconciliation is transparently recorded in Drafting Notes; provenance as a
+  0182 Phase 5 follow-up is traceable end to end.
+- ✅ Scope is bounded to one component and one struct (`FileConfigStore`), a
+  legitimate carve-out of 0182 with standalone value; the `bug` kind fits.
+
+### Recommended Changes
+
+1. **Resolve the `eject` decision and reconcile Requirements, Open Questions and
+   Acceptance Criteria** (addresses: the `eject` major, the three cross-cutting
+   `eject` findings)
+   Decide whether `eject` on a wrong root refuses (`PluginRootUnavailable`) or is
+   a legitimate `EjectOutcome::NoDefault`. Then make exactly one section state it:
+   if in scope, add an acceptance criterion pinning eject's wrong-root outcome and
+   delete Open Question 2; if deferred, remove `eject` from Requirement 2's site
+   list and record the deferral.
+
+2. **Make "wrong root" mean one thing across the item** (addresses: the wrong-root
+   major)
+   Either narrow the Summary/title to "a root that carries no `templates/`
+   directory" so intent matches the criteria, or add a criterion covering a wrong
+   root that contains an unrelated `templates/` directory and note the design's
+   discriminator. Restate AC2's precondition to match AC1's precise wording.
+
+3. **Disambiguate the "three" count** (addresses: the "three sets" major)
+   Distinguish "three accessors" (Summary) from "the sites where the distinction
+   is applied" (Requirement 2) with a single consistent vocabulary, stating how
+   many of each so "three" is never reused for a different set.
+
+4. **Track the `templates/`-presence check as actionable work** (addresses: the
+   assumption minor)
+   Promote "confirm `templates/` is always present in the release artifact" to an
+   Open Question, a first verification step, or a Dependencies note so the
+   coupling is scheduled rather than relied on as prose.
+
+5. **Pin AC3 concretely** (addresses: the AC3 minor)
+   Name the command, the exact exit code, and a specific substring the genuine
+   not-found message must contain, plus the absence of the
+   `ACCELERATOR_PLUGIN_ROOT` diagnostic.
+
+6. **Confirm or split the extended scope; align the slug** (addresses: the scope
+   minor, the slug suggestion)
+   Record why the two slices are one unit (e.g. a shared "is this root an
+   installation?" helper), or split them; and align the filename slug with the
+   broadened title.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: The work item is generally precise about the mechanism, carefully
+separating the "unknown root" (`None`) state from the "known-and-wrong root"
+(`Some(bad path)`) state and anchoring every code symbol with file:line
+references. However, clarity is undermined by an overloaded "three" count (the
+Summary's "three accessors" and Requirement 2's "three sites" are different,
+only-partly-overlapping triples), a direct contradiction between a committed
+requirement and an open question about eject, and a "wrong root" referent whose
+meaning silently narrows between the Summary and the Requirements.
+
+**Strengths**:
+- Every code symbol (`template_names`, `resolve_template`, `plugin_template_path`,
+  `ConfigError::PluginRootUnavailable`, `io_error`, etc.) is anchored with a
+  `store.rs` file:line reference in Technical Notes.
+- The two root states are consistently distinguished throughout — "unknown"
+  (`None`, passes nothing) versus "known and wrong" (`Some(path)`, passes
+  `require_plugin_root`) — with the `Some(path)` mechanism spelled out.
+- Requirements and Acceptance Criteria state concrete, observable outcomes rather
+  than vague desired properties.
+- The Assumption underpinning detection (installation implies a `templates/`
+  directory) is stated explicitly and flagged as needing confirmation.
+- Drafting Notes transparently record the two corrected behavioural claims and the
+  Option-B scope extension.
+
+**Findings**:
+- 🟡 **major** (confidence: high) — *"Three" refers to two different,
+  only-partly-overlapping sets* — Location: Requirements. The Summary names
+  "three plugin-root template accessors" — `template_names`, `resolve_template`'s
+  plugin-default tier, and `plugin_template_path`. Requirement 2 then says "Apply
+  the distinction at all three sites — `resolve_template`'s plugin-default tier,
+  and `plugin_template_path`'s callers `plugin_default` and `eject`". These are
+  two different triples: the second excludes `template_names` and includes
+  `plugin_default` and `eject`, sharing only one member with the first. A reader
+  who maps "all three sites" onto the Summary's "three accessors" will mis-scope
+  the change. Use a single, consistent vocabulary and count.
+- 🟡 **major** (confidence: high) — *Requirement mandates eject behaviour that an
+  Open Question leaves undecided* — Location: Requirements / Open Questions.
+  Requirement 2 commits `eject` to surface `PluginRootUnavailable` on a wrong
+  root; Open Question 2 asks whether it should, "left open". The requirement
+  commits to exactly what the open question says is undecided, so the item does
+  not have a single coherent intent for one of its named sites. Reconcile the two.
+- 🔵 **minor** (confidence: medium) — *"Wrong root" means something broader in the
+  Summary than the Requirements detect* — Location: Summary. The Summary defines a
+  wrong root as "present, but not an Accelerator installation"; the Requirements
+  and Assumption narrow the detected case to "the root carries no `templates/`
+  directory". That establishes "no `templates/` implies not an installation", not
+  the converse: a non-installation root containing a `templates/` directory is a
+  wrong root by the Summary's wording yet caught by none of the Requirements.
+- 🔵 **suggestion** (confidence: low) — *Filename slug and title frame the scope
+  differently* — Location: Frontmatter: title. The slug
+  `template-enumeration-swallows-a-wrong-plugin-root` ("enumeration" points at
+  `template_names` alone) is narrower than the title "Template resolution succeeds
+  silently ..." A reader navigating by filename may expect a `template_names`-only
+  fix. Align the two framings.
+
+### Completeness
+
+**Summary**: For a bug, 0184 is structurally complete and richly populated: a
+precise Summary naming the three affected accessors, a motivating Context, three
+specific Requirements, seven Acceptance Criteria, plus Assumptions, Open
+Questions, Dependencies, Technical Notes and Drafting Notes. The four
+reproduction elements (input, action, expected, actual) are all present, though
+distributed across sections rather than consolidated. The one substantive
+completeness gap is that the `eject` site is scoped in Requirements yet left
+unresolved in Open Questions with no acceptance criterion, so "done" is not fully
+defined for all three sites the item claims.
+
+**Strengths**:
+- The Summary states the bug unambiguously, naming the three specific accessors
+  and the exact failure mode.
+- The Context explains why the work is needed now: 0182 Phase 5 deliberately left
+  these arms alone, the surviving behaviour is pinned as a named characterisation
+  test, and a wrong root became newly plausible in the same change.
+- All four bug reproduction elements are present.
+- Seven specific Acceptance Criteria, including preservation criteria and the
+  full-build gate (`mise run` exits 0).
+- Frontmatter is complete and well-formed for a bug.
+- Optional sections that add value — Assumptions, Open Questions, Dependencies,
+  Technical Notes (with concrete `store.rs` references), Drafting Notes — are all
+  populated.
+
+**Findings**:
+- 🟡 **major** (confidence: medium) — *eject site is scoped but its "done" is
+  undefined and uncovered by any acceptance criterion* — Location: Acceptance
+  Criteria. Requirements name three sites including `plugin_template_path`'s
+  `eject` caller, but Open Questions asks whether eject against a wrong root should
+  refuse at all, and none of the seven Acceptance Criteria define the expected
+  outcome for the eject site. An implementer reaching eject has neither a settled
+  directive nor a criterion to verify against. Resolve the Open Question (or defer
+  eject), and if it stays in scope, add a criterion pinning eject's outcome.
+- 🔵 **suggestion** (confidence: medium) — *Load-bearing assumption's verification
+  is not captured as an actionable step* — Location: Assumptions. The Assumptions
+  section states that every installation ships a `templates/` directory — the
+  signal the entire `NotFound → PluginRootUnavailable` mapping rests on — and
+  self-flags it as unconfirmed, but that confirmation is not elevated to an Open
+  Question or acceptance step. Promote the "confirm against the release artifact"
+  step so the check is tracked.
+
+### Dependency
+
+**Summary**: This bug is unusually well dependency-mapped for its kind: its sole
+upstream dependency (0182) is named, its `done` status is correctly reconciled
+against the frontmatter, and its provenance as a follow-up explicitly raised by
+0182's Phase 5 §3 is captured in Context and confirmed by the referenced plan.
+No downstream consumers are implied by Context or Requirements, so the empty
+Blocks is appropriate rather than a hidden coupling, and the internal
+characterisation-test it inherits is captured with a dedicated acceptance
+criterion. The one coupling worth surfacing more prominently is the load-bearing
+release-artifact assumption on which the new error mapping rests.
+
+**Strengths**:
+- The sole upstream dependency (0182) is named with its correct `done` status, and
+  the Drafting Notes record reconciling that status against the frontmatter
+  `relates_to` — no stale "blocked by" claim and no hidden upstream blocker.
+- Provenance is fully traceable: Context matches the referenced plan's Phase 5 §3
+  that raised this exact item as the follow-up.
+- The inherited characterisation test is named in Context, and an acceptance
+  criterion requires replacing it with its inverse rather than deleting it.
+- No downstream consumers are named or implied, so the absence of Blocks entries
+  reflects the scope accurately.
+
+**Findings**:
+- 🔵 **minor** (confidence: medium) — *Load-bearing release-artefact assumption is
+  not tracked as a precondition* — Location: Assumptions. The fix's core
+  `NotFound → PluginRootUnavailable` mapping rests on the Assumption that "every
+  Accelerator installation ships a `templates/` directory", flagged as "worth
+  confirming against the release artifact's file list before relying on it". This
+  coupling to the distribution/release-artefact structure lives only as a prose
+  assumption. If a valid installation ever ships without `templates/`, the mapping
+  misdiagnoses a genuine installation. Surface the check as a tracked precondition
+  or a Dependencies note.
+
+### Scope
+
+**Summary**: Work item 0184 is a coherent, appropriately-sized bug fix confined to
+a single component (the template accessors of `FileConfigStore` in
+`cli/config-adapters`) and a single defect class: a wrong-but-present plugin root
+degrading silently instead of being diagnosed. Requirements, Acceptance Criteria
+and Summary describe the same scope, and carving it out of the now-done 0182
+(which deliberately stayed scoped to root *presence*) is a legitimate follow-up
+with standalone value. The only scope considerations are the deliberate extension
+from the original `template_names`-only bug to all three accessors — which the
+item itself flags as splittable — and an unresolved in-or-out question for the
+`eject` site.
+
+**Strengths**:
+- All requirements serve one unified purpose: turning a silent-wrong-answer on a
+  known-but-wrong plugin root into a named `PluginRootUnavailable` refusal.
+- Bounded to one component and one struct (`FileConfigStore`); no cross-service or
+  cross-team boundaries are spanned.
+- The boundary is stated explicitly — the Requirements name what must keep working
+  (root-independent config families and project-local overrides).
+- The split from 0182 is well-justified rather than artificial fragmentation.
+- The `bug` kind fits the scope.
+
+**Findings**:
+- 🔵 **minor** (confidence: medium) — *Extended scope bundles two
+  independently-deliverable fixes the item itself flags as splittable* — Location:
+  Drafting Notes. The item was deliberately enlarged (the "Option B" choice) from
+  the original `template_names`-only bug to also cover `resolve_template`'s
+  plugin-default tier and `plugin_template_path`, and the Drafting Notes
+  acknowledge a reviewer "may still prefer to split" that work. The two slices
+  could each be delivered, tested and rolled back independently. Bundling is
+  defensible given the high cohesion, but is worth a deliberate keep-or-split
+  decision rather than an implicit default.
+- 🔵 **suggestion** (confidence: medium) — *Whether the eject site is in scope is
+  left undecided, leaving the unit-of-work boundary partly open* — Location: Open
+  Questions. The Requirements name `eject` as one of three sites, but an Open
+  Question asks whether eject should surface `PluginRootUnavailable` at all, "left
+  open", and no criterion pins eject's behaviour. One of the three named change
+  sites has an unresolved in-or-out status, so the boundary of the deliverable
+  cannot be fully stated. Resolve the eject semantics before implementation (or
+  scope it out) and align Requirements and Acceptance Criteria.
+
+### Testability
+
+**Summary**: As a bug, 0184 is unusually well-specified for verification: the
+broken behaviours are quoted from source, the actual outcomes (header-only table
+at exit 0; `Ok(None)` rendered as a template-name "not found") are named, and most
+criteria pin observable CLI outcomes with an explicit contrast to today's
+behaviour, making them falsifiable in both directions. Two gaps weaken the
+verification strategy: the `eject` site named in Requirements has no acceptance
+criterion and its intended outcome is an unresolved Open Question, and every
+criterion operationalises "a wrong root" as "a root lacking a `templates/`
+directory" — a narrower condition than the Summary's stated intent, leaving a
+plausible wrong-root case unverified. A relative message discriminator in one
+criterion could also be pinned more concretely.
+
+**Strengths**:
+- The bug is reproducibly specified: the offending code is quoted, the actual
+  broken outcomes are named per accessor, and expected outcomes appear in the
+  criteria.
+- AC1 and AC2 are framed as observable CLI outcomes — exit non-zero plus a
+  diagnostic naming the greppable literal `ACCELERATOR_PLUGIN_ROOT` — each with an
+  explicit "replacing today's ..." contrast.
+- AC4 supplies a concrete reproduction (mode `0o000`) and a specific expected
+  error variant naming the path.
+- AC5 anchors the behaviour change at a named existing characterisation test
+  replaced by its inverse.
+- Scope is bounded to three named accessors with no unbounded language, and no
+  criterion is tautological.
+
+**Findings**:
+- 🟡 **major** (confidence: medium) — *eject site has no acceptance criterion and
+  an undecided expected outcome* — Location: Requirements / Open Questions.
+  Requirements direct the fix to "apply the distinction at all three sites — ...
+  and eject", but no Acceptance Criterion exercises `eject`, and the Open
+  Questions leave its intended behaviour undecided. One-third of the mandated
+  change has no pass/fail check and no defined expected outcome. Resolve the Open
+  Question, then add a criterion of the form "`config template <name> --eject`
+  against a root lacking a `templates/` directory yields <decided outcome>"; or
+  scope `eject` out of Requirements until the decision lands.
+- 🟡 **major** (confidence: medium) — *Criteria verify "no `templates/`
+  directory", narrower than the Summary's "wrong root" intent* — Location:
+  Acceptance Criteria. The Summary's intent is that the accessors "succeed
+  silently when the root is known and wrong — present, but not an Accelerator
+  installation", but every criterion operationalises this as a root that lacks a
+  `templates/` directory. A wrong root that contains an unrelated `templates/`
+  directory is covered by no criterion and, by the design's own discriminator,
+  would still succeed silently — the exact failure mode the item exists to close.
+  Either narrow the Summary/title, or add a criterion covering a wrong root that
+  retains a `templates/` directory; and restate AC2's precondition to match AC1's
+  precise wording.
+- 🔵 **minor** (confidence: medium) — *AC3 relies on a relative message
+  discriminator with no exit code or substring pinned* — Location: Acceptance
+  Criteria. AC3 requires a present `templates/` directory lacking `<name>.md` to
+  "still yield a genuine template-not-found ... distinguishable from the message
+  alone", but neither names the command nor pins the expected exit code, and its
+  discriminator is relative (the two messages must merely differ). State the
+  command, the expected exit code, and a specific substring the genuine not-found
+  message must contain, plus that the `ACCELERATOR_PLUGIN_ROOT` diagnostic is
+  absent.
+
+## Re-Review (Pass 2) — 2026-09-08
+
+**Verdict:** REVISE
+
+All five lenses were re-run against the revised work item. Every finding from
+Pass 1 is resolved. The verdict remains REVISE because a fresh pass surfaced two
+new major findings — both pre-existing gaps the first round did not reach, plus
+minor artefacts of the Pass 1 edits.
+
+### Previously Identified Issues
+
+- 🟡 **Clarity**: "Three" refers to two different sets — **Resolved** (Requirement
+  2 now reads "at each plugin-default site"; re-review finds no count collision).
+- 🟡 **Clarity**: Requirement mandates eject behaviour an Open Question leaves
+  undecided — **Resolved** (eject resolved to refuse; the contradiction is gone).
+- 🔵 **Clarity**: "Wrong root" broader in Summary than Requirements — **Resolved**
+  (the Summary now defines the term explicitly and scopes out the retained-
+  `templates/` case; re-review praises the consistent definition).
+- 🟡 **Completeness**: eject scoped but "done" undefined and uncovered —
+  **Resolved** (dedicated eject acceptance criterion added).
+- 🔵 **Completeness**: assumption verification not actionable — **Resolved**
+  (promoted to a tracked precondition under Dependencies).
+- 🔵 **Dependency**: load-bearing release-artefact assumption untracked —
+  **Resolved** (re-review cites "strong dependency hygiene").
+- 🔵 **Scope**: extended scope bundles splittable fixes — **Resolved / accepted**
+  (re-review downgrades to a suggestion, "no change required — the split was
+  consciously declined").
+- 🔵 **Scope**: eject in-or-out undecided — **Resolved**.
+- 🟡 **Testability**: eject has no criterion / undecided outcome — **Resolved**.
+- 🟡 **Testability**: criteria narrower than the "wrong root" intent —
+  **Resolved** (narrowed spec aligns intent and criteria).
+- 🔵 **Testability**: AC3 relative discriminator — **Resolved** (now AC4, praised
+  as a model criterion, falsifiable in both directions).
+
+### New Issues Introduced
+
+- 🟡 **Dependency** (major): The changed `template_names` error semantics
+  propagate to the visualiser server's `visualiser/server/src/compose.rs` — a
+  consumer named in the 0182 plan (Phase 5 §2) that propagates `ConfigError` via
+  `?` into `ComposeError`. That downstream coupling is captured nowhere in the
+  item, so the server would newly hard-error where it previously degraded to an
+  empty template set. Pre-existing coupling, first surfaced this pass. Name the
+  server consumer in Dependencies/Requirements and state whether it refuses
+  identically or is out of scope.
+- 🟡 **Testability** (major): AC7 ("A user override still resolves against a wrong
+  root") names no command, no override setup, and no observable pass condition —
+  unlike AC1–AC6. It cannot lean on the absent-root property
+  `a_user_override_still_resolves_with_no_plugin_root`, which pins a different
+  case. Restate as a full input/action/expected triple.
+- 🔵 **Clarity / Testability** (minor): The new eject criterion (AC3) is framed as
+  an internal enum (`ConfigError::PluginRootUnavailable`) with an ambiguous
+  "naming the root" — variable name or path value? — where AC1/AC2 pin a
+  CLI-observable diagnostic naming `ACCELERATOR_PLUGIN_ROOT`. Artefact of the
+  Pass 1 edit; pin AC3 to the same observable shape and disambiguate.
+- 🔵 **Clarity** (minor): The "Open Questions" section now holds only resolved
+  items (one annotated "Resolved in favour of…", one prefixed "Resolved:"), so
+  the header contradicts its content. Artefact of the Pass 1 edit; retitle to a
+  Decisions section or leave Open Questions as "none".
+- 🔵 **Testability** (minor): AC5's `chmod 0o000` trigger is bypassed when the
+  test runs as root (common in CI containers), so the `Io` branch may never fire.
+  Note the non-root constraint or use an environment-independent trigger (e.g. a
+  `templates` path that is a file). Pre-existing.
+- 🔵 **Testability** (minor, low): AC6's "replaced by its inverse" does not name
+  the concrete replacement assertion; tie it to AC1. Pre-existing.
+- 🔵 **Clarity** (suggestion, low): Requirement 3's heading names "root-independent
+  families" the body never addresses (it discusses only project-local overrides).
+  Pre-existing.
+- 🔵 **Clarity** (suggestion, low): the title's "succeeds silently" describes only
+  `template_names`; the other two accessors misdiagnose rather than succeed.
+- 🔵 **Completeness** (suggestion): the four bug-reproduction elements are present
+  but scattered across Summary and Acceptance Criteria rather than consolidated
+  into a Reproduction section as sibling 0182 does. Pre-existing.
+
+### Assessment
+
+The Pass 1 revisions landed cleanly — the eject decision, the narrowed "wrong
+root", the count fix, the pinned AC4, and the tracked assumption are all
+confirmed resolved, and no lens re-raised them. The item is not yet ready: two
+new majors stand. The **visualiser `compose.rs` downstream coupling** is the
+substantive one — it is a genuine behavioural change in a second component that
+the item does not scope, and it should be decided (refuse identically, or
+explicitly out of scope) before implementation. The **AC7 user-override
+criterion** and the two edit-artefact minors (the eject AC's internal-enum
+framing, the mis-titled "Open Questions" section) are quick, mechanical fixes.
+Addressing these four would clear the path to APPROVE.
+
+## Re-Review (Pass 3) — 2026-09-08
+
+**Verdict:** REVISE
+
+All Pass 2 findings are resolved. The two Pass 2 majors — the visualiser
+`compose.rs` coupling and the terse AC7 — are both confirmed fixed and now
+praised (the server is reasoned into scope with rationale; AC8 is a full
+input/action/expected triple). The verdict remains REVISE because two new majors
+surfaced, both finer than the earlier rounds: a count conflict, and an
+un-exercised code site. This pass shows clear diminishing returns — several new
+findings are consumer-enumeration refinements opened by Pass 2's scope expansion.
+
+### Previously Identified Issues
+
+- 🟡 **Dependency**: visualiser `compose.rs` downstream coupling uncaptured —
+  **Resolved** (brought into scope with a requirement, criterion, dependency
+  entry and technical note; re-review calls it "well-orchestrated").
+- 🟡 **Testability**: AC7 user-override omits action/outcome — **Resolved** (now
+  a full triple, praised).
+- 🔵 **Clarity / Testability**: eject AC internal-enum framing / "naming the root"
+  ambiguity — **Resolved** (re-pinned to a CLI-observable diagnostic naming
+  `ACCELERATOR_PLUGIN_ROOT`; wording standardised).
+- 🔵 **Clarity**: "Open Questions" held only resolved items — **Resolved**
+  (retitled "Decisions"; re-review calls it "honest").
+- 🔵 **Testability**: AC5 `0o000` root-bypass — **Resolved** (environment-
+  independent trigger + non-root guard, praised).
+- 🔵 **Testability**: AC6 "inverse" not concrete — **Resolved** (tied to AC1).
+- 🔵 **Clarity**: Requirement 3 heading vs body — **Resolved** (root-independent
+  families clause added).
+
+### New Issues Introduced
+
+- 🟡 **Clarity** (major): The Summary's "Three plugin-root template accessors"
+  conflicts with Dependencies' "0182 introduced `PluginRootUnavailable` and the
+  two named accessors this extends" — two vs three is unreconciled at the point a
+  reader sizes the work. State how many 0182 covered vs how many this item
+  touches. (Pre-existing "two named accessors" phrasing, first caught this pass.)
+- 🟡 **Testability** (major): Of the four enumerated sites (`template_names`,
+  `resolve_template`'s tier, `plugin_default`, `eject`), the criteria observably
+  exercise only three — `plugin_default` is not driven distinctly. State that
+  `config template <name>` reaches it (so AC2/AC4 cover it) or add a criterion.
+- 🔵 **Dependency** (minor): `eject --all` (`eject_all`, `inbound/cli.rs:541` per
+  the 0182 plan Phase 5 §2) is a second `template_names` consumer whose wrong-root
+  behaviour changes but is uncaptured; AC3 pins only single-target `eject`. Name
+  it and add a refusal criterion.
+- 🔵 **Testability** (minor): AC3 (eject) omits the exact command form (does eject
+  take a name argument?), unlike AC1/AC2. Give the runnable invocation.
+- 🔵 **Testability** (minor): Requirement 4's root-independent-families
+  preservation has no dedicated criterion (relies on the blanket `mise run`
+  gate). Add a `config paths`-style criterion or note existing coverage.
+- 🔵 **Clarity** (minor): Requirements and criteria are cross-referenced by
+  ordinal ("AC1", "Requirement 3") but neither list is numbered, and one ordinal
+  points at the wrong bullet. Number the lists or reference by bold label.
+- 🔵 **Dependency** (minor, low): the visualiser frontend/`visualise` surface
+  consuming the new `ComposeError` is not traced one step further.
+- 🔵 **Clarity / Dependency / Completeness** (suggestions): None-root called
+  "unknown"/"missing"/"absent" interchangeably; "Option B" referenced without
+  definition; distribution lockstep with the launcher artifact not restated for a
+  two-binary change; no consolidated Reproduction block; scope bundle confirmed
+  cohesive (keep).
+
+### Assessment
+
+The item is now high quality and the review has hit diminishing returns. Passes 1
+and 2 closed every structural defect; Pass 3's two majors are a wording conflict
+(two vs three accessors) and a coverage gap (`plugin_default` not distinctly
+exercised) — both cheap to fix, neither a design flaw. Several new findings
+(`eject --all`, the visualiser frontend, distribution lockstep) are
+consumer-enumeration refinements that Pass 2's scope expansion opened, and further
+passes would likely keep surfacing similarly fine points. Recommended close-out: a
+single consolidated fix round covering both majors and the actionable minors
+(number the lists, name `eject --all` with a criterion, clarify the
+`plugin_default`/`config template <name>` relationship, add a root-independent-
+family criterion), then treat the item as ready rather than re-entering the loop.
+
+## Re-Review (Pass 4, targeted: clarity + testability) — 2026-09-08
+
+**Verdict:** COMMENT
+
+A targeted confirmation pass of the two lenses that carried Pass 3 majors. Both
+majors are resolved and no major remains, so the verdict moves from REVISE to
+COMMENT: the work item is acceptable as-is, with only minor polish outstanding.
+The Pass 3 consolidated fix was made after reading the call graph in `store.rs`
+and `inbound/cli.rs`, which also corrected a factual error the clarity lens had
+suggested (0182 gated all three accessors on an absent root, not "two of three").
+
+### Previously Identified Issues
+
+- 🟡 **Clarity**: two-vs-three accessor count unreconciled — **Resolved** (stated
+  consistently as three across Summary, Decisions, Technical Notes, Dependencies).
+- 🟡 **Testability**: `plugin_default` site not exercised — **Resolved** (AC5
+  covers `diff`/`reset`, its verified CLI surface; R2 and the mapping table
+  document that `config template <name>` does not reach it).
+- 🔵 **Dependency**: `eject --all` consumer uncaptured — **Resolved** in the
+  consolidated fix (AC4 + Dependencies entry).
+- 🔵 **Testability**: eject command form / root-independent-family criterion —
+  **Resolved** (AC3 spells `config templates eject <name>`; AC11 added).
+- 🔵 **Clarity**: ordinal references to unnumbered lists — **Resolved** (R1–R4,
+  AC1–AC12 labels; re-review confirms every cross-reference resolves).
+
+### Remaining Minor Polish (addressed in pass 4)
+
+- 🔵 **Testability**: AC11 asserted bare "succeeds" — now pinned to exit 0 **and**
+  non-empty output, since the `--fail-safe` `config` family can exit 0 while
+  degraded.
+- 🔵 **Clarity**: a lone "unknown-root" deviated from the standardised
+  "absent root" — now fixed.
+- 🔵 **Clarity**: "plugin-default tier" vs `plugin_default` near-identical names —
+  R2 now states explicitly they are two distinct sites.
+- 🔵 **Testability** (suggestion): AC6 named the outcome but not the trigger — now
+  gives the concrete compose-path invocation and assertion.
+
+### Assessment
+
+The work item is ready for implementation. Four review passes closed every
+structural defect and every finding above the suggestion floor; the pass-4 minors
+were mechanical and are applied. The item now carries twelve labelled acceptance
+criteria mapped to verified code sites, names every consumer of the changed
+accessors (the three CLI surfaces, `eject --all`, `diff`/`reset`, and the
+visualiser server), and records its decisions and the load-bearing `templates/`
+precondition. Two conscious non-changes remain on the record: no consolidated
+Reproduction block, and the title's "succeeds silently" strictly describing only
+`template_names`.
+
+## Verdict Change — APPROVE (2026-09-08)
+
+The reviewer (Toby Clemson) approved the work item, moving the verdict from
+COMMENT to APPROVE. All findings from the four review passes above the suggestion
+floor are resolved; the only outstanding items are the two conscious non-changes
+noted above (no consolidated Reproduction block; the title's "succeeds silently"
+framing), neither of which blocks implementation. 0184 is accepted as ready for
+planning. Status transition to `ready` handled separately via
+`/accelerator:update-work-item`.
+

--- a/meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md
+++ b/meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md
@@ -1,0 +1,140 @@
+---
+type: "plan-validation"
+id: "2026-09-09-0184-template-resolution-wrong-plugin-root-validation"
+title: "Validation Report: Template Resolution Wrong-Root Refusal"
+date: "2026-09-10T00:28:01+00:00"
+author: "Toby Clemson"
+producer: "validate-plan"
+status: "complete"
+result: "pass"
+target: "plan:2026-09-09-0184-template-resolution-wrong-plugin-root"
+tags: ["cli", "config", "templates", "plugin-root", "visualiser"]
+last_updated: "2026-09-10T00:28:01+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Validation Report: Template Resolution Wrong-Root Refusal
+
+The plan was implemented faithfully across all three phases; every automated
+criterion passes and the production code matches the plan's specified shape
+line-for-line. Result: **pass**. Two beyond-plan fixture fixes were required to
+green the full CI mirror — both anticipated by the work item, neither a
+deviation from intent.
+
+### Implementation Status
+
+✓ Phase 1: `template_names` refuses on a wrong root (R1) — fully implemented
+✓ Phase 2: Plugin-default resolution refuses on a wrong root (R2) — fully implemented
+✓ Phase 3: Compose path surfaces the refusal (R3) — fully implemented
+
+Each phase landed as its own commit — `Refuse template enumeration on a wrong
+plugin root`, `Refuse plugin-default resolution on a wrong plugin root`, `Pin the
+compose-path wrong-root refusal with a contract test` — matching the plan's
+"independently mergeable, tree stays green" sequencing.
+
+### Automated Verification Results
+
+| Check | Command | Status |
+|-------|---------|--------|
+| Error-crate tests | `cargo test -p config` | 🟢 exit 0 |
+| Store tests | `cargo test -p config-adapters` | 🟢 exit 0 |
+| Launcher integration | `cargo test -p accelerator --test config_read` | 🟢 152 passed |
+| Compose contract | `cargo test -p accelerator-visualiser --test compose_contract` | 🟢 6 passed |
+| Format + lint | `mise run cli:check` | 🟢 exit 0 |
+
+✅ The 10 new store tests and 2 new error-crate tests were confirmed by name,
+not only by an aggregate exit code:
+
+- `template_names_refuses_a_root_without_a_templates_dir`, `…_when_templates_is_a_file`,
+  `…_when_the_root_is_a_file`, `…_reports_io_on_an_unreadable_templates`.
+- `resolve_template_refuses_a_wrong_root_with_no_override`,
+  `resolve_template_resolves_a_user_override_against_a_wrong_root` (the hoisting crux),
+  `resolve_template_reports_not_found_for_a_missing_default`.
+- `plugin_default_reports_not_found_for_a_missing_default`,
+  `plugin_default_refuses_a_wrong_root`, `eject_refuses_a_wrong_root`.
+- `plugin_root_not_an_installation_names_the_path_and_variable`,
+  `a_missing_plugin_root_is_a_refusal_and_a_read_failure_is_not`.
+
+✅ The compose boundary test `a_wrong_plugin_root_refuses_to_compose` passes,
+confirming R3 needed no production change — the `?` at `compose.rs:157` already
+propagates the refusal.
+
+⚠️ AC12 (`mise run`, the full local CI mirror) I did **not** re-run — it compiles
+Rust several times and needs a Chromium install for the docs lane. The work
+item records it as satisfied: commit `ylsnwkwn` cleared the docs-site npm
+advisories that blocked `docs:audit:check`, after which a clean `mise run`
+exited 0, forcing two further deterministic fixes (see Deviations). This is the
+one criterion resting on recorded evidence rather than a run in this session.
+
+### Code Review Findings
+
+#### Matches Plan
+
+- **Error variant** — `PluginRootNotAnInstallation { path }` (`cli/config/src/error.rs:67`),
+  its `Display` arm naming the path, the `no templates/ directory` cause, and
+  `ACCELERATOR_PLUGIN_ROOT` (`:142`), and its `is_refusal() == true` classification
+  alongside `PluginRootUnavailable` (`:83`) — all verbatim to the plan. `is_refusal`
+  stays exhaustive (no wildcard), so the variant could not compile unclassified.
+- **Shared helper** — `require_templates_dir` (`cli/config-adapters/src/store.rs:469`)
+  is byte-faithful: one `fs::metadata` probe, `Ok(is_dir)` → path, `Ok(!is_dir)` →
+  refusal, `NotFound | NotADirectory` → refusal, any other error → degradable `io_error`.
+- **Single choke point** — `template_names` (`:412`), `plugin_template_path` (`:490`),
+  `plugin_default` (via `plugin_template_path`, `:434`), `eject` (`:504`), and
+  `resolve_template`'s plugin-default tier (`:400`) all route through the helper.
+- **Override precedence preserved** — the config-path and user-override tiers
+  (`:374-399`) sit ahead of the plugin-default check, so a resolving override still
+  renders at exit 0 under a wrong root.
+- **Compose propagation** — `store.template_names()?` at `compose.rs:157` unchanged;
+  the refusal reaches `ComposeError::Config` intact.
+
+#### Deviations from Plan
+
+- **Public-api fixture regen** (`cli/config/tests/fixtures/public-api.txt`, commit
+  `mlwvoozy`) — the new public variant changed the config crate's surface;
+  `cargo-public-api` demanded the fixture update. Anticipated by AC12, not in the
+  plan's file list. Correct.
+- **Shutdown-test fixture** (`cli/visualiser/server/tests/shutdown.rs`, commit
+  `yswxnryq`) — seeds `templates/` in the test's plugin-root fixture, because compose
+  now correctly refuses a templates-less root. A necessary consequence of R3, not a
+  behavioural change. Correct.
+- **Comment stripping** (commit `rlxrmrzq`) — removed AC/work-item/phase references
+  from code comments per the house "comments are a last resort" rule, net −20 lines
+  across `store.rs`, `config_read.rs`, `compose_contract.rs`. Improvement.
+
+#### Potential Issues
+
+- **Residual layout duplication** — `compose.rs:155` still reconstructs
+  `plugin_root.join("templates")` to build each tier's absolute default path,
+  duplicating the layout fact the helper owns. The plan calls this a conscious
+  out-of-scope choice; the `store-duplication:check` lint passes, so it is within
+  tolerance. No action needed, flagged for the record.
+- **AC8 semantics moved under the plan** — the work item's AC8 originally treated a
+  `templates`-is-a-file root as the representative `Io` fault; the plan reclassified
+  that shape as a structural refusal and reserved `Io` for genuinely-unreadable
+  faults (permission, filesystem loop). The work item was updated (AC8 revised, AC13
+  added) and marks AC1–AC13 satisfied. No stale criterion remains.
+
+### Manual Testing Required
+
+The store and CLI tests already exercise these paths; manual runs are confirmatory
+only, against a real installed plugin rather than a fixture.
+
+1. Wrong-root refusal:
+  - [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config templates list` —
+        exits non-zero, names the root and `ACCELERATOR_PLUGIN_ROOT`, states "not an
+        Accelerator installation".
+  - [ ] Repeat for `template <name>`, `templates eject <name>`, `eject --all`,
+        `diff <name>`, `reset <name>` — each refuses.
+2. Preserved behaviour:
+  - [ ] Against the real plugin root, `config template not-a-real-template` reports a
+        template-not-found naming the template, with no mention of the plugin root.
+  - [ ] `ACCELERATOR_PLUGIN_ROOT=$(mktemp -d) accelerator config paths --fail-safe` —
+        exits 0 with normal non-empty output.
+
+### Recommendations
+
+- **No blockers to merge.** The implementation is complete, tested, and lint-clean.
+- **Close the plan lifecycle** — plan status advanced to `done` by this validation.
+- **Track the AC13 follow-up** noted in the plan (the two extra structural shapes and
+  the AC8 revision) — already reflected in the work item; no separate action.

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -11,9 +11,9 @@ priority: "low"
 parent: "work-item:0136"
 relates_to: ["work-item:0182"]
 tags: ["bug", "cli", "config", "templates", "plugin-root"]
-last_updated: "2026-09-09T15:06:15+00:00"
+last_updated: "2026-09-09T21:55:20+00:00"
 last_updated_by: "Toby Clemson"
-last_updated_note: "Plan-review (2026-09-09 review-1, pass 2) refinements folded back: the wrong-root refusal uses a dedicated ConfigError::PluginRootNotAnInstallation { path } variant naming the offending root, not a reused PluginRootUnavailable; and every structural wrong-root shape fails closed — templates/ missing, a templates that is a file, or a root that is itself a file — with Io reserved for genuinely unreadable faults (permission, filesystem loop). Revised AC8's trigger to a filesystem-loop fault, added AC13 for the two extra structural shapes, broadened the wrong-root definition, and updated R1/R2/AC3/Decisions to the new variant and classification."
+last_updated_note: "Implementation landed (plan 2026-09-09-0184, three phases). Marked AC1–AC11 and AC13 satisfied — each pinned by a store unit test, a config_read integration test, or the compose contract test, plus manual verification. AC8 needed no wording change: its filesystem-loop trigger and its AC13 cross-reference already matched the implemented Io-vs-refusal split. AC12 left open — every lane green except the pre-existing docs:audit:check on unrelated docs-site npm advisories."
 schema_version: 1
 external_id: "PP-714"
 ---
@@ -135,38 +135,38 @@ Every criterion below operationalises "wrong root" as a root that exists but is
 not an installation — its `templates/` is missing or not a directory, or the root
 is itself a file.
 
-- [ ] **AC1** — `config templates list` exits non-zero with a diagnostic naming
+- [x] **AC1** — `config templates list` exits non-zero with a diagnostic naming
       `ACCELERATOR_PLUGIN_ROOT`, replacing the header-only table at exit 0.
       (Exercises `template_names`.)
-- [ ] **AC2** — `config template <name>`, with no resolving override, exits
+- [x] **AC2** — `config template <name>`, with no resolving override, exits
       non-zero naming `ACCELERATOR_PLUGIN_ROOT`, replacing today's `Ok(None)`
       rendered as a template-name "not found". (Exercises `resolve_template`'s
       plugin-default tier.)
-- [ ] **AC3** — `config templates eject <name>` exits non-zero with a diagnostic
+- [x] **AC3** — `config templates eject <name>` exits non-zero with a diagnostic
       naming `ACCELERATOR_PLUGIN_ROOT` (surfacing
       `ConfigError::PluginRootNotAnInstallation`), not `EjectOutcome::NoDefault` —
       the wrong root is diagnosed rather than reported as "nothing to eject".
       (Exercises `eject` → `plugin_template_path`.)
-- [ ] **AC4** — `config templates eject --all` exits non-zero with a diagnostic
+- [x] **AC4** — `config templates eject --all` exits non-zero with a diagnostic
       naming `ACCELERATOR_PLUGIN_ROOT`, replacing today's "exit 0 having ejected
       nothing". (Exercises `eject_all` → `template_names`, the second consumer.)
-- [ ] **AC5** — `config templates diff <name>` and `config templates reset
+- [x] **AC5** — `config templates diff <name>` and `config templates reset
       <name>` each exit non-zero with a diagnostic naming
       `ACCELERATOR_PLUGIN_ROOT`, replacing today's `Ok(None)` rendered as an
       unknown-template error. (These are the observable surface of
       `plugin_default` → `plugin_template_path`.)
-- [ ] **AC6** — invoking the visualiser server's compose path (`compose.rs`)
+- [x] **AC6** — invoking the visualiser server's compose path (`compose.rs`)
       against a store whose plugin root is a wrong root returns
       `Err(ComposeError)` whose message contains `ACCELERATOR_PLUGIN_ROOT` and
       produces no empty template set — asserted by a test at the compose-path
       boundary.
-- [ ] **AC7** — `config template <name>` against an installation whose
+- [x] **AC7** — `config template <name>` against an installation whose
       `templates/` directory is present but lacks `<name>.md`, with no resolving
       override, exits non-zero with a not-found message naming `<name>` and
       **not** mentioning `ACCELERATOR_PLUGIN_ROOT` — so the genuine
       template-not-found is distinguished from the plugin-root refusal by message
       content, not merely by the two messages differing.
-- [ ] **AC8** — a genuine *unreadable* fault yields a `ConfigError::Io` naming the
+- [x] **AC8** — a genuine *unreadable* fault yields a `ConfigError::Io` naming the
       path, not the structural refusal, and does **not** name
       `ACCELERATOR_PLUGIN_ROOT` — so a fault whose validity is undeterminable stays
       degradable. Trigger it with an environment-independent, root-guard-free
@@ -174,24 +174,27 @@ is itself a file.
       `FilesystemLoop` (neither `NotFound` nor `NotADirectory`). The
       `templates`-is-a-file shape is **not** this case — it is a structural refusal
       under AC13.
-- [ ] **AC9** — the characterisation test
+- [x] **AC9** — the characterisation test
       `a_root_without_a_templates_directory_still_renders_an_empty_table` is
       replaced at the same site by a test asserting the empty-`templates/` root
       now yields a non-zero exit whose diagnostic names `ACCELERATOR_PLUGIN_ROOT`
       (the inverse of AC1), rather than deleted.
-- [ ] **AC10** — given a wrong root and a user override configured for `<name>`,
+- [x] **AC10** — given a wrong root and a user override configured for `<name>`,
       `config template <name>` exits 0 and renders the override's content, not the
       `ACCELERATOR_PLUGIN_ROOT` refusal. This is the wrong-root case, distinct
       from the absent-root property
       `a_user_override_still_resolves_with_no_plugin_root`, and needs its own
       coverage.
-- [ ] **AC11** — a root-independent family command (e.g. `config paths`) against
+- [x] **AC11** — a root-independent family command (e.g. `config paths`) against
       a wrong root exits 0 **and** renders its normal non-empty output (not an
       empty or notice-only degradation), exercising R4: the families that never
       read the plugin root are unaffected by the refusal. Exit 0 alone is
       insufficient because the `config` family carries `--fail-safe`.
-- [ ] **AC12** — `mise run` (bare default task) exits 0 end-to-end.
-- [ ] **AC13** — the two remaining structural shapes each fail closed: a root
+- [ ] **AC12** — `mise run` (bare default task) exits 0 end-to-end. Every lane
+      passes except the pre-existing `docs:audit:check`, which fails on unrelated
+      `docs-site/` npm advisories (js-yaml, sharp, smol-toml, svgo) untouched by
+      this change; blocked on a separate dependency-bump, not on this work.
+- [x] **AC13** — the two remaining structural shapes each fail closed: a root
       whose `templates` entry is a file, and a root that is itself a file, make
       `config templates list` exit non-zero with a diagnostic naming
       `ACCELERATOR_PLUGIN_ROOT` — a structural wrong root is refused, not reported

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -11,9 +11,9 @@ priority: "low"
 parent: "work-item:0136"
 relates_to: ["work-item:0182"]
 tags: ["bug", "cli", "config", "templates", "plugin-root"]
-last_updated: "2026-09-09T21:55:20+00:00"
+last_updated: "2026-09-09T23:33:52+00:00"
 last_updated_by: "Toby Clemson"
-last_updated_note: "Implementation landed (plan 2026-09-09-0184, three phases). Marked AC1–AC11 and AC13 satisfied — each pinned by a store unit test, a config_read integration test, or the compose contract test, plus manual verification. AC8 needed no wording change: its filesystem-loop trigger and its AC13 cross-reference already matched the implemented Io-vs-refusal split. AC12 left open — every lane green except the pre-existing docs:audit:check on unrelated docs-site npm advisories."
+last_updated_note: "AC12 ticked: after the docs-site dependency rebase resolved docs:audit:check, a full mise run surfaced two further deterministic failures the implementation had to fix — the config public-api fixture (the new PluginRootNotAnInstallation variant) and the shutdown integration tests (their templates-less plugin-root fixture, which compose now correctly refuses). Both fixed; a clean mise run then exited 0 end-to-end, so every acceptance criterion (AC1–AC13) is now satisfied."
 schema_version: 1
 external_id: "PP-714"
 ---
@@ -190,10 +190,7 @@ is itself a file.
       empty or notice-only degradation), exercising R4: the families that never
       read the plugin root are unaffected by the refusal. Exit 0 alone is
       insufficient because the `config` family carries `--fail-safe`.
-- [ ] **AC12** — `mise run` (bare default task) exits 0 end-to-end. Every lane
-      passes except the pre-existing `docs:audit:check`, which fails on unrelated
-      `docs-site/` npm advisories (js-yaml, sharp, smol-toml, svgo) untouched by
-      this change; blocked on a separate dependency-bump, not on this work.
+- [x] **AC12** — `mise run` (bare default task) exits 0 end-to-end.
 - [x] **AC13** — the two remaining structural shapes each fail closed: a root
       whose `templates` entry is a file, and a root that is itself a file, make
       `config templates list` exit non-zero with a diagnostic naming

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -1,36 +1,45 @@
 ---
 type: "work-item"
 id: "0184"
-title: "template_names succeeds-with-nothing on a plugin root that is not an installation"
+title: "Template resolution succeeds silently on a plugin root that is not an installation"
 date: "2026-07-29T00:00:00+00:00"
 author: "Toby Clemson"
 producer: "implement-plan"
-status: "draft"
+status: "ready"
 kind: "bug"
 priority: "low"
 parent: "work-item:0136"
 relates_to: ["work-item:0182"]
 tags: ["bug", "cli", "config", "templates", "plugin-root"]
-last_updated: "2026-09-05T00:00:00+00:00"
+last_updated: "2026-09-09T15:06:15+00:00"
 last_updated_by: "Toby Clemson"
-last_updated_note: "Reparented under epic 0136 (Migrate Shell Scripts into a Rust CLI): belongs to the shell-to-Rust migration, its shipped cli/ crates, or the launcher runtime-cache cluster."
+last_updated_note: "Plan-review (2026-09-09 review-1, pass 2) refinements folded back: the wrong-root refusal uses a dedicated ConfigError::PluginRootNotAnInstallation { path } variant naming the offending root, not a reused PluginRootUnavailable; and every structural wrong-root shape fails closed — templates/ missing, a templates that is a file, or a root that is itself a file — with Io reserved for genuinely unreadable faults (permission, filesystem loop). Revised AC8's trigger to a filesystem-loop fault, added AC13 for the two extra structural shapes, broadened the wrong-root definition, and updated R1/R2/AC3/Decisions to the new variant and classification."
 schema_version: 1
 external_id: "PP-714"
 ---
 
-# 0184: template_names succeeds-with-nothing on a plugin root that is not an installation
+# 0184: Template resolution succeeds silently on a plugin root that is not an installation
 
 **Kind**: Bug
-**Status**: Draft
+**Status**: Ready
 **Priority**: Low
 **Author**: Toby Clemson
 
 ## Summary
 
-`FileConfigStore::template_names`
+Three plugin-root template accessors in `FileConfigStore`
 ([`cli/config-adapters/src/store.rs`](../../cli/config-adapters/src/store.rs))
-now refuses when the plugin root is *unknown*, but still succeeds with an empty
-list when the root is *known and wrong*:
+now refuse when the plugin root is *absent*, but still succeed silently when
+the root is *present but carries no `templates/` directory* — present, yet (by
+the Assumption below) not an Accelerator installation. Such a root is `Some(path)`,
+so it passes `require_plugin_root` and falls through each accessor's own
+filesystem check. "Wrong root" throughout this item means precisely the
+detectable structural cases: a present root whose `templates/` is missing or is
+not a directory, or a root that is itself a file. A mis-pointed
+root that happens to retain an unrelated `templates/` directory is not
+distinguishable from a valid installation by this signal and is out of scope:
+
+- `template_names` swallows every `read_dir` failure into an empty list:
 
 ```rust
 let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
@@ -38,18 +47,30 @@ let Ok(entries) = fs::read_dir(plugin.join("templates")) else {
 };
 ```
 
-That arm swallows every `read_dir` failure alike — a root pointing at a
-directory that is not an Accelerator installation, a root pointing at a deleted
-path, and a genuine permission or I/O error. The observable is a header-only
-`config templates list` table at exit 0: the same silent-wrong-answer mode 0182
-closed for the unknown-root case, surviving one step further out.
+- `resolve_template`'s plugin-default tier returns `Ok(None)` when `<name>.md`
+  is not a file.
+- `plugin_template_path` tests nothing; its callers `plugin_default` and
+  `eject` do the `is_file()` check and fall through to `Ok(None)` /
+  `EjectOutcome::NoDefault`.
+
+The observable for `template_names` is a header-only `config templates list`
+table at exit 0 — the same silent-wrong-answer mode 0182 closed for the
+absent-root case, surviving one step further out. The other two accessors
+degrade a wrong-root diagnosis into a template-name "not found".
+
+`template_names` is also consumed by the visualiser server's compose path
+([`cli/visualiser/server/src/compose.rs`](../../cli/visualiser/server/src/compose.rs)),
+which forwards `ConfigError` via `?` into `ComposeError`. That consumer is in
+scope: once the accessor refuses on a wrong root, the server must surface the
+refusal rather than swallow it into an empty template set.
 
 ## Context
 
-0182 Phase 5 converted a missing root into `ConfigError::PluginRootUnavailable`
-at the three plugin-content consumers, and deliberately left this arm alone so
-the phase stayed scoped to the root's *presence*. The surviving behaviour is
-pinned as a characterisation test —
+0182 (now `done`) Phase 5 introduced `ConfigError::PluginRootUnavailable` and
+the `require_plugin_root` gate, which these template accessors already call so
+they refuse on an *absent* root, and deliberately left the *wrong-root* arms
+alone so the phase stayed scoped to the root's *presence*. The surviving `template_names` behaviour is pinned as a
+characterisation test —
 `a_root_without_a_templates_directory_still_renders_an_empty_table` in
 `cli/launcher/tests/config_read.rs` — so it is visible rather than implicit, and
 that test is what this item would change.
@@ -60,47 +81,287 @@ the root from its own location, and a directly-invoked launcher passes no
 
 ## Requirements
 
-- Distinguish the `read_dir` failure kinds instead of collapsing them:
-  `ErrorKind::NotFound` (the root carries no `templates/` directory, so it is
-  not an installation) becomes `ConfigError::PluginRootUnavailable`; every other
-  error becomes `ConfigError::Io` naming the path, matching the treatment the
-  other enumerators in this file already give (`custom_lenses`, `skill_names`).
-- Decide whether the same reasoning applies to `resolve_template`'s
-  plugin-default tier and to `plugin_template_path`, which today test
-  `is_file()` and fall through — a wrong root there yields "not found" for every
-  template name, which is a better message than an empty table but still names
-  the template rather than the root.
-- Keep the root-independent families and project-local overrides working: a
-  wrong root must not break `config template <name>` when a user override
-  resolves, which is the property
-  `a_user_override_still_resolves_with_no_plugin_root` pins for the absent-root
-  case.
+- **R1 — `template_names`**: distinguish the failure kinds instead of
+  collapsing them. A *structural* wrong root — `templates/` missing
+  (`ErrorKind::NotFound`), a `templates` entry that is a file, or a root that is
+  itself a file (`ErrorKind::NotADirectory`) — is not an installation and becomes
+  `ConfigError::PluginRootNotAnInstallation`, a refusal naming the offending root
+  and `ACCELERATOR_PLUGIN_ROOT`. Only a genuinely *unreadable* fault (permission
+  denied, filesystem loop) becomes `ConfigError::Io` naming the path — reserving
+  the degradable class for the one case where the root's validity is
+  undeterminable. The `ConfigError::Io` half constructs via the `io_error` helper
+  as `custom_lenses` and `skill_names` do; the refusal half is new and rests on
+  the Assumption below — those siblings enumerate the project config directory and
+  map a missing directory to an empty list, so this is a deliberate divergence,
+  not parity. `template_names` is enumerated by two commands, `config templates
+  list` and `config templates eject --all` (via `eject_all`), so this one fix
+  covers both.
+- **R2 — `resolve_template` plugin-default tier and `plugin_template_path`**:
+  distinguish "the root is not an installation (structurally-invalid
+  `templates/`)" (→ `ConfigError::PluginRootNotAnInstallation`, whose diagnostic
+  names the offending root and `ACCELERATOR_PLUGIN_ROOT`) from "`<name>.md` is
+  genuinely absent inside a valid installation" (→ `Ok(None)`, a genuine
+  template-not-found). Today both cases
+  collapse to `Ok(None)` / `EjectOutcome::NoDefault`, which names the template
+  rather than the root. Apply the distinction at each plugin-default site —
+  `resolve_template`'s plugin-default tier (reached by `config template <name>`),
+  and `plugin_template_path`'s callers `plugin_default` and `eject`. `eject`
+  refuses on a wrong root (`PluginRootNotAnInstallation`) rather than treating it
+  as "nothing to eject". Note the `resolve_template` **plugin-default tier** and the
+  method **`plugin_default`** are two distinct sites despite the near-identical
+  names: the tier is reached by `config template <name>`, whereas `plugin_default`
+  is reached only by `config templates diff <name>` and `config templates reset
+  <name>` — those two commands are the observable surface for its half of the fix
+  (see Technical Notes for the full command-to-site mapping).
+- **R3 — Visualiser server compose path**: the server's `compose.rs`, which
+  forwards `ConfigError` via `?` into `ComposeError`, must propagate the wrong-root
+  refusal as a `ComposeError` whose diagnostic names `ACCELERATOR_PLUGIN_ROOT`
+  rather than composing against an empty template set. The `?` propagation likely
+  needs no production change; the requirement is to confirm the refusal reaches
+  the server boundary intact and to cover it with a test.
+- **R4 — Keep the root-independent families and project-local overrides working**:
+  the root-independent config families (`agents`, `paths`, and the like) never
+  read the plugin root, so a wrong root leaves them unaffected — no change is
+  required of them, and that is the behaviour to preserve. A wrong root must
+  likewise not break `config template <name>` when a user override resolves: the
+  override tiers are checked before the plugin-default tier, so a resolving
+  override never reaches the wrong root — the property
+  `a_user_override_still_resolves_with_no_plugin_root` pins this for the
+  absent-root case.
 
 ## Acceptance Criteria
 
-- [ ] `config templates list` against a root that exists but carries no
-      `templates/` directory exits non-zero with a diagnostic naming
+Every criterion below operationalises "wrong root" as a root that exists but is
+not an installation — its `templates/` is missing or not a directory, or the root
+is itself a file.
+
+- [ ] **AC1** — `config templates list` exits non-zero with a diagnostic naming
       `ACCELERATOR_PLUGIN_ROOT`, replacing the header-only table at exit 0.
-- [ ] A genuine I/O failure on a present `templates/` directory (e.g. mode
-      `0o000`) yields a `ConfigError::Io` naming the path, not the plugin-root
-      refusal — the two are distinguishable from the message alone.
-- [ ] The characterisation test named above is replaced by its inverse rather
-      than deleted, so the change of behaviour is recorded at the same site.
-- [ ] A user override still resolves against a wrong root.
-- [ ] `mise run` (bare default task) exits 0 end-to-end.
+      (Exercises `template_names`.)
+- [ ] **AC2** — `config template <name>`, with no resolving override, exits
+      non-zero naming `ACCELERATOR_PLUGIN_ROOT`, replacing today's `Ok(None)`
+      rendered as a template-name "not found". (Exercises `resolve_template`'s
+      plugin-default tier.)
+- [ ] **AC3** — `config templates eject <name>` exits non-zero with a diagnostic
+      naming `ACCELERATOR_PLUGIN_ROOT` (surfacing
+      `ConfigError::PluginRootNotAnInstallation`), not `EjectOutcome::NoDefault` —
+      the wrong root is diagnosed rather than reported as "nothing to eject".
+      (Exercises `eject` → `plugin_template_path`.)
+- [ ] **AC4** — `config templates eject --all` exits non-zero with a diagnostic
+      naming `ACCELERATOR_PLUGIN_ROOT`, replacing today's "exit 0 having ejected
+      nothing". (Exercises `eject_all` → `template_names`, the second consumer.)
+- [ ] **AC5** — `config templates diff <name>` and `config templates reset
+      <name>` each exit non-zero with a diagnostic naming
+      `ACCELERATOR_PLUGIN_ROOT`, replacing today's `Ok(None)` rendered as an
+      unknown-template error. (These are the observable surface of
+      `plugin_default` → `plugin_template_path`.)
+- [ ] **AC6** — invoking the visualiser server's compose path (`compose.rs`)
+      against a store whose plugin root is a wrong root returns
+      `Err(ComposeError)` whose message contains `ACCELERATOR_PLUGIN_ROOT` and
+      produces no empty template set — asserted by a test at the compose-path
+      boundary.
+- [ ] **AC7** — `config template <name>` against an installation whose
+      `templates/` directory is present but lacks `<name>.md`, with no resolving
+      override, exits non-zero with a not-found message naming `<name>` and
+      **not** mentioning `ACCELERATOR_PLUGIN_ROOT` — so the genuine
+      template-not-found is distinguished from the plugin-root refusal by message
+      content, not merely by the two messages differing.
+- [ ] **AC8** — a genuine *unreadable* fault yields a `ConfigError::Io` naming the
+      path, not the structural refusal, and does **not** name
+      `ACCELERATOR_PLUGIN_ROOT` — so a fault whose validity is undeterminable stays
+      degradable. Trigger it with an environment-independent, root-guard-free
+      fault: a self-referential `templates` symlink, whose `fs::metadata` fails
+      `FilesystemLoop` (neither `NotFound` nor `NotADirectory`). The
+      `templates`-is-a-file shape is **not** this case — it is a structural refusal
+      under AC13.
+- [ ] **AC9** — the characterisation test
+      `a_root_without_a_templates_directory_still_renders_an_empty_table` is
+      replaced at the same site by a test asserting the empty-`templates/` root
+      now yields a non-zero exit whose diagnostic names `ACCELERATOR_PLUGIN_ROOT`
+      (the inverse of AC1), rather than deleted.
+- [ ] **AC10** — given a wrong root and a user override configured for `<name>`,
+      `config template <name>` exits 0 and renders the override's content, not the
+      `ACCELERATOR_PLUGIN_ROOT` refusal. This is the wrong-root case, distinct
+      from the absent-root property
+      `a_user_override_still_resolves_with_no_plugin_root`, and needs its own
+      coverage.
+- [ ] **AC11** — a root-independent family command (e.g. `config paths`) against
+      a wrong root exits 0 **and** renders its normal non-empty output (not an
+      empty or notice-only degradation), exercising R4: the families that never
+      read the plugin root are unaffected by the refusal. Exit 0 alone is
+      insufficient because the `config` family carries `--fail-safe`.
+- [ ] **AC12** — `mise run` (bare default task) exits 0 end-to-end.
+- [ ] **AC13** — the two remaining structural shapes each fail closed: a root
+      whose `templates` entry is a file, and a root that is itself a file, make
+      `config templates list` exit non-zero with a diagnostic naming
+      `ACCELERATOR_PLUGIN_ROOT` — a structural wrong root is refused, not reported
+      as an `Io` fault. Both triggers are environment-independent (no permission
+      fault, no root guard). This distinguishes the structural shapes (refuse) from
+      a genuinely unreadable fault (AC8, `Io`).
+
+## Decisions
+
+No open questions remain. The decisions taken during review:
+
+- **Detection lives in a single shared "is this root an installation?" helper**
+  that validates `templates/` presence and is called by all three accessors,
+  rather than an inline check duplicated per site. This shared helper is why the
+  accessors stay bundled in one item rather than split.
+- **`eject` against a wrong root refuses** with
+  `ConfigError::PluginRootNotAnInstallation` rather than reporting
+  `EjectOutcome::NoDefault`; pinned by its own acceptance criterion above.
+- **The visualiser server compose path is in scope** and refuses identically,
+  rather than being deferred to a follow-up — the change would otherwise switch
+  the server from an empty template set to a hard error unremarked.
+- **The wrong-root refusal uses a dedicated `PluginRootNotAnInstallation { path }`
+  variant**, not a reused `PluginRootUnavailable`. The latter's message says the
+  root is *unknown* and to *set* the variable — misleading for a developer who set
+  it to a real path that simply is not an installation. The dedicated variant
+  names the offending root and the missing-`templates/` cause. (Plan-review
+  decision, 2026-09-09.)
+- **Every structural wrong-root shape fails closed.** Missing `templates/`, a
+  `templates` that is a file, and a root that is itself a file all refuse with
+  `PluginRootNotAnInstallation`; `Io` is reserved for a genuinely *unreadable*
+  fault (permission, filesystem loop), the one case where the root's validity is
+  undeterminable. This keeps every definitely-wrong root fail-closed even under
+  `--fail-safe`. (Plan-review decision, 2026-09-09; refines AC8, adds AC13.)
 
 ## Dependencies
 
-- Blocked by: 0182 (introduces `PluginRootUnavailable` and the two named
-  accessors this builds on).
+- Builds on: 0182 (`done`) — introduced `ConfigError::PluginRootUnavailable` and
+  the `require_plugin_root` gate that all three template accessors already call to
+  refuse on an *absent* root. This item extends the same refusal to the
+  *wrong-root* case (present, no `templates/`): 0182 handled the absent case,
+  0184 handles the wrong case, across the same accessors — the "two named
+  accessors" of an earlier draft was an error, the count is three.
+- Affected consumers of the changed accessors — beyond the primary `config
+  templates list` / `config template <name>` surfaces, three consumers change
+  behaviour on a wrong root and are pinned by criteria above:
+    - `config templates eject --all` (`eject_all`, `inbound/cli.rs:542`)
+      enumerates via `template_names`, so it flips from "exit 0 having ejected
+      nothing" to a refusal (AC4).
+    - `config templates diff <name>` / `reset <name>` reach `plugin_default`, so
+      they flip from an unknown-template error to a refusal (AC5).
+    - the visualiser server's `cli/visualiser/server/src/compose.rs` forwards
+      `template_names`' `ConfigError` via `?` into `ComposeError` (named in the
+      0182 plan, Phase 5 §2), so it flips from an empty template set to a hard
+      error; brought into scope (R3, AC6) rather than left unremarked. The
+      visualiser frontend consuming that `ComposeError` is the ultimate
+      downstream — its surface-level handling of a compose error is out of scope
+      here.
+- Distribution — inherits 0182's launcher/server lockstep. The change alters a
+  shared library (`config-adapters`) whose behaviour ships in two binaries (the
+  launcher and the visualiser server); both must ship at the same plugin version,
+  which 0182's version-keyed cache already guarantees. Noted so the two-binary
+  coupling is on the record.
+- Precondition — the `NotFound → PluginRootNotAnInstallation` mapping assumes every
+  Accelerator installation ships a `templates/` directory (see Assumptions).
+  Confirm this against the release artifact's file list before implementation; if
+  an installation can ship without `templates/`, the absence signal is unreliable
+  and the mapping must be reconsidered.
 
 ## Assumptions
 
 - Every Accelerator installation ships a `templates/` directory, so its absence
-  is a reliable signal that the root is not an installation. Worth confirming
-  against the release artifact's file list before relying on it.
+  is a reliable signal that the root is not an installation. Confirming this
+  against the release artifact's file list is tracked as a pre-implementation
+  precondition under Dependencies.
 
-## References
+## Technical Notes
+
+- Sites: `template_names` (`store.rs:412`), `resolve_template`'s plugin-default
+  tier (`store.rs:400`), and `plugin_template_path` (`store.rs:466`) with its
+  callers `plugin_default` (`store.rs:436`) and `eject` (`store.rs:483`).
+- Command-to-site mapping (the observable surface for each store site):
+
+  | Command | Store site | Wrong-root outcome today |
+  |---------|------------|--------------------------|
+  | `config templates list` | `template_names` | empty table, exit 0 |
+  | `config templates eject --all` | `eject_all` → `template_names` | ejects nothing, exit 0 |
+  | `config template <name>` | `resolve_template` plugin-default tier | `Ok(None)` → not-found |
+  | `config templates eject <name>` | `eject` → `plugin_template_path` | `EjectOutcome::NoDefault` |
+  | `config templates diff <name>` / `reset <name>` | `plugin_default` → `plugin_template_path` | `Ok(None)` → unknown-template |
+  | visualiser compose | `resolve_templates` → `template_names` | empty template set |
+
+  `config template <name>` does **not** reach `plugin_default`; `diff`/`reset`
+  are its only CLI surface (`inbound/cli.rs:579,602`).
+- `require_plugin_root` (`store.rs:73`) is the only gate that raises
+  `PluginRootUnavailable`, and it fires solely on an *absent* root; a
+  wrong-but-present root is `Some(path)` and passes it.
+- `ConfigError::Io { path, detail }` is constructed via the `io_error` helper
+  (`store.rs:729`); `custom_lenses` (`store.rs:294`) and `skill_names`
+  (`store.rs:320`) show the `match … ErrorKind::NotFound` split to follow for
+  the I/O half.
+- Server consumer: `cli/visualiser/server/src/compose.rs` calls `template_names`
+  and forwards its `ConfigError` via `?` into `ComposeError`. Verify the
+  `PluginRootNotAnInstallation` diagnostic survives that conversion to the server
+  boundary and is not flattened into a generic compose failure.
+
+## Drafting Notes
+
+- Corrected two behavioural claims in the prior draft against `store.rs`:
+  `resolve_template`'s plugin-default tier returns `Ok(None)` for a wrong root
+  (it does not name the template), and `plugin_template_path` tests nothing —
+  its callers `plugin_default`/`eject` perform the `is_file()` check.
+- Scope extended to all three plugin-root accessors, beyond the original
+  `template_names`-only bug — the "Option B" choice, where **Option A** was to fix
+  `template_names` alone and **Option B** to fix all three accessors together.
+  This enlarges the item and motivated the title change; a reviewer may still
+  prefer to split the `resolve_template`/`plugin_template_path` work into its own
+  item.
+- Reframed the "matching the siblings" justification: parity with
+  `custom_lenses`/`skill_names` holds only for the `ConfigError::Io` half; the
+  `NotFound → PluginRootUnavailable` mapping is new and rests on the Assumption.
+- Reconciled the dependency on 0182: it is now `done`, so the body no longer
+  states it blocks this item, matching the frontmatter `relates_to`.
+- Review 1 (REVISE) revisions: resolved the `eject` semantics to *refuse*
+  (`PluginRootUnavailable`) and pinned it with a dedicated acceptance criterion;
+  narrowed the Summary's "wrong root" to the detectable no-`templates/`-directory
+  case so intent matches the criteria (a wrong root that retains a `templates/`
+  directory is explicitly out of scope); restated AC2 to match AC1's wording and
+  pinned AC3 to concrete message content; removed the "three sites" count
+  collision in Requirement 2; and promoted the `templates/`-presence check to a
+  tracked precondition under Dependencies. Scope kept bundled per the
+  single-shared-helper rationale.
+- The filename slug (`template-enumeration-...`) reflects the item's original
+  `template_names`-only framing; the kept-bundled scope and the title span
+  `resolve_template`/`plugin_template_path` too. The slug is retained to preserve
+  the stable path and inbound references from 0182.
+- Review 1 pass 2 (REVISE) revisions: brought the visualiser server compose path
+  (`compose.rs`) into scope to refuse identically on a wrong root, adding a
+  requirement, an acceptance criterion, a Dependencies consumer entry and a
+  Technical Note — the item now spans the `config-adapters` and `visualiser`
+  server crates rather than `store.rs` alone. Restated the user-override criterion
+  as a full input/action/expected triple; re-pinned the eject criterion to a
+  CLI-observable diagnostic naming `ACCELERATOR_PLUGIN_ROOT` and standardised that
+  wording across the plugin-root criteria; tied the characterisation-test
+  replacement to the concrete AC1 assertion; noted the non-root constraint on the
+  `0o000` I/O trigger; and retitled "Open Questions" (which held only resolved
+  items) to "Decisions".
+- Review 1 pass 3 (REVISE) revisions, after reading the call graph in `store.rs`
+  and `inbound/cli.rs`: reconciled the accessor count (0182's `require_plugin_root`
+  gate already makes the three accessors refuse on an *absent* root; this item
+  extends the refusal to the *wrong-root* case — the earlier "two named accessors"
+  was wrong). Labelled the Requirements R1–R4 and the Acceptance Criteria AC1–AC12
+  so every ordinal cross-reference resolves. Added AC4 (`eject --all`, a second
+  `template_names` consumer via `eject_all`), AC5 (`diff`/`reset`, the CLI surface
+  of `plugin_default` — `config template <name>` does not reach `plugin_default`),
+  and AC11 (a root-independent family still succeeds), plus a command-to-site
+  mapping table in Technical Notes and the corresponding consumer and
+  distribution-lockstep entries in Dependencies. Pinned the `eject` command forms,
+  standardised the absent-root term, and defined Option A/B.
+- Plan-review (2026-09-09 review-1, pass 2) revisions, folded back from the plan:
+  (1) the wrong-root refusal now uses a dedicated
+  `ConfigError::PluginRootNotAnInstallation { path }` variant naming the offending
+  root — the reused `PluginRootUnavailable` message ("unknown: set
+  ACCELERATOR_PLUGIN_ROOT") misdescribes a set-but-wrong root; R1/R2/AC3/Decisions
+  updated. (2) Every *structural* wrong-root shape fails closed — `templates/`
+  missing, a `templates` that is a file, and a root that is itself a file all
+  refuse — with `Io` reserved for a genuinely unreadable fault (permission,
+  filesystem loop); AC8's trigger became a filesystem-loop symlink (dropping the
+  earlier `0o000` root-guard concern, since the launcher test crate has no
+  root-detection facility), AC13 was added for the two extra structural shapes,
+  and the wrong-root definition was broadened in the Summary and the AC preamble.
 
 - `meta/work/0182-cli-derives-plugin-root-from-own-location.md`
 - `meta/plans/2026-07-27-0182-bootstrap-self-location-and-plugin-root-rename.md`


### PR DESCRIPTION

# [0184] Refuse template resolution on a wrong plugin root

## Summary

Extends 0182's *absent*-root refusal to the *wrong*-root case: a present
plugin root that carries no `templates/` directory is not an Accelerator
installation, so every template command and the visualiser compose path now
refuse with a dedicated diagnostic instead of degrading to a silent empty
answer or a false template-not-found. The refusal names the offending root,
the invalid `templates/` layout, and `ACCELERATOR_PLUGIN_ROOT`, and fails
closed even under `--fail-safe`.

## Changes

- **New error variant** — `ConfigError::PluginRootNotAnInstallation { path }`
  (`cli/config/src/error.rs`), classified `is_refusal() == true` so it fails
  closed identically to `PluginRootUnavailable`, with a message that names the
  path and states the root is not an installation (distinct from the
  absent-root "unknown, set the variable" message).
- **Shared installation-detection helper** — `require_templates_dir`
  (`cli/config-adapters/src/store.rs`) validates `templates/` with a single
  `fs::metadata` probe and becomes the one choke point for `template_names`,
  `plugin_template_path`, `plugin_default`, `eject`, and `resolve_template`'s
  plugin-default tier.
- **Structural shapes fail closed** — a missing `templates/`, a `templates`
  that is a file, and a root that is itself a file all refuse; a genuinely
  *unreadable* fault (permission, filesystem loop) stays the degradable `Io`
  and does not name the variable.
- **Preserved behaviour** — a resolving user override still renders at exit 0
  under a wrong root (override tiers precede the plugin-default check), a valid
  installation missing one template still reports a template-not-found naming
  the template, and the root-independent config families are untouched.
- **Compose boundary** — no production change; the existing `?` at
  `compose.rs:157` propagates the refusal into `ComposeError`, pinned by a new
  contract test.
- **Fixtures** — regenerated the config `public-api.txt` for the new public
  variant and seeded `templates/` in the shutdown-test plugin-root fixture,
  which compose now correctly refuses without.

## Context

- Work item: `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`
- Plan: `meta/plans/2026-09-09-0184-template-resolution-wrong-plugin-root.md`
- Research: `meta/research/codebase/2026-09-08-0184-template-resolution-wrong-plugin-root.md`
- Validation: `meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md`
- Builds on 0182 (CLI derives plugin root from its own location).

## Testing

- [x] Error-crate unit tests — `cargo test -p config` (new variant Display + `is_refusal`)
- [x] Store unit tests — `cargo test -p config-adapters` (10 new tests: three structural refusals, the `Io` arm, the override hoisting crux, genuine-not-found preservation)
- [x] Launcher integration — `cargo test -p accelerator --test config_read` (152 passed, all six commands on a wrong root)
- [x] Compose contract — `cargo test -p accelerator-visualiser --test compose_contract` (wrong root refuses to compose)
- [x] Format + lint — `mise run cli:check` (rustfmt, clippy, store-duplication)
- [ ] Full local CI mirror — `mise run` recorded green in the work item after the docs-site advisory rebase; not re-run in this validation session

## Notes for Reviewers

- **AC8 semantics moved.** The work item's AC8 originally treated a
  `templates`-is-a-file root as the representative `Io` fault; this change
  reclassifies that shape as a structural refusal and reserves `Io` for
  genuinely unreadable faults. AC8 was revised and AC13 added for the two extra
  structural shapes — both reflected in the work item.
- **Deliberate residual duplication.** `compose.rs:155` still reconstructs
  `plugin_root.join("templates")` to build each tier's absolute default path;
  the validity gate is centralised, but relocating the per-name path
  construction behind a store accessor is a wider compose-tier refactor left
  out of scope. The `store-duplication` lint passes.
- Worth focusing on: the ordering invariant that keeps a resolving override
  ahead of the root check (`resolve_template`), and the `NotFound |
  NotADirectory` collapse in `require_templates_dir`.
