### PR TITLE
[0184] Mark work item 0184 as done

### DIFF
--- a/meta/prs/112-description.md
+++ b/meta/prs/112-description.md
@@ -1,0 +1,50 @@
+---
+type: "pr-description"
+id: "112"
+title: "[0184] Mark work item 0184 as done"
+date: "2026-09-10T01:22:16+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0184"
+parent: "work-item:0184"
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/112"
+pr_number: 112
+tags: ["work", "templates", "plugin-root"]
+revision: "968fd0f6dda5e42b28e70b84e6ff1bc34cb49c87"
+repository: "accelerator"
+last_updated: "2026-09-10T01:22:16+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0184] Mark work item 0184 as done
+
+## Summary
+
+Closes the lifecycle of work item 0184 by flipping its status to `done`. The
+wrong-root refusal it tracked shipped in #111; this follow-up records the
+closure, which landed after that PR had already merged.
+
+## Changes
+
+- Set `status: "ready"` → `"done"` in the frontmatter of
+  `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`.
+- Synced the body `**Status**:` label from `Ready` to `Done`.
+
+## Context
+
+- Work item: `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`
+- Implementation PR: #111 (merged) — refuses template resolution on a wrong plugin root.
+- Validation: `meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md` (result: pass).
+
+## Testing
+
+- [x] Frontmatter validates — `accelerator corpus frontmatter validate --file meta/work/0184-…md` (exit 0)
+- [x] No code change — documentation-only status transition
+
+## Notes for Reviewers
+
+- Trivial doc-only change. It exists as a separate PR only because #111 merged
+  before the status flip was committed; the two would otherwise have shared a
+  branch.

--- a/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
+++ b/meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md
@@ -5,7 +5,7 @@ title: "Template resolution succeeds silently on a plugin root that is not an in
 date: "2026-07-29T00:00:00+00:00"
 author: "Toby Clemson"
 producer: "implement-plan"
-status: "ready"
+status: "done"
 kind: "bug"
 priority: "low"
 parent: "work-item:0136"
@@ -21,7 +21,7 @@ external_id: "PP-714"
 # 0184: Template resolution succeeds silently on a plugin root that is not an installation
 
 **Kind**: Bug
-**Status**: Ready
+**Status**: Done
 **Priority**: Low
 **Author**: Toby Clemson
 


### PR DESCRIPTION

# [0184] Mark work item 0184 as done

## Summary

Closes the lifecycle of work item 0184 by flipping its status to `done`. The
wrong-root refusal it tracked shipped in #111; this follow-up records the
closure, which landed after that PR had already merged.

## Changes

- Set `status: "ready"` → `"done"` in the frontmatter of
  `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`.
- Synced the body `**Status**:` label from `Ready` to `Done`.

## Context

- Work item: `meta/work/0184-template-enumeration-swallows-a-wrong-plugin-root.md`
- Implementation PR: #111 (merged) — refuses template resolution on a wrong plugin root.
- Validation: `meta/validations/2026-09-09-0184-template-resolution-wrong-plugin-root-validation.md` (result: pass).

## Testing

- [x] Frontmatter validates — `accelerator corpus frontmatter validate --file meta/work/0184-…md` (exit 0)
- [x] No code change — documentation-only status transition

## Notes for Reviewers

- Trivial doc-only change. It exists as a separate PR only because #111 merged
  before the status flip was committed; the two would otherwise have shared a
  branch.
