### PR TITLE
[0200] Decide vcs guard keeps git log/diff blocked; spawn VCS-agnostic follow-up

### DIFF
--- a/meta/prs/114-description.md
+++ b/meta/prs/114-description.md
@@ -1,0 +1,75 @@
+---
+type: "pr-description"
+id: "114"
+title: "[0200] Decide vcs guard keeps git log/diff blocked; spawn VCS-agnostic follow-up"
+date: "2026-09-10T17:29:57+00:00"
+author: "Toby Clemson"
+producer: "describe-pr"
+status: "complete"
+work_item_id: "0200"
+parent: "work-item:0200"
+relates_to: ["work-item:0286"]
+pr_url: "https://github.com/atomicinnovation/accelerator/pull/114"
+pr_number: 114
+tags: ["vcs", "guard", "spike"]
+revision: "4de586c3beceb4021ee9fe717a892781efd09bb5"
+repository: "accelerator"
+last_updated: "2026-09-10T17:29:57+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# [0200] Decide vcs guard keeps git log/diff blocked; spawn VCS-agnostic follow-up
+
+> Stacked on #112 (`[0184]`). Base is the `0184-mark-work-item-done` branch;
+> GitHub retargets this PR to `main` automatically once #112 merges.
+
+## Summary
+
+Records the outcome of spike 0200: keep `git log` and `git diff` in the vcs
+guard's blocked subcommand set, and close the spike with no code change. Adds
+the spike's first-review artefact, transitions 0200 to done, and spawns
+follow-up 0286 for the real remedy the spike identified.
+
+## Changes
+
+- Record the 0200 spike outcome on the work item — a keep-both decision with
+  per-subcommand rationale, the mode-split findings, and residual risks — and
+  transition it draft → ready → done.
+- Add the spike's first-review document
+  (`meta/reviews/work/0200-…-review-1.md`).
+- Spawn work item 0286, cross-linked to 0200 via a Blocks/blocked_by pair, to
+  make `validate-plan` and `research-issue` VCS-agnostic through a new
+  `accelerator vcs diff` subcommand.
+
+## Context
+
+Spike 0200 asked whether `log`/`diff` should stay in `BLOCKED_SUBCOMMANDS`
+(`cli/vcs/src/guard.rs`). The decision is keep-both, resting on one empirical
+fact: in a pure-jj repo (`--no-colocate`) there is no `.git` working tree, so
+raw `git log`/`git diff` fail with `fatal: not a git repository` regardless of
+the guard. The guard's deny converts that into a helpful `jj` redirect;
+dropping the entries would surface the cryptic git failure instead and would
+not unblock `validate-plan`. The guard's warn-vs-deny outcome is keyed on repo
+mode (pure-jj denies, colocated warns), not on the subcommand — which is why
+`validate-plan` is broken only in pure-jj repos, and why the fix belongs in the
+skills, not the blocklist. That fix is 0286.
+
+Implements work item 0200 (`meta/work/0200-…`); spawns 0286 (`meta/work/0286-…`).
+
+## Testing
+
+- [x] Frontmatter validated on both work items and the review doc
+      (`accelerator corpus frontmatter validate` exits 0).
+- [x] Docs-only change — no source, build, or test files touched, so no code
+      verification applies.
+
+## Notes for Reviewers
+
+- This is a decision record plus a spawned follow-up; there is no code change,
+  and deliberately so (Acceptance Criterion 3 of the spike).
+- Two stale references in the original 0200 brief are corrected in the recorded
+  outcome: the guard has no in-code "threat-model note", and the decision-table
+  fixture now lives at `cli/vcs-test-support/fixtures/vcs-guard/`.
+- 0200 carries `external_id: PP-730`; its done status reaches the remote tracker
+  only on the next work-item sync, not through this PR.

--- a/meta/reviews/work/0200-decide-vcs-guard-log-diff-blocklist-membership-review-1.md
+++ b/meta/reviews/work/0200-decide-vcs-guard-log-diff-blocklist-membership-review-1.md
@@ -1,0 +1,501 @@
+---
+type: "work-item-review"
+id: "0200-decide-vcs-guard-log-diff-blocklist-membership-review-1"
+title: "Work Item Review: Decide whether git log/diff belong in vcs guard's blocked subcommand set"
+date: "2026-09-10T09:29:05+00:00"
+author: "Toby Clemson"
+producer: "review-work-item"
+status: "complete"
+parent: "work-item:0136"
+target: "work-item:0200"
+work_item_id: "0200"
+reviewer: "Toby Clemson"
+verdict: "APPROVE"
+lenses: ["clarity", "completeness", "dependency", "scope", "testability"]
+review_number: 1
+review_pass: 3
+tags: []
+last_updated: "2026-09-10T11:04:20+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+## Work Item Review: Decide whether git log/diff belong in vcs guard's blocked subcommand set
+
+**Verdict:** REVISE
+
+This spike is well-written, tightly bounded, and structurally complete: its
+scoped question, effort constraint, and out-of-scope declaration are all
+explicit, and completeness raised no findings. Two major findings pull the
+verdict to REVISE — both concern the decision's outcome space rather than its
+prose. The acceptance criteria enumerate only two of the four terminal outcomes
+the requirements permit (testability), and the one downstream capability the
+outcome actually gates — `skills/planning/validate-plan` in pure-jj repos, the
+original motivation named in 0169 — is absent from the framing entirely
+(dependency).
+
+### Cross-Cutting Themes
+
+- **Under-specified outcome space and stakes** (flagged by: testability,
+  dependency, scope) — The spike permits four terminal outcomes (change,
+  no-change, informational-tier spin-out, time-box expiry) but only defines
+  "done" for two, and it omits the user-facing consequence — validate-plan
+  staying broken in pure-jj repos — that should weigh in the decision. The
+  informational-tier outcome specifically recurs across three lenses: it has no
+  acceptance criterion (testability major), its follow-up coupling is a one-way
+  reference (dependency suggestion), and it blurs the decide/implement seam
+  (scope suggestion).
+
+### Findings
+
+#### Critical
+
+None.
+
+#### Major
+
+- 🟡 **Testability**: Acceptance Criteria do not cover all terminal outcomes
+  the Requirements permit
+  **Location**: Acceptance Criteria
+  The ACs enumerate only change (AC2) and no-change (AC3), but Requirements
+  also permit an informational-tier decision (out-of-scope, requiring a spawned
+  item) and time-box expiry with only a leaning recorded. Neither maps cleanly
+  to AC2 or AC3, so a verifier reaching those outcomes has no "done" condition.
+
+- 🟡 **Dependency**: Downstream unblock of `skills/planning/validate-plan` not
+  captured
+  **Location**: Dependencies
+  0169 states explicitly that `log`/`diff` sitting in the blocked set blocks
+  `validate-plan` in pure-jj repos, and dropping them would unblock it — the
+  original motivation for reconsidering the blocklist. 0200 frames the decision
+  purely as a consistency/steering trade-off and omits validate-plan entirely,
+  so the team could keep both blocked without weighing that it leaves
+  validate-plan broken.
+
+#### Minor
+
+- 🔵 **Testability**: 'Fifth declared departure' recording obligation is not
+  reflected in any criterion
+  **Location**: Acceptance Criteria
+  Requirements require recording a behaviour change as the fifth declared shell-
+  parity departure, but AC2 lists the tests, fixture, and green `mise run`
+  without any check that the departure itself is recorded, so the parity ledger
+  could silently fall out of sync.
+
+- 🔵 **Clarity**: The 'read-only' criterion does not distinguish log/diff from
+  `git status`
+  **Location**: Summary
+  The Summary singles out `log`/`diff` as read-only with no side effects
+  "unlike `git status`/`git add`/`git commit`" — but `git status` is also
+  read-only, so the stated property does not separate them; the real criterion
+  silently shifts to mental-model steering, which the Context then reapplies to
+  `log`/`diff` too.
+
+#### Suggestions
+
+- 🔵 **Scope**: Spike folds the implementation of its own decision into the
+  same unit
+  **Location**: Requirements
+  The item is a spike but its Requirements and ACs also carry the
+  implementation (updating `BLOCKED_SUBCOMMANDS`, the fixture,
+  `guard_decision_table.rs`, a green `mise run`), blending decide with
+  implement. Impact is low — the change is trivial by 0169's design — but kind
+  and code-landing criteria are slightly at odds.
+
+- 🔵 **Testability**: Investigation evidence supporting the decision is not
+  required by any criterion
+  **Location**: Technical Notes
+  AC1 requires a decision "with rationale" but does not require the rationale to
+  cite the `git`-vs-`jj` output comparison or the warn-vs-deny axis finding the
+  Technical Notes call for, so a decision could pass AC1 without being grounded
+  in the evidence the spike was meant to gather.
+
+- 🔵 **Dependency**: Conditional informational-tier follow-up left as a one-way
+  reference
+  **Location**: Requirements
+  The spawned informational-tier item is referenced only from this spike; if it
+  is created without a back-reference, the gating relationship is captured on
+  one side only.
+
+- 🔵 **Clarity**: Two distinct guard.rs files referenced with inconsistent
+  paths
+  **Location**: Context
+  `cli/vcs-cli/src/guard.rs` is abbreviated to `vcs-cli/src/guard.rs` in the
+  Context but written in full elsewhere; the bare `guard.rs` appears for both
+  crates, so the two referents are easy to conflate.
+
+### Strengths
+
+- ✅ Subcommand arithmetic (13 = 11 + 2) reconciles across Summary, Context,
+  and Open Questions, and pronoun referents resolve cleanly to `git log`/`diff`
+  throughout.
+- ✅ The scoped question is stated unambiguously with three concrete candidate
+  outcomes and a natural stopping point, in both Summary and Open Questions.
+- ✅ An explicit effort constraint (one `/conduct-spike` run) with a defined
+  fallback, clarified in Drafting Notes as an effort budget rather than a wall-
+  clock one.
+- ✅ The informational-tier design is explicitly ruled out of scope and routed
+  to a separate item, consistently across Requirements, Technical Notes, and
+  Drafting Notes.
+- ✅ Deciding `log` and `diff` together is coherent (shared analysis) while
+  still allowing them to land differently — one decision unit, not two bundled
+  concerns.
+- ✅ Upstream inputs (0169, 0198) are captured, marked done and non-blocking,
+  and consistent between prose Dependencies and frontmatter linkage.
+
+### Recommended Changes
+
+1. **Add acceptance criteria for the two uncovered terminal outcomes**
+   (addresses: Acceptance Criteria do not cover all terminal outcomes the
+   Requirements permit)
+   Add an AC for the informational-tier decision ("the outcome is recorded and
+   a separate work item to design the tier is created and linked") and one for
+   time-box expiry ("the current leaning and the specific blocker are recorded
+   on this item").
+
+2. **Name `skills/planning/validate-plan` as the downstream consumer**
+   (addresses: Downstream unblock of `skills/planning/validate-plan` not
+   captured)
+   Record validate-plan's pure-jj blockage in Dependencies and fold it into the
+   Open Questions trade-off, so each candidate outcome's user-facing
+   consequence is explicit and the dependant is visibly resolved on closure.
+
+3. **Add the fifth-departure recording obligation to AC2** (addresses: 'Fifth
+   declared departure' recording obligation is not reflected in any criterion)
+   Extend AC2 to require "the change is recorded as the fifth declared departure
+   from shell parity", naming where that ledger lives.
+
+4. **Sharpen the distinguishing criterion in the Summary** (addresses: The
+   'read-only' criterion does not distinguish log/diff from `git status`)
+   State that `log`/`diff` are singled out because they neither desynchronise
+   the working copy nor duplicate a jj-only capability, and acknowledge that
+   read-only-ness alone (shared with `status`) is not the criterion.
+
+5. **Normalise the guard.rs path references** (addresses: Two distinct guard.rs
+   files referenced with inconsistent paths)
+   Use the full `cli/…` path form for both files on every mention.
+
+6. **Optionally clarify the decide/implement seam** (addresses: Spike folds the
+   implementation of its own decision into the same unit; Investigation
+   evidence supporting the decision is not required by any criterion)
+   Either state that the fixture/test change is in-scope only when trivial, or
+   add a criterion tying the recorded rationale to the `git`-vs-`jj` evidence
+   the Technical Notes call for.
+
+## Per-Lens Results
+
+### Clarity
+
+**Summary**: This spike is unusually well-written and internally consistent for
+its length: the 13 / 11 / 2 subcommand arithmetic reconciles across Summary,
+Context, and Open Questions, pronoun referents resolve cleanly to git log/diff
+throughout, and the 'fifth declared departure' claim checks out against 0169's
+four named departures. The main clarity soft spot is that the Summary's stated
+criterion for why log/diff differ from the other blocked subcommands ('read-
+only, no side effects') does not cleanly separate them from git status, which is
+also read-only, and the Context's counter-case reintroduces the mental-model
+argument for log/diff too. Path references to the two distinct guard.rs files
+are also abbreviated inconsistently.
+
+**Strengths**:
+- The subcommand counts are consistent across sections (13 = 11 + 2).
+- Pronoun referents are unambiguous throughout: every 'they'/'them' in the
+  Context resolves to git log/git diff without competing antecedents.
+- The scope boundary is stated explicitly and consistently across Requirements,
+  Technical Notes, and Drafting Notes.
+
+**Findings**:
+- 🔵 minor (confidence: medium) — **The 'read-only' criterion does not
+  distinguish log/diff from `git status`** (Summary). The Summary distinguishes
+  git log/diff as "read-only commands with no jj-workspace side effects, unlike
+  `git status`/`git add`/`git commit`", but `git status` is itself read-only,
+  so the stated property does not separate log/diff from status; the
+  distinguishing reason silently shifts to mental-model steering, which the
+  Context's counter-case then reapplies to log/diff. A reader cannot pin down
+  the operative criterion — exactly the axis the spike must decide. Suggestion:
+  state that log/diff are singled out because they neither desynchronise the
+  working copy nor duplicate a jj-only capability, and acknowledge read-only-
+  ness alone is not the criterion.
+- 🔵 suggestion (confidence: medium) — **Two distinct guard.rs files referenced
+  with inconsistent paths** (Context). `cli/vcs/src/guard.rs` and
+  `cli/vcs-cli/src/guard.rs` are distinct files; the Context abbreviates the
+  second to `vcs-cli/src/guard.rs` while other sections write it in full, and
+  bare `guard.rs` appears for both crates. Suggestion: use the full `cli/…`
+  path form consistently on every mention.
+
+### Completeness
+
+**Summary**: This spike is structurally and informationally complete for its
+kind. It carries an explicit scoped question, a stated effort constraint (one
+/conduct-spike run), enumerable decision-oriented exit criteria, and every
+relevant section is present and substantively populated. Frontmatter is intact
+with a recognised kind and appropriate draft status. No completeness gaps rise
+to the level of a finding.
+
+**Strengths**:
+- The scoped question is stated unambiguously in both Summary and Open
+  Questions.
+- A concrete effort constraint is present and explicitly clarified as an effort
+  budget, not wall-clock, with a defined fallback.
+- Exit criteria are enumerable decisions rather than vague 'understand X'
+  outcomes, covering both change and no-change branches.
+- The Context genuinely explains the forces behind the work (both the case and
+  counter-case) rather than restating the Summary.
+- Scope boundaries are explicit: the informational-tier is declared out of
+  scope with a spin-out instruction.
+- Frontmatter is complete and correct: recognised kind, appropriate status and
+  priority, populated linkage.
+
+**Findings**: None.
+
+### Dependency
+
+**Summary**: As a spike, 0200's upstream inputs (0169 which built the
+blocklist, 0198 which reshaped the diff output this decision reasons about) are
+both done and correctly captured, so the spike has no hidden blockers. The
+significant gap is downstream: 0169 explicitly states that dropping log/diff
+would unblock `skills/planning/validate-plan` in pure-jj repos, yet 0200 never
+names that consumer, framing the decision purely as a consistency/steering
+trade-off.
+
+**Strengths**:
+- Upstream inputs (0169, 0198) are cleanly captured, marked done and non-
+  blocking, so no hidden prerequisite gates the spike's start.
+- Frontmatter `relates_to` and `parent` are consistent with the prose
+  Dependencies section.
+- The conditional informational-tier spin-out is explicitly reserved rather
+  than silently assumed.
+
+**Findings**:
+- 🟡 major (confidence: high) — **Downstream unblock of
+  `skills/planning/validate-plan` not captured** (Dependencies). 0169 states
+  `validate-plan` is "blocked in pure-jj repos today because log and diff sit in
+  the guard's blocked set" and that dropping them "would unblock" it — the
+  original motivation for reconsidering the blocklist. 0200 omits validate-plan
+  from Dependencies and frames the decision solely as a consistency/steering
+  trade-off. Impact: the team could keep both blocked on consistency grounds
+  without weighing that this leaves validate-plan broken, and anyone tracking
+  what unblocks validate-plan would not find this spike. Suggestion: record
+  validate-plan's pure-jj blockage as the downstream consumer in Dependencies
+  and in the Open Questions trade-off.
+- 🔵 suggestion (confidence: low) — **Conditional informational-tier follow-up
+  left as a one-way reference** (Requirements). The spawned tier item would be
+  gated by this spike; if it does not back-reference the spike, the coupling is
+  captured on one side only. Suggestion: when the decision spawns the tier item,
+  add a Blocks/relates entry here and back-link from the new item.
+
+### Scope
+
+**Summary**: 0200 is a tightly-bounded spike with a specific, answerable
+research question, carrying a clear rationale for both the case and counter-
+case. It is well time-boxed, explicitly defers the informational-tier design to
+a separate follow-up, and keeps the two closely-related subcommands together
+under one shared analysis, which is coherent rather than a bundling problem. The
+only mild scope observation is that the spike folds the potential implementation
+of its own decision into the same unit, blurring the usual decide-then-implement
+boundary.
+
+**Strengths**:
+- Names exactly what is being decided with three concrete candidate outcomes and
+  a natural stopping point.
+- Explicitly time-boxed to one `/conduct-spike` run with a defined fallback.
+- Informational-tier is explicitly ruled out of scope and routed to a separate
+  item.
+- Deciding log and diff together is coherent while still allowing them to land
+  differently — one decision unit.
+- The Assumptions section fences off the guard's threat-model as settled.
+
+**Findings**:
+- 🔵 suggestion (confidence: medium) — **Spike folds the implementation of its
+  own decision into the same unit** (Requirements). The item is a spike but its
+  Requirements and ACs also carry the implementation (updating
+  `BLOCKED_SUBCOMMANDS`, the fixture, `guard_decision_table.rs`, a green `mise
+  run`), blending decide with implement where a spike conventionally produces
+  only the decision. Impact: low — the change is trivial by 0169's design — but
+  kind and code-landing criteria are slightly at odds. Suggestion: keep the
+  shape if comfortable with spikes that land trivial follow-through, or make the
+  decide/implement seam explicit.
+
+### Testability
+
+**Summary**: As a spike, 0200 frames its exit as concrete, checkable
+deliverables — a recorded decision with rationale (AC1) and a well-pinned code-
+change branch tied to named test files, the decision-table fixture, and a green
+`mise run` (AC2). The main weakness is that the Acceptance Criteria partition
+only two terminal outcomes (change vs. no-change) while the Requirements
+explicitly permit two further outcomes (informational-tier spin-out; time-box
+expiry with only a leaning recorded) that have no verifiable done-condition. A
+secondary gap is that the 'fifth declared departure' recording obligation is not
+mirrored in any criterion.
+
+**Strengths**:
+- AC1 states a concrete, existence-checkable deliverable rather than an open-
+  ended 'understand the trade-offs' goal.
+- AC2 pins the change branch to specific observable artefacts plus a definitive
+  `mise run` exit-0 gate.
+- Requirements impose an explicit time-box and treat log and diff as
+  independently decidable.
+
+**Findings**:
+- 🟡 major (confidence: high) — **Acceptance Criteria do not cover all terminal
+  outcomes the Requirements permit** (Acceptance Criteria). The ACs enumerate
+  only change (AC2) and no-change (AC3), but Requirements permit an
+  informational-tier decision (requiring a spawned item) and time-box expiry
+  with a leaning recorded. Neither maps cleanly to AC2 (assumes fixture/tests
+  updated, impossible for a not-yet-built tier) or AC3 (asserts neither changes
+  and a close). Impact: a verifier reaching either uncovered outcome has no AC
+  defining 'done'. Suggestion: add ACs for the informational-tier and time-box-
+  expiry outcomes.
+- 🔵 minor (confidence: high) — **'Fifth declared departure' recording
+  obligation is not reflected in any criterion** (Acceptance Criteria).
+  Requirements require recording a behaviour change as the fifth declared shell-
+  parity departure, but AC2 omits any check that the departure is recorded.
+  Impact: the parity-departure ledger could silently fall out of sync.
+  Suggestion: extend AC2 to include the departure recording, naming where the
+  ledger lives.
+- 🔵 suggestion (confidence: medium) — **Investigation evidence supporting the
+  decision is not required by any criterion** (Technical Notes). The Technical
+  Notes call for comparing real git vs jj output and checking the warn-vs-deny
+  axis, but AC1 requires only a decision "with rationale" — not that the
+  rationale cite this evidence. Impact: the recorded decision could be present
+  yet not demonstrably grounded in the evidence the spike was meant to gather.
+  Suggestion: if the evidence is load-bearing, add a criterion that the rationale
+  references it.
+
+---
+*Review generated by /accelerator:review-work-item*
+
+## Re-Review (Pass 2) — 2026-09-10
+
+**Verdict:** REVISE
+
+All eight pass-1 findings were addressed. Both pass-1 majors are resolved, but
+the acceptance-criteria restructuring that closed the testability major
+introduced two new majors: the change/no-change/tier/expiry branches now
+overlap (a tier-move is itself a "treatment change", so AC2 and AC4 both fire),
+and no criterion requires the recorded rationale to weigh the validate-plan
+consequence that the dependency fix newly made visible. Both are tight
+AC-partitioning fixes.
+
+### Previously Identified Issues
+
+- 🔵 **Clarity**: read-only criterion doesn't distinguish log/diff from `git
+  status` — Resolved. Summary now frames the criterion as desync/duplication,
+  explicitly noting read-only-ness is shared with `status`.
+- 🔵 **Clarity**: inconsistent guard.rs paths — Resolved. Context now uses the
+  full `cli/vcs-cli/src/guard.rs` form.
+- 🟡 **Dependency**: validate-plan downstream unblock not captured — Resolved.
+  Recorded as a downstream consumer in Dependencies and as Open Question 3.
+- 🔵 **Dependency**: informational-tier follow-up one-way reference — Resolved.
+  Dependencies now instructs a Blocks entry plus back-link.
+- 🔵 **Scope**: spike folds implementation into the decision unit — Partially
+  resolved. Guarded with a trivial-only clause and a spin-out for non-trivial
+  changes; the lens now rates it a suggestion and calls it "already well-
+  guarded", but still flags the residual spike/implement blend.
+- 🟡 **Testability**: ACs don't cover all terminal outcomes — Resolved. AC4
+  (tier) and AC5 (time-box expiry) added; but see new AC-overlap majors below.
+- 🔵 **Testability**: fifth-departure recording not in any criterion —
+  Resolved. AC2 now requires recording the departure in 0169's ledger.
+- 🔵 **Testability**: decision evidence not required — Resolved. AC1 now
+  requires the rationale to cite the git-vs-jj output difference and the
+  warn-vs-deny finding.
+
+### New Issues Introduced
+
+- 🟡 **Clarity + Testability**: AC2 ("treatment changes") and AC4 ("move to
+  informational tier") overlap — a tier-move is itself a treatment change, so
+  both branches fire and demand opposite actions (land the code vs defer it).
+  Flagged as major by both lenses. Fix: narrow AC2's trigger to "dropped from
+  `BLOCKED_SUBCOMMANDS` entirely", mutually exclusive with AC4.
+- 🟡 **Testability**: no criterion requires the rationale to weigh the
+  validate-plan pure-jj consequence — the very motivation the dependency fix
+  surfaced. Fix: extend AC1 to require the rationale to address whether the
+  chosen treatment leaves validate-plan broken and whether that cost is
+  outweighed.
+- 🔵 **Testability + Clarity**: AC1 is phrased unconditionally ("A decision is
+  recorded") but AC5 governs the no-decision path — a strict verifier marks AC1
+  failed on the time-box branch. Fix: make AC1 conditional ("If a firm decision
+  is reached…").
+- 🔵 **Dependency**: the write-back to closed item 0169's departures ledger is
+  an unrecorded cross-item coupling; and the non-trivial "separate chore" spawn
+  path lacks the bidirectional-link treatment the tier item received.
+- 🔵 **Clarity**: the warn-vs-deny axis is referenced in AC1 before it is
+  introduced (only Technical Notes characterises it).
+- 🔵 **Testability/Clarity/Dependency suggestions**: AC1 presupposes a warn-vs-
+  deny finding the decision "relied on" (may not materialise); `diff` vs `diff
+  --stat` scope oscillates; Technical Notes should state the jj/git-binary and
+  `git.colocate=false` prerequisites for the empirical comparison.
+
+### Assessment
+
+Not yet ready. The two new majors are artefacts of the AC restructuring rather
+than fresh design gaps, and both are resolved by narrowing AC2's trigger to the
+outright-drop case and adding the validate-plan clause to AC1 — small, local
+edits. Recommend applying those two fixes (plus the AC1-conditional wording),
+then closing out; the remaining items are minor/suggestion polish.
+
+## Re-Review (Pass 3) — 2026-09-10
+
+**Verdict:** COMMENT
+
+Both pass-2 majors are resolved, and no lens raises a major. The remaining
+findings are minor/suggestion polish, several converging on one theme: the
+"non-trivial change" spin-out branch is under-defined (no trigger, no
+acceptance criterion), and the "declared-departures ledger" reference does not
+match 0169's actual section name. The work item is acceptable for a low-
+priority spike as-is.
+
+### Previously Identified Issues (pass 2)
+
+- 🟡 **Clarity + Testability**: AC2/AC4 branch overlap — Resolved. AC2 (and its
+  Requirements bullet) now trigger on "dropped from `BLOCKED_SUBCOMMANDS`
+  outright", mutually exclusive with AC4's tier-move.
+- 🟡 **Testability**: rationale needn't weigh validate-plan — Resolved. AC1 now
+  requires the rationale to address whether the treatment leaves validate-plan
+  broken and whether the cost is outweighed.
+- 🔵 **Testability + Clarity**: AC1 unconditional vs AC5 — Resolved. AC1 is now
+  conditional ("If a firm decision is reached…").
+- 🔵 **Dependency**: 0169 ledger write-back coupling — Resolved. Dependencies
+  now states the outright-drop path amends a closed item's ledger.
+- 🔵 **Dependency**: non-trivial-chore spawn coupling — Resolved. The Blocks +
+  back-link instruction now covers both the tier item and the chore.
+- 🔵 **Clarity**: warn-vs-deny referenced before defined — Resolved. The axis
+  is now introduced in Context at the mode-composition mention.
+- 🔵 **Suggestions** (warn-vs-deny presupposition, diff/--stat scope, env
+  prerequisites) — Resolved. AC1 softened; Context clarifies the `diff`
+  subcommand scope; Technical Notes state the jj/git-binary and
+  `git.colocate=false` prerequisites.
+
+### New Issues Introduced
+
+- 🔵 **Testability**: the non-trivial-drop outcome has no acceptance criterion
+  (AC2 covers only the trivial drop; AC4 covers only the tier), and the "firm
+  decision" boundary between AC1 and AC5 is undefined.
+- 🔵 **Clarity**: outcome vocabulary shifts between Context ("allowed, no
+  suggestion" / "allowed with an informational note") and Requirements
+  ("dropped entirely" / "informational-suggestion tier"); "non-trivial change"
+  has no stated trigger; AC1's per-subcommand rationale obligation is not
+  reconciled with AC3's single "shell parity" rationale; "declared-departures
+  ledger" does not match 0169's "Declared behavioural changes" section name.
+- 🔵 **Dependency**: the outright-drop path should reconcile 0169's "exactly
+  four departures" framing (and any count assertion derived from it), not just
+  append a fifth row.
+
+### Assessment
+
+Ready as a low-priority spike. No structural blockers remain — the outcome
+space is covered for every path a conductor is likely to hit, the rationale
+obligations are concrete and falsifiable, and dependencies are mapped in both
+directions. The residual minors are worth a single tightening pass if touched
+again: define "non-trivial" and give it an AC, unify the outcome vocabulary,
+rename the ledger reference to 0169's actual section, and reconcile AC1/AC3's
+rationale wording. None gates conducting the spike.
+
+## Approval — 2026-09-10
+
+**Verdict:** APPROVE (reviewer override)
+
+Reviewer accepted the work item as ready to conduct despite the residual
+minor/suggestion polish recorded in Pass 3. No structural blockers remain; the
+outstanding items are non-gating and may be folded in if the item is edited
+again. Work item transitioned to `ready`.

--- a/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
+++ b/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
@@ -5,14 +5,14 @@ title: "Decide whether git log/diff belong in vcs guard's blocked subcommand set
 date: "2026-08-06T00:00:00+00:00"
 author: "Toby Clemson"
 producer: "create-work-item"
-status: "ready"
+status: "done"
 kind: "spike"
 priority: "low"
 parent: "work-item:0136"
 relates_to: ["work-item:0169", "work-item:0198"]
 derived_from: ["plan:2026-08-05-0169-vcs-subdomain-and-hooks-migration"]
 tags: ["vcs", "hooks", "guard", "cli"]
-last_updated: "2026-09-10T09:11:22+00:00"
+last_updated: "2026-09-10T11:44:31+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 external_id: "PP-730"
@@ -21,7 +21,7 @@ external_id: "PP-730"
 # 0200: Decide whether git log/diff belong in vcs guard's blocked subcommand set
 
 **Kind**: Spike
-**Status**: Ready
+**Status**: Done
 **Priority**: Low
 **Author**: Toby Clemson
 
@@ -120,6 +120,116 @@ illustrate how far git's default output diverges from `jj diff`.
       leaning and the specific blocker are recorded on this item, per the
       time-box requirement.
 
+## Spike Outcome
+
+**2026-09-10 — one `/conduct-spike` run, within the time-box. Verdict: keep
+both `log` and `diff` in the guard's blocked set; close without a code change
+(Acceptance Criterion 3).**
+
+`log` and `diff` stay in `BLOCKED_SUBCOMMANDS` (`cli/vcs/src/guard.rs:19-22`).
+No behaviour changes, so nothing is appended to 0169's "Declared behavioural
+changes" ledger, no informational-suggestion tier is built, the decision-table
+fixture and `guard_decision_table.rs` are untouched, and `mise run` is not
+re-run because no code moved. `validate-plan`'s pure-jj brokenness is real but
+is neither caused by nor fixed by this blocklist; a VCS-agnostic follow-up
+(0286) owns it — see Dependencies.
+
+## Findings
+
+The brief's "read-only, therefore demotable" framing inverts once the two repo
+modes the guard actually sees are separated. The operative axis is repository
+mode, not read-only-ness — `git status` is read-only too, yet nobody proposes
+dropping it.
+
+The guard's warn-vs-deny outcome is keyed on mode, not on subcommand
+(`cli/vcs-cli/src/guard.rs:71-73`): `Mode::Jj` denies, `Mode::JjColocated`
+warns, `Mode::Git` never evaluates the command. `GuardDecision` itself is
+binary — `Allow` / `Block` (`cli/vcs/src/guard.rs:9-17`); the deny-vs-warn
+choice is made afterwards, per mode. This is the finding that splits the
+picture:
+
+| Mode | mise default? | Guard today | Can raw `git log`/`diff` run? |
+|---|---|---|---|
+| Pure-jj (`--no-colocate`) | No | deny | No — no `.git`; `fatal: not a git repository` |
+| Colocated (`--colocate`) | Yes | warn (non-blocking) | Yes, but diverges from jj |
+
+The mise-pinned jj defaults to `colocate=true`, so real repos are
+predominantly colocated (`jj git init --help`; `CLAUDE.md`).
+
+Empirical evidence, from throwaway probe repos (jj 0.43.0, git 2.55.0):
+
+- Pure-jj (`jj git init --no-colocate`): no `.git` directory exists; the git
+  backing store is a bare repo hidden at `.jj/repo/store/git`, unreachable from
+  the working tree. `git log` exits 128 (`fatal: not a git repository`);
+  `git diff` exits 129. Git cannot serve either command, guard or no guard.
+- Colocated (`jj git init --colocate`): `git log --oneline` shows a *different
+  commit set* than `jj log` — it omits the working-copy commit jj models as a
+  real commit (one commit vs two in the probe). `git diff` is index-relative
+  (unstaged changes); `jj diff` is parent-relative (the whole working-copy
+  commit). The `--stat` summary lines nearly coincide, but the patch bodies
+  differ entirely (git unified vs jj's `Modified regular file` line-numbered
+  form).
+
+Per-subcommand rationale — both land the same way:
+
+- `log` — In pure-jj the deny replaces a cryptic `fatal: not a git repository`
+  with `Use jj instead of git log. Equivalent: jj log`, which is strictly
+  better. In colocated the git-shaped read is genuinely misleading (a different
+  commit set), and the guard's response there is a non-blocking warn, the right
+  severity. Keep.
+- `diff` — Same pure-jj argument. In colocated the index-vs-parent semantics
+  diverge more sharply than `log` does (the staging model git carries and jj
+  does not), which strengthens the case for keeping `diff` blocked rather than
+  weakening it. The `--stat` shape looking similar is incidental; the base of
+  comparison is what differs. Keep.
+
+The `validate-plan` cost is illusory. `validate-plan/SKILL.md:58-59` runs raw
+`git log --oneline -n 20` and `git diff HEAD~N..HEAD` in a Bash block (not the
+`accelerator vcs` abstraction — and there is no `vcs diff` subcommand). It is
+denied only in pure-jj repos. Dropping `log`/`diff` from the blocklist would
+not fix it there: the command would then run and hit `fatal: not a git
+repository`, a worse failure than today's redirect. In colocated repos the warn
+is non-blocking, so validate-plan already works. The blocklist is therefore not
+what breaks validate-plan, and changing it fixes nothing.
+`research-issue/SKILL.md:63,66` shares the same raw-git dependency and the same
+consequence.
+
+Two corrections to the brief, neither of which changes the decision:
+
+- The "threat-model note" the brief cites in `cli/vcs/src/guard.rs` (Assumptions
+  and References) does not exist in the code — a grep for steering, security, or
+  boundary language finds nothing there. The guard's steering-not-security
+  character is real, evidenced by the mode-keyed warn/deny design, but the
+  `file:line` citation is stale.
+- The decision-table fixture has moved to
+  `cli/vcs-test-support/fixtures/vcs-guard/decision-table.json` (138 rows); the
+  brief's `hooks/test-fixtures/…` path is stale. Moot here, since keep-both
+  touches no fixture.
+
+## Recommendation
+
+Keep both `log` and `diff` in `BLOCKED_SUBCOMMANDS`, unchanged. Close this item
+under Acceptance Criterion 3: shell parity retained, no code change.
+
+The real remedy for `validate-plan` (and `research-issue`) is orthogonal — make
+them VCS-agnostic by adding an `accelerator vcs diff` subcommand and repointing
+the skills onto `vcs log`/`vcs diff`, exactly as `skills/vcs/commit/SKILL.md`
+already uses `vcs status`/`vcs log`. That is spun out as work item 0286
+(recorded under Dependencies as a Blocks entry), not built here.
+
+## Residual Risks & Open Questions
+
+- `validate-plan` and `research-issue` stay broken in pure-jj repos until 0286
+  lands. This is not a regression — it is the pre-existing state 0169 declined
+  to change — and dropping the blocklist would make it worse, not better.
+- Revisit the blocklist only if a future `vcs diff` implementation still needed
+  a raw `git` invocation to reach jj's backing store. It will not:
+  `vcs status`/`vcs log` already shell the real binaries under a controlled
+  environment (0198), and `vcs diff` would do the same.
+- The colocated warn on `log`/`diff` is a deliberate nudge, not a bug: the
+  commit-set and index-vs-parent divergences above are exactly the git-shaped
+  read it steers away from.
+
 ## Open Questions
 
 - Does `git log` stay blocked, move to an informational-suggestion tier, or
@@ -148,6 +258,11 @@ illustrate how far git's default output diverges from `jj diff`.
   so validate-plan's pure-jj status is a consequence of whichever way the
   decision lands, and is resolved when this spike closes.
 - Parent: epic 0136.
+- Blocks: work-item:0286 (make `validate-plan`/`research-issue` VCS-agnostic
+  via a new `accelerator vcs diff` subcommand and a repoint of the skills) —
+  spawned by this spike's outcome; it is the real remedy for the pure-jj
+  brokenness that keeping `log`/`diff` blocked leaves in place. Back-linked
+  from 0286.
 - If the decision spawns a downstream item — an "allowed, informational
   suggestion only" tier, or a separate chore for a non-trivial blocklist
   change — that item is gated by this spike; record it here as a Blocks entry

--- a/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
+++ b/meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md
@@ -5,14 +5,14 @@ title: "Decide whether git log/diff belong in vcs guard's blocked subcommand set
 date: "2026-08-06T00:00:00+00:00"
 author: "Toby Clemson"
 producer: "create-work-item"
-status: "draft"
+status: "ready"
 kind: "spike"
 priority: "low"
 parent: "work-item:0136"
-relates_to: ["work-item:0169"]
+relates_to: ["work-item:0169", "work-item:0198"]
 derived_from: ["plan:2026-08-05-0169-vcs-subdomain-and-hooks-migration"]
 tags: ["vcs", "hooks", "guard", "cli"]
-last_updated: "2026-08-06T00:00:00+00:00"
+last_updated: "2026-09-10T09:11:22+00:00"
 last_updated_by: "Toby Clemson"
 schema_version: 1
 external_id: "PP-730"
@@ -21,7 +21,7 @@ external_id: "PP-730"
 # 0200: Decide whether git log/diff belong in vcs guard's blocked subcommand set
 
 **Kind**: Spike
-**Status**: Draft
+**Status**: Ready
 **Priority**: Low
 **Author**: Toby Clemson
 
@@ -30,18 +30,22 @@ external_id: "PP-730"
 `vcs guard` (`vcs::guard::decide`, built in 0169) blocks `git log` and
 `git diff` in a pure-jj repository, denying the call and suggesting
 `jj log`/`jj diff` instead — reproducing `hooks/vcs-guard.sh`'s original
-13-subcommand blocklist verbatim. Both are read-only commands with no
-jj-workspace side effects, unlike `git status`/`git add`/`git commit`, whose
-blocking exists to steer Claude Code away from a git-shaped mental model of
-the working copy. 0169 declined to change this blocklist membership — parity
-with the shell was in scope, not a behavioural redesign — and named this
-item as the place to make the call.
+13-subcommand blocklist verbatim. Both are read-only, but so is `git status`,
+so read-only-ness alone is not the property that singles them out. What
+distinguishes `log`/`diff` is that they neither desynchronise the jj working
+copy from git's index (unlike `git add`/`git commit`) nor duplicate a jj-only
+capability (unlike `git branch`); the rest of the blocklist earns its place by
+steering Claude Code away from a git-shaped mental model of the working copy.
+0169 declined to change this blocklist membership — parity with the shell was
+in scope, not a behavioural redesign — and named this item as the place to
+make the call.
 
 ## Context
 
 The guard is a steering aid, not an access-control boundary (see
-`cli/vcs/src/guard.rs`'s own threat-model note, and `vcs-cli/src/guard.rs`'s
-mode composition): its purpose is nudging Claude Code toward jj-native
+`cli/vcs/src/guard.rs`'s own threat-model note, and
+`cli/vcs-cli/src/guard.rs`'s mode composition — the deny-vs-warn axis the
+guard already distinguishes): its purpose is nudging Claude Code toward jj-native
 commands, not preventing any particular git invocation a determined caller
 could still reach another way. Against that purpose, `git log`/`git diff`
 are a different case from the other eleven blocked subcommands: they cannot
@@ -59,36 +63,95 @@ and `git log`/`git diff --stat` genuinely do produce different output than
 what "changed" means relative to the working copy), so even a read-only
 command steers toward a git-shaped read of the repository if left unblocked.
 
+Throughout, the decision concerns the `diff` subcommand as a whole — the guard
+blocks it regardless of flags — and `--stat` is only the invocation used to
+illustrate how far git's default output diverges from `jj diff`.
+
 ## Requirements
 
 - Decide, with a stated rationale, whether `log` and `diff` stay in
   `vcs::guard`'s `BLOCKED_SUBCOMMANDS` (`cli/vcs/src/guard.rs`), move to an
   "allowed, informational suggestion only" tier if one is introduced, or are
   dropped from the blocklist entirely.
-- If the decision changes behaviour, update the guard decision table fixture
+- If the decision drops `log` and/or `diff` from the blocklist outright,
+  update the guard decision table fixture
   (`hooks/test-fixtures/vcs-guard/decision-table.json`) and
   `cli/vcs-cli/tests/guard_decision_table.rs` to match, and record the
   change as a fifth declared departure from shell parity (0169 named four;
-  this would be the first landed after the port itself).
+  this would be the first landed after the port itself). This fixture/test
+  follow-through is in scope only because 0169 engineered the change to be
+  trivial (removing at most two blocklist entries); a non-trivial change is
+  spun out as a separate chore rather than landed under this spike. A move to
+  an informational tier is not this branch — it is handled by the out-of-scope
+  carve-out below.
 - If the decision is to keep both blocked, close this item with that
   rationale recorded rather than leaving the question open indefinitely.
+- Time-box: one `/conduct-spike` run. If the run ends without a firm
+  decision, record the current leaning and what blocks it rather than
+  extending the box.
+- Introducing an "allowed, informational suggestion only" tier is out of
+  scope here. If the decision points to needing it, record that outcome and
+  spawn a separate work item to design it — do not build the tier in this
+  spike.
 
 ## Acceptance Criteria
 
-- [ ] A decision is recorded, with rationale, for `log` and for `diff`
-      independently (they need not land the same way).
-- [ ] If either subcommand's treatment changes: `vcs::guard::decide`'s tests,
-      the decision-table fixture, and `guard_decision_table.rs` all reflect
-      the new expected outcome; `mise run` (bare default task) exits 0
-      end-to-end.
+- [ ] If a firm decision is reached, it is recorded with rationale for `log`
+      and for `diff` independently (they need not land the same way). The
+      rationale cites the observed `git log`/`git diff --stat` vs `jj log`/`jj
+      diff` output difference; cites the warn-vs-deny axis finding if the
+      decision relied on it, or records that the axis was found not to bear on
+      the decision; and addresses whether the chosen treatment leaves
+      `skills/planning/validate-plan` broken in pure-jj repos and whether that
+      cost is outweighed.
+- [ ] If either subcommand is dropped from `BLOCKED_SUBCOMMANDS` outright:
+      `vcs::guard::decide`'s tests, the decision-table fixture, and
+      `guard_decision_table.rs` all reflect the new expected outcome; the
+      change is recorded as the fifth declared departure from shell parity in
+      0169's declared-departures ledger; and `mise run` (bare default task)
+      exits 0 end-to-end.
 - [ ] If neither changes: the rationale for keeping shell parity here is
       recorded on this item and it is closed without a code change.
+- [ ] If the decision is to move `log` and/or `diff` to an
+      informational-suggestion tier: the outcome is recorded and a separate
+      work item to design that tier is created and linked from this item (per
+      the out-of-scope note in Requirements), without building the tier here.
+- [ ] If the `/conduct-spike` run ends without a firm decision: the current
+      leaning and the specific blocker are recorded on this item, per the
+      time-box requirement.
+
+## Open Questions
+
+- Does `git log` stay blocked, move to an informational-suggestion tier, or
+  drop entirely — and does `git diff` land the same way, or differently?
+  (`git diff`'s "changed relative to index" default diverges from `jj diff`
+  more sharply than `git log` does from `jj log`.)
+- Does nudging toward a jj-native read of the repo outweigh the cost of two
+  exceptions in an otherwise-uniform "the guard blocks git VCS commands"
+  rule?
+- Does keeping `log`/`diff` blocked leave `skills/planning/validate-plan`
+  broken in pure-jj repos, and if so, does the consistency benefit outweigh
+  that user-facing cost? (0169 named unblocking validate-plan as the original
+  motivation for reconsidering the blocklist.)
 
 ## Dependencies
 
 - Relates to: work-item:0169 (built the blocklist this item reconsiders;
-  done, not blocked on this item).
+  done, not blocked on this item). An outright-drop outcome writes a fifth
+  declared departure back to 0169's departures ledger, so this spike amends a
+  closed item on that path.
+- Relates to: work-item:0198 (reworked the `vcs status`/`vcs log` renderer
+  and the `git diff --stat` output shape this decision reasons about; done).
+- Downstream consumer: `skills/planning/validate-plan` — blocked in pure-jj
+  repos because `log` and `diff` sit in the guard's blocked set (per 0169);
+  dropping them would unblock it. This spike's outcome gates that capability,
+  so validate-plan's pure-jj status is a consequence of whichever way the
+  decision lands, and is resolved when this spike closes.
 - Parent: epic 0136.
+- If the decision spawns a downstream item — an "allowed, informational
+  suggestion only" tier, or a separate chore for a non-trivial blocklist
+  change — that item is gated by this spike; record it here as a Blocks entry
+  and back-link from the new item so the coupling is captured on both sides.
 
 ## Assumptions
 
@@ -97,11 +160,34 @@ command steers toward a git-shaped read of the repository if left unblocked.
   item is scoped to blocklist membership, not to whether the guard should
   exist or be hardened.
 
+## Technical Notes
+
+- Compare real output of `git log` / `git diff --stat` against `jj log` /
+  `jj diff` in a pure-jj repo, to gauge how git-shaped the unblocked read
+  actually is.
+- Check whether `vcs::guard` already exposes a warn-vs-deny axis (mode
+  composition in `cli/vcs-cli/src/guard.rs`) an informational tier could
+  reuse, or whether that tier is net-new machinery.
+- The comparison assumes both `jj` and `git` binaries are present and that a
+  genuinely pure-jj state is built with `git.colocate=false` (mise-pinned jj
+  defaults to `colocate=true`), so the environment prerequisite is explicit
+  for whoever conducts the run.
+
+## Drafting Notes
+
+- Time-box read as "one `/conduct-spike` run" (author's steer), not a
+  wall-clock budget.
+- Informational-tier design treated as out of scope, to be spun out as a
+  separate work item if the decision requires it — narrows this spike to a
+  decision plus the parity-fixture update if `log`/`diff` move.
+
 ## References
 
 - `cli/vcs/src/guard.rs` — `BLOCKED_SUBCOMMANDS`, the threat-model note
 - `cli/vcs-cli/src/guard.rs` — mode composition (deny vs warn)
 - `hooks/test-fixtures/vcs-guard/decision-table.json`
 - `meta/work/0169-vcs-subdomain-and-hooks-migration.md`
+- `meta/work/0198-vcs-agnostic-status-log-renderer.md` — adjacent prior art
+  on the `git diff --stat` / `jj diff` output shapes
 - `meta/plans/2026-08-05-0169-vcs-subdomain-and-hooks-migration.md` — Phase
   10, "Not Doing" section

--- a/meta/work/0286-vcs-agnostic-validate-plan-research-issue-diff.md
+++ b/meta/work/0286-vcs-agnostic-validate-plan-research-issue-diff.md
@@ -1,0 +1,100 @@
+---
+type: "work-item"
+id: "0286"
+title: "Make validate-plan and research-issue VCS-agnostic via an accelerator vcs diff subcommand"
+date: "2026-09-10T11:44:31+00:00"
+author: "Toby Clemson"
+producer: "conduct-spike"
+status: "draft"
+kind: "story"
+priority: "low"
+parent: "work-item:0136"
+blocked_by: ["work-item:0200"]
+relates_to: ["work-item:0169", "work-item:0198", "work-item:0200"]
+tags: ["vcs", "cli", "skills"]
+last_updated: "2026-09-10T11:44:31+00:00"
+last_updated_by: "Toby Clemson"
+schema_version: 1
+---
+
+# 0286: Make validate-plan and research-issue VCS-agnostic via an accelerator vcs diff subcommand
+
+**Kind**: Story
+**Status**: Draft
+**Priority**: Low
+**Author**: Toby Clemson
+
+## Summary
+
+`skills/planning/validate-plan` and `skills/research/research-issue` gather
+implementation evidence by running raw `git log` and `git diff` in a Bash
+block. Both are denied by the `vcs guard` in pure-jj repos, so both skills are
+broken there. Repoint them onto VCS-agnostic subcommands — reusing the
+`vcs log` renderer 0198 built, and adding the `vcs diff` subcommand that does
+not yet exist — so they work identically under git, colocated jj, and pure-jj.
+
+## Context
+
+Spawned by spike 0200, which decided to keep `log` and `diff` in the guard's
+`BLOCKED_SUBCOMMANDS` and established that the blocklist is not what breaks
+these skills: in a pure-jj repo (`--no-colocate`) there is no `.git`, so raw
+`git log`/`git diff` fail with `fatal: not a git repository` regardless of the
+guard. Dropping them from the blocklist would replace the guard's helpful
+redirect with that cryptic failure — a worse outcome — so the fix is to stop
+issuing raw git from the skills at all.
+
+The precedent exists. `skills/vcs/commit/SKILL.md` already injects
+`accelerator vcs status` and `accelerator vcs log` via the `!` preprocessor;
+these dispatch to the library-backed adapter (`cli/vcs-cli`), render correctly
+for git or jj, and never issue a raw `git` Bash call the guard would see. 0198
+built `vcs status`/`vcs log` to a VCS-agnostic shape (a flat recent-commit list
+for `log`; a backend-neutral change summary for `status`). No `vcs diff`
+subcommand exists yet — that is the net-new piece.
+
+## Requirements
+
+- Add an `accelerator vcs diff` subcommand rendering a VCS-agnostic working-copy
+  diff, mirroring how `vcs status`/`vcs log` shell the real backend under a
+  scrubbed environment (per 0198). Decide the base of comparison explicitly —
+  git's index-relative default and jj's parent-relative default diverge — and
+  render one consistent meaning across backends.
+- Repoint `skills/planning/validate-plan` off raw `git log`/`git diff` onto the
+  VCS-agnostic path, and update its `allowed-tools` accordingly.
+- Repoint `skills/research/research-issue` off raw `git log`/`git diff`
+  likewise.
+- Verify the skills work under all three repo modes (git-only, colocated jj,
+  pure-jj), with the pure-jj case being the one that is broken today.
+
+## Acceptance Criteria
+
+- [ ] An `accelerator vcs diff` subcommand exists and renders a VCS-agnostic
+      working-copy diff under git, colocated jj, and pure-jj, with a stated and
+      consistent base of comparison.
+- [ ] `validate-plan` and `research-issue` issue no raw `git log`/`git diff`
+      Bash calls; they use the VCS-agnostic path and their `allowed-tools`
+      reflect it.
+- [ ] Both skills gather implementation evidence successfully in a pure-jj repo.
+- [ ] `mise run` (bare default task) exits 0 end-to-end.
+
+## Dependencies
+
+- Blocked by: work-item:0200 (the spike that decided keep-both and spawned this
+  as the real remedy). Back-linked from 0200's Dependencies as a Blocks entry.
+- Relates to: work-item:0198 (built the VCS-agnostic `vcs status`/`vcs log`
+  renderer this extends), work-item:0169 (built the guard and the blocklist).
+- Parent: epic 0136.
+
+## References
+
+- `meta/work/0200-decide-vcs-guard-log-diff-blocklist-membership.md` — the
+  spike outcome that spawned this item
+- `meta/work/0198-vcs-agnostic-status-log-renderer.md` — the VCS-agnostic
+  renderer precedent
+- `skills/planning/validate-plan/SKILL.md` — raw `git log`/`git diff` at
+  lines 58-59
+- `skills/research/research-issue/SKILL.md` — raw `git log`/`git diff` at
+  lines 63, 66
+- `skills/vcs/commit/SKILL.md` — the `!`-preprocessor `vcs status`/`vcs log`
+  pattern to follow
+- `cli/vcs/src/guard.rs`, `cli/vcs-cli/src/guard.rs` — the guard this routes
+  around


### PR DESCRIPTION

# [0200] Decide vcs guard keeps git log/diff blocked; spawn VCS-agnostic follow-up

> Stacked on #112 (`[0184]`). Base is the `0184-mark-work-item-done` branch;
> GitHub retargets this PR to `main` automatically once #112 merges.

## Summary

Records the outcome of spike 0200: keep `git log` and `git diff` in the vcs
guard's blocked subcommand set, and close the spike with no code change. Adds
the spike's first-review artefact, transitions 0200 to done, and spawns
follow-up 0286 for the real remedy the spike identified.

## Changes

- Record the 0200 spike outcome on the work item — a keep-both decision with
  per-subcommand rationale, the mode-split findings, and residual risks — and
  transition it draft → ready → done.
- Add the spike's first-review document
  (`meta/reviews/work/0200-…-review-1.md`).
- Spawn work item 0286, cross-linked to 0200 via a Blocks/blocked_by pair, to
  make `validate-plan` and `research-issue` VCS-agnostic through a new
  `accelerator vcs diff` subcommand.

## Context

Spike 0200 asked whether `log`/`diff` should stay in `BLOCKED_SUBCOMMANDS`
(`cli/vcs/src/guard.rs`). The decision is keep-both, resting on one empirical
fact: in a pure-jj repo (`--no-colocate`) there is no `.git` working tree, so
raw `git log`/`git diff` fail with `fatal: not a git repository` regardless of
the guard. The guard's deny converts that into a helpful `jj` redirect;
dropping the entries would surface the cryptic git failure instead and would
not unblock `validate-plan`. The guard's warn-vs-deny outcome is keyed on repo
mode (pure-jj denies, colocated warns), not on the subcommand — which is why
`validate-plan` is broken only in pure-jj repos, and why the fix belongs in the
skills, not the blocklist. That fix is 0286.

Implements work item 0200 (`meta/work/0200-…`); spawns 0286 (`meta/work/0286-…`).

## Testing

- [x] Frontmatter validated on both work items and the review doc
      (`accelerator corpus frontmatter validate` exits 0).
- [x] Docs-only change — no source, build, or test files touched, so no code
      verification applies.

## Notes for Reviewers

- This is a decision record plus a spawned follow-up; there is no code change,
  and deliberately so (Acceptance Criterion 3 of the spike).
- Two stale references in the original 0200 brief are corrected in the recorded
  outcome: the guard has no in-code "threat-model note", and the decision-table
  fixture now lives at `cli/vcs-test-support/fixtures/vcs-guard/`.
- 0200 carries `external_id: PP-730`; its done status reaches the remote tracker
  only on the next work-item sync, not through this PR.
